### PR TITLE
Add comment explaining why we need to update pkg/version/base.go

### DIFF
--- a/anago
+++ b/anago
@@ -338,7 +338,14 @@ rev_openapi_versions () {
 }
 
 ###############################################################################
-# Updates pkg/version/base.go with RELEASE_VERSION
+# Updates pkg/version/base.go files with RELEASE_VERSION
+#
+# Note: the only reason we update these files is so that the source archives
+# exported by GitHub contain a valid version. Normally the version information
+# is filled in at build time using git metadata (including the tag), but no
+# such metadata is included in the source archives, so we must commit it into
+# the tree before tagging the release.
+#
 # Uses the RELEASE_VERSION global dict
 # @param label - label index to RELEASE_VERSION
 rev_version_base () {


### PR DESCRIPTION
I've been trying to understand why we keep committing changes to `pkg/version/base.go` (and its staging variant) to the release branches, since the build system normally stamps over these values with the relevant metadata from git.

Based on some GitHub archaeology (https://github.com/kubernetes/kubernetes/pull/11941), I believe this is needed only for the source archives exported on GitHub, so I've added a comment indicating such, so that somebody else doesn't have to do the same search I did.

I'm hoping @zmerlynn, @eparis, or @brendandburns can correct me if I'm misunderstanding this.