### PR TITLE
Fix: Postinstall script failure if systemd not running

### DIFF
--- a/debian/xenial/kubeadm/debian/postinst
+++ b/debian/xenial/kubeadm/debian/postinst
@@ -22,8 +22,8 @@ case "$1" in
         # because kubeadm package adds kubelet drop-ins, we must daemon-reload
         # and restart kubelet now. restarting kubelet is ok because kubelet
         # postinst configure step auto-starts it.
-        systemctl daemon-reload >/dev/null || true
-        systemctl restart kubelet >/dev/null || true
+        systemctl daemon-reload 2>/dev/null || true
+        systemctl restart kubelet 2>/dev/null || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/xenial/kubeadm/debian/postinst
+++ b/debian/xenial/kubeadm/debian/postinst
@@ -22,8 +22,8 @@ case "$1" in
         # because kubeadm package adds kubelet drop-ins, we must daemon-reload
         # and restart kubelet now. restarting kubelet is ok because kubelet
         # postinst configure step auto-starts it.
-        systemctl daemon-reload
-        systemctl restart kubelet
+        systemctl daemon-reload >/dev/null || true
+        systemctl restart kubelet >/dev/null || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
If you try to install kubeadm in chroot environment where systemd is not running you will recive error.
This fix uses same way that already uses DEBHELPER for `kubelet.service` unit.

Connected: https://github.com/kubernetes/release/issues/259