### PR TITLE
Use python instead of jq because Jenkins doesn't have jq

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -390,8 +390,10 @@ release::gcs::ensure_release_bucket() {
     logrun rm -f "$new_acl_file"
   fi
 
-  if [[ $($GSUTIL defacl get "gs://$bucket" 2>/dev/null |\
-          jq -r '.[] | select(.entity == "allUsers") | .role') != 'READER' ]]; then
+  if [[ $($GSUTIL defacl get "gs://$bucket" 2>/dev/null | python -c '\
+          import sys,json;\
+          print " ".join(x["role"] for x in json.load(sys.stdin) if x["entity"] == "allUsers")')\
+        != 'READER' ]]; then
     logecho "GCS bucket $bucket is missing default public-read ACL."
     logecho "Please add allUsers: READER to the gs://$bucket defacl and try again."
     return 1


### PR DESCRIPTION
Python one-liner courtesy @rmmh.

I'm not super happy about this, but installing `jq` on all of our Jenkins VMs is quite a hassle, too.

Fixes https://github.com/kubernetes/kubernetes/issues/36839.