### PR TITLE
Remove requirements for /usr/local in anago and branchff

### DIFF
--- a/anago
+++ b/anago
@@ -122,7 +122,7 @@ PROG=${0##*/}
 #+                                 - gcr.io/kubernetes-release-test (mock)
 #+                                 - k8s.gcr.io for --nomock
 #+     [--basedir=dir]           - Specify an alternate base directory
-#+                                 (default: /usr/local/google/$USER or $HOME/anago)
+#+                                 (default: $HOME/anago)
 #+     [--security_layer=]       - A file containing a path to a script to
 #+                                 source/include:
 #+                                 FLAGS_security_layer=/path/to/script
@@ -1488,13 +1488,7 @@ push_all_artifacts () {
 
 BASEDIR=${FLAGS_basedir}
 if [[ -z "${BASEDIR}" ]]; then
-  # Goobuntu machines have a standard path for "local" disk as the home
-  # directory is often stored elsewhere (NFS or something more exotic.)
-  if [[ -d "/usr/local/google" ]]; then
-    BASEDIR="/usr/local/google/$USER"
-  else
-    BASEDIR="$HOME/anago"
-  fi
+  BASEDIR="$HOME/anago"
 fi
 
 # make sure we have the compiled bins in the path

--- a/branchff
+++ b/branchff
@@ -63,8 +63,6 @@ for PREREQ in ${PREREQUISITE_TOOLS[@]}; do
   command -v $PREREQ > /dev/null 2>&1 || common::exit 1 "$PREREQ not installed"
 done;
 
-[[ -w /usr/local ]] || common::exit 1 "/usr/local is not writable."
-
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Set positional args
@@ -92,13 +90,19 @@ gitlib::repo_state || common::exit 1
 ###############################################################################
 # MAIN
 ###############################################################################
-BASEDIR="/usr/local/google/$USER"
+BASEDIR="$(mktemp -d "$TMPDIR/$PROG.XXXXXX")"
 # WORK/BUILD area
 WORKDIR=$BASEDIR/$PROG-$RELEASE_BRANCH
 # Go tools expect the kubernetes src to be under $GOPATH
 export GOPATH=$WORKDIR
 # TREE_ROOT is working branch/tree
 TREE_ROOT=$WORKDIR/src/k8s.io/kubernetes
+
+# Set a trap to cleanup BASEDIR if --cleanup is set.
+if (($FLAGS_cleanup)) ; then
+  trap 'rm -rf "$BASEDIR"' EXIT ERR SIGINT SIGQUIT SIGTERM SIGHUP
+fi
+
 # The real deal?
 if ((FLAGS_nomock)); then
   DRYRUN_FLAG=""
@@ -250,7 +254,12 @@ if common::askyorn -e "OK to push now"; then
 fi
 
 logecho
-logecho "$WORKDIR left intact for reviewing"
+
+if (($FLAGS_cleanup)); then
+  logecho "$BASEDIR has been removed, as the --cleanup flag was provided."
+else
+  logecho "$WORKDIR left intact for reviewing"
+fi
 
 # END script
 common::timestamp end


### PR DESCRIPTION
`branchff`:
- Remove requirement for writable /usr/local
- Set BASEDIR="$(mktemp -d "$TMPDIR/$PROG.XXXXXX")" instead of
  BASEDIR="/usr/local/google/$USER"
- Set trap to cleanup BASEDIR, if `--cleanup` is set

While doing the [first `branchff` for `release-1.16`](https://kubernetes.slack.com/archives/C2C40FMNF/p1565936759296200), I realized that we have an unnecessary requirement in ensuring `/usr/local` is writeable.

(As a note, I needed to temporarily comment out the [repo state check](https://github.com/kubernetes/release/blob/7ca7e1208e38fe323dc520845763d56897657b0a/branchff#L90) locally for `branchff` to allow the local changes that I had. In practice, we should not do that.)

I'll remove that requirement in the [first-pass updates to the Branch Manager handbook](https://github.com/kubernetes/sig-release/pull/757).

`anago`: Remove references to /usr/local/google/$USER

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @idealhack @hoegaarden @tpepper 
cc: @kubernetes/release-engineering 