### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,33 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-# maintainers
-- ixdy
-- listx
-- mikedanese
-# sig-release leads
-- jdumars
-- calebamiles
-# 1.10 patch release manager
-- maciekpytel
-# 1.11 patch release manager
-- foxish
-# 1.12 patch release manager
-- feiskyer
-# 1.13 patch release team
-- aleksandra-malinowska
-- tpepper
-# 1.10 release lead (for completeness, but dupe of sig-release leads)
-#- jdumars
-# 1.11 release lead
-- jberkus
-# 1.12 release lead
-- tpepper
-# 1.13 release lead
-- AishSundar
-# 1.14 release lead
-- spiffxp
-
+  - sig-release-leads
+  - release-engineering
+  - branch-manager-role
+  - patch-release-manager-role
+reviewers:
+  - release-team-lead-role
 labels:
-- sig/release
-- area/release-eng
+  - sig/release
+  - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,27 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  sig-release-leads:
+    - calebamiles
+    - justaugustus
+    - tpepper
+  release-engineering:
+    - aleksandra-malinowska
+    - calebamiles
+    - ixdy
+    - mikedanese
+    - tpepper
+  patch-release-manager-role:
+    - foxish # 1.11
+    - feiskyer # 1.12
+    - aleksandra-malinowska # 1.13
+    - tpepper # 1.13
+  branch-manager-role:
+    - calebamiles # 1.11
+    - dougm # 1.13 / 1.12
+    - hoegaarden # 1.14
+  release-team-lead-role:
+    - jberkus # 1.11
+    - tpepper # 1.12
+    - aishsundar # 1.13
+    - spiffxp # 1.14


### PR DESCRIPTION
Update OWNERS to represent releng project and aliases for PRMT and branch mgmt.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>