### PR TITLE
[prototype] Stage/release Kubernetes on k8s-infra - Phase 0

### DIFF
--- a/anago
+++ b/anago
@@ -119,7 +119,7 @@ PROG=${0##*/}
 #+                                 build version
 #+     [--gcrio_path=]           - Specify the full GCR path to use.
 #+                                 defaults:
-#+                                 - gcr.io/kubernetes-release-test (mock)
+#+                                 - gcr.io/k8s-staging-release-test (mock)
 #+                                 - k8s.gcr.io for --nomock
 #+     [--basedir=dir]           - Specify an alternate base directory
 #+                                 (default: $HOME/anago)

--- a/anago
+++ b/anago
@@ -277,12 +277,7 @@ ensure_registry_acls () {
   # Short of creating a hardcoded map of project-id to registry, translating
   # _ to - seems to be a simple rule to keep this, well, simple.
   for r in ${registries[*]//_/-}; do
-    # In this context, "google-containers" is still used
-    if [[ "$r" == "$GCRIO_PATH_PROD" ]]; then
-      artifact_namespace="google-containers"
-    else
-      artifact_namespace="${r/gcr.io\//}"
-    fi
+    artifact_namespace="${r/gcr.io\//}"
 
     gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
     logecho -n "Checking write access to registry $r: "

--- a/anago
+++ b/anago
@@ -618,7 +618,7 @@ local_kube_cross () {
   local local_image
   local docker_image
 
-  docker_image="${GCRIO_PATH_PROD}/kube-cross"
+  docker_image="${GCRIO_PATH_TEST}/kube-cross"
   version="$(cat "${TREE_ROOT}/build/build-image/cross/VERSION")"
   image="${docker_image}:${version}"
   local_image="${docker_image}:local"

--- a/anago
+++ b/anago
@@ -1429,11 +1429,6 @@ archive_release () {
   # Best effort
   logecho "Copy $WORKDIR $text to $archive_bucket/$build_dir..."
   logrun $GSUTIL -mq cp $dash_args $WORKDIR/* $archive_bucket/$build_dir || true
-
-  logecho -n "Ensure PRIVATE ACL on" \
-             "$archive_bucket/$build_dir/${LOGFILE##*/}\*: "
-  logrun -s $GSUTIL acl ch -d AllUsers \
-            "$archive_bucket/$build_dir/${LOGFILE##*/}*" || true
 }
 
 ##############################################################################

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -12,11 +12,9 @@ timeout: 14400s
 #
 # (Please do not remove this security notice.)
 secrets:
-- kmsKeyName: projects/k8s-staging-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+- kmsKeyName: projects/k8s-staging-release-test/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    # TODO(prototype): Need to configure KMS object to store k8s-release-robot GitHub token
-    #                  on k8s-staging-release-test GCP project.
-    GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
+    GITHUB_TOKEN: CiQAzX5NM13ZVJOM+E0k629PSa7H5Hkm4mJlPbm7hR8nr67KGAoSUQCmb2uz62tmpa7is9YJx8tlEspVytgq5HAvsd9DWey/oRCsv4VkVBRhnNnlpnmQ8eDPXAaS0GfjrP4KuCgT3mM570N1FH6hTN+u7Yg8uaOxWw==
 
 steps:
 - name: gcr.io/cloud-builders/git

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -12,8 +12,10 @@ timeout: 14400s
 #
 # (Please do not remove this security notice.)
 secrets:
-- kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+- kmsKeyName: projects/k8s-staging-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
   secretEnv:
+    # TODO(prototype): Need to configure KMS object to store k8s-release-robot GitHub token
+    #                  on k8s-staging-release-test GCP project.
     GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
 
 steps:

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
   - "--basedir=/workspace"
   - "--tmpdir=/workspace/tmp"
 
-- name: k8s.gcr.io/kube-cross:local
+- name: gcr.io/$PROJECT_ID/kube-cross:local
   dir: "go/src/k8s.io/release"
   env:
   - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -1,4 +1,21 @@
 timeout: 14400s
+
+#### SECURITY NOTICE ####
+# Google Cloud Build (GCB) supports the usage of secrets for build requests.
+# Secrets appear within GCB configs as base64-encoded strings.
+# These secrets are GCP Cloud KMS-encrypted and cannot be decrypted by any human or system
+# outside of GCP Cloud KMS for the GCP project this encrypted resource was created for.
+# Seeing the base64-encoded encrypted blob here is not a security event for the project.
+#
+# More details on using encrypted resources on Google Cloud Build can be found here:
+# https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials
+#
+# (Please do not remove this security notice.)
+secrets:
+- kmsKeyName: projects/k8s-staging-release-test/locations/global/keyRings/release/cryptoKeys/encrypt-0
+  secretEnv:
+    GITHUB_TOKEN: CiQAzX5NM13ZVJOM+E0k629PSa7H5Hkm4mJlPbm7hR8nr67KGAoSUQCmb2uz62tmpa7is9YJx8tlEspVytgq5HAvsd9DWey/oRCsv4VkVBRhnNnlpnmQ8eDPXAaS0GfjrP4KuCgT3mM570N1FH6hTN+u7Yg8uaOxWw==
+
 steps:
 - name: gcr.io/cloud-builders/git
   dir: "go/src/k8s.io"
@@ -63,6 +80,8 @@ steps:
   env:
   - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
   - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
+  secretEnv:
+  - GITHUB_TOKEN
   args:
   - "./anago"
   - "${_RELEASE_BRANCH}"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -1,21 +1,4 @@
 timeout: 14400s
-
-#### SECURITY NOTICE ####
-# Google Cloud Build (GCB) supports the usage of secrets for build requests.
-# Secrets appear within GCB configs as base64-encoded strings.
-# These secrets are GCP Cloud KMS-encrypted and cannot be decrypted by any human or system
-# outside of GCP Cloud KMS for the GCP project this encrypted resource was created for.
-# Seeing the base64-encoded encrypted blob here is not a security event for the project.
-#
-# More details on using encrypted resources on Google Cloud Build can be found here:
-# https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials
-#
-# (Please do not remove this security notice.)
-secrets:
-- kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
-  secretEnv:
-    GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
-
 steps:
 - name: gcr.io/cloud-builders/git
   dir: "go/src/k8s.io"
@@ -40,8 +23,6 @@ steps:
   env:
   - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
   - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
-  secretEnv:
-  - GITHUB_TOKEN
   args:
   - "./anago"
   - "${_RELEASE_BRANCH}"
@@ -82,8 +63,6 @@ steps:
   env:
   - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
   - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
-  secretEnv:
-  - GITHUB_TOKEN
   args:
   - "./anago"
   - "${_RELEASE_BRANCH}"

--- a/gcbmgr
+++ b/gcbmgr
@@ -389,11 +389,14 @@ ARG2=${POSITIONAL_ARGV[1]}
 PROJECT="${PROJECT:-$DEFAULT_PROJECT}"
 # Append $PROJECT to GCLOUD
 GCLOUD+=" --project $PROJECT"
-BUCKET="kubernetes-release"
+BUCKET="${BUCKET:-$DEFAULT_BUCKET}"
 # disk size must take base image into consideration.
 # The amount specified is not what is "free"
 DISK_SIZE="300"
 GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE --format="value(account)")
+
+# Lowercase GCP users
+GCP_USER="$(echo "$GCP_USER" | awk '{print tolower($0)}')"
 # This is used as a tag so convert @ to -at- (for yaml tag field
 # where @ is invalid)
 # First, for @google.com users strip off the @domain.tld

--- a/gcbmgr
+++ b/gcbmgr
@@ -386,7 +386,7 @@ logecho
 # Defaults to "list" operation
 COMMAND=${POSITIONAL_ARGV[0]:-"list"}
 ARG2=${POSITIONAL_ARGV[1]}
-PROJECT="kubernetes-release-test"
+PROJECT="${PROJECT:-$DEFAULT_PROJECT}"
 # Append $PROJECT to GCLOUD
 GCLOUD+=" --project $PROJECT"
 BUCKET="kubernetes-release"

--- a/gcbmgr
+++ b/gcbmgr
@@ -431,7 +431,6 @@ if ((FLAGS_nomock)); then
   NOMOCK="--$NOMOCK_TAG"
 else
   USER_BUCKET=$BUCKET-$GCP_USER_TAG
-  BUCKET+="-gcb"
 fi
 
 # BUILD_POINT used in yaml tags field and is one of:

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -14,6 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+###############################################################################
+# CONSTANTS
+###############################################################################
+
+DEFAULT_PROJECT="k8s-staging-release-test"
+OLD_PROJECT="kubernetes-release-test"
+
+###############################################################################
+# FUNCTIONS
+###############################################################################
+
 ##############################################################################
 # Pulls Jenkins server job cache from GS and preprocesses it into a
 # dictionary stored in $job_path associating full job and build numbers
@@ -1241,7 +1252,7 @@ release::set_globals () {
   GCRIO_PATH_PROD="k8s.gcr.io"
   GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
   # The "test" GCR path
-  GCRIO_PATH_TEST="gcr.io/kubernetes-release-test"
+  GCRIO_PATH_TEST="gcr.io/k8s-staging-release-test"
 
   if ((FLAGS_nomock)); then
     GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_PROD}"

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -18,19 +18,19 @@
 # CONSTANTS
 ###############################################################################
 
-DEFAULT_PROJECT="k8s-staging-release-test"
+readonly DEFAULT_PROJECT="k8s-staging-release-test"
 # TODO(prototype): Temporarily setting this to the staging project to test
 #                  the staging flow with --nomock set.
-PROD_PROJECT="k8s-staging-release-test"
-TEST_PROJECT="${TEST_PROJECT:-${PROJECT_ID:-$DEFAULT_PROJECT}}"
-OLD_PROJECT="kubernetes-release-test"
+readonly PROD_PROJECT="k8s-staging-release-test"
+readonly TEST_PROJECT="${TEST_PROJECT:-${PROJECT_ID:-$DEFAULT_PROJECT}}"
+readonly OLD_PROJECT="kubernetes-release-test"
 
-DEFAULT_BUCKET="k8s-staging-release-test"
+readonly DEFAULT_BUCKET="k8s-staging-release-test"
 # TODO(prototype): Temporarily setting this to the staging project to test
 #                  the staging flow with --nomock set.
-PROD_BUCKET="k8s-staging-release-test"
-MOCK_BUCKET="k8s-staging-release-test"
-OLD_BUCKET="kubernetes-release"
+readonly PROD_BUCKET="k8s-staging-release-test"
+readonly MOCK_BUCKET="k8s-staging-release-test"
+readonly OLD_BUCKET="kubernetes-release"
 
 ###############################################################################
 # FUNCTIONS

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -19,7 +19,12 @@
 ###############################################################################
 
 DEFAULT_PROJECT="k8s-staging-release-test"
+# TODO(prototype): Temporarily setting this to the staging project to test
+#                  the staging flow with --nomock set.
+PROD_PROJECT="k8s-staging-release-test"
+TEST_PROJECT="${TEST_PROJECT:-${PROJECT_ID:-$DEFAULT_PROJECT}}"
 OLD_PROJECT="kubernetes-release-test"
+
 
 ###############################################################################
 # FUNCTIONS
@@ -1249,10 +1254,17 @@ release::set_globals () {
   fi
 
   # The "production" GCR path is now multi-region alias
-  GCRIO_PATH_PROD="k8s.gcr.io"
-  GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
+  # TODO(prototype): Temporarily setting this to the staging project to test
+  #                  the staging flow with --nomock set.
+  #GCRIO_PATH_PROD="k8s.gcr.io"
+  GCRIO_PATH_PROD="gcr.io/$PROD_PROJECT"
+  # TODO(prototype): Temporarily setting this to the staging project to test
+  #                  the staging flow with --nomock set.
+  # TODO(prototype): Once access has been configured, we should set this to
+  #                  k8s-release-test-prod and test image promotion.
+  GCRIO_PATH_PROD_PUSH="gcr.io/$PROD_PROJECT"
   # The "test" GCR path
-  GCRIO_PATH_TEST="gcr.io/k8s-staging-release-test"
+  GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
 
   if ((FLAGS_nomock)); then
     GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_PROD}"

--- a/push-build.sh
+++ b/push-build.sh
@@ -69,9 +69,9 @@ PROG=${0##*/}
 #+     $PROG                     - Do a developer push
 #+     $PROG --nomock --federation --ci
 #+                               - Do a (non-mocked) CI push with federation
-#+     $PROG --bucket=kubernetes-release-$USER
+#+     $PROG --bucket=k8s-staging-release-test-$USER
 #+                               - Do a developer push to
-#+                                 kubernetes-release-$USER
+#+                                 k8s-staging-release-test-$USER
 #+
 #+ FILES
 #+
@@ -112,7 +112,8 @@ common::timestamp begin
 ###############################################################################
 # MAIN
 ###############################################################################
-RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
+RELEASE_BUCKET="${FLAGS_bucket:-"$DEFAULT_BUCKET"}"
+
 # Compatibility with incoming global args
 [[ $KUBE_GCS_UPDATE_LATEST == "n" ]] && FLAGS_noupdatelatest=1
 

--- a/release-notify
+++ b/release-notify
@@ -46,7 +46,7 @@ PROG=${0##*/}
 #+ EXAMPLES
 #+
 #+ FILES
-#+     gs://kubernetes-release{,-$USER,-gcb}/archive/<version/announcement.html
+#+     gs://k8s-staging-release-test{,-$USER,-gcb}/archive/<version>/announcement.html
 #+
 #+ SEE ALSO
 #+     common.sh                 - common function definitions

--- a/relnotes
+++ b/relnotes
@@ -96,6 +96,7 @@ PROG=${0##*/}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
+source $TOOL_LIB_PATH/releaselib.sh
 
 # Validate command-line
 common::argc_validate 1
@@ -181,8 +182,10 @@ create_downloads_table () {
   local heading=$1
   shift
   local url_prefix
-  if [[ "$release_bucket" == "kubernetes-release" ]]; then
-    url_prefix="https://dl.k8s.io"
+  if [[ "$release_bucket" == "$PROD_BUCKET" ]]; then
+    # TODO(prototype): Uncomment this once dl.k8s.io is cut over to new prod.
+    #url_prefix="https://dl.k8s.io"
+    echo ""
   else
     url_prefix="https://storage.googleapis.com/$release_bucket/release"
   fi
@@ -207,7 +210,7 @@ create_body () {
   local release_tars=$1
   local start_tag=$2
   local release_tag=$3
-  local release_bucket=${FLAGS_release_bucket:-"kubernetes-release"}
+  local release_bucket="${FLAGS_release_bucket:-"$PROD_BUCKET"}"
   local title
 
   ((FLAGS_preview)) && title="Branch "


### PR DESCRIPTION
Using this branch for testing. No review required at the moment.

ref: https://github.com/kubernetes/release/issues/911

---

- gcb: Update stage/release configs to use k8s-staging-release-test

- lib/release: Default staging GCP project to k8s-staging-release-test

- lib/release: Temporarily set staging project as GCR prod path

- anago: Remove conditional check for google-containers GCS bucket
  
  Once we cut over to k8s-infra, we will no longer use the
  google-containers artifact namespace, so this conditional check is no
  longer required.

- lib/release: Canonicalize/parameterize GCS bucket names

  There are several places where bucket names are hardcoded.
  This moves the configuration of bucket names to the release library and
  parameterizes them everywhere, so we can easily swap/test alternative
  buckets when required.

- anago: Skip attempts to set GCS object policy on archived log files

  New Kubernetes infra buckets, like k8s-staging-release-test, have a
  bucket-only ACL policy set, which means attempting to set the ACL on an
  object will fail. We should skip this ACL change in those instances, as
  new buckets already default to being publicly readable.

  Ref: https://cloud.google.com/storage/docs/bucket-policy-only

- anago: Ensure kube-cross:local matches the project we stage against

  This tweaks the configuration of local_kube_cross so that it builds
  an image within the staging project. We're changing this as the current
  GCB stage build config points to k8s.gcr.io, which we do not have access
  to push to from the staging GCP project (k8s-staging-release-test).

- lib/release: Set mock bucket and remove Google-isms in bucket/registry

  The current logic for setting globals on buckets and registry names is
  based on a local variable (gcb_user=gcb@google.com), which causes the
  bucket names to always be appended with "-gcb". Here, we clean up some
  of the logic to instead determine bucket/registry names based on global
  variables in the release library.