### PR TITLE
Set up kubernetes tree in a valid go path

### DIFF
--- a/anago
+++ b/anago
@@ -855,9 +855,11 @@ common::runstep get_build_candidate || common::exit 1 "Exiting..."
 
 # WORK/BUILD area
 WORKDIR=$BASEDIR/$PROG-$RELEASE_VERSION_PRIME
+# Go tools expect the kubernetes src to be under $GOPATH
+export GOPATH=$WORKDIR
 # TOOL_ROOT is release/
 # TREE_ROOT is working branch/tree
-TREE_ROOT=$WORKDIR/kubernetes
+TREE_ROOT=$WORKDIR/src/k8s.io/kubernetes
 BUILD_OUTPUT=$TREE_ROOT/_output
 RELEASE_NOTES_MD=$WORKDIR/release-notes.md
 RELEASE_NOTES_HTML=$WORKDIR/release-notes.html

--- a/branchff
+++ b/branchff
@@ -83,8 +83,10 @@ common::timestamp begin
 BASEDIR="/usr/local/google/$USER"
 # WORK/BUILD area
 WORKDIR=$BASEDIR/$PROG-$RELEASE_BRANCH
+# Go tools expect the kubernetes src to be under $GOPATH
+export GOPATH=$WORKDIR
 # TREE_ROOT is working branch/tree
-TREE_ROOT=$WORKDIR/kubernetes
+TREE_ROOT=$WORKDIR/src/k8s.io/kubernetes
 # The real deal?
 if ((FLAGS_nomock)); then
   DRYRUN_FLAG=""

--- a/branchff
+++ b/branchff
@@ -77,6 +77,8 @@ common::logfileinit $MYLOG 10
 # BEGIN script
 common::timestamp begin
 
+gitlib::repo_state || common::exit 1
+
 ###############################################################################
 # MAIN
 ###############################################################################
@@ -149,7 +151,7 @@ fi
 ##############################################################################
 common::stepheader "PUSH UPSTREAM"
 ##############################################################################
-logecho "Go look around in $WORKDIR to make sure things look ok:"
+logecho "Go look around in $TREE_ROOT to make sure things look ok:"
 logecho "# Any files left uncommitted?"
 logecho "* git status -s"
 logecho "# What does the commit look like?"


### PR DESCRIPTION
Fixes a part of kubernetes/kubernetes#36843.

This is the same as #209, except that I added a check to `branchff` to make sure the checked-out release repo is up-to-date.

Also, this is actually a PR from the correct branch off my fork.