### PR TITLE
Rebase master before generating CHANGELOG.

### DIFF
--- a/anago
+++ b/anago
@@ -329,6 +329,14 @@ generate_release_notes() {
   logecho -n "Checkout master branch to make changes: "
   logrun -s git checkout master || return 1
 
+  # The fetch and rebase before editing CHANGELOG.md
+  # avoids merge conflicts if another release cut
+  # completed while we were building this one.
+  logecho -n "Fetch origin/master to get latest CHANGELOG.md: "
+  logrun -s git fetch origin master || return 1
+  logecho -n "Rebase on origin/master before editing CHANGELOG.md: "
+  logrun -s git rebase origin/master || return 1
+
   logecho "Insert $RELEASE_VERSION_PRIME notes into CHANGELOG.md..."
   # Pipe to logrun() vs using directly, because quoting.
   sed -i -e 's/<!-- NEW RELEASE NOTES ENTRY -->/&\n/' \


### PR DESCRIPTION
In the past, I've had anago builds fail at the last second because another release manager cut 1.5.x while I was building 1.6.x. The only reason it failed was because of a merge conflict on the CHANGELOG.

This should prevent that particular conflict by inserting release notes into the latest version of the CHANGELOG file.