### PR TITLE
Fix check_acls in anago

### DIFF
--- a/anago
+++ b/anago
@@ -165,12 +165,10 @@ common::cleanexit () {
 ###############################################################################
 # Simple ACL check to limit nomock runs to a short list of release folks
 check_acls () {
-  case "$USER" in
-    $ACL_LIST) ;;
-            *) logecho "Live releases restricted to certain users!"
-               return 1
-               ;;
-  esac
+  if ! (echo "$USER" | egrep -q -w "$ACL_LIST"); then
+    echo "Live releases restricted to certain users!"
+    return 1
+  fi
 }
 
 ###############################################################################


### PR DESCRIPTION
Previously the `check_acls` was using a `case ... in` to find user in ACL list. That only works if the elements after `in` are a shell array--which they used to be, but the elements were moved into a variable (PR https://github.com/kubernetes/release/pull/131) so they are now evaluated as one big element -- hence the check fails for all users.

The fix replaces the pipe character in the `ACL_LIST` with a new line, and then greps for the specified user. If the value is found the check is passed, if it is not the check fails.

Thanks to @bowei for help debugging and fixing.

Fixes https://github.com/kubernetes/release/issues/142