### PR TITLE
Enhance regular expression for NONE release note variations

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -472,8 +472,10 @@ func ListCommitsWithNotes(
 		// "release note none" that appear in the commit log.
 		exclusionFilters := []string{
 
-			// 'none' or 'n/a' case insensitive with optional trailing whitespace, wrapped in ``` with/without release-note identifier
-			"(?i)```(release-note\\s*)?(none|n/a)?\\s*```",
+			// 'none','n/a','na' case insensitive with optional trailing
+			// whitespace, wrapped in ``` with/without release-note identifier
+			// the 'none','n/a','na' can also optionally be wrapped in quotes ' or "
+			"(?i)```(release-note[s]?\\s*)?('|\")?(none|n/a|na)?('|\")?\\s*```",
 
 			// This filter is too aggressive within the PR body and picks up matches unrelated to release notes
 			// 'none' or 'n/a' case insensitive wrapped optionally with whitespace


### PR DESCRIPTION
This enhances the release notes regex for matching any quoted variant of
case insensitive `NONE`s, as well as contributors who specify
`release-notes` instead of `release-note`.

Example: https://github.com/kubernetes/kubernetes/pull/79933
Major discussion: https://github.com/kubernetes/sig-release/pull/763#discussion_r315064356

Relates to: https://github.com/kubernetes/release/pull/836/files#r320614006

/cc @justaugustus 