### PR TITLE
Add cloud-controller-manager to the list of images that should be pushed

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -815,6 +815,7 @@ release::docker::release () {
   local binaries=(
     "kube-apiserver"
     "kube-controller-manager"
+    "cloud-controller-manager"
     "kube-scheduler"
     "kube-proxy"
     "hyperkube"


### PR DESCRIPTION
Currently an image is being built for the cloud-controller-manager and I assumed that it would get pushed automatically then as well when I wrote PR https://github.com/kubernetes/kubernetes/pull/45154, as it used to be.

However, the code has changed and there are two lists instead of one centralized one as it used to be.
So adding it now. I hope it at least can be pushed for v1.7.2 or so. This _should_ have been pushed in the v1.7.0 release but wasn't.

cc @dchen1107 @ixdy @david-mcmahon @thockin @wlan0