### PR TITLE
add allow-dup flag to allow overwriting

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -531,15 +531,21 @@ release::gcs::stage_and_hash() {
 # Ensure the destination bucket path doesn't already exist
 # @param gcs_destination - GCS destination directory
 # @return 1 on failure or if GCS destination already exists
+#           and --allow_dup does not set
 release::gcs::destination_empty() {
   local gcs_destination=$1
 
   logecho -n "Checking whether $gcs_destination already exists: "
   if $GSUTIL ls $gcs_destination >/dev/null 2>&1 ; then
-    logecho "$FAILED"
     logecho "- Destination exists. To remove, run:"
     logecho "  gsutil -m rm -r $gcs_destination"
-    return 1
+    
+    if ((FLAGS_allow_dup)) ; then
+      logecho "flag --allow-dup set, continue with overwriting"   
+    else
+      logecho "$FAILED"  
+      return 1
+    fi
   fi
   logecho "$OK"
 }

--- a/push-build.sh
+++ b/push-build.sh
@@ -60,6 +60,8 @@ PROG=${0##*/}
 #+     [--noupdatelatest]        - Do not update the latest file
 #+     [--private-bucket]        - Do not mark published bits on GCS as
 #+                                 publicly readable.
+#+     [--allow-dup]             - Do not exit error if the build already
+#+                                 exists on the gcs path.
 #+     [--help | -man]           - display man page for this script
 #+     [--usage | -?]            - display in-line usage
 #+


### PR DESCRIPTION
xref https://github.com/kubernetes/test-infra/issues/6683
Basically now that we moved ci build to prow, we let the build running continuously as a periodic job -
 aka http://k8s-testgrid.appspot.com/sig-release-1.9-all#build-1.9 However it will show up as failed on testgrid if the same build dest already exists.

Add a flag to allow existing gcs destination so that the build job can continue without existing error

/assign @BenTheElder @david-mcmahon 
cc @mbohlool 