### PR TITLE
Better MacOS support

### DIFF
--- a/anago
+++ b/anago
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/anago
+++ b/anago
@@ -177,10 +177,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return usage, uncomment the following line:
 usage=${1:-yes}
 
-# Deal with OSX limitations out the gate for anyone that tries this there
-BASE_ROOT=$(dirname $(readlink -e "$BASH_SOURCE" 2>&1)) \
- || BASE_ROOT="$BASH_SOURCE"
-source $BASE_ROOT/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/branchff
+++ b/branchff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/branchff
+++ b/branchff
@@ -54,7 +54,7 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 usage=${1:-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Set positional args

--- a/branchff
+++ b/branchff
@@ -57,6 +57,12 @@ usage=${1:-yes}
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
 source $TOOL_LIB_PATH/gitlib.sh
 
+# fail early if important prereqs are not fullfilled
+common::cmd::ensure::envsubst
+common::cmd::ensure::generic git
+common::cmd::ensure::generic curl
+common::cmd::ensure::generic make
+
 # Set positional args
 RELEASE_BRANCH=${POSITIONAL_ARGV[0]}
 MASTER_OBJECT=${POSITIONAL_ARGV[1]:-"origin/master"}

--- a/branchff
+++ b/branchff
@@ -88,7 +88,7 @@ gitlib::repo_state || common::exit 1
 ###############################################################################
 # MAIN
 ###############################################################################
-BASEDIR="/usr/local/google/$USER"
+BASEDIR="${BASEDIR:-/usr/local/google/$USER}"
 # WORK/BUILD area
 WORKDIR=$BASEDIR/$PROG-$RELEASE_BRANCH
 # Go tools expect the kubernetes src to be under $GOPATH
@@ -118,7 +118,12 @@ if [[ -d $WORKDIR ]]; then
   logrun rm -rf $WORKDIR || common::exit 1 "Exiting..."
 fi
 
-logrun mkdir -p $WORKDIR
+logrun mkdir -p $WORKDIR || {
+  logecho
+  logecho "$FATAL! cannot create the workdir '$WORKDIR'"
+  logecho 'The workdir can be changed by setting $BASEDIR'
+  common::exit 1
+}
 gitlib::sync_repo $K8S_GITHUB_AUTH_URL $TREE_ROOT || common::exit 1 "Exiting..."
 logrun cd $TREE_ROOT
 

--- a/changelog-update
+++ b/changelog-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/changelog-update
+++ b/changelog-update
@@ -50,7 +50,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 usage=${1:-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Set positional args

--- a/find_green_build
+++ b/find_green_build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/find_green_build
+++ b/find_green_build
@@ -69,7 +69,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 #usage=${1:-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/gcbmgr
+++ b/gcbmgr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Kubernetes Authors All rights reserved.
 #

--- a/gcbmgr
+++ b/gcbmgr
@@ -142,10 +142,8 @@ PROG=${0##*/}
 #+ BUGS/TODO
 #+
 ########################################################################
-# Deal with OSX limitations out the gate for anyone that tries this there
-BASE_ROOT=$(dirname $(readlink -e "$BASH_SOURCE" 2>&1)) \
- || BASE_ROOT="$BASH_SOURCE"
-source $BASE_ROOT/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1150,6 +1150,62 @@ common::stepindex () {
   done
 }
 
+###############################################################################
+# Make sure envsubst is installed, otherwise print how a user might install it
+# and bail out
+common::cmd::ensure::envsubst () {
+  common::cmd::ensure::bail 'envsubst' "$(common::join $'\n' \
+    'Installation' \
+    '  Debian/Ubuntu/...'  \
+    '    $ apt install gettext-base'  \
+    '  MacOS'  \
+    '    $ brew install gettext'  \
+    '    $ ln -s /usr/local/Cellar/gettext/*/bin/envsubst /usr/local/bin/'  \
+  )"
+}
+
+###############################################################################
+# Make sure some command is installed, otherwise print how a user might
+# install it and bail out
+# This is for commands which just can be installed via the package manager and
+# don't need any specific actions at install time
+# @param cmd    name of the command to check for
+# @param debPkg name of the debian package that holds this command
+#               defaults to $cmd
+# @param macPkg name of the brew package that holds this command
+#               defaults to $cmd
+common::cmd::ensure::generic () {
+  local cmd="$1"
+  local debPkg="${2:-$cmd}"
+  local macPkg="${3:-$cmd}"
+  common::cmd::ensure::bail "$cmd" "$(common::join $'\n' \
+    'Installation' \
+    '  Debian/Ubuntu/...'  \
+    '    $ apt install '"$debPkg"  \
+    '  MacOS'  \
+    '    $ brew install '"$macPkg"  \
+  )"
+}
+
+##############################################################################
+# Check if a command is available on the system and bail with a message
+# @param cmd name of the command to check for
+# @param msg the message to print before bailing out
+common::cmd::ensure::bail () {
+  local cmd="$1"
+  local msg="$2"
+
+  if ! command -v "$cmd" >/dev/null 2>&1
+  then
+    {
+      echo "${cmd} not found"
+      echo
+      echo "$msg"
+    } >&2
+    common::exit 1
+  fi
+}
+
 ##############################################################################
 # Validate command-line for re-entrancy
 # Capture the original command-line and warn if subsequent runs differ

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -24,17 +24,24 @@ export PROG
 
 set -o errtrace
 
-# OSX not supported.  Tell them right away
-if [[ $(uname) == "Darwin" ]]; then
-  echo "OSX is not a supported OS for running these tools. Exiting..."
-  exit 1
-fi
+# if OSX id not supported tell them right away
+common::bail_on_mac () {
+  if [[ $(uname) == "Darwin" ]]; then
+    echo "OSX is not a supported OS for running these tools. Exiting..."
+    exit 1
+  fi
+}
+
+readlinkf() {
+  perl -MCwd -e 'print Cwd::abs_path shift' "$1"
+}
+
 
 ##############################################################################
 # COMMON CONSTANTS
 #
-TOOL_LIB_PATH=${TOOL_LIB_PATH:-$(dirname $(readlink -ne $BASH_SOURCE))}
-TOOL_ROOT=${TOOL_ROOT:-$(readlink -ne $TOOL_LIB_PATH/..)}
+TOOL_LIB_PATH=${TOOL_LIB_PATH:-$(dirname $(readlinkf $BASH_SOURCE))}
+TOOL_ROOT=${TOOL_ROOT:-$(readlinkf $TOOL_LIB_PATH/..)}
 PATH=$TOOL_ROOT:$PATH
 # Provide a default EDITOR for those that don't have this set
 : ${EDITOR:="vi"}

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -2,7 +2,7 @@
 #
 # gitlib.sh unit tests
 #
-source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/common.sh"
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # gitlib.sh unit tests
 #

--- a/lib/releaselib_test.sh
+++ b/lib/releaselib_test.sh
@@ -2,7 +2,7 @@
 #
 # releaselib.sh unit tests
 #
-source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/common.sh"
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/lib/releaselib_test.sh
+++ b/lib/releaselib_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # releaselib.sh unit tests
 #

--- a/prin
+++ b/prin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/prin
+++ b/prin
@@ -53,7 +53,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 usage=${1:-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 
 ###############################################################################

--- a/push-build.sh
+++ b/push-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/push-build.sh
+++ b/push-build.sh
@@ -89,7 +89,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 #usage=${1:-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/release-notify
+++ b/release-notify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Kubernetes Authors All rights reserved.
 #

--- a/release-notify
+++ b/release-notify
@@ -59,10 +59,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return usage, uncomment the following line:
 usage=${1:-yes}
 
-# Deal with OSX limitations out the gate for anyone that tries this there
-BASE_ROOT=$(dirname $(readlink -e "$BASH_SOURCE" 2>&1)) \
- || BASE_ROOT="$BASH_SOURCE"
-source $BASE_ROOT/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 

--- a/relnotes
+++ b/relnotes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/relnotes
+++ b/relnotes
@@ -94,7 +94,8 @@ PROG=${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 #usage=${1-yes}
 
-source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+common::bail_on_mac
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Validate command-line

--- a/script-template
+++ b/script-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
@@ -47,7 +47,7 @@ PROG=${0##*/}
 source $(dirname $(readlink -ne $0))/lib/common.sh
 
 cat <<EOF_CAT
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/script-template
+++ b/script-template
@@ -44,7 +44,7 @@ PROG=${0##*/}
 #+
 #-
 ########################################################################
-source $(dirname $(readlink -ne $0))/lib/common.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
 
 cat <<EOF_CAT
 #!/usr/bin/env bash
@@ -103,7 +103,10 @@ PROG=\${0##*/}
 # If NO ARGUMENTS should return *usage*, uncomment the following line:
 #usage=\${1:-yes}
 
-source \$(dirname \$(readlink -ne \$BASH_SOURCE))/lib/common.sh
+source "\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )/lib/common.sh"
+
+# If this script is not supported on mac, bail out early
+common::bail_on_mac
 
 # Process Command-line arguments
 # POSITIONAL_ARGV is provided by common::namevalue after arg preprocessing


### PR DESCRIPTION
This makes `branchff` work on Darwin, given users have a new enough bash.

Most notable changes:
- The check if the system is Darwin has been moved out of `lib/common.sh`, so that scripts can opt in to support Darwin. On the flip side, for now script explicitly need to state that they do not support Darwin
- hashbang has changes to not call the `bash` directly in `bin`
- remove/replace some usages of GNU `readlink`