### PR TITLE
Add --version-suffix flag to push-build.sh

### DIFF
--- a/push-build.sh
+++ b/push-build.sh
@@ -46,6 +46,7 @@ PROG=${0##*/}
 #+     [--bucket=]               - Specify an alternate bucket for pushes
 #+     [--gcs-suffix=]           - Specify a suffix to append to the upload
 #+                                 destination on GCS.
+#+     [--version-suffix=]       - Append suffix to version name if set.
 #+     [--noupdatelatest]        - Do not update the latest file
 #+     [--help | -man]           - display man page for this script
 #+     [--usage | -?]            - display in-line usage
@@ -112,6 +113,10 @@ else
   logecho "kubectl version output:"
   logecho $KUBECTL_OUTPUT
   common::exit 1
+fi
+
+if [[ -n "${FLAGS_version_suffix:-}" ]]; then
+  LATEST+="-${FLAGS_version_suffix}"
 fi
 
 GCS_DEST="devel"


### PR DESCRIPTION
/assign @ixdy @david-mcmahon 

`kubetest` needs to stage the binaries to a gcs path like `gs://kubernetes-release-dev/ci/v1.7.0-alpha+deadbeef-pull-gke` which `--version-suffix=pull-gke` will now allow.

This is needed for the GKE pull jobs: https://github.com/kubernetes/test-infra/blob/master/jobs/pull-kubernetes-e2e-gke.sh#L41