### PR TITLE
Ensure GCS release bucket has public-read defacl

### DIFF
--- a/anago
+++ b/anago
@@ -228,7 +228,7 @@ check_prerequisites () {
   # Verify write access to $RELEASE_BUCKET
   # Insufficient for checking actual writability, but useful:
   # ganpati list-members -g cloud-kubernetes-release -u $USER|fgrep -wq $USER
-  logecho -n "Checking writability to $RELEASE_BUCKET: "
+  logecho -n "Checking writability and ACLs on $RELEASE_BUCKET: "
   if logrun release::gcs::ensure_release_bucket $RELEASE_BUCKET && \
      logrun touch $tempfile && \
      logrun gsutil cp $tempfile gs://$RELEASE_BUCKET && \


### PR DESCRIPTION
We do this rather than copying artifacts with the public-read ACL,
since doing so will remove any owner ACLs.

x-ref #195.

I haven't checked all of the Jenkins GCS buckets yet, so this may likely break some builds until those buckets are fixed.

cc @zmerlynn @rmmh @david-mcmahon @saad-ali 