### PR TITLE
Fix build break introduced in PR #285

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -342,10 +342,10 @@ func main() {
 			Distros: serverDistros,
 			Versions: []version{
 				{
-					Version:          getStableKubeVersion,
-					Revision:         "00",
-					Channel:          ChannelStable,
-					DownloadLinkBase: getReleaseDownloadLinkBase,
+					GetVersion:          getStableKubeVersion,
+					Revision:            "00",
+					Channel:             ChannelStable,
+					GetDownloadLinkBase: getReleaseDownloadLinkBase,
 				},
 				{
 					GetVersion:          getLatestKubeVersion,


### PR DESCRIPTION
Commit 7811417daf744b56cf86e3c8996739629904b4c7 in PR #285 introduced build break:

```
./build.go:345: cannot use getStableKubeVersion (type func() (string, error)) as type string in field value
./build.go:348: cannot use getReleaseDownloadLinkBase (type func(version) (string, error)) as type string in field value
```
Attn: @luxas 