### PR TITLE
Remove unnecessary bazel build options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,0 @@
-# TODO: Remove this default once rules_go is bumped.
-# Ref kubernetes/kubernetes#52677
-build --incompatible_comprehension_variables_do_not_leak=false
-# TODO: remove the following once repo-infra is bumped.
-build --incompatible_disallow_set_constructor=false

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,6 @@ kubernetes.tar.gz
 !\.drone\.sec
 
 /bazel-*
-BUILD.bazel
 
 # Golang dependencies
 /vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ kubernetes.tar.gz
 !\.drone\.sec
 
 /bazel-*
+BUILD.bazel
 
 # Golang dependencies
 /vendor/

--- a/debian/BUILD.bazel
+++ b/debian/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["build.go"],
+    importpath = "k8s.io/release/debian",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/blang/semver:go_default_library"],
+)
+
+go_binary(
+    name = "debian",
+    importpath = "k8s.io/release/debian",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["build_test.go"],
+    importpath = "k8s.io/release/debian",
+    library = ":go_default_library",
+)

--- a/debian/vendor/github.com/blang/semver/BUILD.bazel
+++ b/debian/vendor/github.com/blang/semver/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "json.go",
+        "range.go",
+        "semver.go",
+        "sort.go",
+        "sql.go",
+    ],
+    importpath = "github.com/blang/semver",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "json_test.go",
+        "range_test.go",
+        "semver_test.go",
+        "sort_test.go",
+        "sql_test.go",
+    ],
+    importpath = "github.com/blang/semver",
+    library = ":go_default_library",
+)


### PR DESCRIPTION
As I was building some of the tools in this repo, I noticed that the build options in the repo's `.bazelrc` no longer seem to be necessary.