### PR TITLE
Use HIGHMEM machine type for gcb

### DIFF
--- a/gcb/release.yaml
+++ b/gcb/release.yaml
@@ -35,4 +35,4 @@ tags:
 - RELEASE
 
 options:
-  machineType: N1_HIGHCPU_32
+  machineType: N1_HIGHMEM_32

--- a/gcb/stage.yaml
+++ b/gcb/stage.yaml
@@ -71,4 +71,4 @@ tags:
 - STAGE
 
 options:
-  machineType: N1_HIGHCPU_32
+  machineType: N1_HIGHMEM_32


### PR DESCRIPTION
Switch to high memory [machine type][]

...briefly saw that cross builds were running serially due to memory
pressure. Fix it with the power of the cloud :-)

[machine type]: https://cloud.google.com/compute/docs/machine-types