### PR TITLE
Add KubeCon lightning talk to release note docs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -102,3 +102,4 @@ release and it will end up in the release notes.
 ## Related
 
 * [Original release notes proposal](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/release-notes.md)
+* [Behind The Scenes: Kubernetes Release Notes Tips & Tricks - Mike Arpaia, Kolide (KubeCon 2018 Lightning Talk)](https://www.youtube.com/watch?v=n62oPohOyYs)


### PR DESCRIPTION
This PR adds a link to @marpaia's talk at KubeCon to the release notes documentation. 

I just recently had the need to add a release note to my PR for the first time and was a bit lost because I couldn't quickly find more information about why and how. I found this talk incredibly helpful and a good addition to the written documentation.

I also hope to add a link to `docs/release-notes.md` in the [PR template](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md) towards `docs/release-notes.md` (https://github.com/kubernetes/kubernetes/pull/83049) as well so new contributors can find the document quickly.