### PR TITLE
Actually find PRs that were squash merged

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -404,28 +404,10 @@ func ListCommitsWithNotes(
 func PRFromCommit(client *github.Client, commit *github.RepositoryCommit, opts ...GithubApiOption) (*github.PullRequest, error) {
 	c := configFromOpts(opts...)
 
-	// Thankfully k8s-merge-robot commits the PR number consistently. If this ever
-	// stops being true, this definitely won't work anymore.
-	exp := regexp.MustCompile(`Merge pull request #(?P<number>\d+)`)
-	match := exp.FindStringSubmatch(*commit.Commit.Message)
-	if len(match) == 0 {
-		// If the PR was squash merged, the regexp is different
-		match = regexp.MustCompile(`\(#(?P<number>\d+)\)`).FindStringSubmatch(*commit.Commit.Message)
-		if len(match) != 1 {
-			return nil, errors.New("no matches found when parsing PR from commit")
-		}
-	}
-	result := map[string]string{}
-	for i, name := range exp.SubexpNames() {
-		if i != 0 && name != "" {
-			result[name] = match[i]
-		}
-	}
-	number, err := strconv.Atoi(result["number"])
+	number, err := getPRNumberFromCommitMessage(*commit.Commit.Message)
 	if err != nil {
 		return nil, err
 	}
-
 	// Given the PR number that we've now converted to an integer, get the PR from
 	// the API
 	pr, _, err := client.PullRequests.Get(c.ctx, c.org, c.repo, number)
@@ -549,4 +531,29 @@ func HasString(a []string, x string) bool {
 		}
 	}
 	return false
+}
+
+func getPRNumberFromCommitMessage(commitMessage string) (int, error) {
+	// Thankfully k8s-merge-robot commits the PR number consistently. If this ever
+	// stops being true, this definitely won't work anymore.
+	exp := regexp.MustCompile(`Merge pull request #(?P<number>\d+)`)
+	match := exp.FindStringSubmatch(commitMessage)
+	if len(match) == 0 {
+		// If the PR was squash merged, the regexp is different
+		match = regexp.MustCompile(`\(#(?P<number>\d+)\)`).FindStringSubmatch(commitMessage)
+		if len(match) == 0 {
+			return 0, errors.New("no matches found when parsing PR from commit")
+		}
+	}
+	result := map[string]string{}
+	for i, name := range exp.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+	number, err := strconv.Atoi(result["number"])
+	if err != nil {
+		return 0, err
+	}
+	return number, nil
 }

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -105,3 +105,37 @@ func TestNoteTextFromString(t *testing.T) {
 	result, _ = NoteTextFromString("```release-note\ntest\n```")
 	require.Equal(t, "test", result)
 }
+
+func TestGetPRNumberFromCommitMessage(t *testing.T) {
+	testCases := []struct {
+		name             string
+		commitMessage    string
+		expectedPRNumber int
+	}{
+		{
+			name: "Get PR number from merged PR",
+			commitMessage: `Merge pull request #76030 from andrewsykim/e2e-legacyscheme
+
+    test/e2e: replace legacy scheme with client-go scheme`,
+			expectedPRNumber: 76030,
+		},
+		{
+			name:             "Get PR number from squash merged PR",
+			commitMessage:    "Add swapoff to centos so kubelet starts (#504)",
+			expectedPRNumber: 504,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPRNumber, err := getPRNumberFromCommitMessage(tc.commitMessage)
+			if err != nil {
+				t.Fatalf("Expected no error to occur but got %v", err)
+			}
+			if actualPRNumber != tc.expectedPRNumber {
+				t.Errorf("Expected PR number to be %d but was %d", tc.expectedPRNumber, actualPRNumber)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
The current logic is wrong, as there will be at least two matches, one for the whole regexp and one for the matching group. This fixes that and moves the whole thing into a dedicated func to make it testable, as regexps are only as trustworthy as their tests.

/assign @jeefy @marpaia