### PR TITLE
Add support for running Kubernetes builds via Google Cloud Build

### DIFF
--- a/gcb/build.yaml
+++ b/gcb/build.yaml
@@ -1,0 +1,59 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 7200s
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  dir: 'go/src/k8s.io'
+  args:
+  - clone
+  - --branch=${_KUBERNETES_BRANCH}
+  - ${_KUBERNETES_REPO}
+
+- name: 'gcr.io/cloud-builders/git'
+  dir: 'go/src/k8s.io'
+  args:
+  - clone
+  - --branch=${_RELEASE_TOOL_BRANCH}
+  - ${_RELEASE_TOOL_REPO}
+
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  dir: 'go/src/k8s.io/kubernetes'
+  args:
+  - make
+  - clean
+
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  dir: 'go/src/k8s.io/kubernetes'
+  args:
+  - make
+  - "${_RELEASE_TYPE}"
+
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  dir: 'go/src/k8s.io/kubernetes'
+  args:
+  - ../release/push-build.sh
+  - --verbose
+  - "${_CI}"
+  - "${_NOMOCK}"
+  - "${_BUCKET}"
+  - "${_REGISTRY}"
+  - "${_ALLOW_DUP}"
+  - "${_EXTRA_PUBLISH_FILE}"
+  - "${_HYPERKUBE}"
+
+options:
+  machineType: 'N1_HIGHCPU_32'
+  substitution_option: 'ALLOW_LOOSE'
+
+substitutions:
+  _KUBERNETES_REPO: 'https://github.com/kubernetes/kubernetes.git'
+  _KUBERNETES_BRANCH: 'master'
+  _RELEASE_TOOL_REPO: 'https://github.com/kubernetes/release.git'
+  _RELEASE_TOOL_BRANCH: 'master'
+  _RELEASE_TYPE: 'release-in-a-container'
+  _CI: ''
+  _NOMOCK: ''
+  _BUCKET: '--bucket=kubernetes-release-dev'
+  _REGISTRY: '--registry=gcr.io/kubernetes-ci-images'
+  _ALLOW_DUP: ''
+  _EXTRA_PUBLISH_FILE: ''
+  _HYPERKUBE: ''

--- a/gcb/variants.yaml
+++ b/gcb/variants.yaml
@@ -1,0 +1,23 @@
+variants:
+  build-ci:
+    CI: '--ci'
+    NOMOCK: '--nomock'
+    BUCKET: '--bucket=k8s-staging-release-test'
+    REGISTRY: '--docker-registry=gcr.io/k8s-staging-release-test'
+    ALLOW_DUP: '--allow-dup'
+    EXTRA_PUBLISH_FILE: '--extra-publish-file=k8s-master'
+    HYPERKUBE: '--hyperkube'
+  build-ci-fast:
+    CI: '--ci'
+    NOMOCK: '--nomock'
+    BUCKET: '--bucket=k8s-staging-release-test'
+    REGISTRY: '--docker-registry=gcr.io/k8s-staging-release-test'
+    ALLOW_DUP: '--allow-dup'
+  build-ci-old:
+    CI: '--ci'
+    NOMOCK: '--nomock'
+    BUCKET: '--bucket=kubernetes-release-dev'
+    REGISTRY: '--docker-registry=gcr.io/kubernetes-ci-images'
+    ALLOW_DUP: '--allow-dup'
+    EXTRA_PUBLISH_FILE: '--extra-publish-file=k8s-master'
+    HYPERKUBE: '--hyperkube'

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -1,7 +1,4 @@
-# To rebuild and publish this container run:
-#   gcloud builds submit --config update_build_container.yaml .
-
-FROM ubuntu:18.04
+FROM k8s.gcr.io/kube-cross:v1.12.12-1
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -44,32 +41,60 @@ RUN apt-get -q update \
 # Install gcloud
 # common::set_cloud_binaries() looks for it in this path
 RUN mkdir /opt/google
-RUN curl -sSL https://sdk.cloud.google.com > /tmp/install.sh && \
-    bash /tmp/install.sh --install-dir=/opt/google --disable-prompts
+RUN apt-get -y update \
+    && apt-get -y install \
+        gcc \
+        python2.7 \
+        python-dev \
+        python-setuptools \
+        wget \
+        ca-certificates \
+        # These are necessary for add-apt-respository
+        software-properties-common \
+    # Install Git >2.0.1
+    && apt-get -y update \
+    && apt-get -y install git \
+    # Setup Google Cloud SDK (latest)
+    && curl -sSL https://sdk.cloud.google.com > /tmp/install.sh \
+    && bash /tmp/install.sh --install-dir=/opt/google --disable-prompts \
+    # install crcmod: https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+    && pip install -U crcmod \
+    # Clean up
+    && apt-get -y remove \
+        gcc \
+        python-dev \
+        python-setuptools \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf ~/.config/gcloud
 
+ENV PATH=/opt/google/google-cloud-sdk/bin:$PATH
 
 # Install docker stuff
 #---------------------
 # Based on instructions from:
-# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#uninstall-old-versions
+# https://docs.docker.com/install/linux/docker-ce/debian/
 RUN apt-get -y update \
-    && apt-get install -y \
-        linux-image-extra-virtual \
+    && apt-get -y install \
         apt-transport-https \
         ca-certificates \
         curl \
+        make \
         software-properties-common \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
     && add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-        $(lsb_release -cs) \
-        stable edge" \
-    && apt-get -y update
-
-ARG DOCKER_VERSION=18.06.0~ce~3-0~ubuntu
-RUN apt-get install -y \
-      docker-ce=${DOCKER_VERSION} \
-      unzip
+      "deb [arch=amd64] https://download.docker.com/linux/debian \
+      $(lsb_release -cs) \
+      stable" \
+    && apt-get -y update \
+    && apt-get -y install \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        unzip
 
 # Cleanup a bit
 RUN rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT []


### PR DESCRIPTION
This PR abstracts the steps of the `kubernetes_build` scenario in k/test-infra into GCB build steps and a set of build variants which can be triggered without having to dissect the job configs in test-infra.

This is the k/release counterpart to the following PRs: https://github.com/kubernetes/test-infra/pull/14747, https://github.com/kubernetes/test-infra/pull/14773, https://github.com/kubernetes/test-infra/pull/14788

As a note, I plan on cleaning up the Dockerfile in a future PR. I just want to minimize the changes in this PR, so I can start getting signal on these build runs.

---

- Update the `k8s-cloud-builder` Dockerfile

  Here we instead base the image on the most recent version of
  `k8s.gcr.io/kube-cross` (v1.12.12-1), which is an image that contains
  all of the relevant dependencies to build Kubernetes. We also add
  build steps for the GCP CLI tools (to be able to access GCP resources
  within the image) and install docker (to build and push container
  images to GCR).

- Add `gcb/build.yaml`

  This is a new GCB config file which encapsulates the build steps of
  the `kubernetes_build` scenario, which we use in CI to build
  Kubernetes. Specifically, the following build steps are happening:
    - git clone `kubernetes/kubernetes`
    - git clone `kubernetes/release`
    - (k/k) `make clean`
    - (k/k) `make release-in-a-container`
    - (k/r) `push-build.sh`

- Add `gcb/variants.yaml`

  `variants.yaml` files store a set of build types, which contain a set of
  GCB substitutions, which are interpreted by
  k/test-infra/images/builder before submitting a build or set of builds
  to GCB. This pattern is used in several places in k/test-infra to
  define build variations (primarily for image building via GCB).

  We adopt it here to circumvent creating an additional dependent of
  `gcbmgr`/`anago`.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>