### PR TITLE
Fix cherry-pick release notes behavior

### DIFF
--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -72,7 +72,8 @@ func TestReleaseNoteParsing(t *testing.T) {
 		fmt.Println(sha)
 		commit, _, err := client.Repositories.GetCommit(ctx, "kubernetes", "kubernetes", sha)
 		require.NoError(t, err)
-		_, err = ReleaseNoteFromCommit(commit, client, "0.1")
+		prs, err := PRsFromCommit(client, commit)
+		_, err = ReleaseNoteFromCommit(&Result{commit: commit, pullRequest: prs[0]}, client, "0.1")
 		require.NoError(t, err)
 	}
 }
@@ -212,12 +213,12 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualPRNumber, err := getPRNumberFromCommitMessage(tc.commitMessage)
+			prs, err := prsForCommit(tc.commitMessage)
 			if err != nil {
 				t.Fatalf("Expected no error to occur but got %v", err)
 			}
-			if actualPRNumber != tc.expectedPRNumber {
-				t.Errorf("Expected PR number to be %d but was %d", tc.expectedPRNumber, actualPRNumber)
+			if prs[0] != tc.expectedPRNumber {
+				t.Errorf("Expected PR number to be %d but was %d", tc.expectedPRNumber, prs[0])
 			}
 		})
 	}


### PR DESCRIPTION
On a cherry-pick, we now test the actual cherry-pick PR and as fallback the original PR for a release note.

Regression: https://github.com/kubernetes/release/commit/2aed4b42225edf3c257ce7c46cb86d7bfb99da69
Fixes: https://github.com/kubernetes/release/issues/899

The generated notes for 1.16.1 as a validation:
https://gist.github.com/saschagrunert/725c440f77b4b108745075fd863a908a