### PR TITLE
gitlib::last_releases() gathering master tags incorrectly.

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -59,20 +59,14 @@ gitlib::last_releases () {
   logecho -n "Setting last releases by branch: "
   for release in $($GHCURL $K8S_GITHUB_API/releases|\
                    jq -r '.[] | select(.draft==false) | .tag_name'); do
-    if [[ $release =~ v([0-9]+\.[0-9]+)\.[0-9]+ ]]; then
+    # Alpha releases only on master branch
+    if [[ $release =~ -alpha ]]; then
+      branch_name=master
+    elif [[ $release =~ v([0-9]+\.[0-9]+)\.[0-9]+ ]]; then
       branch_name=release-${BASH_REMATCH[1]}
-      # Keep the latest(first) branch
-      : ${latest_branch:=$branch_name}
-      # Does branch exist?  If not, default tag to master branch
-      git rev-parse --verify origin/$branch_name &>/dev/null ||\
-       branch_name=master
-  
-      LAST_RELEASE[$branch_name]=${LAST_RELEASE[$branch_name]:-$release}
     fi
+    LAST_RELEASE[$branch_name]=${LAST_RELEASE[$branch_name]:-$release}
   done
-
-  # If ${LAST_RELEASE[master]} is unset, set it to the last release-* branch
-  : ${LAST_RELEASE[master]:=${LAST_RELEASE[$latest_branch]}}
 
   logecho -r "$OK"
 }

--- a/relnotes
+++ b/relnotes
@@ -123,8 +123,12 @@ extract_pr_title () {
     body="$(echo "$pull_json" |jq -r '.body' |tr -d '\r')"
 
     # Look for a body release note first and default to title
+    # * indent lines >1
+    # Try to account for and adjust user-entered formatting
     content=$(echo "$body" |\
-              sed -n '/```release-note/,/^```/{/^```/!p;/^```$/q}')
+              sed -n '/```release-note/,/^```/{/^```/!p;/^```$/q}' |\
+              sed -e '/^$/d' -e '2,$s/^\( *\* \)/    \1/g' \
+                  -e '2,$s/^\( *[^ \*]\)/  * \1/g')
 
     # if the release-note block is empty or the template is unchanged, use title
     if [[ -z "$content" ]] || [[ "$content" =~ -OR- ]]; then
@@ -132,8 +136,10 @@ extract_pr_title () {
     fi
 
     author=$(echo "$pull_json" | jq -r '.user.login')
+    content=$(echo "$content" |sed -e '1s/^ *\** */* /g' \
+                                   -e "1s/$/ (#$pr, @$author)/g")
 
-    logecho -r "* $content (#$pr, @$author)"
+    logecho -r "$content"
   done
 }
 


### PR DESCRIPTION
- release::update_job_cache(): increase cache size, dedup flag only for main_job.
- release::set_build_version(): Add range finder to more accurately ID good
builds that fall within a build range (on consecutive jenkins' runs).
- In relnotes, account for and manage formatting from various release note
sources.