### PR TITLE
Add tool for generating contextualized release notes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
+# gazelle:prefix k8s.io/release
 gazelle(
-	name = "gazelle",
-	prefix = "k8s.io/release",
-	external = "vendored",
+    name = "gazelle",
+    external = "vendored",
 )
 
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(name = "buildifier")

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,3 @@ gazelle(
     name = "gazelle",
     external = "vendored",
 )
-
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
-
-buildifier(name = "buildifier")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,30 @@ provides detailed instructions on how to get your ideas and bug fixes seen and a
 
 Please remember to sign the [CNCF CLA](https://github.com/kubernetes/community/blob/master/CLA.md) and
 read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+## Autogenerating Bazel Configs
+
+For Go code, this repository is currently set up with [Gazelle](https://github.com/bazelbuild/bazel-gazelle), which is a tool that can be used to generate Bazel `BUILD` files.
+
+If you add Go code which includes new dependencies, you have to update the [Dep](https://github.com/golang/dep) configs and then use Gazelle to generate the appropriate Bazel configs:
+
+```bash
+# install dep
+go get -u github.com/golang/dep/cmd/dep
+
+# update Gopkg.lock
+dep ensure
+
+# generate the go_repository stanzas in WORKSPACE
+bazel run //:gazelle -- update-repos -from_file=Gopkg.lock
+
+# generate all of the BUILD files
+bazel run //:gazelle
+```
+
+If you add new Go files but do not add any dependencies, the following should be sufficient:
+
+```bash
+# generate all of the BUILD files
+bazel run //:gazelle
+```

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,50 +2,161 @@
 
 
 [[projects]]
+  digest = "1:79421244ba5848aae4b0a5c41e633a04e4894cb0b164a219dc8c15ec7facb7f1"
   name = "github.com/blang/semver"
   packages = ["."]
+  pruneopts = ""
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:48e65aaf8ce34ffb3e8d56daa9417826db162afbc2040705db331e9a2e9eebe3"
+  name = "github.com/go-kit/kit"
+  packages = [
+    "log",
+    "log/level",
+  ]
+  pruneopts = ""
+  revision = "12210fb6ace19e0496167bb3e667dcd91fa9f69b"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:df89444601379b2e1ee82bf8e6b72af9901cbeed4b469fa380a519c89c339310"
+  name = "github.com/go-logfmt/logfmt"
+  packages = ["."]
+  pruneopts = ""
+  revision = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc"
+  version = "v0.4.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:27854310d59099f8dcc61dd8af4a69f0a3597f001154b2fb4d1c41baf2e31ec1"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
   branch = "master"
+  digest = "1:137098e1da0e7ddadf930b2a7418cc408d13471c5c9f4a5ef00ca886d7dc9fda"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "7de811820d2b3b6ef66f466bdae21e494a52b633"
+  pruneopts = ""
+  revision = "2406bfd7f32dea4608923b39352fce69e647e1e1"
 
 [[projects]]
   branch = "master"
+  digest = "1:9abc49f39e3e23e262594bb4fb70abf74c0c99e94f99153f43b143805e850719"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = ""
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
+  digest = "1:1defde183560d2c395f6d10fe8032dd4642a78765b1c65bede2bd0545cfa3d8d"
+  name = "github.com/kolide/kit"
+  packages = [
+    "env",
+    "logutil",
+  ]
+  pruneopts = ""
+  revision = "c155a91098e3c16721433130c82c3525abe4a450"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
+  name = "github.com/kr/logfmt"
+  packages = ["."]
+  pruneopts = ""
+  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+
+[[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:898bc7c802c1e0c20cecd65811e90b7b9bc5651b4a07aefd159451bfb200b2b3"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+  ]
+  pruneopts = ""
   revision = "a04bdaca5b32abe1c069418fb7088ae607de5bd0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3607c401db83333983b982a42f9871b6836d67fcf42e26385abd2f9781e48e1b"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = ""
   revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
+  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c08299dd9abf1a3db1d7f80e48f1b0bc4dd46a8ff832ec85faf881930f144728"
+  input-imports = [
+    "github.com/blang/semver",
+    "github.com/go-kit/kit/log",
+    "github.com/go-kit/kit/log/level",
+    "github.com/google/go-github/github",
+    "github.com/kolide/kit/env",
+    "github.com/kolide/kit/logutil",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/require",
+    "golang.org/x/oauth2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,10 +64,7 @@
   branch = "master"
   digest = "1:1defde183560d2c395f6d10fe8032dd4642a78765b1c65bede2bd0545cfa3d8d"
   name = "github.com/kolide/kit"
-  packages = [
-    "env",
-    "logutil",
-  ]
+  packages = ["env"]
   pruneopts = ""
   revision = "c155a91098e3c16721433130c82c3525abe4a450"
 
@@ -153,7 +150,6 @@
     "github.com/go-kit/kit/log/level",
     "github.com/google/go-github/github",
     "github.com/kolide/kit/env",
-    "github.com/kolide/kit/logutil",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/require",
     "golang.org/x/oauth2",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ can be staged and later released using this method.
 
 ### anago
 
-The main driver for creating staged builds and releases.  This is what runs 
+The main driver for creating staged builds and releases.  This is what runs
 inside GCB after a job is submitted using `gcbmgr`.
 
 ### branchff
@@ -107,7 +107,7 @@ a fully deployed and announced release, add `--nomock` to the command line.
 * [anago](https://github.com/kubernetes/release/blob/master/anago) : Release Tool
 * [branchff](https://github.com/kubernetes/release/blob/master/branchff) : Fast-forward branching helper
 * [find_green_build](https://github.com/kubernetes/release/blob/master/find_green_build) : Ask Jenkins for a good build to use
-* [relnotes](https://github.com/kubernetes/release/blob/master/relnotes) : Scrape github for release notes \(See below for more info\)
+* [release-notes](https://github.com/kubernetes/release/blob/master/cmd/release-notes) : Scrape github for release notes \(See below for more info\)
 * [prin](https://github.com/kubernetes/release/blob/master/prin) : What tags/releases is my PR IN?
 * [changelog-update](https://github.com/kubernetes/release/blob/master/changelog-update) : Update CHANGELOG.md version entries by rescanning github for text and label changes
 * [push-build.sh](https://github.com/kubernetes/release/blob/master/push-build.sh) : Push a developer (or CI) build up to GCS
@@ -115,19 +115,23 @@ a fully deployed and announced release, add `--nomock` to the command line.
 
 ## Release Notes Gathering
 
+For more extensive build and usage documentation for the `release-notes` tool, see the [documentation](./cmd/release-notes/README.md).
+
+Once the tool is installed, use `-h` or `--help` to see the command usage:
+
 ```
-# get details on how to use the tool
-$ relnotes -man
-$ cd /kubernetes
-
-# Show release notes from the last release on a branch to HEAD
-$ relnotes
-
-# Show release notes from the last release on a specific branch to branch HEAD
-$ relnotes --branch=release-1.10
-
-# Show release notes between two specific releases
-$ relnotes v1.10.0..v1.10.1 --branch=release-1.10
+$ release-notes -h
+Usage of release-notes:
+  -end-sha string
+        The commit hash to end at
+  -format string
+        The format for notes output (options: markdown, json) (default "markdown")
+  -github-token string
+        A personal GitHub access token (required)
+  -output string
+        The path to the where the release notes will be printed
+  -start-sha string
+        The commit hash to start at
 ```
 
 ## Building Linux Packages

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,55 @@
 workspace(name = "io_kubernetes_build")
+
+# The native http_archive rule is deprecated. This is a drop-in replacement.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+################################################################################
+# Buildifier: Bazel BUILD file formatting
+################################################################################
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-0.20.0",
+    url = "https://github.com/bazelbuild/buildtools/archive/0.20.0.zip",
+)
+
+load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
+
+buildifier_dependencies()
+
+################################################################################
+# Go Build Definitions
+################################################################################
+
+# Download, load, and initialize the Go build rules.
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.6.0/rules_go-0.6.0.tar.gz",
-    sha256 = "ba6feabc94a5d205013e70792accb6cce989169476668fbaf98ea9b342e13b59",
+    strip_prefix = "rules_go-0.16.6",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.6.zip"],
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
+# Download, load, and initialize the Gazelle tool for generating BUILD files for
+# Go code.
+http_archive(
+    name = "bazel_gazelle",
+    strip_prefix = "bazel-gazelle-0.16.0",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/0.16.0.zip"],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+gazelle_dependencies()
+
+################################################################################
+# Proto Toolchains
+################################################################################
+
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+
 proto_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,20 +4,6 @@ workspace(name = "io_kubernetes_build")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ################################################################################
-# Buildifier: Bazel BUILD file formatting
-################################################################################
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-0.20.0",
-    url = "https://github.com/bazelbuild/buildtools/archive/0.20.0.zip",
-)
-
-load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
-
-buildifier_dependencies()
-
-################################################################################
 # Go Build Definitions
 ################################################################################
 
@@ -26,6 +12,7 @@ http_archive(
     name = "io_bazel_rules_go",
     strip_prefix = "rules_go-0.16.6",
     urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.6.zip"],
+    sha256 = "c0f7e581b17d0b8252e1d0175cb3f6398a579bb91d2e5995f29f6c5985ccd647",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
@@ -40,6 +27,7 @@ http_archive(
     name = "bazel_gazelle",
     strip_prefix = "bazel-gazelle-0.16.0",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/0.16.0.zip"],
+    sha256 = "a5b329e3d929247279005ba3cfda0c092a220085c0ed0505de1dcdd68dfc53bc",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -47,9 +35,98 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 gazelle_dependencies()
 
 ################################################################################
-# Proto Toolchains
+# Go Dependencies
+#
+# Update this with:
+#   bazel run //:gazelle -- update-repos -from_file=Gopkg.lock
 ################################################################################
 
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+go_repository(
+    name = "com_github_blang_semver",
+    commit = "2ee87856327ba09384cabd113bc6b5d174e9ec0f",
+    importpath = "github.com/blang/semver",
+)
 
-proto_register_toolchains()
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    commit = "8991bc29aa16c548c550c7ff78260e27b9ab7c73",
+    importpath = "github.com/davecgh/go-spew",
+)
+
+go_repository(
+    name = "com_github_go_kit_kit",
+    commit = "12210fb6ace19e0496167bb3e667dcd91fa9f69b",
+    importpath = "github.com/go-kit/kit",
+)
+
+go_repository(
+    name = "com_github_go_logfmt_logfmt",
+    commit = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc",
+    importpath = "github.com/go-logfmt/logfmt",
+)
+
+go_repository(
+    name = "com_github_golang_protobuf",
+    commit = "130e6b02ab059e7b717a096f397c5b60111cae74",
+    importpath = "github.com/golang/protobuf",
+)
+
+go_repository(
+    name = "com_github_google_go_github",
+    commit = "2406bfd7f32dea4608923b39352fce69e647e1e1",
+    importpath = "github.com/google/go-github",
+)
+
+go_repository(
+    name = "com_github_google_go_querystring",
+    commit = "53e6ce116135b80d037921a7fdd5138cf32d7a8a",
+    importpath = "github.com/google/go-querystring",
+)
+
+go_repository(
+    name = "com_github_kolide_kit",
+    commit = "c155a91098e3c16721433130c82c3525abe4a450",
+    importpath = "github.com/kolide/kit",
+)
+
+go_repository(
+    name = "com_github_kr_logfmt",
+    commit = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0",
+    importpath = "github.com/kr/logfmt",
+)
+
+go_repository(
+    name = "com_github_pkg_errors",
+    commit = "ba968bfe8b2f7e042a574c888954fccecfa385b4",
+    importpath = "github.com/pkg/errors",
+)
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    commit = "792786c7400a136282c1664665ae0a8db921c6c2",
+    importpath = "github.com/pmezard/go-difflib",
+)
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    commit = "ffdc059bfe9ce6a4e144ba849dbedead332c6053",
+    importpath = "github.com/stretchr/testify",
+)
+
+go_repository(
+    name = "org_golang_google_appengine",
+    commit = "150dc57a1b433e64154302bdc40b6bb8aefa313a",
+    importpath = "google.golang.org/appengine",
+)
+
+go_repository(
+    name = "org_golang_x_net",
+    commit = "a04bdaca5b32abe1c069418fb7088ae607de5bd0",
+    importpath = "golang.org/x/net",
+)
+
+go_repository(
+    name = "org_golang_x_oauth2",
+    commit = "bb50c06baba3d0c76f9d125c0719093e315b5b44",
+    importpath = "golang.org/x/oauth2",
+)

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/release/cmd/release-notes",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/notes:go_default_library",
+        "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/go-kit/kit/log/level:go_default_library",
+        "//vendor/github.com/google/go-github/github:go_default_library",
+        "//vendor/github.com/kolide/kit/env:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "release-notes",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -1,0 +1,84 @@
+# Kubernetes Release Notes Generator
+
+This directory contains a tool called `release-notes` and a set of library utilities at which aim to provide a simple and extensible set of tools for fetching, contextualizing, and rendering release notes for the [Kubernetes](https://github.com/kubernetes/kubernetes) repository.
+
+## Install
+
+The simplest way to install the `release-notes` CLI is via `go get`:
+
+```
+go get k8s.io/release/cmd/release-notes
+```
+
+This will install `release-notes` to `$GOPATH/bin/release-notes`. If you're new to Go, `$GOPATH` default to `~/go`, so look for the binary at `~/go/bin/release-notes`.
+
+## Usage
+
+To generate release notes for a commit range, run:
+
+```
+$ export GITHUB_TOKEN=a_github_api_token
+$ release-notes \
+  -start-sha d0a17cb4bbdf608559f257a76acfaa9acb054903 \
+  -end-sha   91e7b4fd31fcd3d5f436da26c980becec37ceefe
+level=info msg="fetching all commits. this might take a while..."
+level=info msg="got the commits, performing rendering"
+level=info msg="release notes markdown written to file" path=/var/folders/wp/6fkmvjf11gv18tdprv4g2mk40000gn/T/release-notes-048706664
+```
+
+You can also generate the raw notes data into JSON. You can then use a variety of tools (such as `jq`) to slice and dice the output:
+
+```json
+[
+  {
+    "text": "fixed incorrect OpenAPI schema for CustomResourceDefinition objects",
+    "author": "liggitt",
+    "author_url": "https://github.com/liggitt",
+    "pr_url": "https://github.com/kubernetes/kubernetes/pull/65256",
+    "pr_number": 65256,
+    "kinds": [
+      "bug"
+    ],
+    "sigs": [
+      "api-machinery"
+    ]
+  }
+]
+```
+
+## Building From Source
+
+To build the `release-notes` tool, check out this repo to your `$GOPATH`:
+
+```
+git clone git@github.com:kubernetes/release.git $GOPATH/src/k8s.io/release
+```
+
+Run the following from the root of the repository to build the `release-notes` binary:
+
+```
+bazel build //cmd/release-notes
+```
+
+Use the `-h` flag for help:
+
+```
+./bazel-bin/cmd/release-notes/darwin_amd64_stripped/release-notes -h
+```
+
+Install the binary into your path:
+
+```
+cp ./bazel-bin/cmd/release-notes/darwin_amd64_stripped/release-notes /usr/local/bin/release-notes
+```
+
+
+## FAQ
+
+### What do generated notes look like?
+
+Check out the rendering of 1.11's release notes [here](https://gist.github.com/marpaia/acfdb889f362195bb683e9e09ce196bc).
+
+### Why formats are supported?
+
+Right now the tool can output release notes in Markdown and JSON.

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/google/go-github/github"
+	"github.com/kolide/kit/env"
+	"golang.org/x/oauth2"
+	"k8s.io/release/pkg/notes"
+)
+
+type options struct {
+	githubToken string
+	output      string
+	startSHA    string
+	endSHA      string
+	format      string
+}
+
+func parseOptions(args []string) (*options, error) {
+	flagset := flag.NewFlagSet("release-notes", flag.ExitOnError)
+	var (
+		// flGitHubToken contains a personal GitHub access token. This is used to
+		// scrape the commits of the Kubernetes repo.
+		flGitHubToken = flagset.String(
+			"github-token",
+			env.String("GITHUB_TOKEN", ""),
+			"A personal GitHub access token (required)",
+		)
+
+		// flOutput contains the path on the filesystem to where the resultant
+		// release notes should be printed.
+		flOutput = flagset.String(
+			"output",
+			env.String("OUTPUT", ""),
+			"The path to the where the release notes will be printed",
+		)
+
+		// flStartSHA contains the commit SHA where the release note generation
+		// begins.
+		flStartSHA = flagset.String(
+			"start-sha",
+			env.String("START_SHA", ""),
+			"The commit hash to start at",
+		)
+
+		// flEndSHA contains the commit SHA where the release note generation ends.
+		flEndSHA = flagset.String(
+			"end-sha",
+			env.String("END_SHA", ""),
+			"The commit hash to end at",
+		)
+
+		// flFormat is the output format to produce the notes in.
+		flFormat = flagset.String(
+			"format",
+			env.String("FORMAT", "markdown"),
+			"The format for notes output (options: markdown, json)",
+		)
+	)
+
+	// Parse the args.
+	if err := flagset.Parse(args); err != nil {
+		return nil, err
+	}
+
+	// The GitHub Token is required.
+	if *flGitHubToken == "" {
+		return nil, errors.New("GitHub token must be set via -github-token or $GITHUB_TOKEN")
+	}
+
+	// The start SHA is required.
+	if *flStartSHA == "" {
+		return nil, errors.New("The starting commit hash must be set via -start-sha or $START_SHA")
+	}
+
+	// The end SHA is required.
+	if *flEndSHA == "" {
+		return nil, errors.New("The ending commit hash must be set via -end-sha or $END_SHA")
+	}
+
+	return &options{
+		githubToken: *flGitHubToken,
+		output:      *flOutput,
+		startSHA:    *flStartSHA,
+		endSHA:      *flEndSHA,
+		format:      *flFormat,
+	}, nil
+}
+
+func main() {
+	// Use the go-kit structured logger for logging. To learn more about structured
+	// logging see: https://github.com/go-kit/kit/tree/master/log#structured-logging
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = level.NewInjector(logger, level.DebugValue())
+
+	// Parse the CLI options and enforce required defaults
+	opts, err := parseOptions(os.Args[1:])
+	if err != nil {
+		level.Error(logger).Log("msg", "error parsing options", "err", err)
+		os.Exit(1)
+	}
+
+	// Create the GitHub API client
+	ctx := context.Background()
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: opts.githubToken},
+	))
+	githubClient := github.NewClient(httpClient)
+
+	// Fetch a list of fully-contextualized release notes
+	level.Info(logger).Log("msg", "fetching all commits. this might take a while...")
+	releaseNotes, err := notes.ListReleaseNotes(githubClient, logger, opts.startSHA, opts.endSHA, notes.WithContext(ctx))
+	if err != nil {
+		level.Error(logger).Log("msg", "error generating release notes", "err", err)
+		os.Exit(1)
+	}
+	level.Info(logger).Log("msg", "got the commits, performing rendering")
+
+	// Open a handle to the file which will contain the release notes output
+	var output *os.File
+	if opts.output != "" {
+		output, err = os.Open(opts.output)
+		if err != nil {
+			level.Error(logger).Log("msg", "error opening the supplied output file", "err", err)
+			os.Exit(1)
+		}
+	} else {
+		output, err = ioutil.TempFile("", "release-notes-")
+		if err != nil {
+			level.Error(logger).Log("msg", "error creating a temporary file to write the release notes to", "err", err)
+			os.Exit(1)
+		}
+	}
+
+	// Contextualized release notes can be printed in a variety of formats
+	switch opts.format {
+	case "json":
+		enc := json.NewEncoder(output)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(releaseNotes); err != nil {
+			level.Error(logger).Log("msg", "error encoding JSON output", "err", err)
+			os.Exit(1)
+		}
+	case "markdown":
+		doc, err := notes.CreateDocument(releaseNotes)
+		if err != nil {
+			level.Error(logger).Log("msg", "error creating release note document", "err", err)
+			os.Exit(1)
+		}
+
+		if err := notes.RenderMarkdown(doc, output); err != nil {
+			level.Error(logger).Log("msg", "error rendering release note document to markdown", "err", err)
+			os.Exit(1)
+		}
+
+	default:
+		level.Error(logger).Log("msg", fmt.Sprintf("%q is an unsupported format", opts.format))
+		os.Exit(1)
+	}
+
+	level.Info(logger).Log(
+		"msg", "release notes written to file",
+		"path", output.Name(),
+		"format", opts.format,
+	)
+}

--- a/debian/BUILD.bazel
+++ b/debian/BUILD.bazel
@@ -5,19 +5,19 @@ go_library(
     srcs = ["build.go"],
     importpath = "k8s.io/release/debian",
     visibility = ["//visibility:private"],
-    deps = ["//vendor/github.com/blang/semver:go_default_library"],
+    deps = ["//debian/vendor/github.com/blang/semver:go_default_library"],
 )
 
 go_binary(
     name = "debian",
+    embed = [":go_default_library"],
     importpath = "k8s.io/release/debian",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["build_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/release/debian",
-    library = ":go_default_library",
 )

--- a/debian/vendor/github.com/blang/semver/BUILD.bazel
+++ b/debian/vendor/github.com/blang/semver/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "sort.go",
         "sql.go",
     ],
+    importmap = "k8s.io/release/debian/vendor/github.com/blang/semver",
     importpath = "github.com/blang/semver",
     visibility = ["//visibility:public"],
 )
@@ -22,6 +23,6 @@ go_test(
         "sort_test.go",
         "sql_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "github.com/blang/semver",
-    library = ":go_default_library",
 )

--- a/defs/build.bzl
+++ b/defs/build.bzl
@@ -1,28 +1,28 @@
 def _gcs_upload_impl(ctx):
-  targets = []
-  for target in ctx.files.data:
-    targets.append(target.short_path)
+    targets = []
+    for target in ctx.files.data:
+        targets.append(target.short_path)
 
-  ctx.file_action(
-      output = ctx.outputs.targets,
-      content  = "\n".join(targets),
-  )
+    ctx.file_action(
+        output = ctx.outputs.targets,
+        content = "\n".join(targets),
+    )
 
-  ctx.file_action(
-      content = "%s --manifest %s --root $PWD -- $@" % (
-          ctx.attr.uploader.files_to_run.executable.short_path,
-          ctx.outputs.targets.short_path,
-      ),
-      output = ctx.outputs.executable,
-      executable = True,
-  )
+    ctx.file_action(
+        content = "%s --manifest %s --root $PWD -- $@" % (
+            ctx.attr.uploader.files_to_run.executable.short_path,
+            ctx.outputs.targets.short_path,
+        ),
+        output = ctx.outputs.executable,
+        executable = True,
+    )
 
-  return struct(
-      runfiles = ctx.runfiles(
-          files = ctx.files.data + ctx.files.uploader +
-            [ctx.version_file, ctx.outputs.targets]
-          )
-      )
+    return struct(
+        runfiles = ctx.runfiles(
+            files = ctx.files.data + ctx.files.uploader +
+                    [ctx.version_file, ctx.outputs.targets],
+        ),
+    )
 
 gcs_upload = rule(
     attrs = {

--- a/defs/deb.bzl
+++ b/defs/deb.bzl
@@ -1,34 +1,34 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
 
 KUBERNETES_AUTHORS = "Kubernetes Authors <kubernetes-dev+release@googlegroups.com>"
 
 KUBERNETES_HOMEPAGE = "https://kubernetes.io"
 
 def k8s_deb(name, depends = [], description = ""):
-  pkg_deb(
-      name = name,
-      architecture = "amd64",
-      data = name + "-data",
-      depends = depends,
-      description = description,
-      homepage = KUBERNETES_HOMEPAGE,
-      maintainer = KUBERNETES_AUTHORS,
-      package =  name,
-      version = "1.6.0-alpha",
-  )
+    pkg_deb(
+        name = name,
+        architecture = "amd64",
+        data = name + "-data",
+        depends = depends,
+        description = description,
+        homepage = KUBERNETES_HOMEPAGE,
+        maintainer = KUBERNETES_AUTHORS,
+        package = name,
+        version = "1.6.0-alpha",
+    )
 
 def deb_data(name, data = []):
-  deps = []
-  for i, info in enumerate(data):
-    dname = "%s-deb-data-%s" % (name, i)
-    deps += [dname]
+    deps = []
+    for i, info in enumerate(data):
+        dname = "%s-deb-data-%s" % (name, i)
+        deps += [dname]
+        pkg_tar(
+            name = dname,
+            files = info["files"],
+            mode = info["mode"],
+            package_dir = info["dir"],
+        )
     pkg_tar(
-        name = dname,
-        files = info["files"],
-        mode = info["mode"],
-        package_dir = info["dir"],
+        name = name + "-data",
+        deps = deps,
     )
-  pkg_tar(
-      name = name + "-data",
-      deps = deps,
-  )

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "document.go",
+        "notes.go",
+    ],
+    importpath = "k8s.io/release/pkg/notes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/go-kit/kit/log/level:go_default_library",
+        "//vendor/github.com/google/go-github/github:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "document_test.go",
+        "notes_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/google/go-github/github:go_default_library",
+        "//vendor/github.com/kolide/kit/logutil:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+    ],
+)

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/github.com/kolide/kit/logutil:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
     ],

--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -1,0 +1,240 @@
+package notes
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Document represents the underlying structure of a release notes document.
+type Document struct {
+	NewFeatures    []string            `json:"new_features"`
+	ActionRequired []string            `json:"action_required"`
+	APIChanges     []string            `json:"api_changes"`
+	Duplicates     map[string][]string `json:"duplicate_notes"`
+	SIGs           map[string][]string `json:"sigs"`
+	BugFixes       []string            `json:"bug_fixes"`
+	Uncategorized  []string            `json:"uncategorized"`
+}
+
+// CreateDocument assembles an organized document from an unorganized set of
+// release notes
+func CreateDocument(notes []*ReleaseNote) (*Document, error) {
+	doc := &Document{
+		NewFeatures:    []string{},
+		ActionRequired: []string{},
+		APIChanges:     []string{},
+		Duplicates:     map[string][]string{},
+		SIGs:           map[string][]string{},
+		BugFixes:       []string{},
+		Uncategorized:  []string{},
+	}
+
+	for _, note := range notes {
+		categorized := false
+
+		if note.ActionRequired {
+			categorized = true
+			doc.ActionRequired = append(doc.ActionRequired, note.Markdown)
+		} else if note.Feature {
+			categorized = true
+			doc.NewFeatures = append(doc.NewFeatures, note.Markdown)
+		} else if note.Duplicate {
+			categorized = true
+			header := prettifySigList(note.SIGs)
+			existingNotes, ok := doc.Duplicates[header]
+			if ok {
+				doc.Duplicates[header] = append(existingNotes, note.Markdown)
+			} else {
+				doc.Duplicates[header] = []string{note.Markdown}
+			}
+		} else {
+			for _, sig := range note.SIGs {
+				categorized = true
+				notesForSIG, ok := doc.SIGs[sig]
+				if ok {
+					doc.SIGs[sig] = append(notesForSIG, note.Markdown)
+				} else {
+					doc.SIGs[sig] = []string{note.Markdown}
+				}
+			}
+			isBug := false
+			for _, kind := range note.Kinds {
+				switch kind {
+				case "bug":
+					// if the PR has kind/bug, we want to make a note of it, but we don't
+					// include it in the Bug Fixes section until we haven't processed all
+					// kinds and determined that it has no other categorization label.
+					isBug = true
+				case "feature":
+					continue
+				case "api-change", "new-api":
+					categorized = true
+					doc.APIChanges = append(doc.APIChanges, note.Markdown)
+				}
+			}
+
+			// if the note has not been categorized so far, we can toss in one of two
+			// buckets
+			if !categorized {
+				if isBug {
+					doc.BugFixes = append(doc.BugFixes, note.Markdown)
+				} else {
+					doc.Uncategorized = append(doc.Uncategorized, note.Markdown)
+				}
+			}
+		}
+	}
+	return doc, nil
+}
+
+// RenderMarkdown accepts a Document and writes a version of that document to
+// supplied io.Writer in markdown format.
+func RenderMarkdown(doc *Document, w io.Writer) error {
+	// we always want to render the document with SIGs in alphabetical order
+	sortedSIGs := []string{}
+	for sig, _ := range doc.SIGs {
+		sortedSIGs = append(sortedSIGs, sig)
+	}
+	sort.Strings(sortedSIGs)
+
+	// this is a helper so that we don't have to check err != nil on every write
+
+	// first, we create a long-lived err that we can re-use
+	var err error
+
+	// write is a helper that writes a string to the in-scope io.Writer w
+	write := func(s string) {
+		// if write has already failed, just return and don't do anything
+		if err != nil {
+			return
+		}
+		// perform the write
+		_, err = w.Write([]byte(s))
+	}
+
+	// writeNote encapsulates the pre-processing that might happen on a note text
+	// before it gets bulleted and written to the io.Writer
+	writeNote := func(s string) {
+		if !strings.HasPrefix(s, "- ") {
+			s = "- " + s
+		}
+		write(s + "\n")
+	}
+
+	// the "Action Required" section
+	if len(doc.ActionRequired) > 0 {
+		write("## Action Required\n\n")
+		for _, note := range doc.ActionRequired {
+			writeNote(note)
+		}
+		write("\n\n")
+	}
+
+	// the "New Feautres" section
+	if len(doc.NewFeatures) > 0 {
+		write("## New Features\n\n")
+		for _, note := range doc.NewFeatures {
+			writeNote(note)
+		}
+		write("\n\n")
+	}
+
+	// the "API Changes" section
+	if len(doc.APIChanges) > 0 {
+		write("## API Changes\n\n")
+		for _, note := range doc.APIChanges {
+			writeNote(note)
+		}
+		write("\n\n")
+	}
+
+	// the "Duplicate Notes" section
+	if len(doc.Duplicates) > 0 {
+		write("## Notes From Multiple SIGs\n\n")
+		for header, notes := range doc.Duplicates {
+			write(fmt.Sprintf("### %s\n\n", header))
+			for _, note := range notes {
+				writeNote(note)
+			}
+			write("\n")
+		}
+		write("\n")
+	}
+
+	// each SIG gets a section (in alphabetical order)
+	if len(sortedSIGs) > 0 {
+		write("## Notes from Individual SIGs\n\n")
+		for _, sig := range sortedSIGs {
+			write("### SIG " + prettySIG(sig) + "\n\n")
+			for _, note := range doc.SIGs[sig] {
+				writeNote(note)
+			}
+			write("\n")
+		}
+		write("\n\n")
+	}
+
+	// the "Bug Fixes" section
+	if len(doc.BugFixes) > 0 {
+		write("## Bug Fixes\n\n")
+		for _, note := range doc.BugFixes {
+			writeNote(note)
+		}
+		write("\n\n")
+	}
+
+	// we call the uncategorized notes "Other Notable Changes". ideally these
+	// notes would at least have a SIG label.
+	if len(doc.Uncategorized) > 0 {
+		write("## Other Notable Changes\n\n")
+		for _, note := range doc.Uncategorized {
+			writeNote(note)
+		}
+		write("\n\n")
+	}
+
+	return err
+}
+
+// prettySIG takes a sig name as parsed by the `sig-foo` label and returns a
+// "pretty" version of it that can be printed in documents
+func prettySIG(sig string) string {
+	parts := strings.Split(sig, "-")
+	for i, part := range parts {
+		switch part {
+		case "vsphere":
+			parts[i] = "vSphere"
+		case "vmware":
+			parts[i] = "VMWare"
+		case "openstack":
+			parts[i] = "OpenStack"
+		case "api", "aws", "cli", "gcp":
+			parts[i] = strings.ToUpper(part)
+		default:
+			parts[i] = strings.Title(part)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func prettifySigList(sigs []string) string {
+	sigList := ""
+
+	// sort the list so that any group of SIGs with the same content gives us the
+	// same result
+	sort.Strings(sigs)
+
+	for i, sig := range sigs {
+		if i == 0 {
+			sigList = fmt.Sprintf("SIG %s", prettySIG(sig))
+		} else if i == (len(sigs) - 1) {
+			sigList = fmt.Sprintf("%s, and SIG %s", sigList, prettySIG(sig))
+		} else {
+			sigList = fmt.Sprintf("%s, SIG %s", sigList, prettySIG(sig))
+		}
+	}
+
+	return sigList
+}

--- a/pkg/notes/document_test.go
+++ b/pkg/notes/document_test.go
@@ -1,0 +1,23 @@
+package notes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrettySIG(t *testing.T) {
+	cases := map[string]string{
+		"scheduling":        "Scheduling",
+		"cluster-lifecycle": "Cluster Lifecycle",
+		"cli":               "CLI",
+		"aws":               "AWS",
+		"api-machinery":     "API Machinery",
+		"vsphere":           "vSphere",
+		"openstack":         "OpenStack",
+	}
+
+	for input, expected := range cases {
+		require.Equal(t, expected, (prettySIG(input)))
+	}
+}

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1,0 +1,525 @@
+// Copyright 2017 The Kubernetes Authors All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notes
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+)
+
+// ReleaseNote is the type that represents the total sum of all the information
+// we've gathered about a single release note.
+type ReleaseNote struct {
+	// Commit is the SHA of the commit which is the source of this note. This is
+	// also effectively a unique ID for release notes.
+	Commit string `json:"commit"`
+
+	// Text is the actual content of the release note
+	Text string `json:"text"`
+
+	// Markdown is the markdown formatted note
+	Markdown string `json:"markdown"`
+
+	// Author is the GitHub username of the commit author
+	Author string `json:"author"`
+
+	// AuthorUrl is the GitHub URL of the commit author
+	AuthorUrl string `json:"author_url"`
+
+	// PrUrl is a URL to the PR
+	PrUrl string `json:"pr_url"`
+
+	// PrNumber is the number of the PR
+	PrNumber int `json:"pr_number"`
+
+	// Areas is a list of the labels beginning with area/
+	Areas []string `json:"areas,omitempty"`
+
+	// Kinds is a list of the labels beginning with kind/
+	Kinds []string `json:"kinds,omitempty"`
+
+	// SIGs is a list of the labels beginning with sig/
+	SIGs []string `json:"sigs,omitempty"`
+
+	// Indicates whether or not a note will appear as a new feature
+	Feature bool `json:"feature,omitempty"`
+
+	// Indicates whether or not a note is duplicated across SIGs
+	Duplicate bool `json:"duplicate,omitempty"`
+
+	// ActionRequired indicates whether or not the release-note-action-required
+	// label was set on the PR
+	ActionRequired bool `json:"action_required,omitempty"`
+}
+
+// githubApiOption is a type which allows for the expression of API configuration
+// via the "functional option" pattern.
+// For more information on this pattern, see the following blog post:
+// https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type githubApiOption func(*githubApiConfig)
+
+// githubApiConfig is a configuration struct that is used to express optional
+// configuration for GitHub API requests
+type githubApiConfig struct {
+	ctx    context.Context
+	org    string
+	repo   string
+	branch string
+}
+
+// WithContext allows the caller to inject a context into GitHub API requests
+func WithContext(ctx context.Context) githubApiOption {
+	return func(c *githubApiConfig) {
+		c.ctx = ctx
+	}
+}
+
+// WithOrg allows the caller to override the GitHub organization for the API
+// request. By default, it is usually "kubernetes".
+func WithOrg(org string) githubApiOption {
+	return func(c *githubApiConfig) {
+		c.org = org
+	}
+}
+
+// WithRepo allows the caller to override the GitHub repo for the API
+// request. By default, it is usually "kubernetes".
+func WithRepo(repo string) githubApiOption {
+	return func(c *githubApiConfig) {
+		c.repo = repo
+	}
+}
+
+// WithBranch allows the caller to override the repo branch for the API
+// request. By default, it is usually "master".
+func WithBranch(branch string) githubApiOption {
+	return func(c *githubApiConfig) {
+		c.branch = branch
+	}
+}
+
+// ListReleaseNotes produces a list of fully contextualized release notes
+// starting from a given commit SHA and ending at starting a given commit SHA.
+func ListReleaseNotes(
+	client *github.Client,
+	logger log.Logger,
+	start,
+	end string,
+	opts ...githubApiOption,
+) ([]*ReleaseNote, error) {
+	commits, err := ListCommitsWithNotes(client, logger, start, end, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	dedupeCache := map[string]struct{}{}
+	notes := []*ReleaseNote{}
+	for _, commit := range commits {
+		if commit.GetAuthor().GetLogin() != "k8s-ci-robot" {
+			continue
+		}
+
+		note, err := ReleaseNoteFromCommit(commit, client, opts...)
+		if err != nil {
+			level.Error(logger).Log(
+				"err", err,
+				"msg", "error getting the release note from commit while listing release notes",
+				"sha", commit.GetSHA(),
+			)
+			continue
+		}
+
+		if strings.TrimSpace(note.Text) == "NONE" {
+			continue
+		}
+
+		if _, ok := dedupeCache[note.Text]; !ok {
+			notes = append(notes, note)
+			dedupeCache[note.Text] = struct{}{}
+		}
+	}
+
+	return notes, nil
+}
+
+// NoteTextFromString returns the text of the release note given a string which
+// may contain the commit message, the PR description, etc.
+// This is generally the content inside the ```release-note ``` stanza.
+func NoteTextFromString(s string) (string, error) {
+	exps := []*regexp.Regexp{
+		regexp.MustCompile("```release-note\\r\\n(?P<note>.+)"),
+		regexp.MustCompile("```dev-release-note\\r\\n(?P<note>.+)"),
+		regexp.MustCompile("```\\r\\n(?P<note>.+)\\r\\n```"),
+		regexp.MustCompile("```release-note\n(?P<note>.+)\n```"),
+	}
+
+	for _, exp := range exps {
+		match := exp.FindStringSubmatch(s)
+		if len(match) == 0 {
+			continue
+		}
+		result := map[string]string{}
+		for i, name := range exp.SubexpNames() {
+			if i != 0 && name != "" {
+				result[name] = match[i]
+			}
+		}
+		note := strings.TrimRight(result["note"], "\r")
+		note = stripActionRequired(note)
+		note = stripStar(note)
+		return note, nil
+	}
+
+	return "", errors.New("no matches found when parsing note text from commit string")
+}
+
+// ReleaseNoteFromCommit produces a full contextualized release note given a
+// GitHub commit API resource.
+func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Client, opts ...githubApiOption) (*ReleaseNote, error) {
+	pr, err := PRFromCommit(client, commit, opts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing release note from commit %s", commit.GetSHA())
+	}
+
+	text, err := NoteTextFromString(pr.GetBody())
+	if err != nil {
+		return nil, err
+	}
+
+	author := pr.GetUser().GetLogin()
+	authorUrl := fmt.Sprintf("https://github.com/%s", author)
+	prUrl := fmt.Sprintf("https://github.com/kubernetes/kubernetes/pull/%d", pr.GetNumber())
+	IsFeature := HasString(LabelsWithPrefix(pr, "kind"), "feature")
+	IsDuplicate := false
+	sigsListPretty := prettifySigList(LabelsWithPrefix(pr, "sig"))
+	noteSuffix := ""
+
+	if IsActionRequired(pr) || IsFeature {
+		if sigsListPretty != "" {
+			noteSuffix = fmt.Sprintf("Courtesy of %s", sigsListPretty)
+		}
+	} else if len(LabelsWithPrefix(pr, "sig")) > 1 {
+		IsDuplicate = true
+	}
+	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))", text, pr.GetNumber(), prUrl, author, authorUrl)
+
+	if noteSuffix != "" {
+		markdown = fmt.Sprintf("%s %s", markdown, noteSuffix)
+	}
+
+	return &ReleaseNote{
+		Commit:         commit.GetSHA(),
+		Text:           text,
+		Markdown:       markdown,
+		Author:         author,
+		AuthorUrl:      authorUrl,
+		PrUrl:          prUrl,
+		PrNumber:       pr.GetNumber(),
+		SIGs:           LabelsWithPrefix(pr, "sig"),
+		Kinds:          LabelsWithPrefix(pr, "kind"),
+		Areas:          LabelsWithPrefix(pr, "area"),
+		Feature:        IsFeature,
+		Duplicate:      IsDuplicate,
+		ActionRequired: IsActionRequired(pr),
+	}, nil
+}
+
+// ListCommits lists all commits starting from a given commit SHA and ending at
+// a given commit SHA.
+func ListCommits(client *github.Client, start, end string, opts ...githubApiOption) ([]*github.RepositoryCommit, error) {
+	c := configFromOpts(opts...)
+
+	startCommit, _, err := client.Git.GetCommit(c.ctx, c.org, c.repo, start)
+	if err != nil {
+		return nil, err
+	}
+
+	endCommit, _, err := client.Git.GetCommit(c.ctx, c.org, c.repo, end)
+	if err != nil {
+		return nil, err
+	}
+
+	clo := &github.CommitsListOptions{
+		SHA:   c.branch,
+		Since: *startCommit.Committer.Date,
+		Until: *endCommit.Committer.Date,
+		ListOptions: github.ListOptions{
+			Page:    1,
+			PerPage: 100,
+		},
+	}
+
+	commits, resp, err := client.Repositories.ListCommits(c.ctx, c.org, c.repo, clo)
+	if err != nil {
+		return nil, err
+	}
+	clo.ListOptions.Page++
+
+	for clo.ListOptions.Page <= resp.LastPage {
+		commitPage, _, err := client.Repositories.ListCommits(c.ctx, c.org, c.repo, clo)
+		if err != nil {
+			return nil, err
+		}
+		for _, commit := range commitPage {
+			commits = append(commits, commit)
+		}
+		clo.ListOptions.Page++
+	}
+
+	return commits, nil
+}
+
+// ListCommitsWithNotes list commits that have release notes starting from a
+// given commit SHA and ending at a given commit SHA. This function is similar
+// to ListCommits except that only commits with tagged release notes are
+// returned.
+func ListCommitsWithNotes(
+	client *github.Client,
+	logger log.Logger,
+	start,
+	end string,
+	opts ...githubApiOption,
+) ([]*github.RepositoryCommit, error) {
+	filteredCommits := []*github.RepositoryCommit{}
+
+	commits, err := ListCommits(client, start, end, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, commit := range commits {
+		pr, err := PRFromCommit(client, commit, opts...)
+		if err != nil {
+			if err.Error() == "no matches found when parsing PR from commit" {
+				continue
+			}
+		}
+
+		// exclusionFilters is a list of regular expressions that match commits that
+		// do NOT contain release notes. Notably, this is all of the variations of
+		// "release note none" that appear in the commit log.
+		exclusionFilters := []string{
+			"```release-note\\r\\nNONE",
+			"```release-note\\r\\n\\s+NONE",
+			"```release-note\\r\\nNONE",
+			"```release-note\\r\\n\"NONE\"",
+			"```release-note\\r\\nNone",
+			"```release-note\\r\\nnone",
+			"```release-note\\r\\nN/A",
+			"```release-note\\r\\n\\r\\n```",
+			"```release-note\\r\\n```",
+			"/release-note-none",
+			"\\r\\n\\r\\nNONE",
+			"```NONE\\r\\n```",
+			"```release-note \\r\\nNONE\\r\\n```",
+			"NONE\\r\\n```",
+			"\\r\\nNone",
+			"\\r\\nNONE\\r\\n",
+		}
+
+		excluded := false
+
+		for _, filter := range exclusionFilters {
+			match, err := regexp.MatchString(filter, pr.GetBody())
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				excluded = true
+				break
+			}
+		}
+
+		if excluded {
+			continue
+		}
+
+		// Similarly, now that the known not-release-notes are filtered out, we can
+		// use some patterns to find actual release notes.
+		inclusionFilters := []string{
+			"release-note",
+			"Does this PR introduce a user-facing change?",
+		}
+
+		for _, filter := range inclusionFilters {
+			match, err := regexp.MatchString(filter, pr.GetBody())
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				filteredCommits = append(filteredCommits, commit)
+			}
+		}
+	}
+
+	return filteredCommits, nil
+}
+
+// PRFromCommit return an API Pull Request struct given a commit struct. This is
+// useful for going from a commit log to the PR (which contains useful info such
+// as labels).
+func PRFromCommit(client *github.Client, commit *github.RepositoryCommit, opts ...githubApiOption) (*github.PullRequest, error) {
+	c := configFromOpts(opts...)
+
+	// Thankfully k8s-merge-robot commits the PR number consistently. If this ever
+	// stops being true, this definitely won't work anymore.
+	exp := regexp.MustCompile(`Merge pull request #(?P<number>\d+)`)
+	match := exp.FindStringSubmatch(*commit.Commit.Message)
+	if len(match) == 0 {
+		return nil, errors.New("no matches found when parsing PR from commit")
+	}
+	result := map[string]string{}
+	for i, name := range exp.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+	number, err := strconv.Atoi(result["number"])
+	if err != nil {
+		return nil, err
+	}
+
+	// Given the PR number that we've now converted to an integer, get the PR from
+	// the API
+	pr, _, err := client.PullRequests.Get(c.ctx, c.org, c.repo, number)
+	return pr, err
+}
+
+// LabelsWithPrefix is a helper for fetching all labels on a PR that start with
+// a given string. This pattern is used often in the k/k repo and we can take
+// advantage of this to contextualize release note generation with the kind, sig,
+// area, etc labels.
+func LabelsWithPrefix(pr *github.PullRequest, prefix string) []string {
+	labels := []string{}
+	for _, label := range pr.Labels {
+		if strings.HasPrefix(*label.Name, prefix) {
+			labels = append(labels, strings.TrimPrefix(*label.Name, prefix+"/"))
+		}
+	}
+	return labels
+}
+
+// IsActionRequired indicates whether or not the release-note-action-required
+// label was set on the PR.
+func IsActionRequired(pr *github.PullRequest) bool {
+	for _, label := range pr.Labels {
+		if *label.Name == "release-note-action-required" {
+			return true
+		}
+	}
+	return false
+}
+
+// filterCommits is a helper that allows you to filter a set of commits by
+// applying a set of regular expressions over the commit messages. If include is
+// true, only commits that match at least one expression are returned. If include
+// is false, only commits that match 0 of the expressions are returned.
+func filterCommits(
+	client *github.Client,
+	logger log.Logger,
+	commits []*github.RepositoryCommit,
+	filters []string,
+	include bool,
+	opts ...githubApiOption,
+) ([]*github.RepositoryCommit, error) {
+	filteredCommits := []*github.RepositoryCommit{}
+	for _, commit := range commits {
+		body := commit.GetCommit().GetMessage()
+		if commit.GetAuthor().GetLogin() == "k8s-merge-robot" {
+			pr, err := PRFromCommit(client, commit, opts...)
+			if err != nil {
+				level.Info(logger).Log(
+					"msg", "error getting PR from k8s-merge-robot commit",
+					"err", err,
+					"sha", commit.GetSHA(),
+				)
+				continue
+			}
+			body = pr.GetBody()
+		}
+
+		skip := false
+		for _, filter := range filters {
+			match, err := regexp.MatchString(filter, body)
+			if err != nil {
+				return nil, err
+			}
+			if match && !include || !match && include {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		filteredCommits = append(filteredCommits, commit)
+	}
+
+	return filteredCommits, nil
+}
+
+// configFromOpts is an internal helper for turning a set of functional options
+// into a populated *githubApiConfig struct with consistent defaults.
+func configFromOpts(opts ...githubApiOption) *githubApiConfig {
+	c := &githubApiConfig{
+		ctx:    context.Background(),
+		org:    "kubernetes",
+		repo:   "kubernetes",
+		branch: "master",
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+func stripActionRequired(note string) string {
+	expressions := []string{
+		`(?i)\[action required\]\s`,
+		`(?i)action required:\s`,
+	}
+
+	for _, exp := range expressions {
+		re := regexp.MustCompile(exp)
+		note = re.ReplaceAllString(note, "")
+	}
+
+	return note
+}
+
+func stripStar(note string) string {
+	re := regexp.MustCompile(`(?i)\*\s`)
+	return re.ReplaceAllString(note, "")
+}
+
+func HasString(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -1,0 +1,89 @@
+package notes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const (
+	v1_10_0        = "fc32d2f3698e36b93322a3465f63a14e9f0eaead"
+	v1_11_0_alpha1 = "4761788b2afa42a4573a6794902eb93fe666d5c5"
+	v1_11_0_alpha2 = "ed9b25c90241b2b8a1fa10b96381c57f99ca952a"
+	v1_11_0_beta1  = "4e3b2843df571c3b80c834d7c23bc6da1a22aab8"
+	v1_11_0_beta2  = "be2cfcf9e44b5162a294e977329d6c8194748c4e"
+	v1_11_0_rc1    = "8745ea56e3f1f3ad20050c1762eb6ba6f7786675"
+	v1_11_0_rc2    = "d0a17cb4bbdf608559f257a76acfaa9acb054903"
+	v1_11_0_rc3    = "931fc3b3aef9d679436978529fc7065d75352671"
+	v1_11_0        = "91e7b4fd31fcd3d5f436da26c980becec37ceefe"
+)
+
+func githubClient(t *testing.T) *github.Client {
+	token, tokenSet := os.LookupEnv("GITHUB_TOKEN")
+	if !tokenSet {
+		t.Skip("GITHUB_TOKEN is not set")
+	}
+
+	ctx := context.Background()
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	))
+	return github.NewClient(httpClient)
+}
+
+func TestConfigFromOpts(t *testing.T) {
+	// fake config with an override for the org
+	c := configFromOpts(
+		WithOrg("marpaia"),
+	)
+
+	// test the override works
+	require.Equal(t, "marpaia", c.org)
+
+	// test the default value
+	require.Equal(t, "kubernetes", c.repo)
+}
+
+func TestStripActionRequired(t *testing.T) {
+	notes := []string{
+		"[action required] The note text",
+		"[ACTION REQUIRED] The note text",
+		"[AcTiOn ReQuIrEd] The note text",
+	}
+
+	for _, note := range notes {
+		require.Equal(t, "The note text", stripActionRequired(note))
+	}
+}
+
+func TestStripStar(t *testing.T) {
+	notes := []string{
+		"* The note text",
+	}
+
+	for _, note := range notes {
+		require.Equal(t, "The note text", stripStar(note))
+	}
+}
+
+func TestReleaseNoteParsing(t *testing.T) {
+	client := githubClient(t)
+	commitsWithNote := []string{
+		"973dcd0c1a2555a6726aed8248ca816c9771253f",
+		"27e5971c11cfcda703a39ed670a565f0f3564713",
+	}
+	ctx := context.Background()
+
+	for _, sha := range commitsWithNote {
+		fmt.Println(sha)
+		commit, _, err := client.Repositories.GetCommit(ctx, "kubernetes", "kubernetes", sha)
+		require.NoError(t, err)
+		_, err = ReleaseNoteFromCommit(commit, client)
+		require.NoError(t, err)
+	}
+}

--- a/toolbox/relnotes/BUILD.bazel
+++ b/toolbox/relnotes/BUILD.bazel
@@ -13,15 +13,15 @@ go_library(
 
 go_binary(
     name = "relnotes",
+    embed = [":go_default_library"],
     importpath = "k8s.io/release/toolbox/relnotes",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/release/toolbox/relnotes",
-    library = ":go_default_library",
     deps = ["//toolbox/util:go_default_library"],
 )

--- a/toolbox/util/BUILD.bazel
+++ b/toolbox/util/BUILD.bazel
@@ -22,6 +22,6 @@ go_test(
         "github_test.go",
         "gitlib_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/release/toolbox/util",
-    library = ":go_default_library",
 )


### PR DESCRIPTION
As per the request in https://github.com/kubernetes/sig-release/issues/471, this PR moved the `release-notes` tool from a personal repository (https://github.com/marpaia/release-notes) to this repository. I am of course down to move around directory structure and/or make changes to the layout of the code if anyone has code review comments!

This PR also contains some fixes to the Bazel configurations around the Go build integrations and the Gazelle build file autogenerator. 

/area release-eng