### PR TITLE
Fix JSON output for `release-notes`

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -152,6 +152,7 @@ func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNoteList) error {
 	// Open a handle to the file which will contain the release notes output
 	var output *os.File
 	var err error
+	var existingNotes notes.ReleaseNoteList
 
 	if o.output != "" {
 		output, err = os.OpenFile(o.output, os.O_RDWR|os.O_CREATE, 0644)
@@ -171,11 +172,12 @@ func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNoteList) error {
 	switch o.format {
 	case "json":
 		byteValue, _ := ioutil.ReadAll(output)
-		existingNotes := make([]*notes.ReleaseNote, 0)
 
-		if err := json.Unmarshal(byteValue, &existingNotes); err != nil {
-			level.Error(o.logger).Log("msg", "error unmarshalling existing notes", "err", err)
-			return err
+		if len(byteValue) > 0 {
+			if err := json.Unmarshal(byteValue, &existingNotes); err != nil {
+				level.Error(o.logger).Log("msg", "error unmarshalling existing notes", "err", err)
+				return err
+			}
 		}
 
 		if len(existingNotes) > 0 {


### PR DESCRIPTION
Two problems are being addressed:

1) The tool was generating one format while expecting to _read_ a different format.
2) If there was a 0-length file (say someone did `touch release-notes.json` beforehand) it would generate a release notes list and fail.