### PR TITLE
WIP: Add kubelet RPM package builds.

### DIFF
--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -1,0 +1,2 @@
+output/
+*.swp

--- a/rpm/99_bridge.conf
+++ b/rpm/99_bridge.conf
@@ -1,0 +1,19 @@
+{
+  "cniVersion": "0.1.0",
+  "name": "kubenet",
+  "type": "bridge",
+  "bridge": "cbr0",
+  "mtu": 1460,
+  "addIf": "eth0",
+  "isGateway": true,
+  "ipMasq": false,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "172.16.0.0/24",
+    "gateway": "172.16.0.1",
+    "routes": [
+      { "dst": "0.0.0.0/0" }
+    ]
+  }
+}
+

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,0 +1,11 @@
+FROM fedora:24
+MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
+
+RUN dnf install -y rpm-build rpmdevtools createrepo && dnf clean all
+
+RUN rpmdev-setuptree
+
+USER root
+ADD entry.sh /root/
+CMD ["/root/entry.sh"]
+

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,9 @@
+# Kubernetes RPM Builder
+
+This directory contains a spec file for Kubernetes, and a Dockerfile for building the RPMs without requiring RPM specific tooling on the host system.
+
+cd to this directory and run ./build-docker.sh.
+
+A Docker container will be built, and run to build the packages and generate yum repo metadata. Output will be in output/x86_64/ directory.
+
+RPMs are built by downloading upstream published binaries rather than from source.

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -2,7 +2,9 @@
 set -e
 
 sudo docker build -t kubelet-rpm-builder .
