### PR TITLE
removed update-federation-openapi-spec in branchff

### DIFF
--- a/branchff
+++ b/branchff
@@ -191,7 +191,7 @@ fi
 # <snip>
 # Commit your changes in another terminal and then continue here by pressing enter.
 
-USEFUL_UPDATES=(update-openapi-spec update-federation-openapi-spec)
+USEFUL_UPDATES=(update-openapi-spec)
 
 logecho -n "Ensure etcd is up to date: "
 logrun -s hack/install-etcd.sh


### PR DESCRIPTION
this does not exist in k/k anymore

a side note here: installing and running etcd during branch fast-forward seems weird, but I'm not removing `update-openapi-spec` because we are still using it, e.g., https://github.com/kubernetes/kubernetes/commit/233a5a1b9ecb78bf9beae44603d5e846864eba1d.