### PR TITLE
Parameterize GitHub URLs so org and repo can be easily modified

### DIFF
--- a/anago
+++ b/anago
@@ -553,6 +553,7 @@ announce () {
 update_github_release () {
   local release_id
   local id_suffix
+  local k8s_github_url=$(gitlib::github_https_url $K8S_GITHUB_ORG $K8S_GITHUB_REPO)
   local release_verb="Posting"
   local prerelease="true"
   local draft="true"
@@ -568,7 +569,8 @@ update_github_release () {
     # non-draft release posts to github create a tag.  We don't want to
     # create any tags on the repo this way.  The tag should already exist
     # as a result of the release process.
-    if ! $GHCURL $K8S_GITHUB_API/git/refs/tags |jq -r '.[] | .ref' |\
+    if ! gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+        /git/refs/tags | jq -r '.[] | .ref' |\
         egrep -q "^refs/tags/$RELEASE_VERSION_PRIME$"; then
       logecho
       logecho "$FATAL: How did we get here?"
@@ -580,7 +582,8 @@ update_github_release () {
   fi
 
   # Does the release exist yet?
-  release_id=$($GHCURL $K8S_GITHUB_API/releases/tags/$RELEASE_VERSION_PRIME |\
+  release_id=$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+               /releases/tags/$RELEASE_VERSION_PRIME |\
                jq -r '.id')
 
   if [[ -n "$release_id" ]]; then
@@ -597,8 +600,9 @@ update_github_release () {
 
   # post release data
   logecho "$release_verb the $RELEASE_VERSION_PRIME release on github..."
-  local changelog_url="$K8S_GITHUB_URL/blob/master/CHANGELOG.md"
-  release_id=$($GHCURL $K8S_GITHUB_API/releases$id_suffix --data \
+  local changelog_url="$k8s_github_url/blob/master/CHANGELOG.md"
+  release_id=$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+    /releases$id_suffix --data \
    '{
     "tag_name": "'$RELEASE_VERSION_PRIME'",
     "target_commitish": "'$RELEASE_BRANCH'",
@@ -617,30 +621,33 @@ update_github_release () {
 
   # publish binary
   logecho -n "Uploading binary to github: "
-  logrun -s $GHCURL -H "Content-Type:application/x-compressed" \
-   --data-binary @$tarball \
-   "${K8S_GITHUB_API/api\./uploads\.}/releases/$release_id/assets?name=${tarball##*/}"
+  logrun -s gitlib::github_upload $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+    "/releases/$release_id/assets?name=${tarball##*/}"
+    -H "Content-Type:application/x-compressed" \
+    --data-binary @$tarball \
 
   if $draft; then
     logecho
     logecho "$ATTENTION: A draft release of $RELEASE_VERSION_PRIME was" \
-            "created at $K8S_GITHUB_URL/releases."
+            "created at $k8s_github_url/releases."
     logecho
 
     # delete it
     if ((FLAGS_yes)) || \
        common::askyorn -y "Delete draft release (id #$release_id) now"; then
       logecho -n "Deleting the draft release (id #$release_id): "
-      logrun $GHCURL -X DELETE $K8S_GITHUB_API/releases/$release_id
+      logrun gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+        /releases/$release_id -X DELETE
     fi
 
     # verify it was deleted
-    release_id=$($GHCURL $K8S_GITHUB_API/releases/$release_id | jq -r '.id')
+    release_id=$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+      /releases/$release_id | jq -r '.id')
     if [[ -n "$release_id" ]]; then
       logecho -r $FAILED
       logecho "The draft release (id #$release_id) was NOT deleted." \
               "Deal with it by hand"
-      logecho "$K8S_GITHUB_URL/releases/$RELEASE_VERSION_PRIME"
+      logecho "$k8s_github_url/releases/$RELEASE_VERSION_PRIME"
     else
       logecho -r $OK
     fi
@@ -655,7 +662,7 @@ get_build_candidate () {
   local testing_branch
 
   # Are we branching to a new branch?
-  if gitlib::branch_exists $RELEASE_BRANCH; then
+  if gitlib::github_branch_exists $K8S_GITHUB_ORG $K8S_GITHUB_REPO $RELEASE_BRANCH; then
     # If the branch is a 3-part branch (ie. release-1.2.3)
     if [[ $RELEASE_BRANCH =~ $BRANCH_REGEX ]] && \
        [[ -n ${BASH_REMATCH[4]} ]]; then
@@ -676,7 +683,7 @@ get_build_candidate () {
       PARENT_BRANCH=master
       testing_branch=$PARENT_BRANCH
     # if 3 part branch name, check parent exists
-    elif gitlib::branch_exists ${RELEASE_BRANCH%.*}; then
+    elif gitlib::github_branch_exists $K8S_GITHUB_ORG $K8S_GITHUB_REPO ${RELEASE_BRANCH%.*}; then
       PARENT_BRANCH=${RELEASE_BRANCH%.*}
       # The 'missing' . here between 2 and 3 is intentional. It's part of the
       # optional regex.
@@ -712,8 +719,8 @@ get_build_candidate () {
    || return 1
 
   # Check that this tag doesn't exist which may occur if $PROG ran partially
-  if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
-     $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
+  if [[ "$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO /tags \
+     |jq -r '.[] .name')" =~ $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
      logecho
      logecho "The tag $RELEASE_VERSION_PRIME already exists on github."
      logecho "* An old --buildversion was specified on the command-line"
@@ -755,7 +762,8 @@ prepare_workspace () {
   fi
 
   # Sync the tree
-  gitlib::sync_repo $K8S_GITHUB_SSH $TREE_ROOT || return 1
+  gitlib::sync_repo $(gitlib::github_ssh_url $K8S_GITHUB_ORG $K8S_GITHUB_REPO) \
+    $TREE_ROOT || return 1
   logrun cd $TREE_ROOT
 }
 
@@ -875,7 +883,7 @@ common::disk_space_check $BASEDIR $((30*${#RELEASE_VERSION[*]})) ||\
  common::exit 1 "Exiting..."
 
 if [[ $RELEASE_BRANCH =~ release- ]] &&
-   gitlib::branch_exists $RELEASE_BRANCH; then
+  gitlib::github_branch_exists $K8S_GITHUB_ORG $K8S_GITHUB_REPO $RELEASE_BRANCH; then
   ##############################################################################
   common::stepheader "PENDING PRS ON THE $RELEASE_BRANCH BRANCH"
   ##############################################################################
@@ -889,6 +897,7 @@ common::stepheader "SESSION VALUES"
 # Pass in the indexed RELEASE_VERSION dict key by key
 ALL_RELEASE_VERSIONS=($(for key in ${!RELEASE_VERSION[@]}; do
                          echo RELEASE_VERSION[$key]; done))
+
 
 # Depending on the type of operation being performed one of these will be set
 if [[ -n $BRANCH_POINT ]]; then

--- a/branchff
+++ b/branchff
@@ -65,7 +65,7 @@ MASTER_OBJECT=${POSITIONAL_ARGV[1]:-"origin/master"}
 [[ $RELEASE_BRANCH =~ $BRANCH_REGEX ]] || common::exit 1 "Invalid branch name!"
 
 # Branch Exists
-gitlib::branch_exists $RELEASE_BRANCH \
+gitlib::github_branch_exists $K8S_GITHUB_ORG $K8S_GITHUB_REPO $RELEASE_BRANCH \
  || common::exit 1 "$RELEASE_BRANCH doesn't exist.  Exiting..."
 
 ##############################################################################
@@ -113,7 +113,8 @@ if [[ -d $WORKDIR ]]; then
 fi
 
 logrun mkdir -p $WORKDIR
-gitlib::sync_repo $K8S_GITHUB_SSH $TREE_ROOT || common::exit 1 "Exiting..."
+gitlib::sync_repo $(gitlib::github_ssh_url $K8S_GITHUB_ORG $K8S_GITHUB_REPO) \
+  $TREE_ROOT || common::exit 1 "Exiting..."
 logrun cd $TREE_ROOT
 
 ##############################################################################
@@ -122,7 +123,9 @@ common::stepheader "CHECK GIT PUSH ACCESS"
 # TODO: capture state of access without forcing us into a prompt I have to 
 #       expose.
 logecho -n "Checking git push access (verbosely to accept password if needed)"
-logrun -v git push -q --dry-run $K8S_GITHUB_SSH || common::exit 1 "Exiting..."
+logrun -v git push -q --dry-run \
+  $(gitlib::github_ssh_url $K8S_GITHUB_ORG $K8S_GITHUB_REPO)\
+  || common::exit 1 "Exiting..."
 
 ##############################################################################
 common::stepheader "CHECK OUT BRANCH"

--- a/find_green_build
+++ b/find_green_build
@@ -103,7 +103,7 @@ if (($FLAGS_official)) && [[ "$RELEASE_BRANCH" == "master" ]]; then
 fi
 
 # Are we branching to a new branch?
-if gitlib::branch_exists $RELEASE_BRANCH; then
+if gitlib::github_branch_exists $K8S_GITHUB_ORG $K8S_GITHUB_REPO $RELEASE_BRANCH; then
   TESTING_BRANCH=$RELEASE_BRANCH
   BRANCH_OFF_MASTER=0
 else

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -167,7 +167,8 @@ release::set_build_version () {
       build_number=${BASH_REMATCH[8]}
       build_sha1=${BASH_REMATCH[9]}
       build_version=${BASH_REMATCH[2]}.$build_number+$build_sha1
-      build_sha1_date=$($GHCURL $K8S_GITHUB_API/commits?sha=$build_sha1 |\
+      build_sha1_date=$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+                        /commits?sha=$build_sha1 |\
                         jq -r '.[0] | .commit .author .date')
       build_sha1_date=$(date +"%R %m/%d" -d "$build_sha1_date")
     elif [[ $good_job =~ JOB\[([0-9]+)\]=(${VER_REGEX[release]}) ]]; then
@@ -187,7 +188,8 @@ release::set_build_version () {
     # we make code changes on the HEAD of the branch (version.go).
     # Verify if discovered build_version's SHA1 hash == HEAD if branch
     if [[ "$branch" =~ release- ]]; then
-      branch_head=$($GHCURL $K8S_GITHUB_API/commits/$branch |jq -r '.sha')
+      branch_head=$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO \
+                    /commits/$branch |jq -r '.sha')
 
       if [[ $build_sha1 != ${branch_head:0:14} ]]; then
         # TODO: Figure out how to curl a list of last N commits

--- a/relnotes
+++ b/relnotes
@@ -118,7 +118,7 @@ extract_pr_title () {
   local pull_json
 
   for pr in $prs; do
-    pull_json="$($GHCURL $K8S_GITHUB_API/pulls/$pr)"
+    pull_json="$(gitlib::github_repo_query $K8S_GITHUB_ORG $K8S_GITHUB_REPO /pulls/$pr)"
     [[ -z "$pull_json" ]] && return 1
     body="$(echo "$pull_json" |jq -r '.body' |tr -d '\r')"
 
@@ -161,14 +161,14 @@ get_prs_by_label () {
 
   prs_per_page=100
 
-  matching_prs="$($GHCURL ${K8S_GITHUB_SEARCHAPI}label:${label}&per_page=1)"
+  matching_prs="$(gitlib::github_search_prs $K8S_GITHUB_ORG $K8S_GITHUB_REPO label:${label}&per_page=1)"
 
   total="$(echo -n $matching_prs | jq -r '.total_count')"
   # Calculate number of pages, rounding up
   num_pages=$(((total + prs_per_page - 1) / prs_per_page ))
 
   for current_page in `seq 1 $num_pages`; do
-    prs+=($($GHCURL "${K8S_GITHUB_SEARCHAPI}label:${label}&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
+    prs+=($(gitlib::github_search_prs $K8S_GITHUB_ORG $K8S_GITHUB_REPO "label:${label}&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
   done
   echo "${prs[@]}"
 }
@@ -285,6 +285,7 @@ generate_notes () {
   local tempcss=/tmp/$PROG-ca.$$
   local tempfile=/tmp/$PROG-file-1.$$
   local anchor
+  local k8s_github_url=$(gitlib::github_https_url $K8S_GITHUB_ORG $K8S_GITHUB_REPO)
   local -a normal_prs
   local -a action_prs
   local -a experimental_prs
@@ -367,8 +368,7 @@ generate_notes () {
   if ((FLAGS_full)) || [[ $release_tag =~ ${VER_REGEX[dotzero]} ]]; then
     # Check for draft and use it if available
     logecho "Checking if draft release notes exist for $release_tag..."
-    $GHCURL \
-     $K8S_GITHUB_RAW_ORG/features/master/$CURRENT_BRANCH/release-notes-draft.md > $tempfile
+    gitlib::github_raw_download $K8S_GITHUB_ORG features master $CURRENT_BRANCH/release-notes-draft.md > $tempfile
     if [[ -s $tempfile ]]; then
       logecho "Draft found - using for release notes..."
       cat $tempfile >> $PR_NOTES
@@ -457,8 +457,8 @@ EOF+
   if ((FLAGS_htmlize_md)); then
     # Make users and PRs linkable
     # Also, expand anchors (needed for email announce())
-    sed -i -e "s,#\([0-9]\{5\,\}\),[#\1]($K8S_GITHUB_URL/pull/\1),g" \
-        -e "s,\(#v[0-9]\{3\}-\),$K8S_GITHUB_URL/blob/master/CHANGELOG.md\1,g" \
+    sed -i -e "s,#\([0-9]\{5\,\}\),[#\1]($k8s_github_url/pull/\1),g" \
+        -e "s,\(#v[0-9]\{3\}-\),$k8s_github_url/blob/master/CHANGELOG.md\1,g" \
         -e "s,@\([a-zA-Z0-9-]*\),[@\1](https://github.com/\1),g" \
      $RELEASE_NOTES_MD
   fi


### PR DESCRIPTION
This PR gets rid of the various constants hardcoding `kubernetes/kubernetes` replacing them all with functions that take an org and repo. `kubernetes` is still used as the org and repo parameters, so this PR should effectively be a no-op, but it sets up for building a release from a different org/repo.