### PR TITLE
Switch on experimental support in docker CLI

### DIFF
--- a/build/Dockerfile.k8s-cloud-builder
+++ b/build/Dockerfile.k8s-cloud-builder
@@ -47,5 +47,10 @@ RUN \
       stable edge" && \
    apt-get -y update
 
+RUN mkdir /root/.docker
+RUN echo '{' \
+         '    "experimental": "enabled"' \
+         ''} > /root/.docker/config.json
+
 ARG DOCKER_VERSION=18.06.0~ce~3-0~ubuntu
 RUN apt-get install -y docker-ce=${DOCKER_VERSION} unzip


### PR DESCRIPTION
In a70044af72b4a8fb28efd2982931f445060575c0, we wanted to use the experimental support for manifest in the docker CLI, but forgot to turn the flag on.