### PR TITLE
Quarterly OWNERS update

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,7 @@
 approvers:
   - sig-release-leads
   - release-engineering
-  - patch-release-team
 reviewers:
-  - release-team-lead-role
   - branch-managers
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,24 +6,29 @@ aliases:
     - justaugustus
     - tpepper
   release-engineering:
-    - aleksandra-malinowska
-    - calebamiles
-    - ixdy
-    - tpepper
-  patch-release-team:
-    - aleksandra-malinowska
-    - feiskyer
-    - hoegaarden
-    - tpepper
+    - aleksandra-malinowska # Patch Release Team
+    - calebamiles # subproject owner
+    - dougm # Patch Release Team
+    - feiskyer # Patch Release Team
+    - hoegaarden # Patch Release Team
+    - idealhack # Patch Release Team
+    - justaugustus # subproject owner
+    - tpepper # subproject owner / Patch Release Team
   branch-managers:
     - bubblemelon
-    - idealhack
+    - justaugustus
   build-admins:
     - aleksandra-malinowska
     - listx
+    - ps882
     - sumitranr
-  release-team-lead-role:
-    - aishsundar # 1.13
-    - spiffxp # 1.14
-    - claurence # 1.15
-    - lachie83 # 1.16
+  release-notes-approvers:
+    - jeefy
+    - marpaia
+    - onyiny-ang
+    - saschagrunert
+  release-notes-reviewers:
+    - jeefy
+    - marpaia
+    - onyiny-ang
+    - saschagrunert

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - release-engineering
-  - patch-release-team
 reviewers:
   - branch-managers
   - build-admins

--- a/build/debs/OWNERS
+++ b/build/debs/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - release-engineering
-  - patch-release-team
 reviewers:
   - branch-managers
   - build-admins

--- a/build/rpms/OWNERS
+++ b/build/rpms/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - release-engineering
-  - patch-release-team
 reviewers:
   - branch-managers
   - build-admins

--- a/cmd/release-notes/OWNERS
+++ b/cmd/release-notes/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - jeefy
-  - marpaia
-  - onyiny-ang
+  - release-notes-approvers
+reviewers:
+  - release-notes-reviewers

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - release-engineering
-  - patch-release-team
 reviewers:
   - branch-managers
   - build-admins

--- a/pkg/notes/OWNERS
+++ b/pkg/notes/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - jeefy
-  - marpaia
-  - onyiny-ang
+  - release-notes-approvers
+reviewers:
+  - release-notes-reviewers


### PR DESCRIPTION
- Prune Release Team members
- Update Release Engineering OWNERS
  - Include all Release Engineering subproject OWNERS
  - Add new Patch Release Team members (dougm + idealhack)
- Add ps882 to Build Admins
- Add aliases for Release Notes reviewers/approvers

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
/cc @kubernetes/release-engineering
xref: https://github.com/kubernetes/sig-release/pull/793