### PR TITLE
Remove kubectl dependency for kubelet, closes: #97

### DIFF
--- a/debian/xenial/kubeadm/debian/control
+++ b/debian/xenial/kubeadm/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/kubernetes/kubernetes
 
 Package: kubeadm
 Architecture: {{ .DebArch }}
-Depends: kubelet (>= 1.4.0), ${misc:Depends}
+Depends: kubelet (>= 1.4.0), kubectl (>= {{ .Version }}), ${misc:Depends}
 Description: Kubernetes Cluster Bootstrapping Tool
  The Kubernetes command line tool for bootstrapping a Kubernetes cluster.

--- a/debian/xenial/kubelet/debian/control
+++ b/debian/xenial/kubelet/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/kubernetes/kubernetes
 
 Package: kubelet
 Architecture: {{ .DebArch }}
-Depends: docker-engine (>= 1.11.2-0), iptables (>= 1.4.21), kubectl (>= {{ .Version }}), kubernetes-cni (>= 0.3.0.1), iproute2, socat, util-linux, mount, ${misc:Depends}
+Depends: docker-engine (>= 1.11.2-0), iptables (>= 1.4.21), kubernetes-cni (>= 0.3.0.1), iproute2, socat, util-linux, mount, ${misc:Depends}
 Description: Kubernetes Node Agent
  The node agent of Kubernetes, the container cluster manager


### PR DESCRIPTION
As it was discussed in #97, removing `kubectl` dependency from `kubelet` and adding to `kubeadm`.