### PR TITLE
Disallow branchff execution if master contains newer alphas.

### DIFF
--- a/anago
+++ b/anago
@@ -680,6 +680,7 @@ update_github_release () {
 # And global BRANCH_POINT when new branch is created from an existing tag
 get_build_candidate () {
   local testing_branch
+  local latest_official
 
   # Are we branching to a new branch?
   if gitlib::branch_exists $RELEASE_BRANCH; then
@@ -741,6 +742,33 @@ get_build_candidate () {
                                 $RELEASE_BRANCH \
                                 $PARENT_BRANCH \
    || return 1
+
+  # When creating new alphas on the master branch, make sure that X.Y-1.0
+  # has been created first or warn.
+  # This is to ensure that branchff can continue to be used as needed.  User can
+  # override here.
+  if [[ ! $JENKINS_BUILD_VERSION =~ ${VER_REGEX[release]} ]]; then
+    logecho "Invalid format: $JENKINS_BUILD_VERSION"
+    return 1
+  fi
+
+  # For master branch alpha builds, ensure we've released the previous .0 first
+  if [[ -z "$PARENT_BRANCH" && -n ${RELEASE_VERSION[alpha]} ]]; then
+    latest_official=${BASH_REMATCH[1]}.$((${BASH_REMATCH[2]}-1))
+    if [[ ! "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
+       $'\n'v$latest_official$'\n' ]]; then
+      logecho
+      logecho "$WARNING:" \
+              "$latest_official.0 hasn't been tagged/created yet." \
+              "Creating ${RELEASE_VERSION[alpha]} *will* preclude any future" \
+              "branch fast-forwards from master to release-$latest_official."
+      if ! ((FLAGS_yes)); then
+        logecho "Are you *really* sure you want to do this?"
+        common::askyorn "Continue creating ${RELEASE_VERSION[alpha]} now" \
+         || return 1
+      fi
+    fi
+  fi
 
   # Check that this tag doesn't exist which may occur if $PROG ran partially
   if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \

--- a/branchff
+++ b/branchff
@@ -102,7 +102,7 @@ logecho "Follow along in detail: tailf $MYLOG"
 ##############################################################################
 common::stepheader "SESSION DETAILS"
 ##############################################################################
-logecho "NOTE: This is a${DRYRUN_FLAG:-"n ACTUAL"} run!"
+logecho "$ATTENTION: This is a${DRYRUN_FLAG:-"n ACTUAL"} run!"
 
 ##############################################################################
 common::stepheader "SYNC A WORKING REPO"
@@ -115,6 +115,25 @@ fi
 logrun mkdir -p $WORKDIR
 gitlib::sync_repo $K8S_GITHUB_SSH $TREE_ROOT || common::exit 1 "Exiting..."
 logrun cd $TREE_ROOT
+
+# Is the master branch in a reasonable state to fast forward over the branch?
+# When git merges from master to branch, the list of tags is overlaid and
+# sorted chronologically.
+# MERGE_BASE: Show common ancestor object/tag
+# MASTER_DESCRIBE: Show the latest tag on origin/master
+# ANCESTOR_DESCRIBE: Show the tag associated with MERGE_BASE
+MERGE_BASE=$(git merge-base origin/master origin/$RELEASE_BRANCH)
+ANCESTOR_DESCRIBE=$(git describe --abbrev=0 --tags $MERGE_BASE)
+MASTER_DESCRIBE=$(git describe --abbrev=0 --tags origin/master)
+# If these are different, there's a newer (than the branch) tag on master
+# and we cannot do a FF
+if [[ ! $MASTER_DESCRIBE == $ANCESTOR_DESCRIBE ]]; then
+  logecho
+  logecho "$FATAL!  master branch has been tagged to a newer version" \
+          "($MASTER_DESCRIBE)." \
+          "Unable to fast-forward $RELEASE_BRANCH branch to master."
+  common::exit 1
+fi
 
 ##############################################################################
 common::stepheader "CHECK GIT PUSH ACCESS"


### PR DESCRIPTION
Also warn in anago if user is attempting to create/tag new alpha releases
before the last major official release has been created.

Fixes #353 