### PR TITLE
Add ethtool to the kubelet dependenices

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -201,12 +201,12 @@ func main() {
 			Versions: []version{
 				{
 					Version:  "1.4.4",
-					Revision: "00",
+					Revision: "01",
 					Stable:   true,
 				},
 				{
 					Version:  "1.4.4",
-					Revision: "00",
+					Revision: "01",
 					Stable:   false,
 				},
 			},

--- a/debian/xenial/kubelet/debian/control
+++ b/debian/xenial/kubelet/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/kubernetes/kubernetes
 
 Package: kubelet
 Architecture: {{ .DebArch }}
-Depends: iptables (>= 1.4.21), kubernetes-cni (>= 0.3.0.1), iproute2, socat, util-linux, mount, ebtables, ${misc:Depends}
+Depends: iptables (>= 1.4.21), kubernetes-cni (>= 0.3.0.1), iproute2, socat, util-linux, mount, ebtables, ethtool, ${misc:Depends}
 Description: Kubernetes Node Agent
  The node agent of Kubernetes, the container cluster manager


### PR DESCRIPTION
ethtool is required for kubelet, and the preflight check requires it to be present.

@mikedanese @errordeveloper 