### PR TITLE
Always run update_github_release() (even in GCB).

### DIFF
--- a/anago
+++ b/anago
@@ -1556,9 +1556,8 @@ elif ! ((FLAGS_prebuild)); then
     common::stepindex "announce"
     if ((FLAGS_gcb)); then
       common::stepindex "gitlib::update_release_issue"
-    else
-      common::stepindex "update_github_release"
     fi
+    common::stepindex "update_github_release"
   fi
 fi
 
@@ -1833,9 +1832,9 @@ else
   # For GCB create/update a release tracking issue
   if ((FLAGS_gcb)); then
     common::run_stateful "gitlib::update_release_issue $RELEASE_VERSION_PRIME"
-  else
-    common::run_stateful update_github_release
   fi
+
+  common::run_stateful update_github_release
 
   common::stepheader "ARCHIVE RELEASE ON GS"
   common::runstep archive_release

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -393,8 +393,10 @@ gitlib::update_release_issue () {
       logecho "Created issue #$issue_number on github:"
       logecho "http://github.com/$repo/issues/$issue_number"
     else
-      logecho "There was a problem creating the release tracking issue"
-      logecho "This should be done manually."
+      logecho "$WARNING: There was a problem creating the release tracking" \
+              "issue.  This should be done manually."
+      logecho "Contents:"
+      logecho "$text"
     fi
   fi
 }


### PR DESCRIPTION
Output the body of the github issue that would have been created when it isn't.

Fixes 1.7.13 release issue that was hit yesterday.

cc @listx @javier-b-perez 