-mkdir -p output
+echo "Cleaning output directory..."
+sudo rm -rf output/*
+mkdir output
 sudo docker run -ti --rm -v $PWD:/root/rpmbuild/SPECS -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder
 sudo chown -R $USER $PWD/output
 

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -4,7 +4,7 @@ set -e
 sudo docker build -t kubelet-rpm-builder .
 echo "Cleaning output directory..."
 sudo rm -rf output/*
-mkdir output
+mkdir -p output
 sudo docker run -ti --rm -v $PWD:/root/rpmbuild/SPECS -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder
 sudo chown -R $USER $PWD/output
 

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+sudo docker build -t kubelet-rpm-builder .
+mkdir -p output
+sudo docker run -ti --rm -v $PWD:/root/rpmbuild/SPECS -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder
+sudo chown -R $USER $PWD/output
+
+echo
+echo "----------------------------------------"
+echo
+echo "RPMs written to: $PWD/output/x86_64/"
+ls $PWD/output/x86_64/
+echo
+echo "Yum repodata written to: $PWD/output/x86_64/yum/"

--- a/rpm/entry.sh
+++ b/rpm/entry.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-/usr/bin/rpmbuild --define "_sourcedir /root/rpmbuild/SPECS/" -bb /root/rpmbuild/SPECS/kubernetes.spec
+/usr/bin/rpmbuild --define "_sourcedir /root/rpmbuild/SPECS/" -bb /root/rpmbuild/SPECS/kubelet.spec
 
 mkdir -p /root/rpmbuild/RPMS/x86_64/
 createrepo -o /root/rpmbuild/RPMS/x86_64/ /root/rpmbuild/RPMS/x86_64

--- a/rpm/entry.sh
+++ b/rpm/entry.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Entrypoint for the build container to create the rpms and yum repodata:
+
+set -e
+
+/usr/bin/rpmbuild --define "_sourcedir /root/rpmbuild/SPECS/" -bb /root/rpmbuild/SPECS/kubernetes.spec
+
+mkdir -p /root/rpmbuild/RPMS/x86_64/
+createrepo -o /root/rpmbuild/RPMS/x86_64/ /root/rpmbuild/RPMS/x86_64

--- a/rpm/kubelet-wrapper
+++ b/rpm/kubelet-wrapper
@@ -4,7 +4,5 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-source /etc/default/kubelet
-
 /usr/bin/kubelet ${KUBELET_OPTS}
 

--- a/rpm/kubelet-wrapper
+++ b/rpm/kubelet-wrapper
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source /etc/default/kubelet
+
+/usr/bin/kubelet ${KUBELET_OPTS}
+

--- a/rpm/kubelet.env
+++ b/rpm/kubelet.env
@@ -1,0 +1,2 @@
+# Environment variables for kubelet service. (deploys to /etc/sysconfig/kubelet)
+KUBELET_OPTS=""

--- a/rpm/kubelet.service
+++ b/rpm/kubelet.service
@@ -3,6 +3,7 @@ Description=Kubernetes Kubelet Server
 Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
+EnvironmentFile=/etc/sysconfig/kubelet
 ExecStart=/var/lib/kubelet/kubelet-wrapper
 Restart=always
 

--- a/rpm/kubelet.service
+++ b/rpm/kubelet.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/kubernetes/kubernetes
+
+[Service]
+ExecStart=/var/lib/kubelet/kubelet-wrapper
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -1,7 +1,7 @@
 %global KUBE_VERSION 1.3.4
 %global CNI_RELEASE 8a936732094c0941e1543ef5d292a1f4fffa1ac5
 
-Name: kubernetes
+Name: kubelet
 Version: %{KUBE_VERSION}
 Release: 1
 Summary: Container cluster management
@@ -24,7 +24,7 @@ The node agent of Kubernetes, the container cluster manager.
 %package plugin-cni
 
 Summary: Binaries required to provision kubernetes container networking
-Requires: kubernetes
+Requires: kubelet
 
 %description plugin-cni
 Binaries required to provision container networking.
@@ -35,7 +35,7 @@ Binaries required to provision container networking.
 # with this spec file. (where these files are stored) Copy them into
 # the builddir so they can be installed.
 #
-# Example: rpmbuild --define "_sourcedir $PWD" -bb kubernetes.spec
+# Example: rpmbuild --define "_sourcedir $PWD" -bb kubelet.spec
 #
 cp -p %{_sourcedir}/kubelet.service %{_builddir}/
 cp -p %{_sourcedir}/kubelet-wrapper %{_builddir}/

--- a/rpm/kubernetes.spec
+++ b/rpm/kubernetes.spec
@@ -40,6 +40,7 @@ Binaries required to provision container networking.
 cp -p %{_sourcedir}/kubelet.service %{_builddir}/
 cp -p %{_sourcedir}/kubelet-wrapper %{_builddir}/
 cp -p %{_sourcedir}/99_bridge.conf %{_builddir}/
+cp -p %{_sourcedir}/kubelet.env %{_builddir}/
 
 #cp -p %{_sourcedir}/kubelet %{_builddir}/
 
@@ -50,13 +51,16 @@ curl -L --fail "https://storage.googleapis.com/kubernetes-release/release/v%{KUB
 
 install -m 755 -d %{buildroot}%{_bindir}
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
+install -m 755 -d %{buildroot}%{_sysconfdir}/sysconfig
 install -m 755 -d %{buildroot}%{_sysconfdir}/cni/net.d/
 install -m 755 -d %{buildroot}%{_sysconfdir}/kubernetes/manifests/
 install -m 755 -d %{buildroot}/var/lib/kubelet/
 install -p -m 755 -t %{buildroot}%{_bindir}/ kubelet
 install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ kubelet.service
 install -p -m 755 -t %{buildroot}%{_sysconfdir}/cni/net.d/ 99_bridge.conf
+install -p -m 755 kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 install -p -m 755 -t %{buildroot}/var/lib/kubelet/ kubelet-wrapper
+
 
 install -m 755 -d %{buildroot}/opt/cni
 curl -sSL --fail --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-%{CNI_RELEASE}.tar.gz | tar xz
@@ -66,6 +70,7 @@ mv bin/ %{buildroot}/opt/cni/
 %files
 %{_bindir}/kubelet
 %{_sysconfdir}/systemd/system/kubelet.service
+%{_sysconfdir}/sysconfig/kubelet
 /var/lib/kubelet/kubelet-wrapper
 
 %files plugin-cni

--- a/rpm/kubernetes.spec
+++ b/rpm/kubernetes.spec
@@ -1,0 +1,81 @@
+%global KUBE_VERSION 1.3.4
+%global CNI_RELEASE 8a936732094c0941e1543ef5d292a1f4fffa1ac5
+
+Name: kubernetes
+Version: %{KUBE_VERSION}
+Release: 1
+Summary: Container cluster management
+License: ASL 2.0
+
+URL: https://kubernetes.io
+Source0: https://storage.googleapis.com/kubernetes-release/release/v%{KUBE_VERSION}/bin/linux/amd64/kubelet
+Source1: kubelet.service
+
+BuildRequires: curl
+Requires: docker-engine >= 1.10
+Requires: iptables >= 1.4.21
+Requires: socat
+Requires: util-linux
+Requires: ethtool
+
+%description
+The node agent of Kubernetes, the container cluster manager.
+
+%package plugin-cni
+
+Summary: Binaries required to provision kubernetes container networking
+Requires: kubernetes
+
+%description plugin-cni
+Binaries required to provision container networking.
+
+
+%prep
+# Assumes the builder has overridden sourcedir to point to directory
+# with this spec file. (where these files are stored) Copy them into
+# the builddir so they can be installed.
+#
+# Example: rpmbuild --define "_sourcedir $PWD" -bb kubernetes.spec
+#
+cp -p %{_sourcedir}/kubelet.service %{_builddir}/
+cp -p %{_sourcedir}/kubelet-wrapper %{_builddir}/
+cp -p %{_sourcedir}/99_bridge.conf %{_builddir}/
+
+#cp -p %{_sourcedir}/kubelet %{_builddir}/
+
+
+%install
+
+curl -L --fail "https://storage.googleapis.com/kubernetes-release/release/v%{KUBE_VERSION}/bin/linux/amd64/kubelet" -o kubelet
+
+install -m 755 -d %{buildroot}%{_bindir}
+install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
+install -m 755 -d %{buildroot}%{_sysconfdir}/cni/net.d/
+install -m 755 -d %{buildroot}%{_sysconfdir}/kubernetes/manifests/
+install -m 755 -d %{buildroot}/var/lib/kubelet/
+install -p -m 755 -t %{buildroot}%{_bindir}/ kubelet
+install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ kubelet.service
+install -p -m 755 -t %{buildroot}%{_sysconfdir}/cni/net.d/ 99_bridge.conf
+install -p -m 755 -t %{buildroot}/var/lib/kubelet/ kubelet-wrapper
+
+install -m 755 -d %{buildroot}/opt/cni
+curl -sSL --fail --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-%{CNI_RELEASE}.tar.gz | tar xz
+mv bin/ %{buildroot}/opt/cni/
+
+
+%files
+%{_bindir}/kubelet
+%{_sysconfdir}/systemd/system/kubelet.service
+/var/lib/kubelet/kubelet-wrapper
+
+%files plugin-cni
+%{_sysconfdir}/cni/net.d/99_bridge.conf
+/opt/cni
+
+%doc
+
+
+%changelog
+
+* Wed Jul 20 2016 dgoodwin <dgoodwin@redhat.com> - 1.3.0-1
+- Initial packaging.

--- a/rpm/kubernetes.spec
+++ b/rpm/kubernetes.spec
@@ -71,6 +71,7 @@ mv bin/ %{buildroot}/opt/cni/
 %{_bindir}/kubelet
 %{_sysconfdir}/systemd/system/kubelet.service
 %{_sysconfdir}/sysconfig/kubelet
+%{_sysconfdir}/kubernetes/manifests/
 /var/lib/kubelet/kubelet-wrapper
 
 %files plugin-cni


### PR DESCRIPTION
First attempt at the RPMs requested in issue #37. 

This is intended to be relatively self contained build process that can hopefully be integrated into the larger k8s release process, just drop into the
directory and run the build-docker.sh script to launch a Docker
container with appropriate rpm/yum tooling.

Resulting rpms and yum repository metadata will appear in output/
sub-directory and can then just be rsynced, after which client systems just need a simple yum repository file similar to this one I tested with (don't try to use it it's not publically accessible):

```
[root@centos1 ~]# cat /etc/yum.repos.d/kubernetes.repo 
[kubernetes]
name=K8s Repository
baseurl=http://file.rdu.redhat.com/~dgoodwin/kubernetes-rpms/
enabled=1
gpgcheck=0
```

I took an alternate naming scheme from the Debian equivalent in #35 and packaged this as "kubernetes" rather than "kubelet", the reasoning behind this was that between hyperkube, an possible incoming rename to kube, self-hosting, and discussion around kube-master and kube-node etc, I don't know as the kubelet name will survive as the thing a user should be thinking to install. "kubernetes" however, should remain constant at least as a base package in all of this and wherever we end up. This also more closely matches the Fedora RPM packaging today which is further decomposed into the following packages: 

kubernetes.x86_64 : Container cluster management
kubernetes-client.x86_64 : Kubernetes client tools
kubernetes-node.x86_64 : Kubernetes services for node host
kubernetes-master.x86_64 : Kubernetes services for master host

And I suspect we may want to synchronize approaches in the future depending on how all the binary renames play out. 

cc @mikedanese @kubernetes/sig-cluster-lifecycle @detiber @timstclair 
