### PR TITLE
Depends on kubernetes-cni as >=

### DIFF
--- a/debian/build.go
+++ b/debian/build.go
@@ -358,7 +358,7 @@ func getKubeletCNIVersion(v version) (string, error) {
 	}
 
 	if sv.GTE(v190) {
-		return fmt.Sprintf("= %s", cniVersion), nil
+		return fmt.Sprintf(">= %s", cniVersion), nil
 	}
 	return fmt.Sprint("= 0.5.1"), nil
 }

--- a/debian/build_test.go
+++ b/debian/build_test.go
@@ -99,7 +99,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 			deps: []string{
 				"kubelet (>= 1.6.0)",
 				"kubectl (>= 1.6.0)",
-				"kubernetes-cni (= 0.7.5)",
+				"kubernetes-cni (>= 0.7.5)",
 				"${misc:Depends}",
 			},
 		},
@@ -109,7 +109,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 			deps: []string{
 				"kubelet (>= 1.6.0)",
 				"kubectl (>= 1.6.0)",
-				"kubernetes-cni (= 0.7.5)",
+				"kubernetes-cni (>= 0.7.5)",
 				"${misc:Depends}",
 				"cri-tools (>= 1.11.1)",
 			},


### PR DESCRIPTION
Currently both `kubeadm` and `kubelet` Debian packages depend on
`kubernetes-cni` with the "exactly equal" relation (`=`)[1], which
prevents using any `debian_revision`[2] for the `kubernetes-cni`
package:

```
$ dpkg -l kubernetes-cni
...
ii  kubernetes-cni              0.7.5-2        amd64              Kubernetes CNI

$ sudo apt-cache show kubeadm=1.14.1-2
...
Depends: kubelet (>= 1.6.0), kubectl (>= 1.6.0), kubernetes-cni (= 0.7.5), cri-tools (>= 1.12.0)
...

$ sudo apt-get install kubelet=1.14.1-2
...
The following packages have unmet dependencies:
 kubelet : Depends: kubernetes-cni (= 0.7.5) but 0.7.5-2 is to be installed
E: Unable to correct problems, you have held broken packages.
```

This PR changes the dependencies to "later or equal" (`>=`), fixing the
described issue as a result.

[1] https://www.debian.org/doc/debian-policy/ch-relationships.html
[2] https://www.debian.org/doc/debian-policy/ch-controlfields.html#version