### PR TITLE
Remove versionize-docs from branchff

### DIFF
--- a/branchff
+++ b/branchff
@@ -29,7 +29,6 @@ PROG=${0##*/}
 #+ DESCRIPTION
 #+     $PROG fast forwards a K8s release branch to [master object] (defaults to
 #+     HEAD and then prepares the branch as a K8s release branch:
-#+     * build-tools/versionize-docs.sh <branch>
 #+     * Run hack/update-all.sh to ensure compliance of generated files
 #+
 #+
@@ -138,17 +137,10 @@ logrun -s git merge -X ours $MASTER_OBJECT
 logecho -n "update-all.sh: "
 logrun -s hack/update-all.sh
 
-# Redo the branching activities
-logecho -n "Check/rerun versionize-docs.sh again: "
-# TODO: remove once we don't support k8s versions with build/ anymore
-build_dir=build-tools
-[[ -d $build_dir ]] || build_dir=build
-logrun -s $build_dir/versionize-docs.sh $RELEASE_BRANCH
-
 if [[ -n "$(git status -s)" ]]; then
   logecho -n "Commit changes: "
   logrun git add -A
-  logrun -s git commit -am "versionize-docs.sh and update-all.sh." \
+  logrun -s git commit -am "update-all.sh." \
     || common::exit 1 "Exiting..."
 fi
 


### PR DESCRIPTION
`./build-tools/versionize-docs.sh` was removed as part of PR #https://github.com/kubernetes/kubernetes/pull/35546

This PR removes the call from `branchff`.