### PR TITLE
Fix bug setting default branch to branch

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -71,7 +71,7 @@ func (o *options) BindFlags() *flag.FlagSet {
 	flags.StringVar(
 		&o.branch,
 		"branch",
-		env.String("BRANCH", "branch"),
+		env.String("BRANCH", "master"),
 		"Select which branch to scrape. Defaults to `master`",
 	)
 


### PR DESCRIPTION
The default branch should be `master` instead of `branch`.