### PR TITLE
Add flag for release download link base

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -72,6 +72,7 @@ var (
 	allDistros    = stringList{"xenial", "jessie", "precise", "sid", "stretch", "trusty", "utopic", "vivid", "wheezy", "wily", "yakkety"}
 	kubeVersion   = ""
 	revision      = "00"
+	releaseDownloadLinkBase = "https://dl.k8s.io"
 
 	builtins = map[string]interface{}{
 		"date": func() string {
@@ -88,6 +89,7 @@ func init() {
 	flag.Var(&allDistros, "distros", "Distros to build for.")
 	flag.StringVar(&kubeVersion, "kube-version", "", "Distros to build for.")
 	flag.StringVar(&revision, "revision", "00", "Deb package revision.")
+	flag.StringVar(&releaseDownloadLinkBase, "release-download-link-base", "https://dl.k8s.io", "Release download link base.")
 }
 
 func runCommand(pwd string, command string, cmdArgs ...string) error {
@@ -279,7 +281,7 @@ func getCIBuildsDownloadLinkBase(_ version) (string, error) {
 }
 
 func getReleaseDownloadLinkBase(v version) (string, error) {
-	return fmt.Sprintf("https://dl.k8s.io/v%s", v.Version), nil
+	return fmt.Sprintf("%s/v%s", releaseDownloadLinkBase, v.Version), nil
 }
 
 func getKubeadmDependencies(v version) (string, error) {


### PR DESCRIPTION
Add `--release-download-link-base` flag for `debian/build.go`, which
allows to specify custom release binaries download link base instead of
hardcoded `https://dl.k8s.io`.

E.g., to build Debian packages containing custom Kubernetes binaries:
```
docker run \
        --volume="$(pwd)/debian:/src" \
        --volume="$(pwd)/../kubernetes/_output/dockerized:/binaries/v1.12.2" \
        debian-packager \
        --arch amd64 \
        --distros xenial \
        --kube-version 1.12.2 \
        --revision internal1 \
        --release-download-link-base file:///binaries
```