### PR TITLE
Fix errors printed when there are no old log files.

### DIFF
--- a/anago
+++ b/anago
@@ -176,14 +176,15 @@ common::cleanexit () {
 # Copy logs to WORKDIR
 copy_logs_to_workdir () {
   local f
+  local logfiles=$(ls $LOGFILE{,.[0-9]} 2>/dev/null || true)
 
-  for f in $(ls $LOGFILE{,.[0-9]} 2>/dev/null); do
+  for f in $logfiles; do
     common::strip_control_characters $f
     common::sanitize_log $f
   done
 
   logecho -n "Copying $LOGFILE{,.[0-9]} to $WORKDIR: "
-  logrun -s cp -f $LOGFILE{,.[0-9]} $WORKDIR
+  logrun -s cp -f $logfiles $WORKDIR
 }
 
 ###############################################################################


### PR DESCRIPTION
When there are no files matching `anago.log.[0-9]` (e.g. the first time you run anago), the `ls` command triggers the ERR trap, which then prints an error message into the captured output. This results in strange errors like:

```
sed: can't read FAILED: No such file or directory
sed: can't read FAILED: No such file or directory
sed: can't read anago:: No such file or directory
sed: can't read anago:: No such file or directory
sed: can't read DONE: No such file or directory
sed: can't read DONE: No such file or directory
sed: can't read main: No such file or directory
sed: can't read main: No such file or directory
sed: can't read on: No such file or directory
sed: can't read on: No such file or directory
[...]
```

As well as:

```
anago::copy_logs_to_workdir(): Copying /tmp/anago.log{,.[0-9]} to /usr/local/google/enisoc/anago-v1.6.7:
anago::copy_logs_to_workdir(): cp -f /tmp/anago.log /tmp/anago.log.[0-9] /usr/local/google/enisoc/anago-v1.6.7
cp: cannot stat ‘/tmp/anago.log.[0-9]’: No such file or directory
```