### PR TITLE
bump CNI version to 0.7.5 for DEB and RPM

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -23,7 +23,7 @@ const (
 	ChannelUnstable ChannelType = "unstable"
 	ChannelNightly  ChannelType = "nightly"
 
-	cniVersion         = "0.6.0"
+	cniVersion         = "0.7.5"
 	criToolsVersion    = "1.12.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"

--- a/debian/build_test.go
+++ b/debian/build_test.go
@@ -109,7 +109,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 			deps: []string{
 				"kubelet (>= 1.6.0)",
 				"kubectl (>= 1.6.0)",
-				"kubernetes-cni (= 0.6.0)",
+				"kubernetes-cni (= 0.7.5)",
 				"${misc:Depends}",
 				"cri-tools (>= 1.11.0)",
 			},

--- a/debian/xenial/kubernetes-cni/debian/rules
+++ b/debian/xenial/kubernetes-cni/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
-CNI_VERSION = v0.6.0
+CNI_VERSION = v0.7.5
 
 build:
 	echo noop

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -11,10 +11,16 @@
 %define semver() (%1 * 256 * 256 + %2 * 256 + %3)
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
+# no support for %elseif (??)
+# https://github.com/rpm-software-management/rpm/issues/311
+%if %{KUBE_SEMVER} >= %{semver 1 11 0}
+%global CNI_VERSION 0.7.5
+%else
 %if %{KUBE_SEMVER} >= %{semver 1 9 0}
 %global CNI_VERSION 0.6.0
 %else
 %global CNI_VERSION 0.5.1
+%endif
 %endif
 
 %if %{KUBE_SEMVER} >= %{semver 1 12 1}
@@ -86,7 +92,7 @@ Release: %{RPM_RELEASE}
 Summary: Command-line utility for administering a Kubernetes cluster.
 Requires: kubelet >= 1.6.0
 Requires: kubectl >= 1.6.0
-Requires: kubernetes-cni >= 0.6.0
+Requires: kubernetes-cni >= 0.7.5
 Requires: cri-tools >= 1.11.0
 
 %description -n kubeadm
@@ -191,6 +197,9 @@ mv cni-plugins/bin/ %{buildroot}/opt/cni/
 
 
 %changelog
+* Tue Mar 20 2019 Lubomir I. Ivanov <lubomirivanov@vmware.com>
+- Bump CNI version to v0.7.5.
+
 * Tue Sep 25 2018 Chuck Ha <chuck@heptio.com> - 1.12.1
 - Bump cri-tools to 1.12.0.
 


### PR DESCRIPTION
CNI was bumped in k/k to 0.7.5.
it's being backported all the way back to 1.11 due to a CVE:
https://github.com/kubernetes/kubernetes/pull/75455

this PR is based on this "bump CNI to 0.6.0" PR:
https://github.com/kubernetes/release/pull/486

/hold
cc @timothysc @ncdc @chuckha @dixudx 
/assign @ixdy @tpepper @dougm 
