### PR TITLE
Download the kubeadm for the right arch

### DIFF
--- a/debian/xenial/kubeadm/debian/rules
+++ b/debian/xenial/kubeadm/debian/rules
@@ -10,7 +10,7 @@ binary:
 	mkdir -p usr/bin
 	curl  --fail -sS -L \
 		-o usr/bin/kubeadm \
-		"https://storage.googleapis.com/kubeadm/v{{ .Version }}/bin/kubeadm"
+		"https://storage.googleapis.com/kubeadm/v{{ .Version }}/bin/linux/{{ .Arch }}/kubeadm"
 	chmod +x usr/bin/kubeadm
 	dh_testroot
 	dh_auto_install


### PR DESCRIPTION
Fixes so the kubeadm package becomes multiarch

@mikedanese @errordeveloper 