### PR TITLE
Check kubernetes-cross-build looking for green

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -101,6 +101,7 @@ release::set_build_version () {
                      "kubernetes-e2e-gce-reboot$branch_suffix"
                      "kubernetes-e2e-gce-scalability$branch_suffix"
                      "kubernetes-test-go$branch_suffix"
+                     "kubernetes-cross-build$branch_suffix"
                     )
 
   # kubernetes-e2e-gke-subnet - Uses a branch version?


### PR DESCRIPTION
While trying to cut a `v1.5.0-alpha.2`, `anago` selected build #1025, which was otherwise green, but failed build (due to issue https://github.com/kubernetes/kubernetes/issues/35564):

```
* kubernetes-e2e-gce             #25722  #1039   [02:59 10/27]
* (--buildversion=v1.5.0-alpha.1.1039+f11d01076e2388)
- kubernetes-e2e-gce-serial      #2181   #1030   PASSED
- kubernetes-e2e-gce-slow        #10699  #1039   PASSED
- kubernetes-kubemark-5-gce      #16360  #1039   PASSED
- kubernetes-e2e-gce-reboot      #10618  #1039   PASSED
- kubernetes-e2e-gce-scalability #11637  #1039   PASSED
- kubernetes-test-go             #18728  #1039   PASSED
- kubernetes-e2e-gke-serial      #2522   #1035   PASSED
- kubernetes-e2e-gke             #18708  #1039   PASSED
- kubernetes-e2e-gke-slow        #10367  #1039   PASSED

JENKINS_BUILD_VERSION=v1.5.0-alpha.1.1039+f11d01076e2388
RELEASE_VERSION[alpha]=v1.5.0-alpha.2
RELEASE_VERSION_PRIME=v1.5.0-alpha.2

...
+++ [1027 14:25:08] darwin/amd64: go build started
# k8s.io/kubernetes/pkg/util/mount
pkg/util/mount/mount.go:115: unknown Mounter field 'mounterRootfsPath' in struct literal
+++ [1027 14:25:08] windows/amd64: go build started
# k8s.io/kubernetes/pkg/util/mount
pkg/util/mount/mount.go:115: unknown Mounter field 'mounterRootfsPath' in struct literal
```

This PR adds `kubernetes-cross-build` to the list of test suites `anago` checks while looking for a green build.
