### PR TITLE
Don't assume that gcloud is in the same place as gsutil.

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -943,11 +943,16 @@ common::set_cloud_binaries () {
   logecho -n "Checking/setting cloud tools: "
 
   for GSUTIL in "$(which gsutil)" /opt/google/google-cloud-sdk/bin/gsutil; do
-    [[ -x $GSUTIL ]] && break
+    if [[ -x "$GSUTIL" ]]; then
+      break
+    fi
   done
 
-  # gcloud should be in the same place
-  GCLOUD=${GSUTIL/gsutil/gcloud}
+  for GCLOUD in "${GSUTIL}/gsutil/gcloud" "$(which gcloud)"; do
+    if [[ -x "$GCLOUD" ]]; then
+      break
+    fi
+  done
 
   if [[ -x "$GSUTIL" && -x "$GCLOUD" ]]; then
     logecho -r $OK


### PR DESCRIPTION
gsutil and gcloud are not in the same directory on my system and I don't see why they should have to be. This PR searches for gcloud both in the gsutil directory as well as wherever in the user's PATH it might be.

I've tested that this works on my own system and I think it shouldn't break any existing uses but hopefully reviewers with more bash experience can confirm (or tell me how to test).