### PR TITLE
jenkins job cleanups

### DIFF
--- a/debian/jenkins.sh
+++ b/debian/jenkins.sh
@@ -10,14 +10,8 @@ declare -r BUILD_TAG="$(date '+%y%m%d%H%M%S')"
 declare -r IMG_NAME="debian-builder-${DEB_CHANEL}:${BUILD_TAG}"
 declare -r DEB_RELEASE_BUCKET="gs://kubernetes-release-dev/debian/${DEB_CHANEL}"
 
-function cleanup() {
-  docker rmi "${IMG_NAME}" || true
-}
-
-trap cleanup EXIT SIGINT SIGTERM
-
 docker build -t "${IMG_NAME}" debian/
 docker run --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}"
 
 gsutil -m cp -nc bin/* "${DEB_RELEASE_BUCKET}/${BUILD_TAG}/"
-echo "${BUILD_NUMBER}" | gsutil -m cp - "${DEB_RELEASE_BUCKET}/latest"
+gsuilt -m cp <(printf "${BUILD_NUMBER}") "${DEB_RELEASE_BUCKET}/latest"


### PR DESCRIPTION
actually save most recent build version and cache the build image.