### PR TITLE
build/debs: Fix CI download URLs

### DIFF
--- a/build/debs/build.go
+++ b/build/debs/build.go
@@ -270,7 +270,7 @@ func getCRIToolsLatestVersion() (string, error) {
 }
 
 func getLatestKubeCIBuild() (string, error) {
-	return fetchVersion("https://dl.k8s.io/ci-cross/latest.txt")
+	return fetchVersion("https://dl.k8s.io/ci/latest.txt")
 }
 
 func getCIBuildsDownloadLinkBase(_ version) (string, error) {
@@ -279,7 +279,7 @@ func getCIBuildsDownloadLinkBase(_ version) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("https://dl.k8s.io/ci-cross/v%s", latestCiVersion), nil
+	return fmt.Sprintf("https://dl.k8s.io/ci/v%s", latestCiVersion), nil
 }
 
 func getReleaseDownloadLinkBase(v version) (string, error) {


### PR DESCRIPTION
We were publishing cross builds to two locations. 
When https://github.com/kubernetes/test-infra/pull/14030 merges, `https://dl.k8s.io/ci/` (https://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/) will be the canonical location to pull all CI builds from.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @tpepper 
Build Admins:
/assign @listx @aleksandra-malinowska @sumitranr 

cc: @kubernetes/release-engineering 
/priority important-soon
/milestone v1.16
/kind cleanup