### PR TITLE
Use locally available RPM source files if available

### DIFF
--- a/rpm/.dockerignore
+++ b/rpm/.dockerignore
@@ -1,0 +1,3 @@
+docker-build.sh
+Dockerfile
+output/*

--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -1,2 +1,7 @@
+kubelet
+kubeadm
+kubectl
+cni-*.tar.gz
+bin/
 output/
 *.swp

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -7,5 +7,6 @@ RUN rpmdev-setuptree
 
 USER root
 ADD entry.sh /root/
+COPY ./ /root/rpmbuild/SPECS
 CMD ["/root/entry.sh"]
 

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -5,7 +5,7 @@ docker build -t kubelet-rpm-builder .
 echo "Cleaning output directory..."
 sudo rm -rf output/*
 mkdir -p output
-docker run -ti --rm -v $PWD:/root/rpmbuild/SPECS -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder
+docker run -ti --rm -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder
 sudo chown -R $USER $PWD/output
 
 echo

--- a/rpm/entry.sh
+++ b/rpm/entry.sh
@@ -2,6 +2,8 @@
 # Entrypoint for the build container to create the rpms and yum repodata:
 
 set -e
+# Download sources if not already available
+cd /root/rpmbuild/SPECS  && spectool -gf kubelet.spec
 
 /usr/bin/rpmbuild --define "_sourcedir /root/rpmbuild/SPECS/" -bb /root/rpmbuild/SPECS/kubelet.spec
 


### PR DESCRIPTION
Changes to rpm build container:
 * Add source dir in docker build instead of mounting as volume
 * Add .dockerignore to skip adding build scripts

Changes to entry.sh:
 * Use spectool to download sources if not available (enables caching
   and locally available files, such as generated from a manual build)

Changes to kubelet.spec:
 * Add URLs for all source files

Files downloaded from the Internet are not saved back to the host machine.
Updated .gitignore to skip rpm/kube* and cni files.