### PR TITLE
lib/releaselib: Continue publishing md5/sha1 until Kubernetes 1.18

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -623,8 +623,8 @@ release::gcs::locally_stage_release_artifacts() {
     local -r version_minor="${BASH_REMATCH[2]}"
     local -r version_patch="${BASH_REMATCH[3]}"
 
-    # Don't publish md5 & sha1 as of kubernetes release 1.16
-    if [[ "$version_minor" -ge "16" ]]; then
+    # Don't publish md5 & sha1 as of Kubernetes 1.18
+    if [[ "$version_minor" -ge "18" ]]; then
       publish_old_hashes=""
     fi
 


### PR DESCRIPTION
Bumping the version guard on the md5/sha logic to assist kops.
This will break again once the 1.17 branch is cut, so any kops et al testing
logic should be reconfigured to accommodate SHA{256,512} hashes before then.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/release/pull/859#issuecomment-526705296, https://kubernetes.slack.com/archives/C2C40FMNF/p1567190188091000, https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws/1167500303809908737

/assign @BenTheElder @justinsb 
cc: @kubernetes/release-engineering 
/priority critical-urgent
/milestone v1.16