### PR TITLE
Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
 # maintainers
 - ixdy
@@ -24,3 +26,7 @@ approvers:
 - jberkus
 # 1.12 release lead
 - tpepper
+
+labels:
+- sig/release
+- area/release-eng

--- a/OWNERS
+++ b/OWNERS
@@ -8,24 +8,25 @@ approvers:
 # sig-release leads
 - jdumars
 - calebamiles
-# 1.8 patch release manager
-- jpbetz
-# 1.9 patch release manager
-- mbohlool
 # 1.10 patch release manager
 - maciekpytel
 # 1.11 patch release manager
 - foxish
-# 1.8 release lead (for completeness, but dupe of sig-release leads)
-#- jdumars
-# 1.9 release lead
-- enisoc
+# 1.12 patch release manager
+- feiskyer
+# 1.13 patch release team
+- aleksandra-malinowska
+- tpepper
 # 1.10 release lead (for completeness, but dupe of sig-release leads)
 #- jdumars
 # 1.11 release lead
 - jberkus
 # 1.12 release lead
 - tpepper
+# 1.13 release lead
+- AishSundar
+# 1.14 release lead
+- spiffxp
 
 labels:
 - sig/release


### PR DESCRIPTION
This _was_ just me verifying that https://github.com/kubernetes/test-infra/pull/10835 worked by adding a labels: stanza

But as I looked at the list of approvers, I took a crack at updating the OWNERS list based on what was in there

Longer term I feel like it should be reconciled with https://github.com/kubernetes/sig-release/blob/master/release-engineering/OWNERS