### PR TITLE
relnotes: Compare first alpha against latest vX.Y.0.

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -81,11 +81,15 @@ gitlib::last_releases () {
                    jq -r '.[] | select(.draft==false) | .tag_name'); do
     # Alpha releases only on master branch
     if [[ $release =~ -alpha ]]; then
-      branch_name=master
-    elif [[ $release =~ v([0-9]+\.[0-9]+)\.[0-9]+ ]]; then
+      LAST_RELEASE[master]=${LAST_RELEASE[master]:-$release}
+    elif [[ $release =~ v([0-9]+\.[0-9]+)\.([0-9]+(-.+)?) ]]; then
+      # Latest vx.x.0 release goes on both master and release branch.
+      if [[ ${BASH_REMATCH[2]} == "0" ]]; then
+        LAST_RELEASE[master]=${LAST_RELEASE[master]:-$release}
+      fi
       branch_name=release-${BASH_REMATCH[1]}
+      LAST_RELEASE[$branch_name]=${LAST_RELEASE[$branch_name]:-$release}
     fi
-    LAST_RELEASE[$branch_name]=${LAST_RELEASE[$branch_name]:-$release}
   done
 
   logecho -r "$OK"


### PR DESCRIPTION
Previously, the script chose v1.5.0-alpha.2 as the diff base for
v1.6.0-alpha.1. Now it will choose v1.5.0 in that case, so we won't list
changes again that already made it into the previous release.

I decided not to use the latest v1.5.x as the diff base, because
technically those should only contain backports of work that was
actually done against the 1.6 branch.

Fixes https://github.com/kubernetes/release/issues/253.

cc @ethernetdan 