### PR TITLE
Add --build-at-head to find_green_build and skip secondary_jobs gathering

### DIFF
--- a/find_green_build
+++ b/find_green_build
@@ -24,7 +24,7 @@ PROG=${0##*/}
 #+ SYNOPSIS
 #+     $PROG  [--official] [<release branch>]
 #+            [--github-token=<token>] [--exclude-suites="<suite> ..."]
-#+            [--allow-stale-build] [--limit=N]
+#+            [--build-at-head] [--allow-stale-build] [--limit=N]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -46,6 +46,7 @@ PROG=${0##*/}
 #+     [--allow-stale-build] - Keep going even if the build is behind HEAD.
 #+                             This should only be used to display CI status.
 #+                             Branch cuts can't actually use stale builds.
+#+     [--build-at-head]     - (From anago) Just quickly return the HEAD build.
 #+     [--limit=]            - Limit the primary check to a count of N
 #+                             (Default: 100)
 #+     [--help | -man]       - display man page for this script

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -142,10 +142,14 @@ release::set_build_version () {
   # finer granularity at the Jenkin's job level to determine if a build is ok.
   release::get_job_cache -d $job_path/$main_job &
 
-  # Update secondary caches limited by main cache last build number
-  for other_job in ${secondary_jobs[@]}; do
+  # If we're forcing a --build-at-head, we only need to capture the $main_job
+  # details.
+  if ! ((FLAGS_build_at_head)); then
+    # Update secondary caches limited by main cache last build number
+      for other_job in ${secondary_jobs[@]}; do
     release::get_job_cache $job_path/$other_job &
-  done
+    done
+  fi
 
   # Wait for background fetches.
   wait


### PR DESCRIPTION
Follow-on to #425.