### PR TITLE
Add a hard_limit to the number of primary jobs processed for test analysis.

### DIFF
--- a/anago
+++ b/anago
@@ -777,7 +777,7 @@ get_build_candidate () {
     else
       logecho "Asking Jenkins for a good build (this may take some time)..."
       FLAGS_verbose=1 release::set_build_version \
-       $testing_branch "" "$FLAGS_exclude_suites" || return 1
+       $testing_branch "" "$FLAGS_exclude_suites" "100" || return 1
     fi
 
     # The RELEASE_BRANCH should always match with the JENKINS_BUILD_VERSION

--- a/find_green_build
+++ b/find_green_build
@@ -24,7 +24,7 @@ PROG=${0##*/}
 #+ SYNOPSIS
 #+     $PROG  [--official] [<release branch>]
 #+            [--github-token=<token>] [--exclude-suites="<suite> ..."]
-#+            [--allow-stale-build]
+#+            [--allow-stale-build] [--limit=N]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -46,6 +46,8 @@ PROG=${0##*/}
 #+     [--allow-stale-build] - Keep going even if the build is behind HEAD.
 #+                             This should only be used to display CI status.
 #+                             Branch cuts can't actually use stale builds.
+#+     [--limit=]            - Limit the primary check to a count of N
+#+                             (Default: 100)
 #+     [--help | -man]       - display man page for this script
 #+     [--usage | -?]        - display in-line usage
 #+
@@ -122,7 +124,8 @@ fi
 
 logecho
 release::set_build_version $TESTING_BRANCH $LOCAL_CACHE \
-                           "$FLAGS_exclude_suites" || common::exit 1
+                           "$FLAGS_exclude_suites" \
+                           ${FLAGS_limit:-"100"} || common::exit 1
 release::set_release_version $JENKINS_BUILD_VERSION $RELEASE_BRANCH \
                              $BRANCH_OFF_MASTER || common::exit 1
 


### PR DESCRIPTION
And add a --limit flag to find_green_build so it can be controlled via the user.

Since we moved to 1.8 and we have greatly expanded the 'release blocking' CI job list using a dynamic list pulled directly from testgrid, we haven't had a solid set of green results from that expanded list.  This causes the test analyzer to run unbounded for some hours.  We need to limit it.