### PR TITLE
Add terminating dashes to docker command.

### DIFF
--- a/anago
+++ b/anago
@@ -200,7 +200,7 @@ check_prerequisites () {
     logecho -n "Checking cloud account/auth $user: "
     if [[ "$gcloud_auth_list" =~ -\ $user ]] && \
        (logrun gcloud config set account $user && \
-        logrun gcloud docker version >/dev/null 2>&1); then
+        logrun gcloud docker -- version >/dev/null 2>&1); then
       logecho -r "$OK"
     else
       logecho -r "$FAILED"


### PR DESCRIPTION
I wonder if it's worthwhile checking for a minimum docker version.  It's not clear to me how we need to use this so I'm not eager to add that check until we're getting some value from it.