### PR TITLE
anago: direct echo command for easier copy paste

### DIFF
--- a/anago
+++ b/anago
@@ -1752,13 +1752,15 @@ if ((FLAGS_stage)); then
   logecho
   logecho "To release this staged build, run:"
   logecho
-  logecho "$ gcbmgr release ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
-          "--buildversion=$JENKINS_BUILD_VERSION"
+  logecho -n "$ gcbmgr release ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
+             "--buildversion=$JENKINS_BUILD_VERSION"
+  logecho
   logecho
   logecho "-OR-"
   logecho
-  logecho "$ anago ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
-          "--buildversion=$JENKINS_BUILD_VERSION"
+  logecho -n "$ anago ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
+             "--buildversion=$JENKINS_BUILD_VERSION"
+  logecho
   logecho
 
   # Move PROGSTATE


### PR DESCRIPTION
When finishing a successful gcbmgr stage, anago helpfully emits
sample gcbmgr and anago command for the next step of release, but
logecho use of fmtlen can cause the long "--buildversion" to be on
a separate line.  This changes the echo so copy paste reuse of the
emitted command is easier.

Signed-off-by: Tim Pepper <tpepper@vmware.com>