### PR TITLE
[gcbmgr] Fallback to master's version of the kubecross image

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -349,11 +349,8 @@ stage_it () {
     return 1
   fi
 
-  # Get kube_cross version
-  KUBE_CROSS_VERSION=$(curl -s https://raw.githubusercontent.com/kubernetes/kubernetes/$RELEASE_BRANCH/build/build-image/cross/VERSION)
-
-  [[ -z $KUBE_CROSS_VERSION ]] \
-    && common::exit 1 "Unable to set KUBE_CROSS_VERSION.  Exiting..."
+  KUBE_CROSS_VERSION="$( release::kubecross_version "$RELEASE_BRANCH" 'master' )" \
+    || common::exit 1 'Exiting...' >&2
 
   # Submit it
   submit_it

--- a/lib/releaselib_test.sh
+++ b/lib/releaselib_test.sh
@@ -122,4 +122,67 @@ EOF
   ##############################################################################
 }
 
+TEST_kubecross_version() {
+  echo 'Testing release::kubecross_version'
+  echo
+
+  local testName testCases testCase currentTest expRc rc expVer ver
+
+  # array of comma-separated test case inputs:
+  # [0]  expected return code
+  # [1]  expected version
+  # [2:] inputs for the thing under test, release::kubecross_version
+  testCases=(
+    # test against one existing branch
+    '0,v1.10.8-1,release-1.12'
+    # test against one non-existing branch
+    '1,,does-not-exist'
+    # test against a non-existing branch with one fallback that exists
+    '0,v1.10.8-1,does-not-exist,release-1.12'
+    # test against a non-existing branch with multiple fallbacks
+    '0,v1.10.8-1,does-not-exist,release-1.12,release-1.14'
+    # test fallthrough multiple non-existing branches
+    '0,v1.10.8-1,does-not-exist,does-not-exist-either,release-1.12'
+    # test with no branch specified
+    '1,,'
+  )
+
+  # mock curl: the mocked curl only returns a valid version for release-1.12
+  curl() {
+    case "$*" in
+      */kubernetes/release-1.12/build/build-image/cross/VERSION)
+        echo 'v1.10.8-1'      ; return 0
+        ;;
+      *)
+        echo '404: Not found' ; return 1
+        ;;
+    esac
+  }
+
+  for testCase in "${testCases[@]}"
+  do
+    IFS=',' read -r -a currentTest <<< "$testCase"
+
+    # pop off stuff from the array
+    expRc="${currentTest[0]}" ; currentTest=("${currentTest[@]:1}")
+    expVer="${currentTest[0]}" ; currentTest=("${currentTest[@]:1}")
+
+    testName="release::kubecross_version ${currentTest[*]}: "
+
+    rc=0; ver="$( release::kubecross_version "${currentTest[@]}" 2>/dev/null )" || rc=$?
+
+    if [ "$rc" != "$expRc" ]; then
+      echo "${FAILED} ${testName}, expected to return ${expRc}, got ${rc}"
+      continue
+    fi
+
+    if [ "$ver" != "$expVer" ]; then
+      echo "${FAILED} ${testName}, expected version to be ${expVer}, got ${ver}"
+      continue
+    fi
+
+    echo "${PASSED} ${testName}"
+  done
+}
+
 test_main "$@"


### PR DESCRIPTION
One of the first steps in GCB is to compile go things, e.g. the
`blocking-testgrid-tests` binary. Theses binaries are to be compiled
with the same go version as the version of kubernetes itself. Therefore
we use the kubecross image as the image for this GCB task.

Now, when the branch og k/k does not exist, that fails. This can be the
case of an beta cut, because the branch is only to be created by anago.
So for these cases we allow a fallback to the master branch. It is
clearly logged however, that we couldn't determine the kubecross image
version to use and did the fallback.

Also note: This is only for building the binaries used in the tests, not
for building kubernetes itself.

/assign @justaugustus 