### PR TITLE
shellcheck: Fix can't follow non-constant source (SC1090/SC1091)

### DIFF
--- a/lib/common_test.sh
+++ b/lib/common_test.sh
@@ -16,10 +16,10 @@
 
 # common.sh unit tests
 #
-# shellcheck source=../lib/testing.sh
+# shellcheck source=./lib/testing.sh
 source "$(dirname "$(readlink -ne "${BASH_SOURCE[0]}")")/testing.sh"
 
-# shellcheck source=../lib/common.sh
+# shellcheck source=./lib/common.sh
 source "$(dirname "$(readlink -ne "${BASH_SOURCE[0]}")")/common.sh"
 readonly TESTDATA="$( cd "$(dirname "$0")" && pwd )/testdata"
 

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -16,14 +16,14 @@
 
 # gitlib.sh unit tests
 #
-# shellcheck source=../lib/testing.sh
+# shellcheck source=./lib/testing.sh
 source "$(dirname "$(readlink -ne "${BASH_SOURCE[0]}")")/testing.sh"
 
-# shellcheck source=../lib/common.sh
+# shellcheck source=./lib/common.sh
 source "$(dirname "$(readlink -ne "${BASH_SOURCE[0]}")")/common.sh"
-# shellcheck source=../lib/gitlib.sh
+# shellcheck source=./lib/gitlib.sh
 source "$TOOL_LIB_PATH/gitlib.sh"
-# shellcheck source=../lib/releaselib.sh
+# shellcheck source=./lib/releaselib.sh
 source "$TOOL_LIB_PATH/releaselib.sh"
 
 readonly TESTDATA="$( cd "$(dirname "$0")" && pwd )/testdata"


### PR DESCRIPTION
follow up of https://github.com/kubernetes/release/pull/791 that have some shellchecks errors

This PR fixes the incorrect paths for non-constant source paths (SC1090/SC1091)