### PR TITLE
Introduce testgridshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Kubernetes Release
 
-This repo contains the tooling and infrastructure to create Kubernetes releases from the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) main repository.
+This repo contains the tooling and infrastructure to create Kubernetes releases from the [kubernetes/kubernetes] main repository.
 
 ## Intro
 
@@ -26,18 +26,23 @@ development and testing.
 
 Tools | Description
  :---: | --
-[`gcbmgr`](https://github.com/kubernetes/release/blob/master/gcbmgr) | Google Cloud Builder Manager: <br/><br/> This is the main entry point for release managers for producing releases. All release types can be staged and later released using this method.
-[`anago`](https://github.com/kubernetes/release/blob/master/anago) | Release Tool: <br/><br/> The main driver for creating staged builds and releases. This is what runs inside GCB after a job is submitted using `gcbmgr`.
-[`branchff`](https://github.com/kubernetes/release/blob/master/branchff) | Fast-forward branching helper : <br/><br/> A tool used to pull new patches onto the release branch.
-<br/> [`find_green_build`](https://github.com/kubernetes/release/blob/master/find_green_build) <br/><br/> | Asks Jenkins for a good build to use.
-<br/> [`release-notes`](https://github.com/kubernetes/release/blob/master/cmd/release-notes) <br/><br/> | Scrape GitHub for release notes. See [Release Notes Gathering](#release-notes-gathering) for more information.
-<br/> [`prin`](https://github.com/kubernetes/release/blob/master/prin) <br/><br/> | To show release tags of a particular PR or commit.
-<br/> [`changelog-update`](https://github.com/kubernetes/release/blob/master/changelog-update) <br/><br/> | Updates [CHANGELOG.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md) version entries by rescanning github for text and label changes.
-<br/> [`push-build.sh`](https://github.com/kubernetes/release/blob/master/push-build.sh) <br/><br/> | Pushes a developer build or CI Jenkins build up to GCS.
-<br/> [`script-template`](https://github.com/kubernetes/release/blob/master/script-template) <br/><br/> | Generates a script template in the kubernetes/release ecosystem.
-[`testgridshot`](https://github.com/kubernetes/release/blob/master/testgridshot) | Screenshots failing testgrid dashboards and creates a markdown stub that can be copied and pasted into a GitHub issue comment.<br/>This makes it easier to create comments like [this](https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968) as part of the release process.
+[`gcbmgr`](/gcbmgr)                     | Google Cloud Builder Manager:<br/>This is the main entry point for release managers for producing releases. All release types can be staged and later released using this method.
+[`anago`](/anago)                       | Release Tool:<br/>The main driver for creating staged builds and releases. This is what runs inside GCB after a job is submitted using `gcbmgr`.
+[`branchff`](/branchff)                 | Fast-forward branching helper:<br/>A tool used to pull new patches onto the release branch.
+[`find_green_build`](/find_green_build) | Asks Jenkins for a good build to use.
+[`release-notes`](/cmd/release-notes)   | Scrape GitHub for release notes.<br/>See [Release Notes Gathering](#release-notes-gathering) for more information.
+[`prin`](/prin)                         | To show release tags of a particular PR or commit.
+[`changelog-update`](/changelog-update) | Updates [CHANGELOG.md] version entries by rescanning github for text and label changes.
+[`push-build.sh`](/push-build.sh)       | Pushes a developer build or CI Jenkins build up to GCS.
+[`script-template`](/script-template)   | Generates a script template in the kubernetes/release ecosystem.
+[`testgridshot`](/testgridshot)         | Screenshots failing testgrid dashboards and creates a markdown stub that can be copied and pasted into a GitHub issue comment.<br/>This makes it easier to create comments like [this][shot-issue] as part of the release process.
 
-For information on how to use `gcbmgr`, `anago` and `branchff`, see the [Branch Manager Handbook](https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md)
+For information on how to use `gcbmgr`, `anago` and `branchff`, see the [Branch Manager Handbook]
+
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[Branch Manager Handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
+[CHANGELOG.md]: https://git.k8s.io/kubernetes/blob/master/CHANGELOG.md
+[shot-issue]: https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968
 
 ## Release Notes Gathering
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tools | Description
 <br/> [`changelog-update`](https://github.com/kubernetes/release/blob/master/changelog-update) <br/><br/> | Updates [CHANGELOG.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md) version entries by rescanning github for text and label changes.
 <br/> [`push-build.sh`](https://github.com/kubernetes/release/blob/master/push-build.sh) <br/><br/> | Pushes a developer build or CI Jenkins build up to GCS.
 <br/> [`script-template`](https://github.com/kubernetes/release/blob/master/script-template) <br/><br/> | Generates a script template in the kubernetes/release ecosystem.
+[`testgridshot`](https://github.com/kubernetes/release/blob/master/testgridshot) | Screenshots failing testgrid dashboards and creates a markdown stub that can be copied and pasted into a GitHub issue comment.<br/>This makes it easier to create comments like [this](https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968) as part of the release process.
 
 For information on how to use `gcbmgr`, `anago` and `branchff`, see the [Branch Manager Handbook](https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md)
 

--- a/testgridshot
+++ b/testgridshot
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+readonly STATE_FAILING='FAILING'
+readonly STATE_FALKING='FLAKY'
+readonly STATE_PASSING='PASSING'
+
+readonly BOARDS="${BOARDS:-sig-release-master-blocking sig-release-master-upgrade}"
+readonly STATES="${STATES:-${STATE_FAILING}}"
+readonly BLOCK_WIDTH="${BLOCK_WIDTH:-30}"
+readonly WIDTH="${WIDTH:-3000}"
+readonly HEIGHT="${HEIGHT:-2500}"
+readonly RETRY_COUNT="${RETRY_COUNT:-3}"
+readonly RETRY_SLEEP="${RETRY_SLEEP:-2}"
+
+readonly TESTGRID='https://testgrid.k8s.io'
+readonly RENDER_TRON='https://render-tron.appspot.com/screenshot'
+readonly UPLOAD_URL='https://vgy.me/upload'
+readonly ISSUE_STUB_SUFFIX='issue.'
+
+getTestsByStatus() {
+  local b
+
+  for b in ${BOARDS}
+  do
+    curler --retry 0 "${TESTGRID}/${b}/summary" 2>/dev/null \
+      | jq --arg status "$1" -r '
+        to_entries[]
+          | select(.value.overall_status==$status)
+          | .value.dashboard_name + "#" + .key
+      '
+  done
+}
+
+urlencode() {
+  echo "$1" | jq -sRr @uri
+}
+
+genFileName() {
+  echo "${1//[^a-zA-Z0-9]/_}"
+}
+
+curler() {
+  curl -fqsSL --retry "$RETRY_COUNT" --retry-delay "$RETRY_SLEEP" "$@"
+}
+
+log() {
+  echo "$(getTimestamp) ${*}" >&2
+}
+
+upload() {
+  local fileName="$1"
+  curler "$UPLOAD_URL" -F "file=@${fileName}" -F "title=${fileName}"
+}
+
+screenshot() {
+  local url="$1"
+  local target="$2"
+  local urlEncoded renderTronUrl
+
+  urlEncoded="$( urlencode "${url}" )"
+  renderTronUrl="${RENDER_TRON}/${urlEncoded}?width=${WIDTH}&height=${HEIGHT}"
+
+  curler -o "${target}" "$renderTronUrl"
+}
+
+getIssueStubName() {
+  local dir="$1"
+  local idx="$2"
+  printf '%s/%s%05d' "$dir" "$ISSUE_STUB_SUFFIX" "$idx"
+}
+
+combineIssueStubs() {
+  local dir="$1"
+  find "$dir" -name "${ISSUE_STUB_SUFFIX}*" \
+    | sort -n \
+    | xargs cat
+}
+
+getTimestamp() {
+  date '+%Y-%m-%d %H:%M:%S%z'
+}
+
+commaSep() {
+  echo "$*" \
+    | sed -e 's@^\s\+@@' -e 's@\s\+$@@' -e 's@\s\+@, @g'
+}
+
+getHeaderStub() {
+  echo '### Testgrid dashboards'
+
+  echo "Boards checked for $(commaSep "${STATES}"):"
+
+  for b in $BOARDS
+  do
+    echo "- [${b}](${TESTGRID}/${b})"
+  done
+}
+
+main() {
+  local tests t s b
+  local idx=0
+
+  tmpDir="$( mktemp -d )"
+  trap 'rm -rf -- "$tmpDir"' EXIT
+
+  getHeaderStub > "$( getIssueStubName "${tmpDir}" "${idx}" )"
+
+  for s in ${STATES}
+  do
+    mapfile -t tests <<< "$(getTestsByStatus "$s")"
+    for t in "${tests[@]}"
+    do
+      [ -n "${t}" ] || continue
+
+      idx=$(( idx + 1 ))
+      (
+        local testgridUrl timestamp \
+          fileName imageMeta imageUrl fileBaseName fileSize
+
+        localLog() {
+          log "[${idx}]" "$@"
+        }
+
+        localLog "starting ${t}"
+
+        testgridUrl="${TESTGRID}/${t}&width=${BLOCK_WIDTH}"
+        fileName="${tmpDir}/$( genFileName "${t}" ).jpg"
+        fileBaseName="$(basename "$fileName")"
+
+        # create & download screenshot
+        localLog "screenshoting ${testgridUrl} to ${fileBaseName}"
+        screenshot "${testgridUrl}" "${fileName}"
+        timestamp="$( getTimestamp )"
+
+        read -r fileSize <<< "$(wc -c < "$fileName")"
+        localLog "${fileBaseName}: ${fileSize} bytes"
+
+        # upload
+        localLog "uploading ${fileBaseName}"
+        imageMeta="$(
+          upload "$fileName"
+        )"
+
+        imageUrl="$( echo "${imageMeta}" | jq -r '.image' )"
+
+        # generate issue section
+        localLog "generating markdown stub"
+        printf \
+          '\n<details><summary><tt>%s</tt> %s %s <a href="%s">[testgrid]</a></summary><p>\n\n![%s](%s)\n<!-- %s -->\n</p></details>\n' \
+          "${timestamp}" "${s}" "${t}" "${testgridUrl}" "${t}" "${imageUrl}" "${imageMeta}" \
+          > "$( getIssueStubName "${tmpDir}" "$idx" )"
+
+        localLog "done, image is available at ${imageUrl}"
+      )&
+    done
+  done
+
+  wait
+
+  echo
+
+  echo '<!-- ----[ issue comment ]---- -->'
+  combineIssueStubs "${tmpDir}"
+  echo '<!-- ----[ issue comment ]---- -->'
+}
+
+main "$@"

--- a/testgridshot
+++ b/testgridshot
@@ -1,15 +1,80 @@
 #!/usr/bin/env bash
 
-set -e
-set -u
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+
+#+ Usage: testgridshot <release>
+#+
+#+   <release> can be something like 'master', '1.15', ...
+#+
+#+   This will inspect the testgrid dashboards 'blocking' & 'informing' for the
+#+   specified <release>, create screenshots of failing tests, and print a markdown
+#+   stub on standard out. This stub is intended to be copy & pasted into a issue
+#+   comment for the release cutting GitHub issue.
+#+
+#+ Configuration:
+#+   Configuration can be passed in via the environmnet. The following
+#+   variables are available:
+#+
+#+   BOARDS: [default: "blocking informing"]
+#+     Change which boards you are interested in
+#+
+#+   STATES: [default: "FAILING"]
+#+     Change the tests you want to screenshot
+#+     Available states: FAILING, FLAKY, PASSING
+#+
+#+   BLOCK_WIDTH: [default: 30]
+#+     The width of the individual testgrid red & green block.
+#+     Influences on how many test runs will be shown on the screenshot.
+#+
+#+   WIDTH/HEIGHT: [default: WIDTH=3000/HEIGHT=2500]
+#+     The width and height of the generated screenshot in pixel.
+#+
+#+   RETRY_COUNT: [default: 3]
+#+     Change how often we should retry when talking to (curl'ing) APIs.
+#+
+#+   RETRY_SLEEP: [default: 2]
+#+     Change the amount of time we want to wait between consecutive API call
+#+     retries.
+#+
+#+   Example:
+#+     $ BOARDS='all informing' STATES='FAILING FLAKY' BLOCK_WIDTH=10 ./testgridshot 1.15
+#+         Creates dense screenshots of all the 'sig-release-1.15-{all,informing}'
+#+         boards which are either failing or flaking
+#+
+#+ How it works:
+#+   General flow:
+#+   - Get the dasbhoard URLs we are interested in from testgrid's 'summary'
+#+     endpoint
+#+   - Use 'render-tron.appspot.com' to create screenshots of the testgrid
+#+     boards
+#+   - Upload all the screenshots to 'vgy.me'
+#+   - Print a markdown, which links to the images on 'vgy.me', stub on StdOut
+#+   Remarks:
+#+   - Both 'vgy.me' and 'render-tron.appspot.com' might go away anytime
+#+   - The images are not served by 'vgy.me' directly if used in a GitHub issue,
+#+     but by GitHub's camo service
+#+
+
+set -o errexit
+set -o nounset
 set -o pipefail
 
-readonly STATE_FAILING='FAILING'
-readonly STATE_FALKING='FLAKY'
-readonly STATE_PASSING='PASSING'
-
-readonly BOARDS="${BOARDS:-sig-release-master-blocking sig-release-master-upgrade}"
-readonly STATES="${STATES:-${STATE_FAILING}}"
+readonly BOARDS="${BOARDS:-blocking informing}"
+# Available states: FAILING, FLAKY, PASSING
+readonly STATES="${STATES:-FAILING}"
 readonly BLOCK_WIDTH="${BLOCK_WIDTH:-30}"
 readonly WIDTH="${WIDTH:-3000}"
 readonly HEIGHT="${HEIGHT:-2500}"
@@ -21,13 +86,16 @@ readonly RENDER_TRON='https://render-tron.appspot.com/screenshot'
 readonly UPLOAD_URL='https://vgy.me/upload'
 readonly ISSUE_STUB_SUFFIX='issue.'
 
-getTestsByStatus() {
-  local b
+get_tests_by_status() {
+  local status="$1"
+  shift
 
-  for b in ${BOARDS}
+  local board
+
+  for board in "$@"
   do
-    curler --retry 0 "${TESTGRID}/${b}/summary" 2>/dev/null \
-      | jq --arg status "$1" -r '
+    curl_with_retry --retry 0 "${TESTGRID}/${board}/summary" 2>/dev/null \
+      | jq --arg status "$status" -r '
         to_entries[]
           | select(.value.overall_status==$status)
           | .value.dashboard_name + "#" + .key
@@ -39,122 +107,137 @@ urlencode() {
   echo "$1" | jq -sRr @uri
 }
 
-genFileName() {
+gen_file_name() {
   echo "${1//[^a-zA-Z0-9]/_}"
 }
 
-curler() {
+curl_with_retry() {
   curl -fqsSL --retry "$RETRY_COUNT" --retry-delay "$RETRY_SLEEP" "$@"
 }
 
 log() {
-  echo "$(getTimestamp) ${*}" >&2
+  echo "$(get_timestamp) ${*}" >&2
 }
 
 upload() {
-  local fileName="$1"
-  curler "$UPLOAD_URL" -F "file=@${fileName}" -F "title=${fileName}"
+  local file_name="$1"
+  curl_with_retry "$UPLOAD_URL" -F "file=@${file_name}" -F "title=${file_name}"
 }
 
 screenshot() {
   local url="$1"
   local target="$2"
-  local urlEncoded renderTronUrl
+  local url_encoded rendertron_url
 
-  urlEncoded="$( urlencode "${url}" )"
-  renderTronUrl="${RENDER_TRON}/${urlEncoded}?width=${WIDTH}&height=${HEIGHT}"
+  url_encoded="$( urlencode "${url}" )"
+  rendertron_url="${RENDER_TRON}/${url_encoded}?width=${WIDTH}&height=${HEIGHT}"
 
-  curler -o "${target}" "$renderTronUrl"
+  curl_with_retry -o "${target}" "$rendertron_url"
 }
 
-getIssueStubName() {
+get_issue_stub_name() {
   local dir="$1"
   local idx="$2"
   printf '%s/%s%05d' "$dir" "$ISSUE_STUB_SUFFIX" "$idx"
 }
 
-combineIssueStubs() {
+combine_issue_stubs() {
   local dir="$1"
   find "$dir" -name "${ISSUE_STUB_SUFFIX}*" \
     | sort -n \
     | xargs cat
 }
 
-getTimestamp() {
+get_timestamp() {
   date '+%Y-%m-%d %H:%M:%S%z'
 }
 
-commaSep() {
+comma_sep() {
   echo "$*" \
     | sed -e 's@^\s\+@@' -e 's@\s\+$@@' -e 's@\s\+@, @g'
 }
 
-getHeaderStub() {
+get_header_stub() {
+  local board
+
   echo '### Testgrid dashboards'
 
-  echo "Boards checked for $(commaSep "${STATES}"):"
+  echo "Boards checked for $(comma_sep "${STATES}"):"
 
-  for b in $BOARDS
+  for board in "$@"
   do
-    echo "- [${b}](${TESTGRID}/${b})"
+    printf -- '- [%s](%s)\n' "$board" "${TESTGRID}/${board}"
   done
 }
 
-main() {
-  local tests t s b
+usage() {
+  local usage_marker='^#\\+ ?'
+  # shellcheck disable=SC2016
+  local awk_prog='$0 ~ RE { gsub(RE, ""); print }'
+
+  awk -vRE="$usage_marker" "$awk_prog" <"$0" >&2
+}
+
+shoot() {
+  local target_release="$1"
+  local boards
+  local tests t s
   local idx=0
 
-  tmpDir="$( mktemp -d )"
-  trap 'rm -rf -- "$tmpDir"' EXIT
+  tmp_dir="$( mktemp -d )"
+  trap 'rm -rf -- "$tmp_dir"' EXIT
 
-  getHeaderStub > "$( getIssueStubName "${tmpDir}" "${idx}" )"
+  read -r -a boards <<< "$BOARDS"
+  # prepend all elements with 'sig-release-<release>-' to form the full
+  # testgrid dashborad name
+  boards=( "${boards[@]/#/sig-release-${target_release}-}" )
+
+  get_header_stub "${boards[@]}" > "$( get_issue_stub_name "${tmp_dir}" "${idx}" )"
 
   for s in ${STATES}
   do
-    mapfile -t tests <<< "$(getTestsByStatus "$s")"
+    mapfile -t tests <<< "$(get_tests_by_status "$s" "${boards[@]}")"
     for t in "${tests[@]}"
     do
       [ -n "${t}" ] || continue
 
       idx=$(( idx + 1 ))
       (
-        local testgridUrl timestamp \
-          fileName imageMeta imageUrl fileBaseName fileSize
+        local testgrid_url timestamp \
+          file_name image_meta image_url file_base_name file_size
 
-        localLog() {
+        local_log() {
           log "[${idx}]" "$@"
         }
 
-        localLog "starting ${t}"
+        local_log "starting ${t}"
 
-        testgridUrl="${TESTGRID}/${t}&width=${BLOCK_WIDTH}"
-        fileName="${tmpDir}/$( genFileName "${t}" ).jpg"
-        fileBaseName="$(basename "$fileName")"
+        testgrid_url="${TESTGRID}/${t}&width=${BLOCK_WIDTH}"
+        file_name="${tmp_dir}/$( gen_file_name "${t}" ).jpg"
+        file_base_name="$(basename "$file_name")"
 
         # create & download screenshot
-        localLog "screenshoting ${testgridUrl} to ${fileBaseName}"
-        screenshot "${testgridUrl}" "${fileName}"
-        timestamp="$( getTimestamp )"
+        local_log "screenshoting ${testgrid_url} to ${file_base_name}"
+        screenshot "${testgrid_url}" "${file_name}"
+        timestamp="$( get_timestamp )"
 
-        read -r fileSize <<< "$(wc -c < "$fileName")"
-        localLog "${fileBaseName}: ${fileSize} bytes"
+        read -r file_size <<< "$(wc -c < "$file_name")"
+        local_log "${file_base_name}: ${file_size} bytes"
 
         # upload
-        localLog "uploading ${fileBaseName}"
-        imageMeta="$(
-          upload "$fileName"
-        )"
+        local_log "uploading ${file_base_name}"
+        image_meta="$( upload "$file_name" )"
 
-        imageUrl="$( echo "${imageMeta}" | jq -r '.image' )"
+        image_url="$( echo "${image_meta}" | jq -r '.image' )"
 
         # generate issue section
-        localLog "generating markdown stub"
+        local_log "generating markdown stub"
         printf \
           '\n<details><summary><tt>%s</tt> %s %s <a href="%s">[testgrid]</a></summary><p>\n\n![%s](%s)\n<!-- %s -->\n</p></details>\n' \
-          "${timestamp}" "${s}" "${t}" "${testgridUrl}" "${t}" "${imageUrl}" "${imageMeta}" \
-          > "$( getIssueStubName "${tmpDir}" "$idx" )"
+          "${timestamp}" "${s}" "${t}" "${testgrid_url}" "${t}" "${image_url}" "${image_meta}" \
+          > "$( get_issue_stub_name "${tmp_dir}" "$idx" )"
 
-        localLog "done, image is available at ${imageUrl}"
+        local_log "done, image is available at ${image_url}"
       )&
     done
   done
@@ -164,8 +247,19 @@ main() {
   echo
 
   echo '<!-- ----[ issue comment ]---- -->'
-  combineIssueStubs "${tmpDir}"
+  combine_issue_stubs "${tmp_dir}"
   echo '<!-- ----[ issue comment ]---- -->'
+}
+
+main() {
+  local target_release="${1:-}"
+
+  if [ -z "$target_release" ]; then
+    usage
+    exit
+  fi
+
+  shoot "$target_release"
 }
 
 main "$@"

--- a/testgridshot
+++ b/testgridshot
@@ -28,6 +28,10 @@
 #+   Configuration can be passed in via the environmnet. The following
 #+   variables are available:
 #+
+#+   UPLOAD_KEY: [*mandatory*]
+#+     The user key for 'vgy.me'. You need to create an account at 'vgy.me' and a
+#+     user key to be able to upload images.
+#+
 #+   BOARDS: [default: "blocking informing"]
 #+     Change which boards you are interested in
 #+
@@ -50,7 +54,7 @@
 #+     retries.
 #+
 #+   Example:
-#+     $ BOARDS='all informing' STATES='FAILING FLAKY' BLOCK_WIDTH=10 ./testgridshot 1.15
+#+     $ UPLOAD_KEY='<someKey>' BOARDS='all informing' STATES='FAILING FLAKY' BLOCK_WIDTH=10 ./testgridshot 1.15
 #+         Creates dense screenshots of all the 'sig-release-1.15-{all,informing}'
 #+         boards which are either failing or flaking
 #+
@@ -63,7 +67,8 @@
 #+   - Upload all the screenshots to 'vgy.me'
 #+   - Print a markdown, which links to the images on 'vgy.me', stub on StdOut
 #+   Remarks:
-#+   - Both 'vgy.me' and 'render-tron.appspot.com' might go away anytime
+#+   - on 2019-09-03 'vgy.me' disabled anonymous uploads, therefor everyone who
+#+     want's to use that script needs an account at 'vgy.me' currently.
 #+   - The images are not served by 'vgy.me' directly if used in a GitHub issue,
 #+     but by GitHub's camo service
 #+
@@ -85,6 +90,7 @@ readonly TESTGRID='https://testgrid.k8s.io'
 readonly RENDER_TRON='https://render-tron.appspot.com/screenshot'
 readonly UPLOAD_URL='https://vgy.me/upload'
 readonly ISSUE_STUB_SUFFIX='issue.'
+
 
 get_tests_by_status() {
   local status="$1"
@@ -121,7 +127,10 @@ log() {
 
 upload() {
   local file_name="$1"
-  curl_with_retry "$UPLOAD_URL" -F "file=@${file_name}" -F "title=${file_name}"
+  curl_with_retry "$UPLOAD_URL" \
+    -F "userkey=${UPLOAD_KEY}" \
+    -F "file=@${file_name}" \
+    -F "title=${file_name}"
 }
 
 screenshot() {
@@ -259,6 +268,7 @@ main() {
     exit
   fi
 
+  readonly "${UPLOAD_KEY?needs to hold the user key for your account at ${UPLOAD_URL}}"
   shoot "$target_release"
 }
 


### PR DESCRIPTION
As [requested by @justaugustus][req] this is introducing `testgridshot`, a tool that helps creating GitHub issue comments like [these][comment].

This is basically a copy of my [original PoC][poc].

Notes:
- Some people feel that we shouldn't introduce more shell scripts to k/release because 🐚🔥
- Eventually this should go away and be moved to a prow plugin or to anago or such ... in other words: automated away
- While I was there, I cleaned up the README a bit

[req]: https://github.com/kubernetes/sig-release/issues/607#issuecomment-521143245
[comment]: https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968
[poc]: https://gist.github.com/hoegaarden/0e9aab9d29885074a0f60f8398880397

/kind feature
/area release-eng
/sig release
/cc @kubernetes/release-engineering 
/assign @justaugustus 