### PR TITLE
release-notes tool improvements

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -18,167 +18,224 @@ import (
 )
 
 type options struct {
-	githubToken string
-	output      string
-	startSHA    string
-	endSHA      string
-	relVer      string
-	format      string
+	githubToken    string
+	output         string
+	startSHA       string
+	endSHA         string
+	releaseVersion string
+	format         string
+	logger         log.Logger
 }
 
-func parseOptions(args []string) (*options, error) {
-	flagset := flag.NewFlagSet("release-notes", flag.ExitOnError)
-	var (
-		// flGitHubToken contains a personal GitHub access token. This is used to
-		// scrape the commits of the Kubernetes repo.
-		flGitHubToken = flagset.String(
-			"github-token",
-			env.String("GITHUB_TOKEN", ""),
-			"A personal GitHub access token (required)",
-		)
-
-		// flOutput contains the path on the filesystem to where the resultant
-		// release notes should be printed.
-		flOutput = flagset.String(
-			"output",
-			env.String("OUTPUT", ""),
-			"The path to the where the release notes will be printed",
-		)
-
-		// flStartSHA contains the commit SHA where the release note generation
-		// begins.
-		flStartSHA = flagset.String(
-			"start-sha",
-			env.String("START_SHA", ""),
-			"The commit hash to start at",
-		)
-
-		// flEndSHA contains the commit SHA where the release note generation ends.
-		flEndSHA = flagset.String(
-			"end-sha",
-			env.String("END_SHA", ""),
-			"The commit hash to end at",
-		)
-
-		// flRelVer contains the commit SHA where the release note generation ends.
-		flRelVer = flagset.String(
-			"release-version",
-			env.String("RELEASE_VERSION", ""),
-			"The release version to generate notes for. e.g. `1.14`",
-		)
-
-		// flFormat is the output format to produce the notes in.
-		flFormat = flagset.String(
-			"format",
-			env.String("FORMAT", "markdown"),
-			"The format for notes output (options: markdown, json)",
-		)
+func (o *options) BindFlags() *flag.FlagSet {
+	flags := flag.NewFlagSet("release-notes", flag.ContinueOnError)
+	// gitHubToken contains a personal GitHub access token. This is used to
+	// scrape the commits of the Kubernetes repo.
+	flags.StringVar(
+		&o.githubToken,
+		"github-token",
+		env.String("GITHUB_TOKEN", ""),
+		"A personal GitHub access token (required)",
 	)
 
-	// Parse the args.
-	if err := flagset.Parse(args); err != nil {
-		return nil, err
-	}
+	// output contains the path on the filesystem to where the resultant
+	// release notes should be printed.
+	flags.StringVar(
+		&o.output,
+		"output",
+		env.String("OUTPUT", ""),
+		"The path to the where the release notes will be printed",
+	)
 
-	// The GitHub Token is required.
-	if *flGitHubToken == "" {
-		return nil, errors.New("GitHub token must be set via -github-token or $GITHUB_TOKEN")
-	}
+	// startSHA contains the commit SHA where the release note generation
+	// begins.
+	flags.StringVar(
+		&o.startSHA,
+		"start-sha",
+		env.String("START_SHA", ""),
+		"The commit hash to start at",
+	)
 
-	// The start SHA is required.
-	if *flStartSHA == "" {
-		return nil, errors.New("The starting commit hash must be set via -start-sha or $START_SHA")
-	}
+	// endSHA contains the commit SHA where the release note generation ends.
+	flags.StringVar(
+		&o.endSHA,
+		"end-sha",
+		env.String("END_SHA", ""),
+		"The commit hash to end at",
+	)
 
-	// The end SHA is required.
-	if *flEndSHA == "" {
-		return nil, errors.New("The ending commit hash must be set via -end-sha or $END_SHA")
-	}
+	// releaseVersion is the version number you want to tag the notes with.
+	flags.StringVar(
+		&o.releaseVersion,
+		"release-version",
+		env.String("RELEASE_VERSION", ""),
+		"Which release version to tag the entries as.",
+	)
 
-	return &options{
-		githubToken: *flGitHubToken,
-		output:      *flOutput,
-		startSHA:    *flStartSHA,
-		endSHA:      *flEndSHA,
-		relVer:      *flRelVer,
-		format:      *flFormat,
-	}, nil
+	// format is the output format to produce the notes in.
+	flags.StringVar(
+		&o.format,
+		"format",
+		env.String("FORMAT", "markdown"),
+		"The format for notes output (options: markdown, json)",
+	)
+	return flags
 }
 
-func main() {
-	// Use the go-kit structured logger for logging. To learn more about structured
-	// logging see: https://github.com/go-kit/kit/tree/master/log#structured-logging
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = level.NewInjector(logger, level.DebugValue())
-
-	// Parse the CLI options and enforce required defaults
-	opts, err := parseOptions(os.Args[1:])
-	if err != nil {
-		level.Error(logger).Log("msg", "error parsing options", "err", err)
-		os.Exit(1)
-	}
-
+func (o *options) GetReleaseNotes() (notes.ReleaseNoteList, error) {
 	// Create the GitHub API client
 	ctx := context.Background()
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: opts.githubToken},
+		&oauth2.Token{AccessToken: o.githubToken},
 	))
 	githubClient := github.NewClient(httpClient)
 
 	// Fetch a list of fully-contextualized release notes
-	level.Info(logger).Log("msg", "fetching all commits. this might take a while...")
-	releaseNotes, err := notes.ListReleaseNotes(githubClient, logger, opts.startSHA, opts.endSHA, opts.relVer, notes.WithContext(ctx))
+	level.Info(o.logger).Log("msg", "fetching all commits. this might take a while...")
+
+	releaseNotes, err := notes.ListReleaseNotes(githubClient, o.logger, o.startSHA, o.endSHA, o.releaseVersion, notes.WithContext(ctx))
 	if err != nil {
-		level.Error(logger).Log("msg", "error generating release notes", "err", err)
-		os.Exit(1)
+		level.Error(o.logger).Log("msg", "error generating release notes", "err", err)
+		return nil, err
 	}
-	level.Info(logger).Log("msg", "got the commits, performing rendering")
+
+	return releaseNotes, nil
+}
+
+func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNoteList) error {
+	level.Info(o.logger).Log("msg", "got the commits, performing rendering")
 
 	// Open a handle to the file which will contain the release notes output
 	var output *os.File
-	if opts.output != "" {
-		output, err = os.Open(opts.output)
+	var err error
+
+	if o.output != "" {
+		output, err = os.OpenFile(o.output, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {
-			level.Error(logger).Log("msg", "error opening the supplied output file", "err", err)
-			os.Exit(1)
+			level.Error(o.logger).Log("msg", "error opening the supplied output file", "err", err)
+			return err
 		}
 	} else {
 		output, err = ioutil.TempFile("", "release-notes-")
 		if err != nil {
-			level.Error(logger).Log("msg", "error creating a temporary file to write the release notes to", "err", err)
-			os.Exit(1)
+			level.Error(o.logger).Log("msg", "error creating a temporary file to write the release notes to", "err", err)
+			return err
 		}
 	}
 
 	// Contextualized release notes can be printed in a variety of formats
-	switch opts.format {
+	switch o.format {
 	case "json":
+		byteValue, _ := ioutil.ReadAll(output)
+		existingNotes := make([]*notes.ReleaseNote, 0)
+
+		json.Unmarshal(byteValue, &existingNotes)
+
+		if len(existingNotes) > 0 {
+			output.Truncate(0)
+			output.Seek(0, 0)
+
+			for i := 0; i < len(existingNotes); i++ {
+				_, ok := releaseNotes[existingNotes[i].PrNumber]
+				if !ok {
+					releaseNotes[existingNotes[i].PrNumber] = existingNotes[i]
+				}
+			}
+		}
+
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(releaseNotes); err != nil {
-			level.Error(logger).Log("msg", "error encoding JSON output", "err", err)
+			level.Error(o.logger).Log("msg", "error encoding JSON output", "err", err)
 			os.Exit(1)
 		}
 	case "markdown":
 		doc, err := notes.CreateDocument(releaseNotes)
 		if err != nil {
-			level.Error(logger).Log("msg", "error creating release note document", "err", err)
-			os.Exit(1)
+			level.Error(o.logger).Log("msg", "error creating release note document", "err", err)
+			return err
 		}
 
 		if err := notes.RenderMarkdown(doc, output); err != nil {
-			level.Error(logger).Log("msg", "error rendering release note document to markdown", "err", err)
-			os.Exit(1)
+			level.Error(o.logger).Log("msg", "error rendering release note document to markdown", "err", err)
+			return err
 		}
 
 	default:
-		level.Error(logger).Log("msg", fmt.Sprintf("%q is an unsupported format", opts.format))
-		os.Exit(1)
+		errString := fmt.Sprintf("%q is an unsupported format", o.format)
+		level.Error(o.logger).Log("msg", errString)
+		return errors.New(errString)
 	}
 
-	level.Info(logger).Log(
+	level.Info(o.logger).Log(
 		"msg", "release notes written to file",
 		"path", output.Name(),
-		"format", opts.format,
+		"format", o.format,
 	)
+	return nil
+}
+
+func parseOptions(args []string, logger log.Logger) (*options, error) {
+	opts := &options{}
+	flags := opts.BindFlags()
+
+	// Parse the args.
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+
+	// The GitHub Token is required.
+	if opts.githubToken == "" {
+		return nil, errors.New("GitHub token must be set via -github-token or $GITHUB_TOKEN")
+	}
+
+	// The start SHA is required.
+	if opts.startSHA == "" {
+		return nil, errors.New("The starting commit hash must be set via -start-sha or $START_SHA")
+	}
+
+	// The end SHA is required.
+	if opts.endSHA == "" {
+		return nil, errors.New("The ending commit hash must be set via -end-sha or $END_SHA")
+	}
+
+	opts.logger = logger
+
+	return opts, nil
+}
+
+func run(logger log.Logger, args []string) error {
+	// Parse the CLI options and enforce required defaults
+	opts, err := parseOptions(args, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "error parsing options", "err", err)
+		return err
+	}
+
+	// get the release notes
+	releaseNotes, err := opts.GetReleaseNotes()
+	if err != nil {
+		return err
+	}
+
+	err = opts.WriteReleaseNotes(releaseNotes)
+	if err != nil {
+		level.Error(logger).Log("msg", "error writing to file", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	// Use the go-kit structured logger for logging. To learn more about structured
+	// logging see: https://github.com/go-kit/kit/tree/master/log#structured-logging
+	logger := level.NewInjector(
+		log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		level.DebugValue(),
+	)
+
+	if err := run(logger, os.Args[1:]); err != nil {
+		os.Exit(-1)
+	}
 }

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -14,12 +14,14 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/kolide/kit/env"
 	"golang.org/x/oauth2"
+
 	"k8s.io/release/pkg/notes"
 )
 
 type options struct {
 	githubToken    string
 	output         string
+	branch         string
 	startSHA       string
 	endSHA         string
 	releaseVersion string
@@ -45,6 +47,14 @@ func (o *options) BindFlags() *flag.FlagSet {
 		"output",
 		env.String("OUTPUT", ""),
 		"The path to the where the release notes will be printed",
+	)
+
+	// branch is which branch to scrape.
+	flags.StringVar(
+		&o.branch,
+		"branch",
+		env.String("BRANCH", "branch"),
+		"Select which branch to scrape. Defaults to `master`",
 	)
 
 	// startSHA contains the commit SHA where the release note generation
@@ -93,7 +103,7 @@ func (o *options) GetReleaseNotes() (notes.ReleaseNoteList, error) {
 	// Fetch a list of fully-contextualized release notes
 	level.Info(o.logger).Log("msg", "fetching all commits. this might take a while...")
 
-	releaseNotes, err := notes.ListReleaseNotes(githubClient, o.logger, o.startSHA, o.endSHA, o.releaseVersion, notes.WithContext(ctx))
+	releaseNotes, err := notes.ListReleaseNotes(githubClient, o.logger, o.branch, o.startSHA, o.endSHA, o.releaseVersion, notes.WithContext(ctx))
 	if err != nil {
 		level.Error(o.logger).Log("msg", "error generating release notes", "err", err)
 		return nil, err

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -13,8 +13,8 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/go-github/github"
 	"github.com/kolide/kit/env"
-	"github.com/kubernetes/release/pkg/notes"
 	"golang.org/x/oauth2"
+	"k8s.io/release/pkg/notes"
 )
 
 type options struct {

--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -20,7 +20,7 @@ type Document struct {
 
 // CreateDocument assembles an organized document from an unorganized set of
 // release notes
-func CreateDocument(notes []*ReleaseNote) (*Document, error) {
+func CreateDocument(notes ReleaseNoteList) (*Document, error) {
 	doc := &Document{
 		NewFeatures:    []string{},
 		ActionRequired: []string{},

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -133,12 +133,13 @@ func WithBranch(branch string) githubApiOption {
 func ListReleaseNotes(
 	client *github.Client,
 	logger log.Logger,
+	branch,
 	start,
 	end,
 	relVer string,
 	opts ...githubApiOption,
 ) (ReleaseNoteList, error) {
-	commits, err := ListCommitsWithNotes(client, logger, start, end, opts...)
+	commits, err := ListCommitsWithNotes(client, logger, branch, start, end, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -258,8 +259,10 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 
 // ListCommits lists all commits starting from a given commit SHA and ending at
 // a given commit SHA.
-func ListCommits(client *github.Client, start, end string, opts ...githubApiOption) ([]*github.RepositoryCommit, error) {
+func ListCommits(client *github.Client, branch, start, end string, opts ...githubApiOption) ([]*github.RepositoryCommit, error) {
 	c := configFromOpts(opts...)
+
+	c.branch = branch
 
 	startCommit, _, err := client.Git.GetCommit(c.ctx, c.org, c.repo, start)
 	if err != nil {
@@ -308,13 +311,14 @@ func ListCommits(client *github.Client, start, end string, opts ...githubApiOpti
 func ListCommitsWithNotes(
 	client *github.Client,
 	logger log.Logger,
+	branch,
 	start,
 	end string,
 	opts ...githubApiOption,
 ) ([]*github.RepositoryCommit, error) {
 	filteredCommits := []*github.RepositoryCommit{}
 
-	commits, err := ListCommits(client, start, end, opts...)
+	commits, err := ListCommits(client, branch, start, end, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Adds a `-release-version` flag that adds the output to the generated JSON.
- Adds a `-branch` flag that defaults to `master` if unset.
- If `-format` is `json` and `-output` is an existing JSON file, the tool will smartly append (update PRs if existing) to the file rather than generate a new one.
- If `-output` file doesn't exist, create it
- Created a map[int]ReleaseNote to allow for smarter merging of new and existing notes (just for JSON output)
- Cleaned up the run function in main.go (thanks @BenTheElder) so logic can get broken out easier.

This will be useful with future endeavors when using the output of this tool. :smile: 