### PR TITLE
lib/releaselib: Swap non-positional options in find command

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -675,7 +675,7 @@ release::gcs::locally_stage_release_artifacts() {
   # download the binaries directly and don't need tars.
   mapfile -t platforms < <(
     cd "$release_stage/client" || return 1
-    find . -type d -mindepth 1 -maxdepth 1 | cut -c 3-)
+    find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-)
   for platform in "${platforms[@]}"; do
     src="$release_stage/client/$platform/$release_kind/client/bin/*"
     dst="bin/${platform/-//}/"
@@ -949,7 +949,7 @@ release::docker::release () {
 
   mapfile -t arches < <(
   cd "$release_images" || return 1
-  find . -type d -mindepth 1 -maxdepth 1 | cut -c 3-)
+  find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-)
   for arch in "${arches[@]}"; do
     for tarfile in "$release_images/$arch"/*.tar; do
       # There may be multiple tags; just get the first


### PR DESCRIPTION
Follow up to @dougm's comment (https://github.com/kubernetes/release/pull/802#pullrequestreview-257243041):
> @dims are you testing this on a Mac? On Ubuntu with:
> 
> ```
> % find --version
> find (GNU findutils) 4.7.0-git
> Copyright (C) 2016 Free Software Foundation, Inc.
> License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
> This is free software: you are free to change and redistribute it.
> There is NO WARRANTY, to the extent permitted by law.
> 
> Written by Eric B. Decker, James Youngman, and Kevin Dalley.
> Features enabled: D_TYPE O_NOFOLLOW(enabled) LEAF_OPTIMISATION FTS(FTS_CWDFD) CBO(level=2) 
> ```
> 
> find complains:
> 
> ```
> % find . -type d -mindepth 1 -maxdepth 1 | cut -c 3-
> find: warning: you have specified the -mindepth option after a non-option argument -type, but options are not positional (-mindepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
> 
> find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
> ```
> 
> No complaints on Ubuntu or Mac with:
> 
> ```
> % find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-
> ```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>