### PR TITLE
Revert "Don't assume that gcloud is in the same place as gsutil."

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -943,16 +943,11 @@ common::set_cloud_binaries () {
   logecho -n "Checking/setting cloud tools: "
 
   for GSUTIL in "$(which gsutil)" /opt/google/google-cloud-sdk/bin/gsutil; do
-    if [[ -x "$GSUTIL" ]]; then
-      break
-    fi
+    [[ -x $GSUTIL ]] && break
   done
 
-  for GCLOUD in "${GSUTIL}/gsutil/gcloud" "$(which gcloud)"; do
-    if [[ -x "$GCLOUD" ]]; then
-      break
-    fi
-  done
+  # gcloud should be in the same place
+  GCLOUD=${GSUTIL/gsutil/gcloud}
 
   if [[ -x "$GSUTIL" && -x "$GCLOUD" ]]; then
     logecho -r $OK


### PR DESCRIPTION
Reverts kubernetes/release#695.

For some reason the scripts now fail to find gsutil and gcloud when run inside of gcr.io/kubernetes-release-test/k8s-cloud-builder. See https://github.com/kubernetes/release/pull/695#issuecomment-483761711.