### PR TITLE
Reducing layers in godep Dockerfile

### DIFF
--- a/build/godep-builder/Dockerfile
+++ b/build/godep-builder/Dockerfile
@@ -1,14 +1,14 @@
-FROM golang
+FROM golang:1.12
 
 LABEL "source.repo"="github/kubernetes/release/build/godep-builder"
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH
 
-RUN go version
-RUN go get github.com/tools/godep
-RUN godep version
-RUN apt-get update && \
+RUN go version && \
+    go get github.com/tools/godep && \
+    godep version && \
+    apt-get update && \
     apt-get install -y build-essential
 
 ENTRYPOINT ["/gopath/bin/godep"]


### PR DESCRIPTION
I noticed that the Dockerfile in godeps creates many new layers needlessly. Given that Docker recommends reducing the layers (unless doing a multi-stage build, which this one isn't doing), it seems like combining these steps into a single RUN command would help a little.

I also added a golang:latest flag to make it more explicit which version of the golang container we can pull from. I think it may be beneficial to use specific version number in the future too.