### PR TITLE
lib/gitlib: Update GHCURL to use an Authorization header

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -21,8 +21,8 @@
 # CONSTANTS
 ###############################################################################
 GITHUB_TOKEN=${FLAGS_github_token:-$GITHUB_TOKEN}
-[[ -n $GITHUB_TOKEN ]] && GITHUB_TOKEN_FLAG=("-u" "$GITHUB_TOKEN:x-oauth-basic")
-GHCURL="curl -s --fail --retry 10 ${GITHUB_TOKEN_FLAG[*]}"
+[[ -n $GITHUB_TOKEN ]] && GITHUB_AUTH_HEADER=("-H" \"Authorization: token "${GITHUB_TOKEN}"\")
+GHCURL="curl -s --fail --retry 10 ${GITHUB_AUTH_HEADER[*]}"
 GITHUB_API='https://api.github.com'
 GITHUB_API_GRAPHQL="${GITHUB_API}/graphql"
 K8S_GITHUB_API_ROOT="${GITHUB_API}/repos"


### PR DESCRIPTION
anago is currently asking for a password, assuming the username is
actually the OAuth token, instead of the username. This switches to
using an Authorization header instead as suggested by GitHub docs.

ref: https://developer.github.com/v3/#oauth2-token-sent-in-a-header

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @feiskyer @idealhack @hoegaarden 