### PR TITLE
Prevent release script from creating GCS buckets or modifying defacls.

### DIFF
--- a/anago
+++ b/anago
@@ -361,7 +361,7 @@ check_prerequisites () {
 
   # Verify write access to $WRITE_RELEASE_BUCKETS
   for rb in ${WRITE_RELEASE_BUCKETS[*]}; do
-    release::gcs::ensure_release_bucket $rb || return 1
+    release::gcs::check_release_bucket $rb || return 1
   done
 }
 

--- a/push-build.sh
+++ b/push-build.sh
@@ -178,8 +178,8 @@ GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE \
                              --format="value(account)" 2>/dev/null)
 [[ -n "$GCP_USER" ]] || common::exit 1 "Unable to set a valid GCP credential!"
 
-logecho -n "Check/make release bucket $RELEASE_BUCKET: "
-logrun -s release::gcs::ensure_release_bucket $RELEASE_BUCKET || common::exit 1
+logecho -n "Check release bucket $RELEASE_BUCKET: "
+logrun -s release::gcs::check_release_bucket $RELEASE_BUCKET || common::exit 1
 
 # These operations can hit bumps and are re-entrant so retry up to 3 times
 max_attempts=3


### PR DESCRIPTION
The release script should not create GCS buckets or modify their defacls if they are not what the script expects. This is dangerous because private buckets can be quietly made publicly readable or a new bucket could be incorrectly created.

/cc @ixdy @BenTheElder 