### PR TITLE
Use shell parameter substitution to convert GCP_USER value to lowercase

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -396,7 +396,7 @@ DISK_SIZE="300"
 GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE --format="value(account)")
 
 # Lowercase GCP users
-GCP_USER="$(echo "$GCP_USER" | awk '{print tolower($0)}')"
+GCP_USER="${GCP_USER,,}"
 # This is used as a tag so convert @ to -at- (for yaml tag field
 # where @ is invalid)
 # First, for @google.com users strip off the @domain.tld

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1228,7 +1228,7 @@ release::set_globals () {
     fi
 
     # Lowercase GCP user
-    GCP_USER="$(echo "$GCP_USER" | awk '{print tolower($0)}')"
+    GCP_USER="${GCP_USER,,}"
   fi
 
   if ((FLAGS_stage)); then


### PR DESCRIPTION
TIL about this substitution! Thanks for the tip, Hannes! :)
ref: https://github.com/kubernetes/release/pull/909#discussion_r341512314

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hoegaarden @saschagrunert 