### PR TITLE
Remove all instances of docker tag -f

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -770,6 +770,7 @@ release::docker::release () {
         logecho "Release legacy $legacy_docker_target:"
 
         logecho -n "- Tagging: "
+        logrun -s docker rmi "$registry/$legacy_docker_target" || true
         logrun -r 5 -s docker tag -f "$registry/$docker_target" \
                               "$registry/$legacy_docker_target" 2>/dev/null
 


### PR DESCRIPTION
This goes in conjunction with https://github.com/kubernetes/kubernetes/pull/34361

docker tag -f is not a flag on recent versions of docker