### PR TITLE
Enable extended regexp for openapi spec version bump.

### DIFF
--- a/anago
+++ b/anago
@@ -304,7 +304,7 @@ rev_version_base () {
   #########################################################################
   for f in ${swagger_files[*]}; do
     # Strip any suffix off incoming RELEASE_VERSION[$label]
-    sed -i 's,"version": "'${VER_REGEX[release]}'","version": "'${RELEASE_VERSION[$label]//-*}'",g' $f
+    sed -i -r 's,"version": "'${VER_REGEX[release]}'","version": "'${RELEASE_VERSION[$label]//-*}'",g' $f
     logrun git add $f
   done
 


### PR DESCRIPTION
This part didn't work on my machine: https://github.com/kubernetes/kubernetes/commits/b8dcfd025c03ec213d8c64247e2730ad29af9f8d

I think this is why.