### PR TITLE
Ensure branchff stops if check_binaries fails

### DIFF
--- a/branchff
+++ b/branchff
@@ -59,7 +59,7 @@ source "$(dirname "$(readlink -ne "${BASH_SOURCE[0]}")")/lib/common.sh"
 
 # Check prerequisites
 
-common::check_binaries git go jq make
+common::check_binaries git go jq make || common::exit
 
 [[ -w /usr/local ]] || common::exit 1 "/usr/local is not writable."
 


### PR DESCRIPTION
This is just something I noticed. Since my changes to branchff with `check_binaries` I did not add a fail statement. Fixing this here