### PR TITLE
Use release function to push federation image to registry

### DIFF
--- a/push-build.sh
+++ b/push-build.sh
@@ -99,6 +99,7 @@ RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
 KUBECTL_OUTPUT=$(cluster/kubectl.sh version --client 2>&1 || true)
 if [[ "$KUBECTL_OUTPUT" =~ GitVersion:\"(${VER_REGEX[release]}(\.${VER_REGEX[build]})?(-dirty)?)\", ]]; then
   LATEST=${BASH_REMATCH[1]}
+  KUBE_DOCKER_VERSION=${LATEST//+/_}
   if ((FLAGS_ci)) && [[ "$KUBECTL_OUTPUT" =~ GitTreeState:\"dirty\" ]]; then
     logecho "Refusing to push dirty build with --ci flag given."
     logecho "CI builds should always be performed from clean commits."
@@ -185,8 +186,19 @@ if ((FLAGS_federation)); then
   common::stepheader PUSH FEDERATION
   ############################################################################
   logecho -n "Push federation images: "
-  # FEDERATION_PUSH_REPO_BASE should be set by the calling job (yaml)
-  logrun -s ${KUBE_ROOT}/federation/develop/push-federation-images.sh
+  GCLOUD_PROJECT=$($GCLOUD config list project --format 'value(core.project)')
+  if [[ -z "${GCLOUD_PROJECT}" ]]; then
+    logecho "No account authorized through gcloud. So using FEDERATION_PUSH_REPO_BASE to push images"
+    KUBE_DOCKER_REGISTRY=${FEDERATION_PUSH_REPO_BASE}
+  else
+    logecho "Account authorized through gcloud. So using GCLOUD_PROJECT to push images"
+    KUBE_DOCKER_REGISTRY="gcr.io/${GCLOUD_PROJECT}"
+  fi
+
+  release::docker::release \
+   ${KUBE_DOCKER_REGISTRY} \
+   ${KUBE_DOCKER_VERSION} \
+   || common::exit 1 "Exiting..."
 fi
 
 # END script


### PR DESCRIPTION
This is with ref to https://github.com/kubernetes/kubernetes/issues/44402
It was decided to push images to registry for all build jobs (and not only federation build job).
This PR is the first step to use the gcloud project to push the image and it does that within federation builds right now. Once this starts working in subsequent steps, we can remove federation specific builds and start pushing images in all builds.

cc @madhusudancs @fejta @ixdy