### PR TITLE
lib/gitlib: Fix shellcheck disable for gitlib::github_acls

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -132,9 +132,9 @@ gitlib::github_api_token () {
 ##############################################################################
 # Checks github ACLs
 # returns 1 on failure
-# Disable shellcheck for dynamically defined variable
-# shellcheck disable=SC2154
-export PROGSTEP[gitlib::github_acls]="CHECK GITHUB AUTH"
+# Disable shellcheck for dynamically defined variable, used externally
+# shellcheck disable=SC2034,SC2154
+PROGSTEP[gitlib::github_acls]="CHECK GITHUB AUTH"
 gitlib::github_acls () {
 
   gitlib::github_api_token || return 1


### PR DESCRIPTION
`./gcbmgr` throws a warning on `gitlib::github_acls` - before:
```
$ ./gcbmgr 
/home/augustus/go/src/k8s.io/release/lib/gitlib.sh: line 137: export: `PROGSTEP[gitlib::github_acls]': not a valid identifier
gcbmgr: BEGIN main on auggievmw01 Tue Jul  2 23:35:07 EDT 2019

Checking whether required binaries are available...
OK
Checking /home/augustus/go/src/k8s.io/release state: OK
Checking/setting cloud tools: OK

Last 3  jobs:
<snip>
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>