### PR TITLE
Simplify systemd unit for Debian

### DIFF
--- a/debian/xenial/kubelet/debian/kubelet.install
+++ b/debian/xenial/kubelet/debian/kubelet.install
@@ -1,4 +1,2 @@
 usr/bin/kubelet usr/bin/
 lib/systemd/system/kubelet.service lib/systemd/system/
-var/lib/kubelet/kubelet-wrapper var/lib/kubelet/
-etc/default/kubelet etc/default

--- a/debian/xenial/kubelet/etc/default/kubelet
+++ b/debian/xenial/kubelet/etc/default/kubelet
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-KUBELET_OPTS=""

--- a/debian/xenial/kubelet/lib/systemd/system/kubelet.service
+++ b/debian/xenial/kubelet/lib/systemd/system/kubelet.service
@@ -1,10 +1,12 @@
 [Unit]
-Description=Kubernetes Kubelet Server
-Documentation=https://github.com/kubernetes/kubernetes
+Description=kubelet: The Kubernetes Node Agent
+Documentation=http://kubernetes.io/docs/
 
 [Service]
-ExecStart=/var/lib/kubelet/kubelet-wrapper
+ExecStart=/usr/bin/kubelet
 Restart=always
+StartLimitInterval=0
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/xenial/kubelet/var/lib/kubelet/kubelet-wrapper
+++ b/debian/xenial/kubelet/var/lib/kubelet/kubelet-wrapper
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o nounset
-set -o errexit
-set -o pipefail
-
-source /etc/default/kubelet
-
-/usr/bin/kubelet ${KUBELET_OPTS}


### PR DESCRIPTION
After looking reviewing what Docker does in 1.12 and how `Environment` and `EnvironmentFile` work, @mikedanese and I came to the conclusion that it's better to simply rely on drop-ins for setting any flags user has to set. If they have to use bash, they can generate a drop-in with bash etc.