### PR TITLE
Do not generate checksums for SUM{256,512}SUMS in the checksum files

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -704,8 +704,10 @@ release::gcs::locally_stage_release_artifacts() {
   # Write the release checksum files.
   # We checksum everything except our checksum files, which we do next.
   logecho "- Writing artifact hashes to SHA256SUMS/SHA512SUMS files..."
-  find "${gcs_stage}" -type f -printf '%P\0' | xargs -0 -I {} shasum -a 256 "${gcs_stage}/{}" >> "${gcs_stage}/SHA256SUMS"
-  find "${gcs_stage}" -type f -printf '%P\0' | xargs -0 -I {} shasum -a 512 "${gcs_stage}/{}" >> "${gcs_stage}/SHA512SUMS"
+  find "${gcs_stage}" -type f -printf '%P\0' | xargs -0 -I {} shasum -a 256 "${gcs_stage}/{}" >> SHA256SUMS
+  find "${gcs_stage}" -type f -printf '%P\0' | xargs -0 -I {} shasum -a 512 "${gcs_stage}/{}" >> SHA512SUMS
+  # After all the checksum files are generated, move them into the bucket staging area
+  mv SHA256SUMS SHA512SUMS "$gcs_stage"
 
   logecho "- Hashing files in ${gcs_stage##$build_output/}..."
   find "$gcs_stage" -type f | while read -r path; do


### PR DESCRIPTION
We can just keep the checksum files outside of the bucket staging area
so that they do not get checksummed themselves. Once all checksum files
have been created, we can move them into the bucket staging area.

If we have the files in the staging area, they get checksummed themselves, but might not / are probably not fully written yet, therefore their checksum might be / is probably wrong anyway.

This PR disables writing the checksums of the files `SHA{256,512}SUMS` into themselves. However `SHA{256,512}SUMS`'s checksums will still be available in the files `SHA{256,512}SUMS.sha{256,512}`. 

ref: https://github.com/kubernetes/release/pull/860

/assign @justaugustus @justinsb 
/kind cleanup
/milestone v1.16
