### PR TITLE
Fix python import error in build.py

### DIFF
--- a/debian/build.py
+++ b/debian/build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import logging
+import sys
 import subprocess
 
 # to build multiarch you might need to add the architectures


### PR DESCRIPTION
`sys.exit` [call](https://github.com/kubernetes/release/blob/0a3da543e2cf9df7959083b8eaaf23d5104c283d/debian/build.py#L79) fails with import error exception, if `rc` is not `0`.