### PR TITLE
Prepare to use RBE for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,49 @@
+build --verbose_failures
 test --test_output=errors
 
+# Note needs an instance name
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-0.27.0.bazelrc
+build:remote --jobs=500
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=@io_k8s_repo_infra//:rbe_with_network
+build:remote --host_platform=@io_k8s_repo_infra//:rbe_with_network
+build:remote --platforms=@io_k8s_repo_infra//:rbe_with_network
+
+build:remote --define=EXECUTOR=remote
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --remote_timeout=3600
+
+# Alt: --google_credentials=some_file.json
+build:remote --google_default_credentials=true
+
+# Minimize what is downloaded
+build:inmemory --experimental_inmemory_jdeps_files
+build:inmemory --experimental_inmemory_dotd_files
+
+# Minimize what is downloaded
+build:toplevel --config=inmemory
+build:toplevel --experimental_remote_download_outputs=toplevel
+
+build:minimal --config=inmemory
+build:minimal --experimental_remote_download_outputs=minimal
+
+build:remote --config=toplevel
+
+run:remote --experimental_remote_download_outputs=all --noexperimental_inmemory_jdeps_files --noexperimental_inmemory_dotd_files
+
+# Compose the remote configs with an instance name
+# A couple examples below:
+
+# --config=ci-instance adds the instance name
+build:ci-instance --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
+
+# Config we want to use in ci
+#build:ci --config=remote --config=ci-instance # TODO(fejta): uncomment after presubmits set this
+build:ci --noshow_progress


### PR DESCRIPTION
/assign @justaugustus 

`--noshow_progress` will help reduce spam, and also allows me to update the test-infra job to add a `--config=ci` without failing.

Once that is in, then I can uncomment the `build:ci --config=remote` to make this do a remote build.

Finally this also allows us to validate that the new bazel job is working :)