### PR TITLE
Allow customized mailto for announcement.

### DIFF
--- a/anago
+++ b/anago
@@ -28,6 +28,7 @@ PROG=${0##*/}
 #+            [--basedir=<alt base work dir>] <branch>
 #+            [--security_layer=/path/to/pointer/to/script]
 #+            [--exclude-suites="<suite> ..."]
+#+            [--mailto=<email1>,<email2>]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -96,6 +97,8 @@ PROG=${0##*/}
 #+                                 Default: $HOME/.kubernetes-releaserc
 #+     [--exclude-suites=]       - Space separated list of CI suites to exclude
 #+                                 from go/nogo criteria
+#+     [--mailto=]               - Comma-separated list of addresses to send
+#+                                 announcement email to. Overrides default list.
 #+     [--help | -man]           - display man page for this script
 #+     [--usage | -?]            - display in-line usage
 #+
@@ -555,12 +558,17 @@ announce () {
   local announcement_text=/tmp/$PROG-announce.$$
 
   ((FLAGS_nomock)) || mailto=$USER@$DOMAIN_NAME
+  mailto=${FLAGS_mailto:-$mailto}
 
   if [[ -n "$PARENT_BRANCH" ]]; then
     create_branch_announcement
   else
     create_announcement
   fi > $announcement_text
+
+  ((FLAGS_yes)) \
+   || common::askyorn -e "Pausing here. Confirm announce to $mailto" \
+   || common::exit 1 "Exiting..."
 
   logecho "Announcing k8s $RELEASE_VERSION_PRIME to $mailto..."
 


### PR DESCRIPTION
Also prompt before sending email. These overrides were useful during the security release process.