### PR TITLE
Option to skip remote binaries for local testing/builds

### DIFF
--- a/build/debs/bionic/kubeadm/debian/rules
+++ b/build/debs/bionic/kubeadm/debian/rules
@@ -2,15 +2,20 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
+KUBE_USE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
+ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
+	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/kubeadm usr/bin/kubeadm
+else
 	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubeadm \
 		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubeadm"
+endif
 
 	chmod +x usr/bin/kubeadm
 	dh_testroot

--- a/build/debs/bionic/kubectl/debian/rules
+++ b/build/debs/bionic/kubectl/debian/rules
@@ -2,15 +2,20 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
+KUBE_USE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
-	curl  --fail -sS -L --retry 5 \
+ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
+	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .Arch }}/kubeadm usr/bin/kubectl
+else
+	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubectl \
 		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubectl"
+endif
 	chmod +x usr/bin/kubectl
 	dh_testroot
 	dh_auto_install

--- a/build/debs/bionic/kubelet/debian/rules
+++ b/build/debs/bionic/kubelet/debian/rules
@@ -2,15 +2,20 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
+KUBE_USE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
-	curl  --fail -sS -L --retry 5 \
+ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
+	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .Arch }}/kubeadm usr/bin/kubelet
+else
+	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubelet \
 		"{{ .DownloadLinkBase }}/bin/linux/{{ .Arch }}/kubelet"
+endif
 	chmod +x usr/bin/kubelet
 	dh_testroot
 	dh_auto_install

--- a/build/rpms/build.sh
+++ b/build/rpms/build.sh
@@ -37,6 +37,14 @@ else
   )
 fi
 
+if [[ "${KUBE_USE_LOCAL_ARTIFACTS:-}" == "y" ]]; then
+  LOCAL_OUTPUT_DIRECTORY="$(go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux"
+  echo "Using binaries from ${LOCAL_OUTPUT_DIRECTORY}"
+  sed -i "s|^Source0:.*|Source0: ${LOCAL_OUTPUT_DIRECTORY}/${GOARCH}/kubelet|" "${SRC_PATH}/kubelet.spec"
+  sed -i "s|^Source2:.*|Source2: ${LOCAL_OUTPUT_DIRECTORY}/${GOARCH}/kubectl|" "${SRC_PATH}/kubelet.spec"
+  sed -i "s|^Source3:.*|Source3: ${LOCAL_OUTPUT_DIRECTORY}/${GOARCH}/kubeadm|" "${SRC_PATH}/kubelet.spec"
+fi
+
 # TODO: Add support for multiple spec files once we break packages out into separate specs.
 for ARCH in "${ARCHS[@]}"; do
   IFS=/ read -r GOARCH RPMARCH<<< "${ARCH}"; unset IFS;


### PR DESCRIPTION
when we build local artifacts, we should be able to build debs and rpms w/o needing to push them out to a remote server.

example `go run build.go -arch amd64 -distros bionic -kube-version 1.17.0` should work with this change once you run make quick-release or make cross (as long as artifacts can be found in `k8s.io/kubernetes/_output/dockerized/bin/linux`)

I'd like to use this in the CAPG e2e CI job to install latest debs (built from binaries in k/k) without having to push the binaries to GCS