### PR TITLE
Fix broken pipe error when checking pip packages.

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -669,7 +669,7 @@ common::check_pip_packages () {
   logecho -n "Checking required PIP packages: "
 
   for prereq in $*; do
-    pip list |fgrep -qw $prereq || missing+=($prereq)
+    pip list | fgrep -w $prereq > /dev/null || missing+=($prereq)
   done
 
   if ((${#missing[@]}>0)); then


### PR DESCRIPTION
The -q flag causes grep to close stdin as soon as it finds a match. This upsets pip, which results in the following error, although the command still works as expected overall.

```
Checking required PIP packages: Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 235, in main
    return command.main(cmd_args)
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 156, in main
    logger.fatal('Exception:\n%s' % format_exc())
  File "/usr/lib/python2.7/dist-packages/pip/log.py", line 111, in fatal
    self.log(self.FATAL, msg, *args, **kw)
  File "/usr/lib/python2.7/dist-packages/pip/log.py", line 164, in log
    consumer.flush()
IOError: [Errno 32] Broken pipe
OK
```