### PR TITLE
Fix build break - Deal better with wild cards

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -575,7 +575,7 @@ release::gcs::push_release_artifacts() {
   # We explicitly don't set an ACL in the cp call, since doing so will override
   # any default bucket ACLs.
   logecho -n "- Copying artifacts to $dest: "
-  logrun -s "$GSUTIL" -qm cp -rc "$src/*" "$dest/" || return 1
+  logrun -s "$GSUTIL" -qm cp -rc "$src"/* "$dest/" || return 1
 
   # This small sleep gives the eventually consistent GCS bucket listing a chance
   # to stabilize before the diagnostic listing. There's no way to directly
@@ -616,7 +616,7 @@ release::gcs::locally_stage_release_artifacts() {
 
   # Stage everything in release directory
   logecho "- Staging locally to ${gcs_stage##$build_output/}..."
-  release::gcs::stage_and_hash "$gcs_stage" "$release_tars/*" . || return 1
+  release::gcs::stage_and_hash "$gcs_stage" "$release_tars"/* . || return 1
 
   if [[ "$release_kind" == "kubernetes" ]]; then
     local gce_path=$release_stage/full/kubernetes/cluster/gce


### PR DESCRIPTION
Fix problem in latest logs - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1146138862850936833/

```
I0702 20:29:33.385] - Copying artifacts to gs://kubernetes-release-dev/ci/v1.16.0-alpha.0.1799+4a1f71076bcaec: 
I0702 20:29:33.385] push-build.sh::release::gcs::push_release_artifacts(): /google-cloud-sdk/bin/gsutil -qm cp -rc /go/src/k8s.io/kubernetes/_output/gcs-stage/v1.16.0-alpha.0.1799+4a1f71076bcaec/* gs://kubernetes-release-dev/ci/v1.16.0-alpha.0.1799+4a1f71076bcaec/
W0702 20:29:33.486] tar: *: Cannot stat: No such file or directory
W0702 20:29:33.486] tar: Exiting with failure status due to previous errors
W0702 20:29:33.486] tar: /go/src/k8s.io/kubernetes/_output/release-stage/client/-- darwin-386 darwin-amd64 linux-386 linux-amd64 linux-arm linux-arm64 linux-ppc64le linux-s390x windows-386 windows-amd64/kubernetes/client/bin: Cannot open: No such file or directory
W0702 20:29:33.487] tar: Error is not recoverable: exiting now
W0702 20:29:33.487] tar: This does not look like a tar archive
W0702 20:29:33.487] tar: Exiting with failure status due to previous errors
I0702 20:29:35.043] OK
```