### PR TITLE
branchff: Return only one remote when querying for release repo

### DIFF
--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -306,7 +306,7 @@ gitlib::repo_state () {
 
   local remotePattern="${expectedRemote}(.git)* \(fetch\)$"
 
-  local remote=$( git -C "$TOOL_ROOT" remote -v | grep -E "$remotePattern" | cut -f1 )
+  local remote=$( git -C "$TOOL_ROOT" remote -v | grep -E "$remotePattern" -m 1 | cut -f1 )
   local commit=$(git -C "$TOOL_ROOT" \
                      ls-remote --heads "$remote" refs/heads/master | cut -f1)
   local output=$(git -C "$TOOL_ROOT" branch --contains "$commit" "$branch" 2>&-)


### PR DESCRIPTION
In instances where multiple git remotes referencing kubernetes/release
are configured, branchff will return them all, resulting in a failure.

This adds "-m 1" to the grep command, which will match only the first
remote.

Error:
```shell
$ ./branchff release-1.17
branchff: BEGIN main on auggievmw01 Thu Oct 31 05:55:01 EDT 2019

fatal: 'origin
up' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Checking /home/augustus/go/src/k8s.io/release state: FAILED

/home/augustus/go/src/k8s.io/release is not up to date.
$ git pull

branchff: DONE main on auggievmw01 Thu Oct 31 05:55:01 EDT 2019 in 0s
```

My remotes:

```shell
$ git remote -v
a	git@github.com:justaugustus/release.git (fetch)
a	git@github.com:justaugustus/release.git (push)
a-http	https://github.com/justaugustus/release.git (fetch)
a-http	https://github.com/justaugustus/release.git (push)
origin	https://github.com/kubernetes/release (fetch)
origin	https://github.com/kubernetes/release (push)
tp	https://github.com/tpepper/release.git (fetch)
tp	https://github.com/tpepper/release.git (push)
up	git@github.com:kubernetes/release.git (fetch)
up	git@github.com:kubernetes/release.git (push)
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hoegaarden @cpanato 