### PR TITLE
 Minor release notes formatting issue for code blocks #681 

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -201,7 +201,9 @@ func NoteTextFromString(s string) (string, error) {
 				result[name] = match[i]
 			}
 		}
-		note := strings.Replace(result["note"], "\r", "", -1)
+
+		note := strings.Replace(result["note"], "#", "&#35;", -1)
+		note = strings.Replace(note, "\r", "", -1)
 		note = stripActionRequired(note)
 		note = stripStar(note)
 		return note, nil

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -92,6 +92,10 @@ func TestNoteTextFromString(t *testing.T) {
 	// single line, without carriage return
 	result, _ = NoteTextFromString("```release-note\ntest\n```")
 	require.Equal(t, "test", result)
+
+	result, _ = NoteTextFromString("```release-note\n#test\n```")
+	require.Equal(t, "&#35;test", result)
+
 }
 
 func TestGetPRNumberFromCommitMessage(t *testing.T) {


### PR DESCRIPTION
Attempts to fix https://github.com/kubernetes/release/issues/681

Replace "#" in notes by the literal character and adds a test.
