### PR TITLE
re-add LOCAL_CACHE to lib/common.sh

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1341,3 +1341,4 @@ mkdir -p "$TMPDIR"
 
 # Set some values that depend on $TMPDIR
 PROGSTATE=$TMPDIR/$PROG-runstate
+export LOCAL_CACHE="$TMPDIR/buildresults-cache.$$"


### PR DESCRIPTION
I removed this variable in the script when editing for shellcheck compliance, but I'm beginning to think it may be needed. It looks like scripts such as anago and find_green_build import it.

https://github.com/kubernetes/release/blob/master/anago#L225
https://github.com/kubernetes/release/blob/master/find_green_build#L88