### PR TITLE
Add error check for json unmarshal

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -173,7 +173,10 @@ func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNoteList) error {
 		byteValue, _ := ioutil.ReadAll(output)
 		existingNotes := make([]*notes.ReleaseNote, 0)
 
-		json.Unmarshal(byteValue, &existingNotes)
+		if err := json.Unmarshal(byteValue, &existingNotes); err != nil {
+			level.Error(o.logger).Log("msg", "error unmarshalling existing notes", "err", err)
+			return err
+		}
 
 		if len(existingNotes) > 0 {
 			output.Truncate(0)


### PR DESCRIPTION
This PR adds a simple check for `json.Unmarshal`.