### PR TITLE
[WIP] Allow parameterized RPM builds

### DIFF
--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -4,4 +4,5 @@ kubectl
 cni-*.tar.gz
 bin/
 output/
+sources/
 *.swp

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:24
+FROM fedora:27
 MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 
 RUN dnf install -y rpm-build rpmdevtools createrepo && dnf clean all
@@ -7,5 +7,12 @@ RUN rpmdev-setuptree
 
 USER root
 ADD entry.sh /root/
-COPY ./ /root/rpmbuild/SPECS
+
+# Only put the spec file in SPECS
+COPY kubelet.spec /root/rpmbuild/SPECS
+
+# Put sources that don't vary per arch in a common directory. The entry.sh script copies them to the
+# appropriate source directory based on the arch being built.
+COPY 10-kubeadm-post-1.8.conf 10-kubeadm-pre-1.8.conf kubelet.service /root/common-sources/
+
 ENTRYPOINT ["/root/entry.sh"]

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -1,18 +1,63 @@
 #!/bin/sh
 set -e
 
+# Clean the output directory first, so any RPMs that were built during a previous run are not
+# included in the context sent when building the image.
+echo "Cleaning output directory"
+sudo rm -rf output
+
+# Build the image
 docker build -t kubelet-rpm-builder .
-echo "Cleaning output directory..."
-sudo rm -rf output/*
+
+# Prep the output directory where the built RPMs go
 mkdir -p output
-docker run -ti --rm -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder $1
-sudo chown -R $USER $PWD/output
+
+if [[ -z "${KEEP_SOURCES}" ]]; then
+  echo "Cleaning sources directory"
+  rm -rf sources/*
+else
+  echo "Using existing sources directory"
+fi
+
+# Allow overriding the major.minor.patch-release values.
+if [[ -n "${KUBE_MAJOR}" ]]; then
+  KUBE_MAJOR_ARG=(-e KUBE_MAJOR=${KUBE_MAJOR})
+fi
+
+if [[ -n "${KUBE_MINOR}" ]]; then
+  KUBE_MINOR_ARG=(-e KUBE_MINOR=${KUBE_MINOR})
+fi
+
+if [[ -n "${KUBE_PATCH}" ]]; then
+  KUBE_PATCH_ARG=(-e KUBE_PATCH=${KUBE_PATCH})
+fi
+
+if [[ -n "${RPM_RELEASE}" ]]; then
+  RPM_RELEASE_ARG=(-e RPM_RELEASE=${RPM_RELEASE})
+fi
+
+# Build the RPMs. The 'sources' directory is bind mounted into the container, so you can
+# pre-download sources if you wish.
+docker run --rm \
+  -v "$PWD"/output/:/root/rpmbuild/RPMS/ \
+  -v "$PWD"/sources/x86_64/:/root/rpmbuild/SOURCES/x86_64/ \
+  -v "$PWD"/sources/armhfp/:/root/rpmbuild/SOURCES/armhfp/ \
+  -v "$PWD"/sources/aarch64/:/root/rpmbuild/SOURCES/aarch64/ \
+  -v "$PWD"/sources/ppc64le/:/root/rpmbuild/SOURCES/ppc64le/ \
+  -v "$PWD"/sources/s390x/:/root/rpmbuild/SOURCES/s390x/ \
+  "${KUBE_MAJOR_ARG[@]}" \
+  "${KUBE_MINOR_ARG[@]}" \
+  "${KUBE_PATCH_ARG[@]}" \
+  "${RPM_RELEASE_ARG[@]}" \
+  kubelet-rpm-builder \
+  "$1"
+sudo chown -R "$USER" "$PWD"/output
 
 echo
 echo "----------------------------------------"
 echo
 echo "RPMs written to: "
-ls $PWD/output/*/
+ls "$PWD"/output/*/
 echo
 echo "Yum repodata written to: "
-ls $PWD/output/*/repodata/
+ls "$PWD"/output/*/repodata/

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -1,9 +1,9 @@
-%global KUBE_MAJOR 1
-%global KUBE_MINOR 9
-%global KUBE_PATCH 0
+%{!?KUBE_MAJOR: %global KUBE_MAJOR 1}
+%{!?KUBE_MINOR: %global KUBE_MINOR 9}
+%{!?KUBE_PATCH: %global KUBE_PATCH 0}
 %global KUBE_VERSION %{KUBE_MAJOR}.%{KUBE_MINOR}.%{KUBE_PATCH}
-%global RPM_RELEASE 0
-%global ARCH amd64
+%{!?RPM_RELEASE: %global RPM_RELEASE 0}
+%{!?ARCH: %global ARCH amd64}
 
 # This expands a (major, minor, patch) tuple into a single number so that it
 # can be compared against other versions. It has the current implementation
@@ -93,9 +93,9 @@ Command-line utility for administering a Kubernetes cluster.
 #
 
 %if %{KUBE_SEMVER} >= %{semver 1 8 0}
-ln -s 10-kubeadm-post-1.8.conf %SOURCE4
+ln -sf 10-kubeadm-post-1.8.conf %SOURCE4
 %else
-ln -s 10-kubeadm-pre-1.8.conf %SOURCE4
+ln -sf 10-kubeadm-pre-1.8.conf %SOURCE4
 %endif
 
 cp -p %SOURCE0 %{_builddir}/


### PR DESCRIPTION
Make changes to the RPM build tooling to allow the user to specify the
major.minor.patch-release values instead of having them hard-coded in
the spec file.

Other changes include:

- Upgrade image to fedora:27

- Only copy the spec file to SPECS

- Copy the common source files to /root/common-sources (and then into
  each arch's source directory at build time)

- Clean the output directory prior to creating the kubelet-rpm-builder
  image

- Bind mount the source directories into the container so downloaded
  sources are preserved

- Add an optional environment variable, KEEP_SOURCES, that preserves
  files in the bind mounted source directories (avoiding the need to
  re-download source files, or allowing you to "bring your own")

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>

cc @skriss @nrb @enisoc @timothysc @dgoodwin 