### PR TITLE
Fixing mapfile to use -t instead of -i argument

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1285,7 +1285,7 @@ common::validate_command_line () {
 
   logecho
   if [[ -f $PROGSTATE ]]; then
-    mapfile -i last_args < <(awk '/^CMDLINE: / {for(i=2;i<=NF;++i)print $i}' "$PROGSTATE")
+    mapfile -t last_args < <(awk '/^CMDLINE: / {for(i=2;i<=NF;++i)print $i}' "$PROGSTATE")
     if [[ ${args[*]} != "${last_args[*]}" ]]; then
       logecho "A previous incomplete run using different command-line values" \
               "exists."


### PR DESCRIPTION
Fixing mapfile to use -t instead of -i argument--something that I broke in my lib/common.sh shellcheck PR