### PR TITLE
Bail out and print clear error when assoc arrays are not supported

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -24,7 +24,11 @@ export PROG
 
 set -o errtrace
 
-declare -A some_var || (echo "Bash version >= 4.0 required" && exit 1)
+# shellcheck disable=SC2034
+declare -A some_var >/dev/null 2>&1 || {
+  echo "Bash with support for associative arrays (version >= 4.0) required"
+  exit 1
+}
 
 if [[ $(uname) == "Darwin" ]]; then
   # Support for OSX.


### PR DESCRIPTION
- Removing the subshell, so we actually bail out of the whole script
  (and not only the subshell)
- Specifically state which feature we are missing
- Hide error from `declare` to remove clutter
- Opportunistically add the shellcheck directive as we are not actually
  using that declared variable

/cc @kubernetes/release-engineering 