### PR TITLE
Beautify markdown for multi-line release notes

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -230,7 +230,7 @@ func NoteTextFromString(s string) (string, error) {
 		note := strings.ReplaceAll(result["note"], "#", "&#35;")
 		note = strings.ReplaceAll(note, "\r", "")
 		note = stripActionRequired(note)
-		note = stripStar(note)
+		note = dashify(note)
 		return note, nil
 	}
 
@@ -326,10 +326,13 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 	} else if len(LabelsWithPrefix(pr, "sig")) > 1 {
 		IsDuplicate = true
 	}
-	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))", text, pr.GetNumber(), prUrl, author, authorUrl)
+
+	indented := strings.ReplaceAll(text, "\n", "\n  ")
+	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
+		indented, pr.GetNumber(), prUrl, author, authorUrl)
 
 	if noteSuffix != "" {
-		markdown = fmt.Sprintf("%s %s", markdown, noteSuffix)
+		markdown = fmt.Sprintf("%s\n\n  %s", markdown, noteSuffix)
 	}
 
 	return &ReleaseNote{
@@ -612,6 +615,10 @@ func stripStar(note string) string {
 func stripDash(note string) string {
 	re := regexp.MustCompile(`(?i)\-\s`)
 	return re.ReplaceAllString(note, "")
+}
+
+func dashify(note string) string {
+	return strings.ReplaceAll(note, "* ", "- ")
 }
 
 func HasString(a []string, x string) bool {


### PR DESCRIPTION
I added some slight indentation and start-to-dash conversion to make the output of the generated markdown a bit easier to read.

[before](https://github.com/kubernetes/sig-release/blob/3750e2465047a7e72d5eb471ed1fefa7a8d7ddc8/releases/release-1.16/release-notes-draft.md) vs [after](https://gist.github.com/saschagrunert/a3b7622909f843ccd7fa261a6ad62d7c)