### PR TITLE
Adding check_binaries command that is distinct from check_packages to lib/common.sh

### DIFF
--- a/anago
+++ b/anago
@@ -342,8 +342,8 @@ check_prerequisites () {
   # We check for docker here as a word which passes for docker-ce and
   # docker-engine as docker packages are in transiation of deprecating
   # docker-engine
-  common::check_packages jq pandoc docker ${PREREQUISITE_PACKAGES[*]} \
-   || return 1
+  common::check_binaries jq pandoc docker || return 1
+  common::check_packages ${PREREQUISITE_PACKAGES[*]} || return 1
   common::check_pip_packages yq || return 1
 
   security_layer::auth_check 2 || return 1

--- a/branchff
+++ b/branchff
@@ -58,10 +58,7 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
 
 # Check prerequisites
 
-PREREQUISITE_TOOLS=("git" "jq" "go" "make")
-for PREREQ in ${PREREQUISITE_TOOLS[@]}; do
-  command -v $PREREQ > /dev/null 2>&1 || common::exit 1 "$PREREQ not installed"
-done;
+common::check_binaries git go jq make
 
 [[ -w /usr/local ]] || common::exit 1 "/usr/local is not writable."
 

--- a/find_green_build
+++ b/find_green_build
@@ -101,7 +101,7 @@ MYLOG=$TMPDIR/$PROG.log
 common::logfileinit $MYLOG 10
 
 gitlib::github_api_token
-common::check_packages jq
+common::check_binaries jq
 common::check_pip_packages yq
 common::set_cloud_binaries
 

--- a/gcbmgr
+++ b/gcbmgr
@@ -372,7 +372,7 @@ common::logfileinit $MYLOG 10
 # BEGIN script
 common::timestamp begin
 
-common::check_packages jq git bsdmainutils || common::exit 1 "Exiting..."
+common::check_binaries jq git column || common::exit 1 "Exiting..."
 gitlib::repo_state || common::exit 1 "Exiting..."
 
 # Ensure some prerequisites

--- a/relnotes
+++ b/relnotes
@@ -511,7 +511,7 @@ common::timestamp begin
 gitlib::github_api_token
 
 # Check for packages
-common::check_packages jq pandoc
+common::check_binaries jq pandoc
 
 # Build LAST_RELEASE dictionary
 gitlib::last_releases

--- a/script-template
+++ b/script-template
@@ -149,6 +149,7 @@ common::timestamp begin
 # common::askyorn - Ask a simple yes or no question (see common.sh for details)
 # common::stepheader - Bolded, logged bullet points for your output
 # common::exit - Exit cleanly
+# common::check_binaries - Checks for binary prereqs
 # common::check_packages - Check for package prereqs
 # common::disk_space_check - Check disk space
 


### PR DESCRIPTION
My motivation for this PR comes from this issue here: https://github.com/kubernetes/release/issues/684

Specifically, for many prerequisites that the scripts here require, we check whether a distribution-specific package for them exists. So, for example, if I install the `jq` binary from source, `common::check_packages jq` would fail even though I'm using Ubuntu simply because I didn't install using `apt`.

Requiring that binaries come from specific packages causes problems when the packages that contain those binaries changes, or is different between Linux distribution. It also prevents non-mainstream, and non-Linux-based distros, from using these scripts. I think checking for binaries, directly, is much for flexible.