### PR TITLE
Fix build break - manifest has to be an array of images

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -984,10 +984,10 @@ release::docker::release () {
     local archs
     archs=$(sed -e 's/^[[:space:]]*//' <<< "${manifest_images[$image]}")
     local manifest
-    manifest=$(sed -e "s~[^ ]*~$image\-&:$version~g" <<< "$archs")
+    read -r -a manifest <<< "$(sed -e "s~[^ ]*~$image\-&:$version~g" <<< "$archs")"
     # This command will push a manifest list: "${registry}/${image}-ARCH:${version}" that points to each architecture depending on which platform you're pulling from
     logecho "Creating manifest image ${image}:${version}..."
-    logrun -r 5 -s docker manifest create --amend "${image}:${version}" "${manifest}" || return 1
+    logrun -r 5 -s docker manifest create --amend "${image}:${version}" "${manifest[@]}" || return 1
     for arch in ${archs}; do
       logecho "Annotating ${image}-${arch}:${version} with --arch ${arch}..."
       logrun -r 5 -s docker manifest annotate --arch "${arch}" "${image}:${version}" "${image}-${arch}:${version}" || return 1


### PR DESCRIPTION
Looks like we are treating the list of images ("manifest") as a single string, break that into an array instead.

Please see log for error: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1146329503094542337/
```
I0703 09:18:49.163] push-build.sh::release::docker::release(): docker manifest create --amend gcr.io/kubernetes-ci-images/kube-controller-manager:v1.16.0-alpha.0.1835_ca342ecb5a0b3e gcr.io/kubernetes-ci-images/kube-controller-manager-arm:v1.16.0-alpha.0.1835_ca342ecb5a0b3e gcr.io/kubernetes-ci-images/kube-controller-manager-ppc64le:v1.16.0-alpha.0.1835_ca342ecb5a0b3e gcr.io/kubernetes-ci-images/kube-controller-manager-s390x:v1.16.0-alpha.0.1835_ca342ecb5a0b3e gcr.io/kubernetes-ci-images/kube-controller-manager-amd64:v1.16.0-alpha.0.1835_ca342ecb5a0b3e gcr.io/kubernetes-ci-images/kube-controller-manager-arm64:v1.16.0-alpha.0.1835_ca342ecb5a0b3e
I0703 09:18:49.220] invalid reference format
```
Change-Id: Ifc2b2643f0608e8cfd50a28d457ce700167a1ecf