### PR TITLE
release: keep images in registry if PURGE_IMAGES=no

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -953,7 +953,9 @@ release::docker::release () {
       # TODO: Use docker direct when fixed later
       #logrun -r 5 -s docker push "${new_tag_with_arch}" || return 1
       logrun -r 5 -s $GCLOUD docker -- push "${new_tag_with_arch}" || return 1
-      logrun docker rmi $orig_tag ${new_tag_with_arch} || true
+      if [[ "${PURGE_IMAGES:-yes}" == "yes" ]] ; then
+        logrun docker rmi $orig_tag ${new_tag_with_arch} || true
+      fi
 
     done
   done
@@ -972,7 +974,11 @@ release::docker::release () {
       logrun -r 5 -s docker manifest annotate --arch ${arch} ${image}:${version} ${image}-${arch}:${version} || return 1
     done
     logecho "Pushing manifest image ${image}:${version}..."
-    logrun -r 5 -s docker manifest push --purge ${image}:${version} || return 1
+    local purge=""
+    if [[ "${PURGE_IMAGES:-yes}" == "yes" ]] ; then
+      purge="--purge"
+    fi
+    logrun -r 5 -s docker manifest push ${image}:${version} ${purge} || return 1
   done
 
   # Always reset back to $GCP_USER


### PR DESCRIPTION
Re-add support to keep docker images and manifest after these are pushed into registry by the push-build.sh script.
Original change https://github.com/kubernetes/release/pull/749
Reverted in https://github.com/kubernetes/release/pull/814

This is controlled using PURGE_IMAGES=no environment variable, if not defined will default to "yes", which is the current behavior.

Example:
export PURGE_IMAGES=no
../release/push-build.sh 
--nomock --bucket=${GCS_RELEASE_BUCKET} --private-bucket 
--docker-registry=${REGISTRY}