### PR TITLE
Revert image manifest changes

### DIFF
--- a/anago
+++ b/anago
@@ -348,27 +348,6 @@ check_prerequisites () {
 
   security_layer::auth_check 2 || return 1
 
-  logecho -n "Checking Docker version: "
-  docker_version=$(docker version --format '{{.Client.Version}}' | cut -d"-" -f1)
-  if [[ ${docker_version} != 18.06.0 && ${docker_version} < 18.06.0 ]]; then
-    logecho "Minimum docker version 18.06.0 is required for " \
-            "creating and pushing manifest images[found: ${docker_version}]"
-    return 1
-  fi
-  logecho -r "$OK"
-
-  # TODO: Remove this section once docker manifest command promoted
-  # from Experimental
-  logecho -n "Checking Docker CLI Experimental status: "
-  cli_experimental=$(docker version --format '{{.Client.Experimental}}' | cut -d"-" -f1)
-  if [[ "${cli_experimental}" == "false" ]]; then
-    logecho "Docker Client Experimental flag is false, should be enabled to " \
-            "push the manifest images"
-    logecho "More info: https://docs.docker.com/edge/engine/reference/commandline/manifest_create/"
-    return 1
-  fi
-  logecho -r "$OK"
-
   if ! ((FLAGS_gcb)); then
     ensure_gcp_users || return 1
   fi

--- a/build/Dockerfile.k8s-cloud-builder
+++ b/build/Dockerfile.k8s-cloud-builder
@@ -47,10 +47,5 @@ RUN \
       stable edge" && \
    apt-get -y update
 
-RUN mkdir /root/.docker
-RUN echo '{' \
-         '    "experimental": "enabled"' \
-         ''} > /root/.docker/config.json
-
 ARG DOCKER_VERSION=18.06.0~ce~3-0~ubuntu
 RUN apt-get install -y docker-ce=${DOCKER_VERSION} unzip

--- a/build/Dockerfile.k8s-cloud-builder
+++ b/build/Dockerfile.k8s-cloud-builder
@@ -1,7 +1,7 @@
 # To rebuild and publish this container run:
 #   gcloud builds submit --config update_build_container.yaml .
 
-FROM ubuntu:16.04
+FROM ubuntu
 
 # Install packages
 RUN apt-get -q update && apt-get install -qqy apt-transport-https \
@@ -47,5 +47,7 @@ RUN \
       stable edge" && \
    apt-get -y update
 
-ARG DOCKER_VERSION=18.06.0~ce~3-0~ubuntu
+# As of 2018-04-10, leaving this pinned to 17.09 due to image pull issues
+# with 17.12
+ARG DOCKER_VERSION=17.09.0~ce-0~ubuntu
 RUN apt-get install -y docker-ce=${DOCKER_VERSION} unzip

--- a/build/Dockerfile.k8s-cloud-builder
+++ b/build/Dockerfile.k8s-cloud-builder
@@ -50,7 +50,7 @@ RUN \
 RUN mkdir /root/.docker
 RUN echo '{' \
          '    "experimental": "enabled"' \
-         '}' > /root/.docker/config.json
+         ''} > /root/.docker/config.json
 
 ARG DOCKER_VERSION=18.06.0~ce~3-0~ubuntu
 RUN apt-get install -y docker-ce=${DOCKER_VERSION} unzip


### PR DESCRIPTION
Reverting changes made to the release tooling to support [image manifests][] as we were unable to get the 
changes working in time for the 1.12.0. We'll try again for 1.12.2 at the earliest.

[image manifests]: https://docs.docker.com/edge/engine/reference/commandline/manifest/