### PR TITLE
Mark the users config file as a config file

### DIFF
--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -169,7 +169,7 @@ mv cni-plugins/bin/ %{buildroot}/opt/cni/
 %{_sysconfdir}/kubernetes/manifests/
 
 %if %{KUBE_SEMVER} >= %{semver 1 11 0}
-%{_sysconfdir}/sysconfig/kubelet
+%config(noreplace) %{_sysconfdir}/sysconfig/kubelet
 %endif
 
 %files -n kubernetes-cni


### PR DESCRIPTION
The kubelet package contains a file allowing users to override settings
as needed. It lacked a flag telling rpm not to overwrite it though,
forcing the user to put it back after every upgrade. After this change
upgrades do not automatically overwrite the users settings.
