### PR TITLE
Support release candidates in anago

### DIFF
--- a/anago
+++ b/anago
@@ -22,7 +22,7 @@ PROG=${0##*/}
 #+     $PROG - Kubernetes Release Tool
 #+
 #+ SYNOPSIS
-#+     $PROG  [--yes] [--nomock] [--noclean] [--official]
+#+     $PROG  [--yes] [--nomock] [--noclean] [--rc] [--official]
 #+            [--buildversion=<jenkins build version>]
 #+            [--basedir=<alt base work dir>] <branch>
 #+            [--security_layer=/path/to/pointer/to/script]
@@ -32,8 +32,9 @@ PROG=${0##*/}
 #+ DESCRIPTION
 #+     $PROG produces Kubernetes releases.
 #+
-#+     Driven by the named source <branch> and an optional [--official] flag,
-#+     $PROG determines what needs to be released and calculates the version.
+#+     Driven by the named source <branch> and an optional [--rc] or
+#+     [--official] flag, $PROG determines what needs to be released
+#+     and calculates the version.
 #+
 #+     [--buildversion=] will override the automatic check for a build version
 #+     Mostly used for testing as a way to re-use a known good build version.
@@ -51,19 +52,22 @@ PROG=${0##*/}
 #+     prompts.  <branch> is one of master, release-1.2, etc. and the release
 #+     is based on the <branch> value and the [--official] flag:
 #+
-#+     Branch   Official    Type
-#+     ------   --------    ----
-#+     master               alpha
-#+     master      X        N/A
-#+     release-*            beta
-#+     release-*   X        official
+#+     Branch     RC  Official    Type
+#+     ------     --  --------    ----
+#+     master                     alpha
+#+     master                     alpha
+#+     master     X               N/A
+#+     master            X        N/A
+#+     release-*                  beta
+#+     release-*  X               release candidate
+#+     release-*         X        official
 #+
 #+     NOTE: <branch> can exist already or not.  If the branch doesn't exist,
 #+           it will be branched from master as part of the run.
 #+
 #+     VALUES USED AND DISPLAYED DURING RUNS:
 #+     * The RELEASE_VERSION dictionary is indexed by each of the types of
-#+       releases that will be processed for a session (alpha,beta,official)
+#+       releases that will be processed for a session (alpha,beta,rc,official)
 #+     * RELEASE_VERSION_PRIME is the primary release version
 #+     * GCRIO_REPO and RELEASE_BUCKET are the publish locations
 #+
@@ -75,6 +79,7 @@ PROG=${0##*/}
 #+     [--noclean]               - Attempt to work in existing workspace
 #+                                 Not always possible and ignored when --nomock
 #+                                 is set
+#+     [--rc]                    - Release candidates on release branches only
 #+     [--official]              - Official releases on release branches only
 #+     [--buildversion=ver]      - Override Jenkins check and set a specific
 #+                                 build version
@@ -91,6 +96,8 @@ PROG=${0##*/}
 #+     $PROG --yes master        - Do a mock alpha release from master
 #+                                 and don't stop/prompt
 #+     $PROG release-1.1         - Do a mock beta release from release-1.1
+#+     $PROG --rc release-1.1
+#+                               - Do a mock release candidate from release-1.1
 #+     $PROG --official release-1.1
 #+                               - Do a mock official release from release-1.1
 #+     $PROG --nomock --official release-1.1
@@ -129,14 +136,18 @@ RELEASE_BRANCH=${POSITIONAL_ARGV[0]}
  || common::exit 1 "Invalid branch name!"
 
 # Check arg conflicts
-if ((FLAGS_official)); then
+if ((FLAGS_rc)) || ((FLAGS_official)); then
   if [[ "$RELEASE_BRANCH" == "master" ]]; then
-    common::exit 1 "Can't do official releases on master!"
+    common::exit 1 "Can't do release candidate or official releases on master!"
   fi
 else
   if [[ -n ${BASH_REMATCH[4]} ]]; then
     common::exit 1 "Only --official releases are allowed on 3-part branches!"
   fi
+fi
+
+if ((FLAGS_rc)) && ((FLAGS_official)); then
+  common::exit 1 "Can't do release candidate and official release!"
 fi
 
 ###############################################################################
@@ -272,7 +283,7 @@ rev_version_base () {
     gitminor=${BASH_REMATCH[2]}
   fi
 
-  [[ "$label" =~ ^beta ]] && minor_plus="+"
+  [[ "$label" =~ ^beta || "$label" =~ ^rc ]] && minor_plus="+"
 
   sed -i -e "s/\(gitMajor *string = \)\"[^\"]*\"/\1\"$gitmajor\"/g" \
       -e "s/\(gitMinor *string = \)\"[^\"]*\"/\1\"$gitminor$minor_plus\"/g" \
@@ -372,7 +383,7 @@ prepare_tree () {
 
   # rev base.go
   case $label in
-    beta*|official) rev_version_base $label ;;
+    beta*|rc|official) rev_version_base $label ;;
   esac
 
   # generate docs on new branches (from master) only
@@ -429,6 +440,7 @@ build_tree () {
 # NOTES:
 # * alpha is alone, pushes tags only
 # * beta is alone, pushes branch and tags
+# * rc is alone, pushes branch and tags
 # * official pushes both official and beta items - branch and tags
 # * New branch tags a new alpha on master, new beta on new branch and pushes
 #   new branch and tags on both
@@ -766,6 +778,7 @@ archive_release () {
 # Default mode is a mocked release workflow
 : ${FLAGS_nomock:=0}
 : ${FLAGS_noclean:=0}
+: ${FLAGS_rc:=0}
 : ${FLAGS_official:=0}
 
 # Set with --buildversion or set it later in release::set_build_version()
@@ -886,7 +899,8 @@ fi
 common::printvars -p WORKDIR WORKDIR TREE_ROOT $DISPLAY_VERSION \
                      RELEASE_VERSION_PRIME ${ALL_RELEASE_VERSIONS[@]} \
                      RELEASE_BRANCH GCRIO_REPO RELEASE_BUCKET \
-                     FLAGS_nomock FLAGS_noclean FLAGS_official LOGFILE
+                     FLAGS_nomock FLAGS_noclean FLAGS_rc FLAGS_official \
+                     LOGFILE
 
 if [[ -n "$PARENT_BRANCH" ]]; then
   logecho

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -36,10 +36,10 @@ K8S_GITHUB_SSH='git@github.com:kubernetes/kubernetes.git'
 # 3=.Patch
 # 4=Patch
 BRANCH_REGEX="master|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$"
-# release - 1=Major, 2=Minor, 3=Patch, 4=-(alpha|beta), 5=rev
+# release - 1=Major, 2=Minor, 3=Patch, 4=-(alpha|beta|rc), 5=rev
 # dotzero - 1=Major, 2=Minor
 # build - 1=build number, 2=sha1
-declare -A VER_REGEX=([release]="v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha|-beta)*\.*(0|[1-9][0-9]*)?"
+declare -A VER_REGEX=([release]="v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha|-beta|-rc)*\.*(0|[1-9][0-9]*)?"
                       [dotzero]="v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.0$"
                       [build]="([0-9]{1,})\+([0-9a-f]{5,40})"
                      )

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -16,6 +16,7 @@ DOTZERO="v1.4.0"
 SHORT="v1.4.5"
 LONG="v1.4.5-alpha.0"
 SHA="v1.4.5-alpha.0.435+8c67d08e3a535d"
+RC="v1.4.5-rc.1"
 
 printf "%-40s" "$DOTZERO : "
 if [[ $DOTZERO =~ ${VER_REGEX[dotzero]} ]]; then
@@ -40,6 +41,13 @@ fi
 
 printf "%-40s" "$SHA : "
 if [[ $SHA =~ ${VER_REGEX[release]}\.${VER_REGEX[build]} ]]; then
+  echo "$PASSED Value: ${BASH_REMATCH[0]}"
+else
+  echo "$FAILED"
+fi
+
+printf "%-40s" "$RC : "
+if [[ $RC =~ ${VER_REGEX[release]} ]]; then
   echo "$PASSED Value: ${BASH_REMATCH[0]}"
 else
   echo "$FAILED"

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -325,11 +325,11 @@ release::set_release_version () {
   build_version[major]=${BASH_REMATCH[1]}
   build_version[minor]=${BASH_REMATCH[2]}
   build_version[patch]=${BASH_REMATCH[3]}
-  build_version[label]=${BASH_REMATCH[4]}
-  build_version[labelid]=${BASH_REMATCH[5]}
+  build_version[label]=${BASH_REMATCH[4]}       # -alpha, -beta, -rc
+  build_version[labelid]=${BASH_REMATCH[5]}     # rev
 
   # RELEASE_VERSION_PRIME is the default release version for this session/type
-  # Other labels such as alpha and beta are set as needed
+  # Other labels such as alpha, beta, and rc are set as needed
   # Index ordering is important here as it's how they are processed
   if [[ "$parent_branch" == master ]]; then
     # This is a new branch, set new alpha and beta versions
@@ -364,6 +364,16 @@ release::set_release_version () {
         RELEASE_VERSION[beta]="v${build_version[major]}.${build_version[minor]}"
         RELEASE_VERSION[beta]+=".$((${build_version[patch]}+1))-beta.0"
       fi
+    elif ((FLAGS_rc)) || [[ "${build_version[label]}" == "-rc" ]]; then
+      # betas not allowed after release candidates
+      RELEASE_VERSION[rc]="$RELEASE_VERSION_PRIME"
+      if [[ "${build_version[label]}" == "-rc" ]]; then
+        RELEASE_VERSION[rc]+="-rc.$((${build_version[labelid]}+1))"
+      else
+        # Start release candidates at 1 instead of 0
+        RELEASE_VERSION[rc]+="-rc.1"
+      fi
+      RELEASE_VERSION_PRIME="${RELEASE_VERSION[rc]}"
     else
       RELEASE_VERSION[beta]="$RELEASE_VERSION_PRIME${build_version[label]}"
       RELEASE_VERSION[beta]+=".$((${build_version[labelid]}+1))"


### PR DESCRIPTION
I think this probably works. Still need to do a mock run to test it.

The basic workflow is that you'd call `anago --rc release.1.6` once we want to cut the first release candidate, and that'll create `v1.6.0-rc.1`. Any `anago` calls after that (with or without `--rc`) will create `-rc.2`, `-rc.3`, etc. Passing `--official` will produce the `v1.6.0` build.

It would not surprise me if there are some bugs or incorrect assumptions in some of the logic here (it's kinda hard to test). It'd be good to double-check the auto-generated versions (for all branches, not just 1.6) until we're certain it's working properly.

cc @kubernetes/release-team 