### PR TITLE
Improve note parsing

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -192,7 +192,7 @@ func ListReleaseNotes(
 		// exclusionFilters is a list of regular expressions that match notes text that
 		// are deemed to have no content and should NOT be added to release notes.
 		exclusionFilters := []string{
-			"^([nN][oO][nN][eE]|[nN]/[aA])$", // 'none' or 'n/a' case insensitive
+			"^(?i)(none|n/a)$", // 'none' or 'n/a' case insensitive
 		}
 		excluded := false
 		for _, filter := range exclusionFilters {
@@ -470,10 +470,11 @@ func ListCommitsWithNotes(
 		exclusionFilters := []string{
 			
 			// 'none' or 'n/a' case insensitive with optional trailing whitespace, wrapped in ``` with/without release-note identifier
-			"```(release-note\\s*)?([nN][oO][nN][eE]|[nN]/[aA])?\\s*```",
+			"(?i)```(release-note\\s*)?(none|n/a)?\\s*```",
 
-			// 'none' case insensitive wrapped optionally with whitespace
-			"\\s*[nN][oO][nN][eE]\\s*",
+			// This filter is too aggressive within the PR body and picks up matches unrelated to release notes
+			// 'none' or 'n/a' case insensitive wrapped optionally with whitespace
+			// "(?i)\\s*(none|n/a)\\s*",
 
 			// simple '/release-note-none' tag
 			"/release-note-none",

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -468,26 +468,14 @@ func ListCommitsWithNotes(
 		// do NOT contain release notes. Notably, this is all of the variations of
 		// "release note none" that appear in the commit log.
 		exclusionFilters := []string{
-			// "```release-note\\r\\nNONE",
-			// "```release-note\\r\\n\\s+NONE",
-			// "```release-note\\r\\nNONE",
-			// "```release-note\\r\\n\"NONE\"",
-			// "```release-note\\r\\nNone",
-			// "```release-note\\r\\nnone",
-			// "```release-note\\r\\nN/A",
-			// "```release-note\\r\\n\\r\\n```",
-			// "```release-note\\r\\n```",
-			// "/release-note-none",
-			// "\\r\\n\\r\\nNONE",
-			// "```NONE\\r\\n```",
-			// "```release-note \\r\\nNONE\\r\\n```",
-			// "NONE\\r\\n```",
-			// "\\r\\nNone",
-			// "\\r\\nNONE\\r\\n",
+			
 			// 'none' or 'n/a' case insensitive with optional trailing whitespace, wrapped in ``` with/without release-note identifier
 			"```(release-note\\s*)?([nN][oO][nN][eE]|[nN]/[aA])?\\s*```",
+
 			// 'none' case insensitive wrapped optionally with whitespace
 			"\\s*[nN][oO][nN][eE]\\s*",
+
+			// simple '/release-note-none' tag
 			"/release-note-none",
 		}
 


### PR DESCRIPTION
It was noticed in the following [PR #727 - Add initial release notes draft for 1.16](https://github.com/kubernetes/sig-release/pull/727), that there were a few notes that got pulled through into the release notes draft that should have been excluded.

This PR aims to tighten up the parsing to ensure that we are not adding incorrect notes to the release notes. Debug logging has also been added to facilitate the ongoing checking of what is being excluded or included in the final release notes.