### PR TITLE
Fix testinfra config.yaml file location

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -125,7 +125,7 @@ release::set_build_version () {
 
   # Get the list of 'blocking' jobs rom testgrid config yamls
   local -a all_jobs=($($GHCURL \
-   $K8S_GITHUB_RAW_ORG/test-infra/master/testgrid/config/config.yaml \
+   $K8S_GITHUB_RAW_ORG/test-infra/master/testgrid/config.yaml \
    2>/dev/null |\
    $yq -r '.[] | .[] | select (.name?=="sig-'$branch'-blocking") |.dashboard_tab[].test_group_name' 2>/dev/null))
 


### PR DESCRIPTION
Look like the location of config file is changed in test-infra repo. This fixes it.

ref: https://github.com/kubernetes/test-infra/pull/6605/files#diff-0e9f7582435fdc364e5f7adce048d956