### PR TITLE
Update OWNERS (6/23/19)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,17 +10,20 @@ aliases:
     - calebamiles
     - ixdy
     - tpepper
-  patch-release-manager-role:
-    - feiskyer # 1.12
-    - aleksandra-malinowska # 1.13 / 1.14 / 1.15
-    - tpepper # 1.13 / 1.14 / 1.15
-    - hoegaarden # 1.13 / 1.14 / 1.15
-  branch-manager-role:
-    - dougm # 1.12 / 1.13
-    - hoegaarden # 1.14
-    - bubblemelon # 1.15
+  patch-release-team:
+    - aleksandra-malinowska
+    - feiskyer
+    - hoegaarden
+    - tpepper
+  branch-managers:
+    - bubblemelon
+    - idealhack
+  build-admins:
+    - aleksandra-malinowska
+    - listx
+    - sumitranr
   release-team-lead-role:
-    - tpepper # 1.12
     - aishsundar # 1.13
     - spiffxp # 1.14
     - claurence # 1.15
+    - lachie83 # 1.16

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -1,12 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-release-leads
   - release-engineering
   - patch-release-team
 reviewers:
-  - release-team-lead-role
   - branch-managers
+  - build-admins
 labels:
-  - sig/release
   - area/release-eng

--- a/debian/OWNERS
+++ b/debian/OWNERS
@@ -1,12 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-release-leads
   - release-engineering
   - patch-release-team
 reviewers:
-  - release-team-lead-role
   - branch-managers
+  - build-admins
 labels:
-  - sig/release
   - area/release-eng

--- a/rpm/OWNERS
+++ b/rpm/OWNERS
@@ -1,12 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-release-leads
   - release-engineering
   - patch-release-team
 reviewers:
-  - release-team-lead-role
   - branch-managers
+  - build-admins
 labels:
-  - sig/release
   - area/release-eng


### PR DESCRIPTION
- Add Lachie Evenson to release-team-lead-role for 1.16
- Rename branch-manager-role to branch-managers
- Rename patch-release-manager-role to patch-release-team
- Move branch-managers to reviewers
- Add build-admins (ref: https://github.com/kubernetes/sig-release/pull/689)
- Add OWNERS to build, debian, rpm directories

Signed-off-by: Stephen Augustus <saugustus@vmware.com>