### PR TITLE
Pin cloud-builder base to ubuntu:16.04

### DIFF
--- a/build/Dockerfile.k8s-cloud-builder
+++ b/build/Dockerfile.k8s-cloud-builder
@@ -1,7 +1,7 @@
 # To rebuild and publish this container run:
 #   gcloud builds submit --config update_build_container.yaml .
 
-FROM ubuntu
+FROM ubuntu:16.04
 
 # Install packages
 RUN apt-get -q update && apt-get install -qqy apt-transport-https \


### PR DESCRIPTION
The 'ubuntu' image is now 18.04, missing easy_install by default.