### PR TITLE
Follow redirects when validating uploaded version files.

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -706,7 +706,7 @@ release::gcs::publish () {
 
     # If public, validate public link
     logecho -n "* Validating uploaded version file at $public_link: "
-    contents="$(curl -s $public_link)"
+    contents="$(curl -Ls $public_link)"
   else
     # If not public, validate using gsutil
     logecho -n "* Validating uploaded version file at $publish_file_dst: "


### PR DESCRIPTION
dl.k8s.io/release/latest-1.5.txt redirects to storage.googleapis.com.

This changed in #221.