### PR TITLE
WIP: Release email notification mechanism.

### DIFF
--- a/README-gcb.md
+++ b/README-gcb.md
@@ -48,6 +48,17 @@ $ gcbmgr -man
 Guidance from `gcbmgr staged` instructs you how to release a staged build on
 GCB or the desktop.
 
-NOTE: Releases from GCB are currently unable to send email, so the update
-      occurs in the form of a new release tracking issue on the
-      kubernetes/sig-release repo (k8s-release-robot/sig-release for mock runs).
+**NOTE:**
+Releases from GCB are currently unable to send email, so the update
+occurs in the form of a new release tracking issue on the
+kubernetes/sig-release repo (k8s-release-robot/sig-release for mock runs).
+
+To send the standard e-mail announcement after a release on GCB, you may
+use the helper `release-notify` which will grab the notification details
+from gs://<BUCKET>/archive/anago-$VERSION/announcement.html:
+```
+$ release-notify $VERSION
+```
+
+This works like the rest of the tool and honors --nomock and prompts
+before any mail is sent.

--- a/anago
+++ b/anago
@@ -906,7 +906,7 @@ push_git_objects () {
 
 ###############################################################################
 # generate the announcement text to be mailed and published
-create_branch_announcement () {
+branch_announcement_text () {
   cat <<EOF
 Kubernetes team,
 <P>
@@ -920,7 +920,7 @@ EOF
 
 ###############################################################################
 # generate the announcement text to be mailed and published
-create_announcement () {
+release_announcement_text () {
   cat <<EOF
 Kubernetes team,
 <P>
@@ -939,55 +939,33 @@ EOF
 }
 
 ###############################################################################
-# Mail out the announcement
-# @param subject - the subject for the email notification
+# Construct META for the announcement and send it out
+# @optparam --branch - Default announcement type is 'release' or --branch.
 PROGSTEP[announce]="ANNOUNCE BRANCH OR RELEASE"
 announce () {
-  local mailto="gke-kubernetes-org@google.com"
-        mailto+=",kubernetes-dev@googlegroups.com"
-        mailto+=",kubernetes-announce@googlegroups.com"
   local arg="$1"
-  local subject
-  local announcement_text=$TMPDIR/$PROG-announce.$$
+  local announcement_file=$WORKDIR/announcement.html
+  local subject_subject=$WORKDIR/announcement-subject.txt
 
-  ((FLAGS_nomock)) || mailto=$GCP_USER
-  mailto=${FLAGS_mailto:-$mailto}
+  logecho "Creating k8s $RELEASE_VERSION_PRIME announcement in $WORKDIR..."
 
   if [[ "$arg" == "--branch" ]]; then
-    subject="k8s $RELEASE_BRANCH branch has been created"
+    echo "k8s $RELEASE_BRANCH branch has been created" > $subject_file
+    branch_announcement_text
   else
-    subject="k8s $RELEASE_VERSION_PRIME is live!"
-  fi
+    echo "k8s $RELEASE_VERSION_PRIME is live!" > $subject_file
+    release_announcement_text
+  fi > $announcement_file
 
-  if [[ -n "$PARENT_BRANCH" ]]; then
-    create_branch_announcement
-  else
-    create_announcement
-  fi > $announcement_text
-
-  ((FLAGS_yes)) \
-   || common::askyorn -e "Pausing here. Confirm announce to $mailto" \
-   || common::exit 1 "Exiting..."
-
+  # Only send from desktop
   if ((FLAGS_gcb)); then
-    logecho "Copying k8s $RELEASE_VERSION_PRIME announcement text" \
-            "to $WORKDIR..."
-    logrun cp $announcement_text $WORKDIR/announcement.html
+    logecho "$WARNING: Email cannot be sent from GCB.  Execute the following" \
+            "after a completed release to send email notification:"
+    logecho
+    logecho "$ release-notifier $RELEASE_VERSION_PRIME"
   else
-    logecho "Announcing k8s $RELEASE_VERSION_PRIME to $mailto..."
-
-    # Always cc invoker
-    # Due to announcements landing on public mailing lists requiring membership,
-    # post from the invoking user (for now until this is productionized further)
-    # and use reply-to to ensure replies go to the right place.
-    common::sendmail -h "$mailto" "K8s-Anago<$GCP_USER>" \
-                     "K8s-Anago<cloud-kubernetes-release@google.com>" \
-                     "$subject" "$GCP_USER" \
-                     "$announcement_text" || return 1
-
+    release::send_announcement || return 1
   fi
-
-  logrun rm -f $announcement_text
 }
 
 ###############################################################################
@@ -1398,100 +1376,6 @@ push_all_artifacts () {
   fi
 }
 
-##############################################################################
-# Sets major global variables
-# RELEASE_GB - space requirements per build
-# GCP_USER - The user that drives the entire release
-# RELEASE_BUCKET - mock or standard release bucket location
-# BUCKET_TYPE - stage or release
-# WRITE_RELEASE_BUCKETS - array of writable buckets
-# READ_RELEASE_BUCKETS - array of readable buckets for multiple sourcing of 
-#                        mock staged builds
-# GCRIO_REPO - GCR repo based on mock or --nomock
-# ALL_CONTAINER_REGISTRIES - when running mock this array also contains
-#                            google_containers so we can check access in mock
-#                            mode before an actual release occurs
-set_globals () {
-  # Define the placeholder/"role" user for GCB
-  local gcb_user="gcb@google.com"
-
-  logecho -n "Setting global variables: "
-
-  # Default disk requirements per version - Modified in found_staged_location()
-  RELEASE_GB="75"
-
-  if ((FLAGS_gcb)); then
-    # a placeholder that satisfies @google.com conditional below
-    GCP_USER="$gcb_user"
-  else
-    # Nothing should work without this.  The entire release workflow depends
-    # on it whether running from the desktop or GCB
-    GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE \
-                                 --format="value(account)" 2>/dev/null)
-    if [[ -z "$GCP_USER" ]]; then
-      logecho $FAILED
-      logecho "Unable to set a valid GCP credential!"
-      return 1
-    fi
-  fi
-
-  RELEASE_BUCKET="kubernetes-release"
-  if [[ $GCP_USER =~ "@google.com" ]]; then
-    WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
-    READ_RELEASE_BUCKETS=("$RELEASE_BUCKET")
-  fi
-
-  if ((FLAGS_stage)); then
-    BUCKET_TYPE="stage"
-  else
-    BUCKET_TYPE="release"
-  fi
-
-  if ((FLAGS_nomock)); then
-    GCRIO_REPO="${FLAGS_gcrio_repo:-google_containers}"
-    ALL_CONTAINER_REGISTRIES=("$GCRIO_REPO")
-  else
-    # GCS buckets cannot contain @ or "google", so for those users, just use
-    # the "$USER" portion of $GCP_USER/$gcb_user
-    RELEASE_BUCKET_USER="$RELEASE_BUCKET-${GCP_USER%%@google.com}"
-    RELEASE_BUCKET_GCB="$RELEASE_BUCKET-${gcb_user%%@google.com}"
-    RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/@/-at-}"
-    RELEASE_BUCKET_GCB="${RELEASE_BUCKET_GCB/@/-at-}"
-    # GCP also doesn't like anything even remotely looking like a domain name
-    # in the bucket name so convert . to -
-    RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/\./-}"
-    RELEASE_BUCKET_GCB="${RELEASE_BUCKET_GCB/\./-}"
-    RELEASE_BUCKET="$RELEASE_BUCKET_USER"
-
-    # All the RELEASE_BUCKETS we could possibly write to
-    WRITE_RELEASE_BUCKETS+=("$RELEASE_BUCKET_USER")
-    # All the RELEASE_BUCKETS we could possibly read from (for staging)
-    READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET_USER")
-    # If a regular user is running mocks, also look in the GCB mock bucket for
-    # releases
-    ((FLAGS_gcb)) || READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET_GCB")
-
-    # Set GCR values
-    GCRIO_REPO="${FLAGS_gcrio_repo:-kubernetes-release-test}"
-    [[ $GCP_USER =~ "@google.com" ]] \
-      && ALL_CONTAINER_REGISTRIES=("$GCRIO_REPO" "google_containers")
-
-    # This is passed to logrun() where appropriate when we want to mock
-    # specific activities like pushes
-    LOGRUN_MOCK="-m"
-  fi
-
-  # TODO:
-  # These KUBE_ globals extend beyond the scope of the new release refactored
-  # tooling so to pass these through as flags will require fixes across
-  # kubernetes/kubernetes and kubernetes/release which we can do at a later time
-  export KUBE_DOCKER_REGISTRY="gcr.io/$GCRIO_REPO"
-  export KUBE_RELEASE_RUN_TESTS=n
-  export KUBE_SKIP_CONFIRMATIONS=y
-
-  logecho $OK
-}
-
 ###############################################################################
 # MAIN
 ###############################################################################
@@ -1598,7 +1482,7 @@ fi
 
 # Set the majorify of global values
 # Moved here b/c now depends on gcloud
-set_globals
+release::set_globals
 
 ((FLAGS_stage)) || common::run_stateful gitlib::github_acls
 

--- a/release-notify
+++ b/release-notify
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Set PROGram name
+PROG=${0##*/}
+########################################################################
+#+
+#+ NAME
+#+     $PROG - Kubernetes Release Notification Tool
+#+
+#+ SYNOPSIS
+#+     $PROG  <version> [--nomock] [--security_layer=/path/to/pointer/to/script]
+#+     $PROG  [--helpshort|--usage|-?]
+#+     $PROG  [--help|-man]
+#+
+#+ DESCRIPTION
+#+     Kubernetes releases produced on GCB are not able to send email
+#+     notifications.  Use this helper tool to quickly send out a standard
+#+     release notification after a release.  You can also see from the logs
+#+     on GCB exactly the command to issue to send a notification following
+#+     a GCB-based release.
+#+
+#+ OPTIONS
+#+     [--nomock]                - Notifications to lists
+#+     [--security_layer=]       - A file containing a path to a script to
+#+                                 source/include:
+#+                                 FLAGS_security_layer=/path/to/script
+#+     [--help | -man]           - display man page for this script
+#+     [--usage | -?]            - display in-line usage
+#+
+#+ EXAMPLES
+#+
+#+ FILES
+#+     gs://kubernetes-release{,-$USER,-gcb}/archive/<version/announcement.html
+#+
+#+ SEE ALSO
+#+     common.sh                 - common function definitions
+#+     gitlib.sh                 - git/jenkins function definitions
+#+     releaselib.sh             - release/push-specific functions
+#+
+#+ BUGS/TODO
+#+
+########################################################################
+# If NO ARGUMENTS should return usage, uncomment the following line:
+usage=${1:-yes}
+
+# Deal with OSX limitations out the gate for anyone that tries this there
+BASE_ROOT=$(dirname $(readlink -e "$BASH_SOURCE" 2>&1)) \
+ || BASE_ROOT="$BASH_SOURCE"
+source $BASE_ROOT/lib/common.sh
+source $TOOL_LIB_PATH/gitlib.sh
+source $TOOL_LIB_PATH/releaselib.sh
+
+# Validate command-line
+common::argc_validate 1 || common::exit 1 "Exiting..."
+
+# Set positional args
+RELEASE_VERSION=${POSITIONAL_ARGV[0]}
+
+###############################################################################
+# MAIN
+###############################################################################
+# Default mode is a mocked release workflow
+: ${FLAGS_nomock:=0}
+
+##############################################################################
+# Initialize logs
+##############################################################################
+# Initialize and save up to 10 (rotated logs)
+if ((FLAGS_stage)); then
+  LOGFILE=$TMPDIR/$PROG-stage.log
+else
+  LOGFILE=$TMPDIR/$PROG.log
+fi
+common::logfileinit $LOGFILE 10
+
+# BEGIN script
+common::timestamp begin
+
+# Additional functionality
+common::security_layer
+security_layer::auth_check 1 || common::exit 1
+
+common::set_cloud_binaries
+release::set_globals
+
+release::send_announcement || common::exit 1
+
+common::timestamp end


### PR DESCRIPTION
With the use of GCB for releases, there is not "role" user that can send out mail from that service.  As a replacement, a "release tracking issue" is created in kubernetes/sig-release.  To further get us to parity with  the full desktop experience, this PR splits off the notification tooling from `anago` into a standalone helper that the release manager can run easily after releasing using GCB.  

Running this tool is optional, but most probably desired at least as a way to phase out the standard notification mechanism and move the community toward the release tracking issue as the primary method of notification.