### PR TITLE
lib: Fixing releaselib issues

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -111,7 +111,7 @@ release::set_build_version () {
   local good_job_count=0
   local first_build_number
   local branch_head
-  branch_head=$("$GHCURL" "$K8S_GITHUB_API/commits/$branch" |jq -r '.sha')
+  branch_head=$($GHCURL "$K8S_GITHUB_API/commits/$branch" |jq -r '.sha')
   # Shorten
   branch_head=${branch_head:0:14}
   # The instructions below for installing yq put it in /usr/local/bin
@@ -201,7 +201,7 @@ release::set_build_version () {
       ((good_job_count==1)) && first_build_number=$build_number
       build_sha1=${BASH_REMATCH[9]}
       build_version=${BASH_REMATCH[2]}.$build_number+$build_sha1
-      build_sha1_date=$("$GHCURL" "$K8S" "$GITHUB_API/commits?sha=$build_sha1" |\
+      build_sha1_date=$($GHCURL "$K8S" "$GITHUB_API/commits?sha=$build_sha1" |\
                         jq -r '.[0] | .commit .author .date')
       build_sha1_date=$(date +"%R %m/%d" -d "$build_sha1_date")
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -125,7 +125,7 @@ release::set_build_version () {
   esac
 
   local all_jobs
-  makefile -t "$all_jobs" < <(common::run_gobin blocking-testgrid-tests "$branch")
+  mapfile -t "$all_jobs" < <(common::run_gobin blocking-testgrid-tests "$branch")
 
   if [[ -z ${all_jobs[*]} ]]; then
     logecho "$FAILED: Curl to testgrid/config/config.yaml"


### PR DESCRIPTION
During anago run from 1.12.10:
```
Step #2: ================================================================================
Step #2: SET BUILD CANDIDATE (2/6)
Step #2: ================================================================================
Step #2: 
Step #2: Asking Jenkins for a good build (this may take some time)...
Step #2: /workspace/go/src/k8s.io/release/lib/releaselib.sh: line 114: curl -s --fail --retry 10 -u xxx command not found
Step #2: /workspace/go/src/k8s.io/release/lib/releaselib.sh: line 128: makefile: command not found
Step #2: FAILED: Curl to testgrid/config/config.yaml
Step #2: No sig-release-1.12-blocking list found in the testgrid config.yaml!
Step #2: [2019-Jul-02 08:31:57 UTC] get_build_candidate in 17m5s
Step #2: FAILED in get_build_candidate.
Step #2: 
Step #2: RELEASE INCOMPLETE! Exiting...
Step #2: 
Step #2: 
Step #2: anago: DONE main on d9ca591bbcff Tue Jul 2 08:31:57 UTC 2019 in 17m14s
Finished Step #2
ERROR
ERROR: build step 2 "gcr.io/kubernetes-release-test/k8s-cloud-builder" failed: exit status 1
```

/assign @justaugustus 