### PR TITLE
Add Unit Tests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,18 @@ verify: #verify-shellcheck ## Runs verification scripts to ensure correct execut
 verify-shellcheck: ## Runs shellcheck
 	./hack/verify-shellcheck.sh
 
+##@ Tests
+
+.PHONY: test
+test: test-go test-sh ## Runs unit tests to ensure correct execution
+
+.PHONY: test-go 
+test-go: ## Run all golang tests
+	./hack/test-go.sh
+	
+.PHONY: test-sh
+test-sh: ## Runs all shellscript tests
+	./hack/test-sh.sh
 ##@ Helpers
 
 .PHONY: help

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+go test ./...

--- a/hack/test-sh.sh
+++ b/hack/test-sh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+find . -type f -name '*_test.sh' -print0 | xargs -0 -n1 /usr/bin/env bash


### PR DESCRIPTION
This is to get the ball rolling on:
https://github.com/kubernetes/release/issues/779

I wanted something like `go test ./...` but could not get the test to pass (even inside the golang:12 container). I decided, then, to instead specify which directories to run go test into. This may be a good thing as it allows us be granular and enable/disable testing in certain places. I also like golang testing not relying on bazel

cc @hoegaarden 

As always, please let me know any/all improvements to make :)