### PR TITLE
Trim token & correct PRs URL

### DIFF
--- a/anago
+++ b/anago
@@ -1387,7 +1387,7 @@ prepare_workspace () {
       return 1
     fi
     # Sync the tree
-    gitlib::sync_repo "$K8S_GITHUB_AUTH_URL $TREE_ROOT" || return 1
+    gitlib::sync_repo "$K8S_GITHUB_AUTH_URL" "$TREE_ROOT" || return 1
   fi
 }
 

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -226,7 +226,7 @@ gitlib::pending_prs () {
     msg=$(sed 's, *\* *, * ,g' <<< "$msg")
     printf "%-8s $sep %-4s $sep %-10s $sep %-18s $sep %s\n" \
            "#$pr" "$milestone" "@$login" "$(date +"%F %R" -d "$date")" "$msg"
-  done < <($GHCURL "$K8S_GITHUB_API/pulls\?state\=open\&base\=$branch" |\
+  done < <($GHCURL "${K8S_GITHUB_API}/pulls?state=open&base=${branch}" |\
            jq -r \
             '.[] | "\(.number)\t\(.milestone.title)\t\(.user.login)\t\(.updated_at)\t\(.title)"')
 }

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -21,6 +21,9 @@
 # CONSTANTS
 ###############################################################################
 GITHUB_TOKEN=${FLAGS_github_token:-$GITHUB_TOKEN}
+# for cases where the token is prvided with leading/trailing whitespaces we
+# just trim them here. The assumption is that the token itself will never have
+# whitespaces. If that is not true anymore, this breaks.
 GITHUB_TOKEN="$( echo "$GITHUB_TOKEN" | tr -d '[:space:]' )"
 [[ -n "$GITHUB_TOKEN" ]] && GITHUB_TOKEN_FLAG=("-u" "${GITHUB_TOKEN}:x-oauth-basic")
 GHCURL="curl -s --fail --retry 10 ${GITHUB_TOKEN_FLAG[*]}"

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -21,7 +21,8 @@
 # CONSTANTS
 ###############################################################################
 GITHUB_TOKEN=${FLAGS_github_token:-$GITHUB_TOKEN}
-[[ -n $GITHUB_TOKEN ]] && GITHUB_TOKEN_FLAG=("-u" "$GITHUB_TOKEN:x-oauth-basic")
+GITHUB_TOKEN="$( echo "$GITHUB_TOKEN" | tr -d '[:space:]' )"
+[[ -n $GITHUB_TOKEN ]] && GITHUB_TOKEN_FLAG=("-u" "${GITHUB_TOKEN}:x-oauth-basic")
 GHCURL="curl -s --fail --retry 10 ${GITHUB_TOKEN_FLAG[*]}"
 GITHUB_API='https://api.github.com'
 GITHUB_API_GRAPHQL="${GITHUB_API}/graphql"

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -22,7 +22,7 @@
 ###############################################################################
 GITHUB_TOKEN=${FLAGS_github_token:-$GITHUB_TOKEN}
 GITHUB_TOKEN="$( echo "$GITHUB_TOKEN" | tr -d '[:space:]' )"
-[[ -n $GITHUB_TOKEN ]] && GITHUB_TOKEN_FLAG=("-u" "${GITHUB_TOKEN}:x-oauth-basic")
+[[ -n "$GITHUB_TOKEN" ]] && GITHUB_TOKEN_FLAG=("-u" "${GITHUB_TOKEN}:x-oauth-basic")
 GHCURL="curl -s --fail --retry 10 ${GITHUB_TOKEN_FLAG[*]}"
 GITHUB_API='https://api.github.com'
 GITHUB_API_GRAPHQL="${GITHUB_API}/graphql"

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -159,7 +159,7 @@ TEST_get_team_members() {
 }
 
 TEST_pending_prs() {
-  echo "Testing gitlab::pendig_prs"
+  echo "Testing gitlab::pending_prs"
   echo
 
   local branch='release-1.12'

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -162,7 +162,7 @@ TEST_pending_prs() {
   echo "Testing gitlab::pending_prs"
   echo
 
-  local branch='release-1.12'
+  local branch='release-1.15'
   local mockResponse='[{"number":123,"milestone":{"title":"foobar"},"user":{"login":"batman"},"updated_at":"2019-07-03T08:48:34Z","title":"best PR"}]'
   local expectedCallArgs="-s --fail --retry 10 https://api.github.com/repos/kubernetes/kubernetes/pulls?state=open&base=${branch}"
 


### PR DESCRIPTION
"for cases where the token is prvided with leading/trailing whitespaces we
just trim them here. The assumption is that the token itself will never have
whitespaces. If that is not true anymore, this breaks."

/cc @pswica 
/assign @justaugustus 