### PR TITLE
No longer need to update base.go via rev_version_base().

### DIFF
--- a/anago
+++ b/anago
@@ -415,52 +415,6 @@ rev_openapi_versions () {
 }
 
 ###############################################################################
-# Updates pkg/version/base.go files with RELEASE_VERSION
-#
-# Note: the only reason we update these files is so that the source archives
-# exported by GitHub contain a valid version. Normally the version information
-# is filled in at build time using git metadata (including the tag), but no
-# such metadata is included in the source archives, so we must commit it into
-# the tree before tagging the release.
-#
-# Uses the RELEASE_VERSION global dict
-# @param label - label index to RELEASE_VERSION
-rev_version_base () {
-  local label=$1
-  local version_file="pkg/version/base.go"
-  local staging_file="staging/src/k8s.io/client-go/$version_file"
-  local minor_plus
-  local gitmajor
-  local gitminor
-
-  logecho "Updating $version_file to ${RELEASE_VERSION[$label]}..."
-
-  if [[ ${RELEASE_VERSION[$label]} =~ ${VER_REGEX[release]} ]]; then
-    gitmajor=${BASH_REMATCH[1]}
-    gitminor=${BASH_REMATCH[2]}
-  fi
-
-  [[ "$label" =~ ^beta || "$label" =~ ^rc ]] && minor_plus="+"
-
-  sed -i -e "s/\(gitMajor *string = \)\"[^\"]*\"/\1\"$gitmajor\"/g" \
-      -e "s/\(gitMinor *string = \)\"[^\"]*\"/\1\"$gitminor$minor_plus\"/g" \
-    -e "s/\(gitVersion *string = \)\"[^\"]*\"/\1\"${RELEASE_VERSION[$label]}+\$Format:%h\$\"/g" $version_file
-
-  logecho -n "Formatting $version_file: "
-  logrun -s gofmt -s -w $version_file
-  logrun git add $version_file
-  if [[ -f $staging_file ]]; then
-    logrun cp $version_file $staging_file
-    logrun git add $staging_file
-  fi
-
-  logecho -n "Committing versioned files: "
-  logrun -s git commit -am \
-                "Kubernetes version ${RELEASE_VERSION[$label]} file updates"
-}
-
-
-###############################################################################
 # Update $CHANGELOG_FILE on master
 PROGSTEP[generate_release_notes]="GENERATE RELEASE NOTES"
 generate_release_notes () {
@@ -609,11 +563,6 @@ prepare_tree () {
 
   # Now set the branch we're on
   branch=$(gitlib::current_branch)
-
-  # rev base.go
-  case $label in
-    beta*|rc|official) rev_version_base $label || return 1 ;;
-  esac
 
   # if this is a new branch, rev openapi-spec version files
   if [[ -n "$PARENT_BRANCH" ]]; then


### PR DESCRIPTION
Ref kubernetes/kubernetes#55353.

Do not submit until kubernetes/kubernetes#55353 is submitted and cherrypicked to all active release branches.