### PR TITLE
push-build.sh: push docker images from tarfiles

### DIFF
--- a/anago
+++ b/anago
@@ -1039,6 +1039,7 @@ for label in ${!RELEASE_VERSION[@]}; do
   common::runstep release::docker::release \
    $KUBE_DOCKER_REGISTRY \
    ${RELEASE_VERSION[$label]} \
+   $BUILD_OUTPUT-${RELEASE_VERSION[$label]} \
    || common::exit 1 "Exiting..."
 
   common::runstep release::gcs::publish_version \

--- a/push-build.sh
+++ b/push-build.sh
@@ -194,8 +194,8 @@ if [[ -n "${FLAGS_docker_registry:-}" ]]; then
   ##############################################################################
   # TODO: support Bazel too
   # Docker tags cannot contain '+'
-  release::docker::release_from_tarfiles $KUBE_ROOT/_output \
-    $FLAGS_docker_registry ${LATEST/+/_}
+  release::docker::release $FLAGS_docker_registry ${LATEST/+/_} \
+    $KUBE_ROOT/_output
 fi
 
 # If not --ci, then we're done here.

--- a/push-build.sh
+++ b/push-build.sh
@@ -48,6 +48,8 @@ PROG=${0##*/}
 #+                                 (normally devel or ci)
 #+     [--gcs-suffix=]           - Specify a suffix to append to the upload
 #+                                 destination on GCS.
+#+     [--docker-registry=]      - If set, push docker images to specified
+#+                                 registry/project
 #+     [--version-suffix=]       - Append suffix to version name if set.
 #+     [--noupdatelatest]        - Do not update the latest file
 #+     [--help | -man]           - display man page for this script
@@ -185,6 +187,16 @@ while ((attempt<max_attempts)); do
   ((attempt++))
 done
 ((attempt>=max_attempts)) && common::exit 1 "Exiting..."
+
+if [[ -n "${FLAGS_docker_registry:-}" ]]; then
+  ##############################################################################
+  common::stepheader PUSH DOCKER IMAGES
+  ##############################################################################
+  # TODO: support Bazel too
+  # Docker tags cannot contain '+'
+  release::docker::release_from_tarfiles $KUBE_ROOT/_output \
+    $FLAGS_docker_registry ${LATEST/+/_}
+fi
 
 # If not --ci, then we're done here.
 ((FLAGS_ci)) || common::exit 0 "Exiting..."


### PR DESCRIPTION
Adds a `--docker-registry` flag to push-build.sh; if set, all images in `_output/release-images` will be pushed to the specified registry/project.

Depends on https://github.com/kubernetes/kubernetes/pull/47939.
A part of addressing https://github.com/kubernetes/test-infra/issues/1400.

cc @luxas @madhusudancs @roberthbailey 