### PR TITLE
Fixing shellcheck warnings in entry.sh

### DIFF
--- a/rpm/entry.sh
+++ b/rpm/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Entrypoint for the build container to create the rpms and yum repodata:
 # Usage: ./entry.sh GOARCH/RPMARCH,GOARCH/RPMARCH,....
 
@@ -7,7 +7,7 @@ set -e
 declare -a ARCHS
 
 if [ $# -gt 0 ]; then
-  IFS=','; ARCHS=($1); unset IFS;
+  IFS=','; mapfile -t ARCHS < <($1); unset IFS;
 else
   #GOARCH/RPMARCH
   ARCHS=(
@@ -19,16 +19,16 @@ else
   )
 fi
 
-for ARCH in ${ARCHS[@]}; do
-  IFS=/ read GOARCH RPMARCH<<< ${ARCH}; unset IFS;
+for ARCH in "${ARCHS[@]}"; do
+  IFS=/ read -r GOARCH RPMARCH<<< "${ARCH}"; unset IFS;
   SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-  mkdir -p ${SRC_PATH}
-  cp -r /root/rpmbuild/SPECS/* ${SRC_PATH}
+  mkdir -p "${SRC_PATH}"
+  cp -r /root/rpmbuild/SPECS/* "${SRC_PATH}"
   echo "Building RPM's for ${GOARCH}....."
-  sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/kubelet.spec
+  sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/kubelet.spec"
   # Download sources if not already available
-  cd ${SRC_PATH} && spectool -gf kubelet.spec
-  /usr/bin/rpmbuild --target ${RPMARCH} --define "_sourcedir ${SRC_PATH}" -bb ${SRC_PATH}/kubelet.spec
-  mkdir -p /root/rpmbuild/RPMS/${RPMARCH}
-  createrepo -o /root/rpmbuild/RPMS/${RPMARCH}/ /root/rpmbuild/RPMS/${RPMARCH}
+  cd "${SRC_PATH}" && spectool -gf kubelet.spec
+  /usr/bin/rpmbuild --target "${RPMARCH}" --define "_sourcedir ${SRC_PATH}" -bb "${SRC_PATH}/kubelet.spec"
+  mkdir -p "/root/rpmbuild/RPMS/${RPMARCH}"
+  createrepo -o "/root/rpmbuild/RPMS/${RPMARCH}/" "/root/rpmbuild/RPMS/${RPMARCH}"
 done


### PR DESCRIPTION
Please see: https://github.com/kubernetes/release/pull/742 and https://github.com/kubernetes/release/issues/726 for more details and context.

Some extra notes:
1. Shellcheck failed when the shebang was `#!/bin/sh` due to constructs like declare and arrays not existing in POSIX shell.
2. I found that our build container, fedora 24, has bash
3. This, and our new standard drifting toward having `#!/usr/bin/env bash`, prompted my changes. 