### PR TITLE
anago: Fix position of tar --exclude directive in `stage_source_tree`

### DIFF
--- a/anago
+++ b/anago
@@ -1449,7 +1449,7 @@ stage_source_tree () {
   local jbv="$JENKINS_BUILD_VERSION"
 
   logecho -n "Tar up staged source tree: "
-  logrun -s tar cvfz $WORKDIR/src.tar.gz -C $WORKDIR src --exclude="_output-*" \
+  logrun -s tar cvfz $WORKDIR/src.tar.gz --exclude="_output-*" -C $WORKDIR src \
    || return 1
   logecho -n "Archive fully staged source tree on GCS: "
   logrun -s $GSUTIL -m cp $WORKDIR/src.tar.gz \


### PR DESCRIPTION
Newer versions of tar require the exclude directive to proceed the
directory to be tar-ed.

Without this, the following error will occur:
"The following options were used after any non-optional arguments in
archive create or update mode.  These options are positional and affect
only arguments that follow them.  Please, rearrange them properly.
--exclude '_output-*' has no effect
Exiting with failure status due to previous errors"

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @xmudrii
cc: @kubernetes/release-engineering 
/kind bug
/priority critical-urgent