### PR TITLE
Set GOPROXY and GOSUMDB ...

### DIFF
--- a/gcb/stage.yaml
+++ b/gcb/stage.yaml
@@ -30,6 +30,8 @@ steps:
   - "GOPATH=/workspace/go"
   - "GOBIN=/workspace/bin"
   - "GO111MODULE=on"
+  - "GOPROXY=https://proxy.golang.org"
+  - "GOSUMDB=sum.golang.org"
   args:
   - "./compile-release-tools"
 


### PR DESCRIPTION
... to fix an issue that git.apache.org went away. This, as a
side-effect, should also make go module downloads faster.

See also: https://github.com/kubernetes/test-infra/pull/14173

/assign @idealhack 
/milestone v1.16