### PR TITLE
Trim [] in anchors of TOC

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -848,7 +848,7 @@ common::mdtoc () {
     # make a valid anchor
     anchor=${heading,,}
     anchor=${anchor// /-}
-    anchor=${anchor//[\.\?\*\,\/()]/}
+    anchor=${anchor//[\.\?\*\,\/\[\]()]/}
     # Keep track of dups and identify
     if [[ -n ${count[$anchor]} ]]; then
       ((count[$anchor]++)) ||true


### PR DESCRIPTION
If not, they will be invalid links. See: https://github.com/kubernetes/kubernetes/pull/54055

/cc @david-mcmahon @Bradamant3