### PR TITLE
Mount with :z mode when starting containers to build packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ you encounter.
 You can build the deb packages in a Docker container like this:
 ```
 docker build --tag=debian-packager debian
-docker run --volume="$(pwd)/debian:/src" debian-packager
+docker run --volume="$(pwd)/debian:/src:z" debian-packager
 ```
 
 The build runs for a while, after it's done you will find the output in `debian/bin`.

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -5,7 +5,7 @@ docker build -t kubelet-rpm-builder .
 echo "Cleaning output directory..."
 sudo rm -rf output/*
 mkdir -p output
-docker run -ti --rm -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder $1
+docker run -ti --rm -v $PWD/output/:/root/rpmbuild/RPMS/:z kubelet-rpm-builder $1
 sudo chown -R $USER $PWD/output
 
 echo


### PR DESCRIPTION
This change will allow to build packages on SELinux-enabled hosts.