### PR TITLE
Fix Debian packages build

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.12
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
Debian packages build is failing because it uses golang:1.7 base Docker
image based on Debian "jessie" release, which is broken because of
`jessie-updates` removal, please see #691 for details.

This PR updates base Docker image for Debian to golang:1.12 based on
Debian "stretch" release.