### PR TITLE
Set all shebangs to #!/usr/bin/env bash

### DIFF
--- a/anago
+++ b/anago
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/branchff
+++ b/branchff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/changelog-update
+++ b/changelog-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/debian/jenkins.sh
+++ b/debian/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o errexit

--- a/find_green_build
+++ b/find_green_build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/gcbmgr
+++ b/gcbmgr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Kubernetes Authors All rights reserved.
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/gitlib_test.sh
+++ b/lib/gitlib_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # gitlib.sh unit tests
 #

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/lib/releaselib_test.sh
+++ b/lib/releaselib_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # releaselib.sh unit tests
 #

--- a/prin
+++ b/prin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/release-notify
+++ b/release-notify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Kubernetes Authors All rights reserved.
 #

--- a/relnotes
+++ b/relnotes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/rpm/docker-build.sh
+++ b/rpm/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 docker build -t kubelet-rpm-builder .

--- a/rpm/entry.sh
+++ b/rpm/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Entrypoint for the build container to create the rpms and yum repodata:
 # Usage: ./entry.sh GOARCH/RPMARCH,GOARCH/RPMARCH,....
 

--- a/script-template
+++ b/script-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
@@ -47,7 +47,7 @@ PROG=${0##*/}
 source $(dirname $(readlink -ne $0))/lib/common.sh
 
 cat <<EOF_CAT
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #


### PR DESCRIPTION
This reimplements #771 after the revert in #814.
The debian packaging scripts are intentionally excluded here.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>