### PR TITLE
Allow specifying a repo-path for local clones

### DIFF
--- a/pkg/notes/git.go
+++ b/pkg/notes/git.go
@@ -3,20 +3,26 @@ package notes
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"regexp"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
+// Wrapper type for a Kubernetes repository instance
+type KubernetesRepo struct{ *git.Repository }
+
 // RevParse parses a git revision and returns a SHA1 on success, otherwise an
 // error.
-func RevParse(rev, workDir string) (string, error) {
-	repo, err := git.PlainOpen(workDir)
-	if err != nil {
-		return "", err
+func (k *KubernetesRepo) RevParse(rev string) (string, error) {
+	// Prefix all non-tags the default remote "origin"
+	if isVersion, _ := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev); !isVersion {
+		rev = "origin/" + rev
 	}
 
-	ref, err := repo.ResolveRevision(plumbing.Revision(rev))
+	// Try to resolve the rev
+	ref, err := k.ResolveRevision(plumbing.Revision(rev))
 	if err != nil {
 		return "", err
 	}
@@ -24,21 +30,60 @@ func RevParse(rev, workDir string) (string, error) {
 	return ref.String(), nil
 }
 
-// CloneTempRepository creates a temp directory containing the provided
-// GitHub repository via owner and name. It returns that directory if cloning
-// of the repository was successful, otherwise an error.
-func CloneTempRepository(owner, name string) (string, error) {
-	dir, err := ioutil.TempDir("", "release-notes")
-	if err != nil {
-		return "", err
+// NewKubernetesRepo creates a temp directory containing the provided
+// GitHub repository via owner and name.
+//
+// If a repoPath is given, then the function tries to update the repository.
+//
+// The funciton returns the repository if cloning or updating of the repository
+// was successful, otherwise an error.
+func NewKubernetesRepo(repoPath, owner, name string) (*KubernetesRepo, error) {
+	targetDir := ""
+	if repoPath != "" {
+		_, err := os.Stat(repoPath)
+
+		if err == nil {
+			// The file or directory exists, just try to update the repo
+			return updateRepo(repoPath)
+
+		} else if os.IsNotExist(err) {
+			// The directory does not exists, we still have to clone it
+			targetDir = repoPath
+
+		} else {
+			// Something else bad happended
+			return nil, err
+		}
+
+	} else {
+		// No repoPath given, use a random temp dir instead
+		t, err := ioutil.TempDir("", "release-notes")
+		if err != nil {
+			return nil, err
+		}
+		targetDir = t
 	}
 
-	_, err = git.PlainClone(dir, false, &git.CloneOptions{
-		URL: fmt.Sprintf("https://github.com/%s/%s", owner, name),
+	r, err := git.PlainClone(targetDir, false, &git.CloneOptions{
+		URL:      fmt.Sprintf("https://github.com/%s/%s", owner, name),
+		Progress: os.Stdout,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+	return &KubernetesRepo{r}, nil
+}
 
-	return dir, nil
+// updateRepo tries to open the provided repoPath and fetches the latest
+// changed from the configured remote location
+func updateRepo(repoPath string) (*KubernetesRepo, error) {
+	r, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	err = r.Fetch(&git.FetchOptions{Progress: os.Stdout})
+	if err != nil && err != git.NoErrAlreadyUpToDate {
+		return nil, err
+	}
+	return &KubernetesRepo{r}, nil
 }


### PR DESCRIPTION
This adds a new `--repo-path` option to the notes generator to specify a
local git repository copy for version information retrieval. This should
speed up the overall clone behavior since we now can preserve the
kubernetes repository locally.
