### PR TITLE
Allow processing multiline release notes

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -179,10 +179,11 @@ func ListReleaseNotes(
 // This is generally the content inside the ```release-note ``` stanza.
 func NoteTextFromString(s string) (string, error) {
 	exps := []*regexp.Regexp{
-		regexp.MustCompile("```release-note\\r\\n(?P<note>.+)"),
-		regexp.MustCompile("```dev-release-note\\r\\n(?P<note>.+)"),
-		regexp.MustCompile("```\\r\\n(?P<note>.+)\\r\\n```"),
-		regexp.MustCompile("```release-note\n(?P<note>.+)\n```"),
+		// (?s) is needed for '.' to be matching on newlines, by default that's disabled
+		regexp.MustCompile("(?s)```release-note\\r\\n(?P<note>.+)\\r\\n```"),
+		regexp.MustCompile("(?s)```dev-release-note\\r\\n(?P<note>.+)"),
+		regexp.MustCompile("(?s)```\\r\\n(?P<note>.+)\\r\\n```"),
+		regexp.MustCompile("(?s)```release-note\n(?P<note>.+)\n```"),
 	}
 
 	for _, exp := range exps {
@@ -196,7 +197,7 @@ func NoteTextFromString(s string) (string, error) {
 				result[name] = match[i]
 			}
 		}
-		note := strings.TrimRight(result["note"], "\r")
+		note := strings.Replace(result["note"], "\r", "", -1)
 		note = stripActionRequired(note)
 		note = stripStar(note)
 		return note, nil

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -87,3 +87,21 @@ func TestReleaseNoteParsing(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestNoteTextFromString(t *testing.T) {
+	// multi line
+	result, _ := NoteTextFromString("```release-note\r\ntest\r\ntest\r\n```")
+	require.Equal(t, "test\ntest", result)
+
+	// single line
+	result, _ = NoteTextFromString("```release-note\r\ntest\r\n```")
+	require.Equal(t, "test", result)
+
+	// multi line, without carriage return
+	result, _ = NoteTextFromString("```release-note\ntest\ntest\n```")
+	require.Equal(t, "test\ntest", result)
+
+	// single line, without carriage return
+	result, _ = NoteTextFromString("```release-note\ntest\n```")
+	require.Equal(t, "test", result)
+}


### PR DESCRIPTION
Right now we were not able to get multi-line release notes if they were present in the PR description. That was caused by the way the regular expression matching was defined. This PR fixes that allowing multi-line output from the notes tool.