### PR TITLE
fix bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,5 +3,4 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:prefix k8s.io/release
 gazelle(
     name = "gazelle",
-    external = "vendored",
 )

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -7,11 +7,11 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/notes:go_default_library",
-        "//vendor/github.com/go-kit/kit/log:go_default_library",
-        "//vendor/github.com/go-kit/kit/log/level:go_default_library",
-        "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/github.com/kolide/kit/env:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
+        "@com_github_go_kit_kit//log:go_default_library",
+        "@com_github_go_kit_kit//log/level:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_kolide_kit//env:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )
 

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -9,10 +9,10 @@ go_library(
     importpath = "k8s.io/release/pkg/notes",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/go-kit/kit/log:go_default_library",
-        "//vendor/github.com/go-kit/kit/log/level:go_default_library",
-        "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/github.com/pkg/errors:go_default_library",
+        "@com_github_go_kit_kit//log:go_default_library",
+        "@com_github_go_kit_kit//log/level:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
     ],
 )
 
@@ -24,8 +24,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/github.com/stretchr/testify/require:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )


### PR DESCRIPTION
It looks like gazelle was configured to use the wrong external mode in this repository - we haven't vendored any of the third-party dependencies into `vendor/`. Switching to bazel "external" dependencies seems to work, however.

/assign @marpaia
Fixes #677