### PR TITLE
Restart/reload the kubelet service when kubeadm is installed

### DIFF
--- a/debian/xenial/kubeadm/debian/postinst
+++ b/debian/xenial/kubeadm/debian/postinst
@@ -19,6 +19,11 @@ set -o nounset
 
 case "$1" in
     configure)
+        # because kubeadm package adds kubelet drop-ins, we must daemon-reload
+        # and restart kubelet now. restarting kubelet is ok because kubelet
+        # postinst configure step auto-starts it.
+        systemctl daemon-reload
+        systemctl restart kubelet
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Because the kubeadm deb drops in some kubelet configuration, we must:
```
systemctl daemon-reload && systemctl restart kubelet
```
in its postinst configure step, otherwise kubelet starts up with no flags and doesn't crashloop, so `kubeadm` setup fails.