### PR TITLE
Makefile: Disable shellcheck verify to clear up CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ verify-published-rpms: ## Ensure rpms have been published
 
 .PHONY: verify verify-shellcheck
 
-verify: verify-shellcheck ## Runs verification scripts to ensure correct execution
+# TODO: Uncomment verify-shellcheck once we finish shellchecking the repo.
+#       ref: https://github.com/kubernetes/release/issues/726
+verify: #verify-shellcheck ## Runs verification scripts to ensure correct execution
 
 verify-shellcheck: ## Runs shellcheck
 	./hack/verify-shellcheck.sh


### PR DESCRIPTION
[`release-verify`](https://testgrid.k8s.io/sig-release-misc#release-verify) is consistently failing because of shellcheck errors. 
We reverted the shellcheck updates in #814, so let's comment this out until #726 is closed. 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @pswica @alejandrox1 