### PR TITLE
Optimize github API calls to find PRs by label

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -23,6 +23,7 @@
 GHCURL="curl -s --fail --retry 10 -u ${GITHUB_TOKEN:-$FLAGS_github_token}:x-oauth-basic"
 JCURL="curl -g -s --fail --retry 10"
 K8S_GITHUB_API='https://api.github.com/repos/kubernetes/kubernetes'
+K8S_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20repo:kubernetes/kubernetes%20'
 K8S_GITHUB_URL='https://github.com/kubernetes/kubernetes'
 K8S_GITHUB_SSH='git@github.com:kubernetes/kubernetes.git'
 

--- a/relnotes
+++ b/relnotes
@@ -147,6 +147,31 @@ extract_pr_title () {
   done
 }
 
+###############################################################################
+# Get merged PRs that match a specified label
+# @param label - A label(string) to use for searching github PRs
+get_prs_by_label () {
+  local label="$1"
+  local matching_prs
+  local -a prs
+  local total
+  local current_page
+  local num_pages
+  local prs_per_page
+
+  prs_per_page=100
+
+  matching_prs="$($GHCURL ${K8S_GITHUB_SEARCHAPI}label:${label}&per_page=1)"
+
+  total="$(echo -n $matching_prs | jq -r '.total_count')"
+  # Calculate number of pages, rounding up
+  num_pages=$(((total + prs_per_page - 1) / prs_per_page ))
+
+  for current_page in `seq 1 $num_pages`; do
+    prs+=($($GHCURL "${K8S_GITHUB_SEARCHAPI}label:${label}&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
+  done
+  echo "${prs[@]}"
+}
 
 ###############################################################################
 # Create the release note markdown body
@@ -234,10 +259,12 @@ generate_notes () {
   local pretty_range
   local labels
   local body
-  local counter=0
   local tempcss=/tmp/$PROG-ca.$$
   local changelog=$(git rev-parse --show-toplevel)/CHANGELOG.md
   local anchor
+  local -a normal_prs
+  local -a action_prs
+  local -a experimental_prs
   local -a notes_normal
   local -a notes_action
   local -a notes_experimental
@@ -292,21 +319,21 @@ generate_notes () {
   done < <(git log $range --format="%s" --grep="Merge pull")
 
   logecho
-  for pr in ${prs[*]}; do
-    ((counter++))
-    # Reset line
-    printf "\r%-80s" " "
-    echo -ne "\rScanning PRs between $pretty_range on the" \
-             "$CURRENT_BRANCH branch ($counter/${#prs[*]})"
-    labels="$($GHCURL $K8S_GITHUB_API/issues/$pr/labels |\
-              jq -r '.[] | (.name| tostring)')"
 
-    if [[ "$labels" =~ $'\n'release-note-breaking-change$'\n' ||
-          "$labels" =~ $'\n'release-note-action-required$'\n' ]]; then
+  echo "Scanning action required PR labels on the $CURRENT_BRANCH branch..."
+  action_prs=($(get_prs_by_label release-note-breaking-change))
+  action_prs+=($(get_prs_by_label release-note-action-required))
+  echo "Scanning experimental PR label on the $CURRENT_BRANCH branch..."
+  experimental_prs=($(get_prs_by_label release-note-experimental))
+  echo "Scanning release-note PR label on the $CURRENT_BRANCH branch..."
+  normal_prs=($(get_prs_by_label release-note))
+
+  for pr in ${prs[*]}; do
+    if [[ " ${action_prs[@]} " =~ " ${pr} " ]]; then
       notes_action+=("$pr")
-    elif [[ "$labels" =~ $'\n'release-note-experimental$'\n' ]]; then
+    elif [[ " ${experimental_prs[@]} " =~ " ${pr} " ]]; then
       notes_experimental+=("$pr")
-    elif [[ "$labels" =~ $'\n'release-note$'\n' ]]; then
+    elif [[ " ${normal_prs[@]} " =~ " ${pr} " ]]; then
       notes_normal+=("$pr")
     fi
   done


### PR DESCRIPTION
Reduces number of API calls by a factor of 10 (150 down to ~20)
and speeds up the total script execution by about 3x.

This approach could be improved by limiting by milestones, but
predicting all milestones included may be difficult. Instead, it simply
retrieves all PRs containing release note labels, paged 100 at a time.

Fixes #146