### PR TITLE
Comment out generate-docs on new branches.

### DIFF
--- a/anago
+++ b/anago
@@ -609,17 +609,18 @@ prepare_tree () {
     beta*) rev_openapi_versions $label || return 1 ;;
   esac
 
+  # COMMENTING OUT FOR NOW AS THE WAY FORWARD IS NOT CLEAR
   # generate docs on new branches (from master) only
   # If the entirety of this session is based on a branch from master
   # (PARENT_BRANCH), and this iteration of prepare_tree() is operating on
   # the NON-master branch itself, versionize the docs
-  if [[ "$PARENT_BRANCH" == "master" && "$branch" != "master" ]]; then
-    logecho -n "Generating docs for ${RELEASE_VERSION[$label]}: "
-    logrun -s $TREE_ROOT/hack/generate-docs.sh || return 1
-    logecho -n "Committing: "
-    logrun -s git commit -am \
-              "Generating docs for ${RELEASE_VERSION[$label]} on $branch."
-  fi
+  #if [[ "$PARENT_BRANCH" == "master" && "$branch" != "master" ]]; then
+  #  logecho -n "Generating docs for ${RELEASE_VERSION[$label]}: "
+  #  logrun -s $TREE_ROOT/hack/generate-docs.sh || return 1
+  #  logecho -n "Committing: "
+  #  logrun -s git commit -am \
+  #            "Generating docs for ${RELEASE_VERSION[$label]} on $branch."
+  #fi
 
   git_tag $label $branch
 }


### PR DESCRIPTION
This one has a long history of confusion over exactly what is wanted.  
#478 Attempts to generate docs at release time but that has it's own unworked-out issues such as leaving uncommited files in the tree causing -dirty among other hassles. 
#487 Simply ensures this doesn't happen at branch fast forward time.  This change to anago should have gone in alongside that one. 