### PR TITLE
Mark one of the duplicate kubernetes-cni builds as unstable.

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -223,7 +223,7 @@ func main() {
 				{
 					Version:  "0.3.0.1-07a8a2",
 					Revision: "00",
-					Stable:   true,
+					Stable:   false,
 				},
 			},
 		},


### PR DESCRIPTION
It looks like both `kubernetes-cni` build entries were accidentally marked as stable, which did duplicate work that overwrote the first build's output.

Every other package in this file follows the same pattern of listing two identical builds, one as `Stable: true` and the other as `Stable: false`, except for this one, which had them both set to `true`.

CC @mikedanese 