### PR TITLE
Add SHA auto discovery feature for release notes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.38.0 // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-kit/kit v0.9.0
 	github.com/google/go-github/v28 v28.1.1
 	github.com/kolide/kit v0.0.0-20190123023048-c155a91098e3

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/release/pkg/notes",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_blang_semver//:go_default_library",
         "@com_github_go_kit_kit//log:go_default_library",
         "@com_github_go_kit_kit//log/level:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",

--- a/pkg/notes/git.go
+++ b/pkg/notes/git.go
@@ -5,7 +5,11 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strings"
 
+	"github.com/blang/semver"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -86,4 +90,74 @@ func updateRepo(repoPath string) (*KubernetesRepo, error) {
 		return nil, err
 	}
 	return &KubernetesRepo{r}, nil
+}
+
+func (k *KubernetesRepo) DiscoverRevs(logger log.Logger) (start, end string, err error) {
+	// Find the last non patch version tag, then resolve its revision
+	version, err := k.latestNonPatchFinalVersion()
+	if err != nil {
+		return "", "", err
+	}
+	versionTag := "v" + version.String()
+	level.Info(logger).Log("msg", "latest non patch version "+versionTag)
+	start, err = k.RevParse(versionTag)
+	if err != nil {
+		return "", "", err
+	}
+
+	// If a release branch exists for the next version, we use it. Otherwise we
+	// fallback to the master branch.
+	end, err = k.releaseBranchOrMasterRev(logger, version.Major, version.Minor+1)
+	if err != nil {
+		return "", "", err
+	}
+
+	return start, end, nil
+}
+
+func (k *KubernetesRepo) latestNonPatchFinalVersion() (semver.Version, error) {
+	latestFinalTag := semver.Version{}
+
+	tags, err := k.Tags()
+	if err != nil {
+		return latestFinalTag, err
+	}
+
+	found := false
+	_ = tags.ForEach(func(t *plumbing.Reference) error {
+		tag := strings.TrimPrefix(t.Name().Short(), "v")
+		ver, err := semver.Make(tag)
+
+		if err == nil {
+			// We're searching for the latest, non patch final tag
+			if ver.Patch == 0 && len(ver.Pre) == 0 {
+				if ver.GT(latestFinalTag) {
+					latestFinalTag = ver
+					found = true
+				}
+			}
+		}
+		return nil
+	})
+	if !found {
+		return latestFinalTag, fmt.Errorf("unable to find latest non patch release")
+	}
+	return latestFinalTag, nil
+}
+
+func (k *KubernetesRepo) releaseBranchOrMasterRev(logger log.Logger, major, minor uint64) (rev string, err error) {
+	relBranch := fmt.Sprintf("release-%d.%d", major, minor)
+	rev, err = k.RevParse(relBranch)
+	if err == nil {
+		level.Info(logger).Log("msg", "found release branch "+relBranch)
+		return rev, nil
+	}
+
+	rev, err = k.RevParse("master")
+	if err == nil {
+		level.Info(logger).Log("msg", "no release branch found, using master")
+		return rev, nil
+	}
+
+	return "", err
 }


### PR DESCRIPTION
This PR requires https://github.com/kubernetes/release/pull/879 to be merged first, whereas its commit is included here as well.

---

This adds a new command line option `--discover`, which currently
supports the values:

- `none`: No automatic start or end SHA discovery enabled, this means
  that `--{start,end}-{sha,rev}` has to be specified

- `minor-to-latest`: It will try to automatically discover the revisions
  by doing:
  1. Finding the latest Kubernetes final tag and resolve its revision
  2. Find either a release branch for the next minor version or use the
     master branch, then resolve its revision

`minor-to-latest` is the most common workflow in the current release
notes team, whereas other workflows can be added in the future, to cover
use cases like `patch-to-patch` for automation via anago.
