### PR TITLE
releaselib: add REMOVE_IMAGES_AFTER_RELEASE to keep images

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -953,7 +953,7 @@ release::docker::release () {
       # TODO: Use docker direct when fixed later
       #logrun -r 5 -s docker push "${new_tag_with_arch}" || return 1
       logrun -r 5 -s $GCLOUD docker -- push "${new_tag_with_arch}" || return 1
-      if [[ "${REMOVE_IMAGES_AFTER_RELEASE:-y}" == "y" ]] ; then
+      if [[ "${PURGE_IMAGES:-yes}" == "yes" ]] ; then
         logrun docker rmi $orig_tag ${new_tag_with_arch} || true
       fi
     done
@@ -974,7 +974,7 @@ release::docker::release () {
     done
     logecho "Pushing manifest image ${image}:${version}..."
     local purge=""
-    if [[ "${REMOVE_IMAGES_AFTER_RELEASE:-y}" == "y" ]] ; then
+    if [[ "${PURGE_IMAGES:-yes}" == "yes" ]] ; then
       purge="--purge"
     fi
     logrun -r 5 -s docker manifest push ${purge} ${image}:${version} || return 1


### PR DESCRIPTION
Add support to keep docker images and manifest after these are pushed into registry by the push-build.sh script.
This is controlled using PURGE_IMAGES=no environment variable, if not defined will default to "yes", which is the current behavior.

Example:
export PURGE_IMAGES=no
../release/push-build.sh \
  --nomock --bucket=${GCS_RELEASE_BUCKET} --private-bucket \
  --docker-registry=${REGISTRY}

docker images:
REPOSITORY                           TAG             IMAGE ID
gcr.io/google_containers/kube-proxy  v1.12.9  09a2377a4efd
gcr.io/REGISTRY/kube-proxy-amd64     v1.12.9  09a2377a4efd
k8s.gcr.io/kube-proxy                v1.12.9  09a2377a4efd