### PR TITLE
Trim leading and trailing spaces from note

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -253,6 +253,7 @@ func NoteTextFromString(s string) (string, error) {
 		note = strings.ReplaceAll(note, "\r", "")
 		note = stripActionRequired(note)
 		note = dashify(note)
+		note = strings.TrimSpace(note)
 		return note, nil
 	}
 


### PR DESCRIPTION
This removes the trailing space from notes, for example

```
    My release note
```

Will now result in `My release note` as text and markdown.