### PR TITLE
anago: push to gcr.io/google-containers

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1128,8 +1128,7 @@ release::set_globals () {
 
   # The "production" GCR path is now multi-region alias
   GCRIO_PATH_PROD="k8s.gcr.io"
-  # The "production" push path to that multi-region alias has a staging- prefix
-  GCRIO_PATH_PROD_PUSH="staging-$GCRIO_PATH_PROD"
+  GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
   # The "test" GCR path
   GCRIO_PATH_TEST="gcr.io/kubernetes-release-test"
 


### PR DESCRIPTION
staging-k8s.gcr.io now points to gcr.io/k8s-image-staging (a true
staging GCR separated from gcr.io/google-containers --- the way it
should be). But since we want GCRIO_PATH_PROD_PUSH to actually point to
a production GCR, we can't use staging-k8s.gcr.io; instead we point to
the actual underlying production GCR, gcr.io/google-containers.