### PR TITLE
fix typo - lost the .Arch for kubeadm

### DIFF
--- a/build/debs/packages/latest/kubeadm/debian/rules
+++ b/build/debs/packages/latest/kubeadm/debian/rules
@@ -10,7 +10,7 @@ build:
 binary:
 	mkdir -p usr/bin
 ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
-	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/kubeadm usr/bin/kubeadm
+	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .Arch }}/kubeadm usr/bin/kubeadm
 else
 	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubeadm \


### PR DESCRIPTION
Lost the architecture for kubeadm!