### PR TITLE
Add federation binaries to the list of pushed images.

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -666,6 +666,8 @@ release::docker::release () {
     "kube-scheduler"
     "kube-proxy"
     "hyperkube"
+    "federation-apiserver"
+    "federation-controller-manager"
   )
 
   [[ "$registry" =~ gcr.io/ ]] && docker_push_cmd=("$GCLOUD" "docker")


### PR DESCRIPTION
Doing this in kubernetes/release repo too until we complete the deprecation
of release functionality in the main kubernetes repo.

Ref https://github.com/kubernetes/kubernetes/pull/24629 https://github.com/kubernetes/kubernetes/issues/27382