### PR TITLE
Fixing arrays in common.sh after shellcheck cleanup

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -782,7 +782,7 @@ common::check_pip_packages () {
     logecho "PREREQ: Missing prerequisites: ${missing[*]}" \
             "Run the following and try again:"
     logecho
-    for prereq in ${missing[*]}; do
+    for prereq in "${missing[@]}"; do
       logecho "$ sudo pip install $prereq"
     done
     return 1
@@ -884,7 +884,7 @@ common::check_packages () {
     logecho "PREREQ: Missing prerequisites: ${missing[*]}" \
             "Run the following and try again:"
     logecho
-    for prereq in ${missing[*]}; do
+    for prereq in "${missing[@]}"; do
       if [[ -n ${PREREQUISITE_INSTRUCTIONS[$prereq]} ]]; then
         logecho "# See ${PREREQUISITE_INSTRUCTIONS[$prereq]}"
       else


### PR DESCRIPTION
Motivation from some comments by @spiffxp on a merged PR. More context can be gathered from this issue here.