### PR TITLE
Do not allocate tty or use interactive flags in scripts

### DIFF
--- a/build/package-in-docker.sh
+++ b/build/package-in-docker.sh
@@ -52,7 +52,7 @@ mkdir -p "${OUTPUT_DIR}"
 
 case "${PACKAGE_TYPE}" in
 "debs")
-  docker run -ti --rm -v "${OUTPUT_DIR}:/src/bin" "${IMG_NAME}" "$@"
+  docker run --rm -v "${OUTPUT_DIR}:/src/bin" "${IMG_NAME}" "$@"
   echo
   echo "----------------------------------------"
   echo
@@ -60,7 +60,7 @@ case "${PACKAGE_TYPE}" in
   ls -alth "${OUTPUT_DIR}"
 ;;
 "rpms")
-  docker run -ti --rm -v "${OUTPUT_DIR}:/root/rpmbuild/RPMS/" "${IMG_NAME}" "$@"
+  docker run --rm -v "${OUTPUT_DIR}:/root/rpmbuild/RPMS/" "${IMG_NAME}" "$@"
   echo
   echo "----------------------------------------"
   echo

--- a/build/rpms/docker-build.sh
+++ b/build/rpms/docker-build.sh
@@ -5,7 +5,7 @@ docker build -t kubelet-rpm-builder .
 echo "Cleaning output directory..."
 sudo rm -rf output/*
 mkdir -p output
-docker run -ti --rm -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder $1
+docker run --rm -v $PWD/output/:/root/rpmbuild/RPMS/ kubelet-rpm-builder $1
 sudo chown -R $USER $PWD/output
 
 echo


### PR DESCRIPTION
We can't run this in CI properly, we end up with stuff like:
```
Cleaning output directory...
+ [[ ! -d /home/prow/go/src/k8s.io/release/_output/debs ]]
+ mkdir -p /home/prow/go/src/k8s.io/release/_output/debs
+ case "${PACKAGE_TYPE}" in
+ docker run -ti --rm -v /home/prow/go/src/k8s.io/release/_output/debs:/src/bin deb-builder:190826011345
the input device is not a TTY
Makefile:26: recipe for target 'build-debs' failed
make: *** [build-debs] Error 1
```

Change-Id: Ib4df1a30b79ddc2e4c6a396fcee331c45dfcb919