### PR TITLE
Remove references to build-tools/

### DIFF
--- a/anago
+++ b/anago
@@ -97,7 +97,7 @@ PROG=${0##*/}
 #+                               - Do an official release from release-1.1
 #+
 #+ FILES
-#+     build-tools/release.sh
+#+     build/release.sh
 #+
 #+ SEE ALSO
 #+     common.sh                 - common function definitions
@@ -405,7 +405,7 @@ build_tree () {
   # Should be an arg at some point
   export KUBE_DOCKER_IMAGE_TAG="$version"
 
-  # TODO: Ideally we update LOCAL_OUTPUT_ROOT in build-tools/common.sh to be
+  # TODO: Ideally we update LOCAL_OUTPUT_ROOT in build/common.sh to be
   #       modifiable.  In the meantime just mv the dir after it's done
   # Not until https://github.com/kubernetes/kubernetes/issues/23839
   #logrun -s make release OUT_DIR=$BUILD_OUTPUT-${RELEASE_VERSION[$label]}

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -404,7 +404,7 @@ release::gcs::ensure_release_bucket() {
 
 ###############################################################################
 # Create a unique bucket name for releasing Kube and make sure it exists.
-# TODO: There is a version of this in kubernetes/build-tools/common.sh. Refactor.
+# TODO: There is a version of this in kubernetes/build/common.sh. Refactor.
 # @param gcs_stage - the staging directory
 # @param source and destination arguments
 # @return 1 if tar fails

--- a/push-build.sh
+++ b/push-build.sh
@@ -28,7 +28,7 @@ PROG=${0##*/}
 #+     $PROG  [--help|-man]
 #+
 #+ DESCRIPTION
-#+     Replaces kubernetes/build-tools/push-*-build.sh.
+#+     Replaces kubernetes/build/push-*-build.sh.
 #+     Used for pushing developer builds and Jenkins' continuous builds.
 #+
 #+     Developer pushes simply run as they do pushing to devel/ on GCS.
@@ -173,10 +173,7 @@ if ((FLAGS_federation)); then
   ############################################################################
   logecho -n "Push federation images: "
   # FEDERATION_PUSH_REPO_BASE should be set by the calling job (yaml)
-  # TODO: remove once we don't support k8s versions with build/ anymore
-  build_dir=${KUBE_ROOT}/build-tools
-  [[ -d $build_dir ]] || build_dir=${KUBE_ROOT}/build
-  logrun -s $build_dir/push-federation-images.sh
+  logrun -s ${KUBE_ROOT}/build/push-federation-images.sh
 fi
 
 # END script


### PR DESCRIPTION
None of the kubernetes branches have `build-tools/` anymore, so we can remove all references to it.

x-ref kubernetes/kubernetes#38126