### PR TITLE
rpms: change CNI version check to ">="

### DIFF
--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -54,7 +54,7 @@ Source7: https://github.com/kubernetes-incubator/cri-tools/releases/download/v%{
 BuildRequires: systemd
 BuildRequires: curl
 Requires: iptables >= 1.4.21
-Requires: kubernetes-cni = %{CNI_VERSION}
+Requires: kubernetes-cni >= %{CNI_VERSION}
 Requires: socat
 Requires: util-linux
 Requires: ethtool
@@ -197,6 +197,9 @@ mv cni-plugins/bin/ %{buildroot}/opt/cni/
 
 
 %changelog
+* Thu May 30 2019 Tim Pepper <tpepper@vmware.com>
+- Change CNI version check to ">="
+
 * Tue Mar 20 2019 Lubomir I. Ivanov <lubomirivanov@vmware.com>
 - Bump CNI version to v0.7.5.
 


### PR DESCRIPTION
Pull https://github.com/kubernetes/release/pull/716 changed the Deb
package metadata to check the CNI version with a ">=".

There is still ongoing debate on the right way to curate our package
metadata relative to dependencies.  But in the meantime...We need this
to be consistent across packaging.

So this commit does the same as #716 but also for RPMs.

Signed-off-by: Tim Pepper <tpepper@vmware.com>