### PR TITLE
Fix pushing bazel built federation release to GCS

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1032,11 +1032,13 @@ release::docker::release_from_tarfiles () {
 # This is achieved by looking for the most recent kubernetes.tar.gz tarball
 # in both the dockerized and Bazel output trees.
 # @param kube_root - Root of kubernetes tree
+# @param release_kind - Kind of release. kubernetes or federation
 # @return 0 if built with Bazel, 1 otherwise
 release::was_built_with_bazel() {
   local kube_root=$1
+  local release_kind=$2
   local most_recent_release_tar=$( (ls -t \
-    $kube_root/{_output,bazel-bin/build}/release-tars/kubernetes.tar.gz \
+    $kube_root/{_output,bazel-bin/build}/release-tars/$release_kind.tar.gz \
     2>/dev/null || true) | head -n 1)
 
   [[ $most_recent_release_tar =~ /bazel-bin/ ]]

--- a/push-build.sh
+++ b/push-build.sh
@@ -117,7 +117,7 @@ RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
 KUBE_ROOT=$(pwd -P)
 
 USE_BAZEL=false
-if release::was_built_with_bazel $KUBE_ROOT; then
+if release::was_built_with_bazel $KUBE_ROOT $FLAGS_release_kind; then
   USE_BAZEL=true
   bazel build //:version
   LATEST=$(cat $KUBE_ROOT/bazel-genfiles/version)


### PR DESCRIPTION
In federation, we are trying to migrate to use bazel built release. push_build.sh appears to be broken to push federation release built from bazel to GCS. This PR should fix this issue and enable pushing bazel built federation release

/assign @david-mcmahon 
/cc @kubernetes/sig-multicluster-pr-reviews 