### PR TITLE
Make sure essential packages are installed

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -367,6 +367,7 @@ common::logfileinit $MYLOG 10
 # BEGIN script
 common::timestamp begin
 
+common::check_packages jq git bsdmainutils || common::exit 1 "Exiting..."
 gitlib::repo_state || common::exit 1 "Exiting..."
 
 # Ensure some prerequisites
@@ -377,7 +378,6 @@ if ! common::set_cloud_binaries; then
   logecho "https://developers.google.com/cloud/sdk/"
   common::exit 1 "Exiting..."
 fi
-common::check_packages jq || common::exit 1 "Exiting..."
 
 logecho
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -942,7 +942,7 @@ common::set_cloud_binaries () {
 
   logecho -n "Checking/setting cloud tools: "
 
-  for GSUTIL in $(which gsutil) /opt/google/google-cloud-sdk/bin/gsutil; do
+  for GSUTIL in "$(which gsutil)" /opt/google/google-cloud-sdk/bin/gsutil; do
     [[ -x $GSUTIL ]] && break
   done
 


### PR DESCRIPTION
Fixes: #659 

----

When essential OS packages are missing:
```
# ./gcbmgr
gcbmgr: BEGIN main on 42d92a142fbb Mon Feb 25 09:24:15 UTC 2019

Checking required system packages: FAILED
PREREQ: Missing prerequisites: jq git bsdmainutils Run the following and
try again:

$ sudo apt-get install jq
$ sudo apt-get install git
$ sudo apt-get install bsdmainutils

Exiting...


gcbmgr: DONE main on 42d92a142fbb Mon Feb 25 09:24:15 UTC 2019 in 0s
# 
```

When gcloud tools are missing:
```
# ./gcbmgr
gcbmgr: BEGIN main on 42d92a142fbb Mon Feb 25 09:24:47 UTC 2019

Checking required system packages: OK
Checking /release state: OK
Checking/setting cloud tools: FAILED
Releasing Kubernetes requires gsutil and gcloud. Please download,
install and authorize through the Google Cloud SDK:

https://developers.google.com/cloud/sdk/

Exiting...


gcbmgr: DONE main on 42d92a142fbb Mon Feb 25 09:24:48 UTC 2019 in 1s
#
```