### PR TITLE
Fix rpm build after CNI 0.6.0 changes

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -306,9 +306,9 @@ func getKubeletCNIVersion(v version) (string, error) {
 	}
 
 	if sv.GTE(v190) {
-		return fmt.Sprintf(">= %s", cniVersion), nil
+		return fmt.Sprintf("= %s", cniVersion), nil
 	}
-	return fmt.Sprint("<= 0.5.1"), nil
+	return fmt.Sprint("= 0.5.1"), nil
 }
 
 func main() {

--- a/debian/build.go
+++ b/debian/build.go
@@ -300,7 +300,7 @@ func getKubeletCNIVersion(v version) (string, error) {
 		return "", err
 	}
 
-	v190, err := semver.Make("1.9.0")
+	v190, err := semver.Make("1.9.0-alpha.0")
 	if err != nil {
 		return "", err
 	}

--- a/debian/xenial/kubelet/debian/control
+++ b/debian/xenial/kubelet/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/kubernetes/kubernetes
 
 Package: kubelet
 Architecture: {{ .DebArch }}
-Depends: iptables (>= 1.4.21), kubernetes-cni (>= 0.5.1), iproute2, socat, util-linux, mount, ebtables, ethtool, ${misc:Depends}
+Depends: iptables (>= 1.4.21), kubernetes-cni ({{ .KubeletCNIVersion }}), iproute2, socat, util-linux, mount, ebtables, ethtool, ${misc:Depends}
 Description: Kubernetes Node Agent
  The node agent of Kubernetes, the container cluster manager

--- a/debian/xenial/kubernetes-cni/debian/rules
+++ b/debian/xenial/kubernetes-cni/debian/rules
@@ -2,15 +2,16 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
-CNI_RELEASE = 0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
+CNI_VERSION = v0.6.0
 
 build:
 	echo noop
 
 binary:
+	mkdir -p ./bin
 	curl -sSL --fail --retry 5 \
-		"https://dl.k8s.io/network-plugins/cni-{{ .Arch }}-$(CNI_RELEASE).tar.gz" \
-		| tar xz
+		"https://dl.k8s.io/network-plugins/cni-plugins-{{ .Arch }}-$(CNI_VERSION).tgz" \
+		| tar -C ./bin -xz
 	dh_testroot
 	dh_auto_install
 	dh_shlibdeps

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -38,11 +38,7 @@ Source5: https://dl.k8s.io/network-plugins/cni-plugins-%{ARCH}-v%{CNI_VERSION}.t
 
 BuildRequires: curl
 Requires: iptables >= 1.4.21
-%if %{KUBE_SEMVER} >= %{semver 1 9 0}
-Requires: kubernetes-cni >= %{CNI_VERSION}
-%else
-Requires: kubernetes-cni <= %{CNI_VERSION}
-%endif
+Requires: kubernetes-cni = %{CNI_VERSION}
 Requires: socat
 Requires: util-linux
 Requires: ethtool


### PR DESCRIPTION
This builds on top of the changes in https://github.com/kubernetes/release/pull/446 to start using CNI 0.6.0 in Kubernetes 1.9, but fixes the rpm build:

- Version `kubernetes-cni` package on the CNI version actually used.
- Fix `Source5` parse problem with Kubernetes < 1.9.0
- Extract `cni-plugins` to its own directory and fix `mv` commands

See the newer commit for my fixes. I've tested that the rpms actually build for both Kubernetes 1.8.x and 1.9.0-beta.2, and that their contents look reasonable, but haven't actually started real clusters using them for deep end-to-end testing (yet).

CC @enisoc @dixudx