### PR TITLE
Bump k8s to v1.5.1 and patch kubeadm to fix an insecure auth option

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -184,12 +184,12 @@ func main() {
 			Distros: allDistros,
 			Versions: []version{
 				{
-					Version:  "1.5.0",
+					Version:  "1.5.1",
 					Revision: "00",
 					Stable:   true,
 				},
 				{
-					Version:  "1.5.0",
+					Version:  "1.5.1",
 					Revision: "00",
 					Stable:   false,
 				},
@@ -200,12 +200,12 @@ func main() {
 			Distros: serverDistros,
 			Versions: []version{
 				{
-					Version:  "1.5.0",
+					Version:  "1.5.1",
 					Revision: "00",
 					Stable:   true,
 				},
 				{
-					Version:  "1.5.0",
+					Version:  "1.5.1",
 					Revision: "00",
 					Stable:   false,
 				},
@@ -233,12 +233,12 @@ func main() {
 			Versions: []version{
 				{
 					// Remember to update xenial/kubeadm/debian/rules with the same version
-					Version:  "1.6.0-alpha.0-2046-b4d09bf6727606",
+					Version:  "1.6.0-alpha.0-2074-a092d8e0f95f52",
 					Revision: "00",
 					Stable:   true,
 				},
 				{
-					Version:  "1.6.0-alpha.0-2046-b4d09bf6727606",
+					Version:  "1.6.0-alpha.0-2074-a092d8e0f95f52",
 					Revision: "00",
 					Stable:   false,
 				},

--- a/debian/xenial/kubeadm/debian/rules
+++ b/debian/xenial/kubeadm/debian/rules
@@ -10,7 +10,7 @@ binary:
 	mkdir -p usr/bin
 	curl --fail -sSL \
 		-o usr/bin/kubeadm \
-		"https://dl.k8s.io/ci-cross/v1.6.0-alpha.0.2046+b4d09bf6727606/bin/linux/{{ .Arch }}/kubeadm"
+		"https://dl.k8s.io/ci-cross/v1.6.0-alpha.0.2074+a092d8e0f95f52/bin/linux/{{ .Arch }}/kubeadm"
 
 	chmod +x usr/bin/kubeadm
 	dh_testroot

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -1,7 +1,7 @@
-%global KUBE_VERSION 1.5.0
-%global KUBEADM_VERSION 1.6.0-alpha.0.2046+b4d09bf6727606
+%global KUBE_VERSION 1.5.1
+%global KUBEADM_VERSION 1.6.0-alpha.0.2074+a092d8e0f95f52
 %global CNI_RELEASE 07a8a28637e97b22eb8dfe710eeae1344f69d16e
-%global RPM_RELEASE 2
+%global RPM_RELEASE 0
 
 Name: kubelet
 Version: %{KUBE_VERSION}
@@ -53,7 +53,7 @@ Command-line utility for interacting with a Kubernetes cluster.
 %package -n kubeadm
 
 Version: 1.6.0
-Release: %{RPM_RELEASE}.alpha.0.2046.b4d09bf6727606
+Release: %{RPM_RELEASE}.alpha.0.2074.a092d8e0f95f52
 Summary: Command-line utility for administering a Kubernetes cluster. (ALPHA)
 Requires: kubelet >= 1.4.0
 Requires: kubectl >= 1.4.0
@@ -120,8 +120,8 @@ mv bin/ %{buildroot}/opt/cni/
 
 
 %changelog
-* Fri Dec 6 2016 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk> - 1.5.0
-- Bump version of kubelet and kubectl to v1.5.0, plus kubeadm to the third stable version
+* Tue Dec 13 2016 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk> - 1.5.1
+- Bump version of kubelet and kubectl to v1.5.1, plus kubeadm to the third stable version
 
 * Fri Dec 6 2016 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk> - 1.5.0-beta.2
 - Bump version of kubelet and kubectl


### PR DESCRIPTION
@mikedanese

Followup #229 

I know v1.5.1 isn't out really yet, but when it is, please merge and push all packages to unstable and we'll test them, then we can promote them to stable.
 
cc @dgoodwin 