### PR TITLE
Better hash algorithms for k8s binaries

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -665,6 +665,7 @@ release::gcs::locally_stage_release_artifacts() {
   find $gcs_stage -type f | while read path; do
     common::md5 $path > "$path.md5" || return 1
     common::sha $path 1 > "$path.sha1" || return 1
+    common::sha $path 512 > "$path.sha512" || return 1
   done
 }
 


### PR DESCRIPTION
Let's please add sha512 as well. adding both 256 and 512 may take a lot
more time. Also checking the ASF, they are shipping sha1 and sha512, so
we are in good company.

https://dist.apache.org/repos/dist/release/ant/binaries/

Fixes https://github.com/kubernetes/kubernetes/issues/68555

Change-Id: I23977b5b71558d7b6bee51238ba5898a5a8f29f5