### PR TITLE
Enable stable channel for ppc64le and s390x arch

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -377,12 +377,7 @@ func main() {
 		} else {
 			c.DebArch = c.Arch
 		}
-		// Skip platforms that do not have binaries for a channel
-		if len(v.Channel) != 0 {
-			if v.Channel == "stable" && (c.Arch == "s390x" || c.Arch == "ppc64le") {
-				return nil
-			}
-		}
+
 		return c.run()
 	}); err != nil {
 		log.Fatalf("err: %v", err)


### PR DESCRIPTION
As we have 1.6.1 as latest stable release and we have target binaries for both ppc64le and s390x platform, so this PR is for enabling back stable channel for these architecture.