### PR TITLE
fix method name: getKubeadmKubeletConfigFile

### DIFF
--- a/debian/build_test.go
+++ b/debian/build_test.go
@@ -56,7 +56,7 @@ func TestGetKubeadmConfig(t *testing.T) {
 		v := version{
 			Version: tc.version,
 		}
-		kubeadmConfig, err := getKubeadmConfig(v)
+		kubeadmConfig, err := getKubeadmKubeletConfigFile(v)
 
 		if err != nil {
 			if !tc.expectErr {


### PR DESCRIPTION
fix method name typo that introduced by #413.

/cc @pipejakob 
/assign @mikedanese 