### PR TITLE
Set locale for perl scripts

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -35,9 +35,11 @@ TOOL_LIB_PATH=${TOOL_LIB_PATH:-$(dirname $(readlink -ne $BASH_SOURCE))}
 TOOL_ROOT=${TOOL_ROOT:-$(readlink -ne $TOOL_LIB_PATH/..)}
 PATH=$TOOL_ROOT:$PATH
 LOCAL_CACHE="/tmp/buildresults-cache.$$"
+# Set locale to POSIX for perl commands
+LANG=C
 # Provide a default EDITOR for those that don't have this set
 : ${EDITOR:="vi"}
-export PATH TOOL_ROOT TOOL_LIB_PATH EDITOR
+export PATH TOOL_ROOT TOOL_LIB_PATH EDITOR LANG
 
 # Pretty curses stuff for terminals
 if [[ -t 1 ]]; then


### PR DESCRIPTION
`push-build.sh` spits out a bunch of warnings that the perl commands fall back to POSIX:
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46487/pull-kubernetes-e2e-gce-etcd3/33195/?log#log

This explicitly sets the locale to POSIX right off the bat.