### PR TITLE
Fix mapfile param -t in scrpts branchff and prin.

### DIFF
--- a/branchff
+++ b/branchff
@@ -169,7 +169,7 @@ logecho -n "Merging $MASTER_OBJECT into $RELEASE_BRANCH branch: "
 # releases occurring between branch and branchff, resolve specifically in favor
 # of the branched (deleted) version of those files.
 if ! logrun -s git merge -X ours "$MASTER_OBJECT"; then
-  mapfile -i DELETED_FILES < <(git status -s |
+  mapfile -t DELETED_FILES < <(git status -s |
                    awk '$1 == "DU" && $2 ~ /CHANGELOG-/ {print $2}')
 
   ((${#DELETED_FILES[*]}==0)) \

--- a/prin
+++ b/prin
@@ -159,7 +159,7 @@ elif [[ "${POSITIONAL_ARGV[0]}" =~ ^[a-zA-Z0-9]*$ ]]; then
 				|grep "$COMMIT" \
 				|grep "Merge pull request" \
 				|cut -d'-' -f1)
-    mapfile -i CP_COMMITS < <(git log --pretty=format:"%H - %an, %ar : %s" \
+   mapfile -t CP_COMMITS < <(git log --pretty=format:"%H - %an, %ar : %s" \
 				|grep "$COMMIT" \
 				|grep "cherry-pick-of-" \
 				|cut -d'-' -f1)


### PR DESCRIPTION
Reference to #770, Mapfile takes parameter `-t` not `-i`
Following scripts `branchff` and `prin` are needed updated too. 