### PR TITLE
Validation checks and messaging improvements

### DIFF
--- a/anago
+++ b/anago
@@ -631,10 +631,11 @@ prepare_tree () {
 # Make cross only
 # This very low level split of the build required to run exactly 'make cross'
 # only using the kube-cross container image
-# @param version - The kubernetes version to build
+# @param label - The label to process
 PROGSTEP[make_cross]="MAKE CROSS"
 make_cross () {
-  local version=${RELEASE_VERSION[$1]}
+  local label=$1
+  local version=${RELEASE_VERSION[$label]}
   local branch
 
   checkout_object $label
@@ -657,10 +658,11 @@ make_cross () {
 
 ##############################################################################
 # Build the Kubernetes tree
-# @param version - The kubernetes version to build
+# @param label - The label to process
 PROGSTEP[build_tree]="BUILD TREE"
 build_tree () {
-  local version=${RELEASE_VERSION[$1]}
+  local label=$1
+  local version=${RELEASE_VERSION[$label]}
   local branch
 
   checkout_object $label

--- a/anago
+++ b/anago
@@ -1665,6 +1665,7 @@ if [[ -z $STAGED_LOCATION ]]; then
   # No release notes for X.Y.Z-beta.0 releases
   [[ -z "$PARENT_BRANCH" ]] && common::run_stateful generate_release_notes
 else
+  logecho
   # Force complete for these three stages
   for label in ${!RELEASE_VERSION[@]}; do
     SKIP_STEPS+=(prepare_tree+$label build_tree+$label)

--- a/anago
+++ b/anago
@@ -1429,14 +1429,6 @@ if [[ -z "${BASEDIR}" ]]; then
   fi
 fi
 
-if ! ((FLAGS_buildonly)) && ! common::set_cloud_binaries; then
-  logecho "Releasing Kubernetes requires gsutil and gcloud. Please download,"
-  logecho "install and authorize through the Google Cloud SDK:"
-  logecho
-  logecho "https://developers.google.com/cloud/sdk/"
-  common::exit 1 "Exiting..."
-fi
-
 # TODO:
 # These KUBE_ globals extend beyond the scope of the new release refactored
 # tooling so to pass these through as flags will require fixes across
@@ -1497,6 +1489,15 @@ if ! ((FLAGS_gcb)); then
 
   # Additional functionality
   common::security_layer
+fi
+
+# Set cloud binaries
+if ! ((FLAGS_buildonly)) && ! common::set_cloud_binaries; then
+  logecho "Releasing Kubernetes requires gsutil and gcloud. Please download,"
+  logecho "install and authorize through the Google Cloud SDK:"
+  logecho
+  logecho "https://developers.google.com/cloud/sdk/"
+  common::exit 1 "Exiting..."
 fi
 
 ((FLAGS_stage)) || common::run_stateful gitlib::github_acls

--- a/anago
+++ b/anago
@@ -953,7 +953,7 @@ announce () {
     common::sendmail -h "$mailto" "K8s-Anago<$USER_AT_DOMAIN>" \
                      "K8s-Anago<cloud-kubernetes-release@google.com>" \
                      "$subject" "$USER_AT_DOMAIN" \
-                     "$announcement_text" --html || return 1
+                     "$announcement_text" || return 1
 
   fi
 
@@ -1350,8 +1350,7 @@ push_all_artifacts () {
      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
 
     common::runstep release::gcs::publish_version \
-     $BUCKET_TYPE $version $BUILD_OUTPUT-$version \
-                  ${STAGED_BUCKET:-$RELEASE_BUCKET} || return 1
+     $BUCKET_TYPE $version $BUILD_OUTPUT-$version $RELEASE_BUCKET || return 1
   fi
 }
 

--- a/anago
+++ b/anago
@@ -1608,8 +1608,8 @@ logecho -r "${TPUT[BOLD]}>>>>>>>>${TPUT[OFF]}" \
 
 common::run_stateful prepare_workspace
 
-common::run_stateful \
-  "common::disk_space_check $BASEDIR $(($RELEASE_GB*${#RELEASE_VERSION[*]}))"
+common::run_stateful --strip-args \
+ "common::disk_space_check $BASEDIR $(($RELEASE_GB*${#RELEASE_VERSION[*]}))"
 
 # Everything happens in the TREE_ROOT context
 logrun cd $TREE_ROOT
@@ -1665,9 +1665,6 @@ if [[ -z $STAGED_LOCATION ]]; then
   [[ -z "$PARENT_BRANCH" ]] && common::run_stateful generate_release_notes
 else
   # Force complete for these three stages
-  logecho
-  logecho "$FOUND staged sources - Marking steps complete:"
-
   for label in ${!RELEASE_VERSION[@]}; do
     SKIP_STEPS+=(prepare_tree+$label build_tree+$label)
     ((FLAGS_gcb)) && SKIP_STEPS+=(make_cross+$label)
@@ -1676,7 +1673,7 @@ else
   for entry in ${SKIP_STEPS[*]}; do
      # Check and add for re-entrancy
      if ! common::check_state $entry; then
-       logecho "- $entry"
+       logecho "$ATTENTION: Skipping $entry step executed during staging"
        common::check_state -a $entry
      fi
   done

--- a/anago
+++ b/anago
@@ -591,7 +591,7 @@ prepare_tree () {
     return 1
   fi
 
-  checkout_object $label
+  checkout_object $label || return 1
 
   # Now set the branch we're on
   branch=$(gitlib::current_branch)
@@ -1112,6 +1112,10 @@ branchff_sanity_check () {
 PROGSTEP[get_build_candidate]="SET BUILD CANDIDATE"
 get_build_candidate () {
   local testing_branch
+  local branch_head=$($GHCURL $K8S_GITHUB_API/commits/$RELEASE_BRANCH |\
+                      jq -r '.sha')
+  # Shorten
+  branch_head=${branch_head:0:14}
 
   # Are we branching to a new branch?
   if gitlib::branch_exists $RELEASE_BRANCH; then
@@ -1167,6 +1171,17 @@ get_build_candidate () {
       common::exit 1
     fi
 
+    # The build version should never be behind HEAD on release branches
+    if [[ "$RELEASE_BRANCH" =~ release-([0-9]{1,})\. ]]; then
+      if [[ $JENKINS_BUILD_VERSION =~ ${VER_REGEX[build]} && \
+            ${BASH_REMATCH[2]} != $branch_head ]]; then
+        logecho
+        logecho "$FATAL: The $RELEASE_BRANCH HEAD is ahead of the chosen" \
+                "commit. Releases on release branches must be run from HEAD."
+        return 1
+      fi
+    fi
+
     # Check state of master branch before continuing
     branchff_sanity_check $JENKINS_BUILD_VERSION
   fi
@@ -1184,14 +1199,15 @@ set_release_values () {
                                 $PARENT_BRANCH \
    || return 1
 
-  # Check that this tag doesn't exist which may occur if $PROG ran partially
+  # Check that this tag doesn't exist. Staged builds may be old
   if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
-     $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
+        $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
      logecho
-     logecho "The tag $RELEASE_VERSION_PRIME already exists on github."
-     logecho "* An old --buildversion was specified on the command-line"
+     logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
+     logecho "An old --buildversion was specified on the command-line."
      return 1
   fi
+
 }
 
 ##############################################################################
@@ -1497,7 +1513,7 @@ common::run_stateful get_build_candidate JENKINS_BUILD_VERSION \
                                          PARENT_BRANCH BRANCH_POINT
 # Computes a few things and creates a globals and dictionaries - not stateful
 # Always Computed from JENKINS_BUILD_VERSION
-set_release_values
+set_release_values || common::exit 1 "Exiting..."
 
 # Set values based on derived/computed values above
 # WORK/BUILD area

--- a/anago
+++ b/anago
@@ -1607,8 +1607,10 @@ logecho -r "${TPUT[BOLD]}>>>>>>>>${TPUT[OFF]}" \
 
 common::run_stateful prepare_workspace
 
+# Store RELEASE_GB key=value in $PROGSTATE
 common::run_stateful --strip-args \
- "common::disk_space_check $BASEDIR $(($RELEASE_GB*${#RELEASE_VERSION[*]}))"
+ "common::disk_space_check $BASEDIR $(($RELEASE_GB*${#RELEASE_VERSION[*]}))" \
+ RELEASE_GB
 
 # Everything happens in the TREE_ROOT context
 logrun cd $TREE_ROOT

--- a/anago
+++ b/anago
@@ -562,7 +562,7 @@ git_tag () {
   local label=$1
   local branch=$2
   local commit_string
-  local label_common
+  local label_common="$label"
 
   # Ensure a common name for label in case we're using the special beta indexes
   [[ "$label" =~ ^beta ]] && label_common="beta"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -551,7 +551,7 @@ common::namevalue () {
             eval export FLAGS_${arg//-/_}=1
           fi
           ;;
-    *) POSITIONAL_ARGV+=("$arg")
+    *) POSITIONAL_ARGV+=($arg)
        ;;
     esac
   done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -983,17 +983,17 @@ common::sendmail () {
     return 1
   fi
 
-  (
+  {
   cat <<EOF+
-To: "$to"
-From: "$from"
-Subject: "$subject"
-Cc: "$cc"
-Reply-To: "$reply_to"
+To: $to
+From: $from
+Subject: $subject
+Cc: $cc
+Reply-To: $reply_to
 EOF+
   ((html)) && echo "Content-Type: text/html"
   cat $file
-  ) |/usr/sbin/sendmail -t
+  } |/usr/sbin/sendmail -t
 }
 
 # Stubs for security_layer functions

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -701,7 +701,7 @@ release::gcs::publish_version () {
                 )
 
   logecho
-  logecho "Publish official pointer text files to $bucker..."
+  logecho "Publish official pointer text files to $bucket..."
 
   for publish_file in ${publish_files[@]}; do
     # If there's a version that's above the one we're trying to release, don't


### PR DESCRIPTION
Check for non-head release branch build versions before continuing.
Fix tag check and exit in set_release_values().
Move common:set_cloud_binaries() check to a more logical place.
Add --strip-args to common::run_stateful() to allow stripping of args from messaging
Improve messaging for skipped staged steps.
Fix to common::sendmail() and callers.
Store RELEASE_GB in state file.