### PR TITLE
Support federation release to be pushed to GCS

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -580,54 +580,57 @@ release::gcs::locally_stage_release_artifacts() {
   local release_stage=$build_output/release-stage
   local release_tars=$build_output/release-tars
   local gcs_stage=$build_output/gcs-stage/$version
-  local gce_path=$release_stage/full/kubernetes/cluster/gce
   local src
   local dst
-  local gci_path
 
   logecho "Locally stage release artifacts..."
 
   logrun rm -rf $gcs_stage || return 1
   logrun mkdir -p $gcs_stage || return 1
 
-  # GCI path changed in 1.2->1.3 time period
-  if [[ -d $gce_path/gci ]]; then
-    gci_path=$gce_path/gci
-  else
-    gci_path=$gce_path/trusty
-  fi
-
   # Stage everything in release directory
   logecho "- Staging locally to ${gcs_stage##$build_output/}..."
   release::gcs::stage_and_hash $gcs_stage $release_tars/* . || return 1
 
-  # Having the configure-vm.sh script and and trusty code from the GCE cluster
-  # deploy hosted with the release is useful for GKE.
-  release::gcs::stage_and_hash $gcs_stage $gce_path/configure-vm.sh extra/gce \
-   || return 1
-  release::gcs::stage_and_hash $gcs_stage $gci_path/node.yaml extra/gce \
-   || return 1
-  release::gcs::stage_and_hash $gcs_stage $gci_path/master.yaml extra/gce \
-   || return 1
-  release::gcs::stage_and_hash $gcs_stage $gci_path/configure.sh extra/gce \
-   || return 1
+  if [[ "$FLAGS_release_kind" == "kubernetes" ]]; then
+    local gce_path=$release_stage/full/kubernetes/cluster/gce
+    local gci_path
+
+    # GCI path changed in 1.2->1.3 time period
+    if [[ -d $gce_path/gci ]]; then
+      gci_path=$gce_path/gci
+    else
+      gci_path=$gce_path/trusty
+    fi
+
+    # Having the configure-vm.sh script and and trusty code from the GCE cluster
+    # deploy hosted with the release is useful for GKE.
+    release::gcs::stage_and_hash $gcs_stage $gce_path/configure-vm.sh extra/gce \
+      || return 1
+    release::gcs::stage_and_hash $gcs_stage $gci_path/node.yaml extra/gce \
+      || return 1
+    release::gcs::stage_and_hash $gcs_stage $gci_path/master.yaml extra/gce \
+      || return 1
+    release::gcs::stage_and_hash $gcs_stage $gci_path/configure.sh extra/gce \
+      || return 1
+  fi
 
   # Upload the "naked" binaries to GCS.  This is useful for install scripts that
   # download the binaries directly and don't need tars.
   platforms=($(cd "$release_stage/client"; echo *))
   for platform in "${platforms[@]}"; do
-    src="$release_stage/client/$platform/kubernetes/client/bin/*"
+    src="$release_stage/client/$platform/$FLAGS_release_kind/client/bin/*"
     dst="bin/${platform/-//}/"
     # We assume here the "server package" is a superset of the "client package"
     if [[ -d "$release_stage/server/$platform" ]]; then
-      src="$release_stage/server/$platform/kubernetes/server/bin/*"
+      src="$release_stage/server/$platform/$FLAGS_release_kind/server/bin/*"
     fi
     release::gcs::stage_and_hash $gcs_stage "$src" "$dst" || return 1
 
     # Upload node binaries if they exist and this isn't a 'server' platform.
     if [[ ! -d "$release_stage/server/$platform" ]]; then
       if [[ -d "$release_stage/node/$platform" ]]; then
-        src="$release_stage/node/$platform/kubernetes/node/bin/*"
+        src="$release_stage/node/$platform/$FLAGS_release_kind/node/bin/*"
         release::gcs::stage_and_hash $gcs_stage "$src" "$dst" || return 1
       fi
     fi

--- a/push-build.sh
+++ b/push-build.sh
@@ -49,6 +49,8 @@ PROG=${0##*/}
 #+     [--bucket=]               - Specify an alternate bucket for pushes
 #+     [--release-type=]         - Override auto-detected release type
 #+                                 (normally devel or ci)
+#+     [--release-kind=]         - Kind of release to push to GCS. Supported
+#+                                 values are kubernetes(default) or federation.
 #+     [--gcs-suffix=]           - Specify a suffix to append to the upload
 #+                                 destination on GCS.
 #+     [--docker-registry=]      - If set, push docker images to specified
@@ -102,6 +104,9 @@ common::timestamp begin
 RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
 # Compatibility with incoming global args
 [[ $KUBE_GCS_UPDATE_LATEST == "n" ]] && FLAGS_noupdatelatest=1
+
+# Default to kubernetes
+: ${FLAGS_release_kind:="kubernetes"}
 
 # This will canonicalize the path
 KUBE_ROOT=$(pwd -P)


### PR DESCRIPTION
We are in the process of moving out federation out of core kubernetes. As part of that we need to be having a separate release and release package for federation. federation code is hosted on `github.com/kubernetes/federation` repo and the federation release package is built from this repo and we plan to have separate GCS bucket for federation releases (`kubernetes-federation-release`).
This PR will enable us to push the federation release to GCS from CI job.

/assign @david-mcmahon 
/cc @marun @irfanurrehman @kubernetes/sig-multicluster-pr-reviews 

p.s: @marun, request to provide little more context if necessary.