### PR TITLE
Modify relnotes, remove deprecated PR template logic.

### DIFF
--- a/relnotes
+++ b/relnotes
@@ -135,7 +135,7 @@ extract_pr_title () {
                   -e '2,$s/^\( *[^ \*]\)/    * \1/g')
 
     # if the release-note block is empty or the template is unchanged, use title
-    if [[ -z "$content" ]] || [[ "$content" =~ -OR- ]]; then
+    if [[ -z "$content" ]]; then
       content=$(echo "$pull_json" | jq -r '.title')
     fi
 

--- a/relnotes
+++ b/relnotes
@@ -134,7 +134,7 @@ extract_pr_title () {
               sed -e '/^$/d' -e '2,$s/^\( *\* \)/        \1/g' \
                   -e '2,$s/^\( *[^ \*]\)/    * \1/g')
 
-    # if the release-note block is empty or the template is unchanged, use title
+    # if the release-note block is empty (unchanged from the template), use title
     if [[ -z "$content" ]]; then
       content=$(echo "$pull_json" | jq -r '.title')
     fi


### PR DESCRIPTION
The "-OR-" part in the pull_request_template.md has been removed (in kubernetes/kubernetes#30167). 

Note: currently release note body in the template is empty, so leaving it unchanged falls into the first condition, and keeping the second condition doesn't break anything.