### PR TITLE
fix kubernetes-cni version bug

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -306,9 +306,9 @@ func getKubeletCNIVersion(v version) (string, error) {
 	}
 
 	if sv.GTE(v190) {
-		return fmt.Sprintf("= %s", cniVersion), nil
+		return fmt.Sprintf("= %s-00", cniVersion), nil
 	}
-	return fmt.Sprint("= 0.5.1"), nil
+	return fmt.Sprint("= 0.5.1-00"), nil
 }
 
 func main() {

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -38,7 +38,7 @@ Source5: https://dl.k8s.io/network-plugins/cni-plugins-%{ARCH}-v%{CNI_VERSION}.t
 
 BuildRequires: curl
 Requires: iptables >= 1.4.21
-Requires: kubernetes-cni = %{CNI_VERSION}
+Requires: kubernetes-cni = %{CNI_VERSION}-0
 Requires: socat
 Requires: util-linux
 Requires: ethtool


### PR DESCRIPTION
Released debian package version usually has `-00` as postfix, yum package gets `-0`.

Fixes: kubernetes/kubernetes#57334

/assign @pipejakob @ixdy 
/cc @luxas 