### PR TITLE
[anago] publishing-bot issue does not assign correctly #713

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -403,7 +403,7 @@ gitlib::get_team_members() {
   query='query ($org:String!, $team:String!) {
     organization(login: $org) {
       team(slug: $team) {
-        members(next: 100) {
+        members {
           nodes {
             login
           }


### PR DESCRIPTION
I found that the command `get_team_members` failed because of the `(next: 100)` section command (the api didn't recognize this small stanza).

When I run without that section, the command works like a charm.

Addresses: https://github.com/kubernetes/release/issues/713