### PR TITLE
Start kubelet with systemd on package install

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -7,6 +7,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       dpkg-dev \
       build-essential \
       debhelper \
+      dh-systemd \
     && apt-get upgrade -y \
     && apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/debian/xenial/kubelet/debian/control
+++ b/debian/xenial/kubelet/debian/control
@@ -2,7 +2,7 @@ Source: kubelet
 Section: misc
 Priority: optional
 Maintainer: Kubernetes Authors <kubernetes-dev@google.com>
-Build-Depends: curl, ca-certificates, debhelper (>= 8.0.0)
+Build-Depends: curl, ca-certificates, debhelper (>= 8.0.0), dh-systemd (>= 1.5)
 Standards-Version: 3.9.4
 Homepage: https://kubernetes.io
 Vcs-Git: https://github.com/kubernetes/kubernetes.git

--- a/debian/xenial/kubelet/debian/postinst
+++ b/debian/xenial/kubelet/debian/postinst
@@ -21,8 +21,6 @@ set -o nounset
 
 case "$1" in
     configure)
-        systemctl enable kubelet
-        systemctl start kubelet
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/xenial/kubelet/debian/rules
+++ b/debian/xenial/kubelet/debian/rules
@@ -16,10 +16,13 @@ binary:
 	dh_auto_install
 	dh_shlibdeps
 	dh_install
+	dh_systemd_enable
+	dh_installinit
+	dh_systemd_start
 	dh_installdeb
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb
 
 %:
-	dh $@
+	dh $@ --with systemd


### PR DESCRIPTION
* Use special helper to enable and start the service.
* It also automatically generates `postinst`,  `postrm`, `prerm` hooks.

Systemd service Debian [packaging guide](https://wiki.debian.org/Teams/pkg-systemd/Packaging).

Closes: #91
Depends-on: #93