### PR TITLE
Add ability to easily build prerelease rpms for testing.

### DIFF
--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -6,6 +6,20 @@
 %global RPM_RELEASE 1
 %global ARCH amd64
 
+# If you want to build rpms for a prerelease version, you should set this to
+# the version suffix after MAJOR.MINOR.PATCH. For instance, if you want to
+# build 1.8.0-beta.1, set:
+#
+# %global KUBE_MAJOR 1
+# %global KUBE_MINOR 8
+# %global KUBE_PATCH 0
+# %global KUBE_VERSION_SUFFIX -beta.1
+#
+# However, the rpm version and name will still only be MAJOR.MINOR.PATCH, so
+# only use this for testing of prerelease versions. When building a normal
+# release, keep the suffix set to %{nil}.
+%global KUBE_VERSION_SUFFIX %{nil}
+
 # This expands a (major, minor, patch) tuple into a single number so that it
 # can be compared against other versions. It has the current implementation
 # assumption that none of these numbers will exceed 255.
@@ -19,10 +33,10 @@ Summary: Container cluster management
 License: ASL 2.0
 
 URL: https://kubernetes.io
-Source0: https://dl.k8s.io/v%{KUBE_VERSION}/bin/linux/%{ARCH}/kubelet
+Source0: https://dl.k8s.io/v%{KUBE_VERSION}%{KUBE_VERSION_SUFFIX}/bin/linux/%{ARCH}/kubelet
 Source1: kubelet.service
-Source2: https://dl.k8s.io/v%{KUBE_VERSION}/bin/linux/%{ARCH}/kubectl
-Source3: https://dl.k8s.io/v%{KUBE_VERSION}/bin/linux/%{ARCH}/kubeadm
+Source2: https://dl.k8s.io/v%{KUBE_VERSION}%{KUBE_VERSION_SUFFIX}/bin/linux/%{ARCH}/kubectl
+Source3: https://dl.k8s.io/v%{KUBE_VERSION}%{KUBE_VERSION_SUFFIX}/bin/linux/%{ARCH}/kubeadm
 Source4: 10-kubeadm.conf
 Source5: https://dl.k8s.io/network-plugins/cni-%{ARCH}-%{CNI_RELEASE}.tar.gz
 


### PR DESCRIPTION
This change adds a new `KUBE_VERSION_SUFFIX` variable that can be set to something like `-rc.1` or `-alpha.0` to be appended to the normal `MAJOR.MINOR.PATCH` version when fetching binaries. Otherwise, it's currently difficult to build rpms for testing of releases before they've been officially cut.