### PR TITLE
Update the deb packaging script to make unstable fetch versions from the CI

### DIFF
--- a/debian/xenial/kubeadm/debian/rules
+++ b/debian/xenial/kubeadm/debian/rules
@@ -10,7 +10,7 @@ binary:
 	mkdir -p usr/bin
 	curl --fail -sSL \
 		-o usr/bin/kubeadm \
-		"https://dl.k8s.io/ci-cross/v1.6.0-alpha.0.2074+a092d8e0f95f52/bin/linux/{{ .Arch }}/kubeadm"
+		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubeadm"
 
 	chmod +x usr/bin/kubeadm
 	dh_testroot

--- a/debian/xenial/kubectl/debian/rules
+++ b/debian/xenial/kubectl/debian/rules
@@ -10,7 +10,7 @@ binary:
 	mkdir -p usr/bin
 	curl  --fail -sS -L \
 		-o usr/bin/kubectl \
-		"https://dl.k8s.io/v{{ .Version }}/bin/linux/{{ .Arch }}/kubectl"
+		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubectl"
 	chmod +x usr/bin/kubectl
 	dh_testroot
 	dh_auto_install

--- a/debian/xenial/kubelet/debian/rules
+++ b/debian/xenial/kubelet/debian/rules
@@ -10,7 +10,7 @@ binary:
 	mkdir -p usr/bin
 	curl  --fail -sS -L \
 		-o usr/bin/kubelet \
-		"https://dl.k8s.io/v{{ .Version }}/bin/linux/{{ .Arch }}/kubelet"
+		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubelet"
 	chmod +x usr/bin/kubelet
 	dh_testroot
 	dh_auto_install


### PR DESCRIPTION
In the future, we can consider a "nightly" channel as well.

We should just incorporate the rpm packaging process in this script or something later
cc @dgoodwin 

We should still bump the stable versions manually after we've validated them.

PTAL @mikedanese 