### PR TITLE
Improve error message when we can't detect build version

### DIFF
--- a/push-build.sh
+++ b/push-build.sh
@@ -97,11 +97,15 @@ RELEASE_BUCKET_MIRROR=$FLAGS_bucket_mirror
 # Compatibility with incoming global args
 [[ $KUBE_GCS_UPDATE_LATEST == "n" ]] && FLAGS_noupdatelatest=1
 
-if [[ $(cluster/kubectl.sh version --client 2>&1) =~ \
-      GitVersion:\"(${VER_REGEX[release]}\.${VER_REGEX[build]})\", ]]; then
+KUBECTL_OUTPUT=$(cluster/kubectl.sh version --client 2>&1 || true)
+if [[ "$KUBECTL_OUTPUT" =~ GitVersion:\"(${VER_REGEX[release]}\.${VER_REGEX[build]})\", ]]; then
   LATEST=${BASH_REMATCH[1]}
 else
-  common::exit 1 "Unable to get latest version from build tree.  Exiting..."
+  logecho "Unable to get latest version from build tree!"
+  logecho
+  logecho "kubectl version output:"
+  logecho $KUBECTL_OUTPUT
+  common::exit 1
 fi
 
 GCS_DEST="devel"


### PR DESCRIPTION
Two recent PRs (https://github.com/kubernetes/kubernetes/pull/35896, https://github.com/kubernetes/kubernetes/pull/32530) have had mysterious failures in CI:
```
I1101 14:20:34.286] push-build.sh: BEGIN main on agent-pr-78 Tue Nov  1 14:20:34 PDT 2016
I1101 14:20:34.287] 
I1101 14:20:34.314] 
I1101 14:20:34.317] Unable to get latest version from build tree.  Exiting...
I1101 14:20:34.321] 
I1101 14:20:34.323] 
I1101 14:20:34.324] push-build.sh: DONE main on agent-pr-78 Tue Nov  1 14:20:34 PDT 2016 in 0s
```

In both cases, they were due to errors in some of the scripts in the PRs, but this wasn't at all obvious.

This change makes these sorts of errors more obvious. For example, instead of
```
$ ../release/push-build.sh 
...
Unable to get latest version from build tree.  Exiting...
```

it now shows
```
$ ../release/push-build.sh 
...
Unable to get latest version from build tree!

kubectl version output:
cluster/../cluster/../cluster/gce/../../cluster/gce/../../cluster/common.sh:
line 2: asdfsf: command not found
```
