### PR TITLE
Fix logging of docker-build.sh

### DIFF
--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -14,4 +14,4 @@ echo
 echo "RPMs written to: $PWD/output/x86_64/"
 ls $PWD/output/x86_64/
 echo
-echo "Yum repodata written to: $PWD/output/x86_64/yum/"
+echo "Yum repodata written to: $PWD/output/x86_64/repodata/"


### PR DESCRIPTION
The repodata is actually output to `$PWD/output/x86_64/repodata/` instead of `$PWD/output/x86_64/yum/`