### PR TITLE
Find PRs that were squash merged

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -405,7 +405,11 @@ func PRFromCommit(client *github.Client, commit *github.RepositoryCommit, opts .
 	exp := regexp.MustCompile(`Merge pull request #(?P<number>\d+)`)
 	match := exp.FindStringSubmatch(*commit.Commit.Message)
 	if len(match) == 0 {
-		return nil, errors.New("no matches found when parsing PR from commit")
+		// If the PR was squash merged, the regexp is different
+		match = regexp.MustCompile(`\(#(?P<number>\d+)\)`).FindStringSubmatch(*commit.Commit.Message)
+		if len(match) != 1 {
+			return nil, errors.New("no matches found when parsing PR from commit")
+		}
 	}
 	result := map[string]string{}
 	for i, name := range exp.SubexpNames() {


### PR DESCRIPTION
This PR allows to find PRs from commits that were squash merged.

I didn't add unittests because `PRFromCommit` requires a `github.Client` and it seems there is no fake implementation of it. Maybe consider switching to the github client implementation from test-infra?  It does have a mock client: https://github.com/kubernetes/test-infra/tree/master/prow/github/fakegithub