### PR TITLE
Update shellcheck script to search all files with *sh shebangs

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -36,13 +36,7 @@ SHELLCHECK_IMAGE="koalaman/shellcheck-alpine:v0.6.0@sha256:7d4d712a2686da99d3758
 all_shell_scripts=()
 while IFS=$'\n' read -r script;
   do git check-ignore -q "$script" || all_shell_scripts+=("$script");
-done < <(find . -name "*.sh" \
-  -not \( \
-    -path ./_\*      -o \
-    -path ./.git\*   -o \
-    -path ./vendor\* -o \
-    \( -path ./third_party\* -a -not -path ./third_party/forked\* \) \
-  \))
+done < <(grep -irl '#!.*sh' . --exclude-dir={_\*,.git\*,vendor\*})
 
 # common arguments we'll pass to shellcheck
 SHELLCHECK_OPTIONS=(


### PR DESCRIPTION
Okay, one more round with this shellcheck script :smile: 

Several of the shell scripts in this repo do not have `.sh`
extensions, which means we will miss shellcheck-ing them with a
`find` that considers only the file name.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/cc @pswica 
/assign @spiffxp @BenTheElder 
/sig release
/area release-eng
ref: #726, #740, #742, #753 