### PR TITLE
Add -- between "gcloud docker" and docker args

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -739,7 +739,7 @@ release::docker::release () {
     "hyperkube"
   )
 
-  [[ "$registry" =~ gcr.io/ ]] && docker_push_cmd=("$GCLOUD" "docker")
+  [[ "$registry" =~ gcr.io/ ]] && docker_push_cmd=("$GCLOUD" "docker" "--")
 
   # Activate credentials for the k8s.production.user@gmail.com
   [[ "$registry" == "gcr.io/google_containers" ]] \


### PR DESCRIPTION
To address this warning:
> WARNING: The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right. IMPORTANT: previously, commands allowed the omission of the --, and unparsed arguments were treated as implementation args. This usage is being deprecated and will 
be removed in March 2017.
This will be strictly enforced in March 2017. Use 'gcloud beta docker' to see new behavior.