### PR TITLE
Update shebangs to `#!/usr/bin/env bash`

### DIFF
--- a/anago
+++ b/anago
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/branchff
+++ b/branchff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/changelog-update
+++ b/changelog-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/debian/jenkins.sh
+++ b/debian/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o errexit

--- a/find_green_build
+++ b/find_green_build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/gcbmgr
+++ b/gcbmgr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Kubernetes Authors All rights reserved.
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+#
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/releaselib_test.sh
+++ b/lib/releaselib_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+#
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/release-notify
+++ b/release-notify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Kubernetes Authors All rights reserved.
 #

--- a/relnotes
+++ b/relnotes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 docker build -t kubelet-rpm-builder .

--- a/script-template
+++ b/script-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
@@ -48,7 +48,7 @@ PROG=${0##*/}
 source "$(dirname "$(readlink -ne "$0")")/lib/common.sh"
 
 cat <<EOF_CAT
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #


### PR DESCRIPTION
Referencing @spiffxp's [review comment here](https://github.com/kubernetes/release/pull/752/files#r298431005):
> I find I can't run this with my >4.0 version of bash as installed by homebrew unless I invoke as `bash ./prin` or change the hashbang to `#!/usr/bin/env bash`

It would probably be helpful for OS X users to be able to utilize these scripts as well, especially as we build up the Release Managers team.

Consider this a first step. There's no attempt to modify any script logic here, outside of the shebangs.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>