### PR TITLE
Add flags to show status of all suites in find_green_build.

### DIFF
--- a/find_green_build
+++ b/find_green_build
@@ -24,6 +24,7 @@ PROG=${0##*/}
 #+ SYNOPSIS
 #+     $PROG  [--official] [<release branch>]
 #+            [--github-token=<token>] [--exclude-suites="<suite> ..."]
+#+            [--allow-stale-build]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -39,9 +40,12 @@ PROG=${0##*/}
 #+ OPTIONS
 #+     [--official]          - Produce an official release version for a
 #+                             release branch
-#+     --github-token=       - Must be specified if GITHUB_TOKEN not set
-#+     --exclude-suites=     - Space separated list of CI suites to exclude
+#+     [--github-token=]     - Must be specified if GITHUB_TOKEN not set
+#+     [--exclude-suites=]   - Space separated list of CI suites to exclude
 #+                             from go/nogo criteria
+#+     [--allow-stale-build] - Keep going even if the build is behind HEAD.
+#+                             This should only be used to display CI status.
+#+                             Branch cuts can't actually use stale builds.
 #+     [--help | -man]       - display man page for this script
 #+     [--usage | -?]        - display in-line usage
 #+

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -512,11 +512,11 @@ common::namevalue () {
             name=${arg%%=*}
             value=${arg#*=}
             # change -'s to _ in name for legal vars in bash
-            eval export FLAGS_${name/-/_}=\""$value"\"
+            eval export FLAGS_${name//-/_}=\""$value"\"
           else
             # bool=1
             # change -'s to _ in name for legal vars in bash
-            eval export FLAGS_${arg/-/_}=1
+            eval export FLAGS_${arg//-/_}=1
           fi
           ;;
     *) POSITIONAL_ARGV+=("$arg")

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -193,7 +193,11 @@ release::set_build_version () {
         logecho "$ATTENTION: The $branch branch HEAD is ahead of the last" \
                 "good Jenkins run by $commit_count commits." \
                 "Wait for Jenkins to catch up."
-        return 1
+        if ((FLAGS_allow_stale_build)); then
+          logecho
+        else
+         return 1
+       fi
       fi
     fi
 
@@ -259,10 +263,13 @@ release::set_build_version () {
       else
         ((FLAGS_verbose)) && \
          logecho "$(printf '%-7s %-7s' -- --)" \
-                    "${TPUT[RED]}GIVE UP${TPUT[OFF]}"
+                    "${TPUT[RED]}FAILED${TPUT[OFF]}"
         giveup_build_number=$build_number
         job_count=0
-        break
+        # Note: We used to break here to fail fast.
+        # However, it's often useful to see the full
+        # list of failing jobs, so now we keep going.
+        continue
       fi
     done
 


### PR DESCRIPTION
When find_green_build fails, this makes it easier to see all the problems that exist, instead of just the first problem found.