### PR TITLE
fix 10-kubeadm.conf file premission

### DIFF
--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -146,7 +146,7 @@ install -p -m 755 -t %{buildroot}%{_bindir}/ kubelet
 install -p -m 755 -t %{buildroot}%{_bindir}/ kubectl
 install -p -m 755 -t %{buildroot}%{_bindir}/ kubeadm
 install -p -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system/ kubelet.service
-install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/kubelet.service.d/ 10-kubeadm.conf
+install -p -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system/kubelet.service.d/ 10-kubeadm.conf
 install -p -m 755 -t %{buildroot}%{_bindir}/ cri-tools/crictl
 
 %if %{KUBE_SEMVER} >= %{semver 1 11 0}


### PR DESCRIPTION
Fix below issue:
systemd[1]: Configuration file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf is marked executable. Please remove executable permission bits. Proceeding anyway.