### PR TITLE
gitlib: fix handling of remote url

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -290,7 +290,7 @@ gitlib::push_master () {
 # Ensure TOOL_ROOT running with a synced repo.
 #
 gitlib::repo_state () {
-  local expectedRemote="${RELEASE_TOOL_REPO:-/kubernetes/release}"
+  local expectedRemote="${RELEASE_TOOL_REPO:-[:/]kubernetes/release}"
   local expectedBranch="${RELEASE_TOOL_BRANCH:-master}"
 
   local branch=$(gitlib::current_branch "$TOOL_ROOT") || return 1
@@ -300,16 +300,9 @@ gitlib::repo_state () {
     return 1
   fi
 
-  local remotePattern="$(
-    echo "${expectedRemote}" \
-      | awk -F '[:/]' '{ print $(NF-1) "/" $NF }'
-  )"
-  # make sure all '/' in the remote are escaped
-  remotePattern="${expectedRemote//\//\\\/}(.git)* \(fetch\)$"
+  local remotePattern="${expectedRemote}(.git)* \(fetch\)$"
 
-  local remote=$(
-    git -C "$TOOL_ROOT" remote -v | awk "-vP=${remotePattern}" '$0 ~ P {print $1}'
-  )
+  local remote=$( git -C "$TOOL_ROOT" remote -v | grep -E "$remotePattern" | cut -f1 )
   local commit=$(git -C "$TOOL_ROOT" \
                      ls-remote --heads "$remote" refs/heads/master | cut -f1)
   local output=$(git -C "$TOOL_ROOT" branch --contains "$commit" "$branch" 2>&-)


### PR DESCRIPTION
This reapplies the fix in https://github.com/kubernetes/release/pull/735.

Currently, it fails with the error:

```
awk: warning: escape sequence `\/' treated as plain `/'
awk: warning: escape sequence `\(' treated as plain `('
awk: warning: escape sequence `\)' treated as plain `)'
fatal: No path specified. See 'man git-pull' for valid url syntax
```

I could reproduce this while working on https://github.com/kubernetes/release/pull/735 as well, so it doesn't seem to be new or introduced recently. My very raw guess is that this occurs because of discrepancies between different implementations of awk.

/cc @idealhack @hoegaarden @feiskyer @justaugustus 