### PR TITLE
Add DOCKER_CLI_EXPERIMENTAL flag to enable docker manifest command

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -940,6 +940,9 @@ release::docker::release () {
     done
   done
 
+  # Ensure that the docker command line supports the manifest images
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
   for image in "${!manifest_images[@]}"; do
     local archs=$(echo "${manifest_images[$image]}" | sed -e 's/^[[:space:]]*//')
     local manifest=$(echo $archs | sed -e "s~[^ ]*~$image\-&:$version~g")


### PR DESCRIPTION
`ci-kubernetes-cross-build` job is calling below script which is executing `docker manifest` and creating a trouble because we are setting the experimental flag only anago script, so this PR will fix whoever calls the `release::docker::release` function directly.

Run: ('../release/push-build.sh', '--nomock', '--verbose', '--ci', '--gcs-suffix=-cross', '--release-kind=kubernetes', '--docker-registry=gcr.io/kubernetes-ci-images')