### PR TITLE
Start kubelet as soon as you install it on Ubuntu Xenial

### DIFF
--- a/debian/xenial/kubelet/debian/postinst
+++ b/debian/xenial/kubelet/debian/postinst
@@ -21,6 +21,8 @@ set -o nounset
 
 case "$1" in
     configure)
+        systemctl enable kubelet
+        systemctl start kubelet
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
(even if this means it crashloops). Fixes #91.