### PR TITLE
Move notes git implementation into dedicated package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,7 @@ filegroup(
         "//cmd/krel:all-srcs",
         "//cmd/release-notes:all-srcs",
         "//lib:all-srcs",
+        "//pkg/git:all-srcs",
         "//pkg/notes:all-srcs",
         "//pkg/util:all-srcs",
     ],

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/cmd/release-notes",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/git:go_default_library",
         "//pkg/notes:go_default_library",
         "@com_github_go_kit_kit//log:go_default_library",
         "@com_github_go_kit_kit//log/level:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kolide/kit/env"
 	"golang.org/x/oauth2"
 
+	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/notes"
 )
 
@@ -296,11 +297,11 @@ func parseOptions(args []string, logger log.Logger) (*options, error) {
 
 	// Check if we want to automatically discover the revisions
 	if opts.discoverMode == revisionDiscoveryModeMinorToLatest {
-		repo, err := notes.NewKubernetesRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
+		repo, err := git.CloneOrOpenRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
 		if err != nil {
 			return nil, err
 		}
-		start, end, err := repo.DiscoverRevs(logger)
+		start, end, err := repo.LatestNonPatchFinalToLatest()
 		if err != nil {
 			return nil, err
 		}
@@ -323,7 +324,7 @@ func parseOptions(args []string, logger log.Logger) (*options, error) {
 	// Check if we have to parse a revision
 	if opts.startRev != "" || opts.endRev != "" {
 		level.Info(logger).Log("msg", "cloning/updating repository to discover start or end sha")
-		repo, err := notes.NewKubernetesRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
+		repo, err := git.CloneOrOpenRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["git.go"],
+    importpath = "k8s.io/release/pkg/git",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_blang_semver//:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,47 +1,48 @@
-package notes
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
 
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 // Wrapper type for a Kubernetes repository instance
-type KubernetesRepo struct{ *git.Repository }
-
-// RevParse parses a git revision and returns a SHA1 on success, otherwise an
-// error.
-func (k *KubernetesRepo) RevParse(rev string) (string, error) {
-	// Prefix all non-tags the default remote "origin"
-	if isVersion, _ := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev); !isVersion {
-		rev = "origin/" + rev
-	}
-
-	// Try to resolve the rev
-	ref, err := k.ResolveRevision(plumbing.Revision(rev))
-	if err != nil {
-		return "", err
-	}
-
-	return ref.String(), nil
+type Repo struct {
+	*git.Repository
+	dir string
 }
 
-// NewKubernetesRepo creates a temp directory containing the provided
+// CloneOrOpenRepo creates a temp directory containing the provided
 // GitHub repository via owner and name.
 //
 // If a repoPath is given, then the function tries to update the repository.
 //
 // The function returns the repository if cloning or updating of the repository
 // was successful, otherwise an error.
-func NewKubernetesRepo(repoPath, owner, name string) (*KubernetesRepo, error) {
+func CloneOrOpenRepo(repoPath, owner, name string) (*Repo, error) {
 	targetDir := ""
 	if repoPath != "" {
 		_, err := os.Stat(repoPath)
@@ -61,7 +62,7 @@ func NewKubernetesRepo(repoPath, owner, name string) (*KubernetesRepo, error) {
 
 	} else {
 		// No repoPath given, use a random temp dir instead
-		t, err := ioutil.TempDir("", "release-notes")
+		t, err := ioutil.TempDir("", "k8s-")
 		if err != nil {
 			return nil, err
 		}
@@ -75,12 +76,12 @@ func NewKubernetesRepo(repoPath, owner, name string) (*KubernetesRepo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &KubernetesRepo{r}, nil
+	return &Repo{Repository: r, dir: targetDir}, nil
 }
 
 // updateRepo tries to open the provided repoPath and fetches the latest
 // changed from the configured remote location
-func updateRepo(repoPath string) (*KubernetesRepo, error) {
+func updateRepo(repoPath string) (*Repo, error) {
 	r, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, err
@@ -89,25 +90,49 @@ func updateRepo(repoPath string) (*KubernetesRepo, error) {
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		return nil, err
 	}
-	return &KubernetesRepo{r}, nil
+	return &Repo{Repository: r, dir: repoPath}, nil
 }
 
-func (k *KubernetesRepo) DiscoverRevs(logger log.Logger) (start, end string, err error) {
+func (r *Repo) Cleanup() error {
+	log.Printf("Deleting %s...", r.dir)
+	return os.RemoveAll(r.dir)
+}
+
+// RevParse parses a git revision and returns a SHA1 on success, otherwise an
+// error.
+func (r *Repo) RevParse(rev string) (string, error) {
+	// Prefix all non-tags the default remote "origin"
+	if isVersion, _ := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev); !isVersion {
+		rev = "origin/" + rev
+	}
+
+	// Try to resolve the rev
+	ref, err := r.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return "", err
+	}
+
+	return ref.String(), nil
+}
+
+// LatestNonPatchFinalToLatest tries to discover the start (latest v1.xx.0) and
+// end (release-1.xx or master) revision inside the repository
+func (r *Repo) LatestNonPatchFinalToLatest() (start, end string, err error) {
 	// Find the last non patch version tag, then resolve its revision
-	version, err := k.latestNonPatchFinalVersion()
+	version, err := r.latestNonPatchFinalVersion()
 	if err != nil {
 		return "", "", err
 	}
 	versionTag := "v" + version.String()
-	level.Info(logger).Log("msg", "latest non patch version "+versionTag)
-	start, err = k.RevParse(versionTag)
+	log.Printf("latest non patch version %s", versionTag)
+	start, err = r.RevParse(versionTag)
 	if err != nil {
 		return "", "", err
 	}
 
 	// If a release branch exists for the next version, we use it. Otherwise we
 	// fallback to the master branch.
-	end, err = k.releaseBranchOrMasterRev(logger, version.Major, version.Minor+1)
+	end, err = r.releaseBranchOrMasterRev(version.Major, version.Minor+1)
 	if err != nil {
 		return "", "", err
 	}
@@ -115,10 +140,10 @@ func (k *KubernetesRepo) DiscoverRevs(logger log.Logger) (start, end string, err
 	return start, end, nil
 }
 
-func (k *KubernetesRepo) latestNonPatchFinalVersion() (semver.Version, error) {
+func (r *Repo) latestNonPatchFinalVersion() (semver.Version, error) {
 	latestFinalTag := semver.Version{}
 
-	tags, err := k.Tags()
+	tags, err := r.Tags()
 	if err != nil {
 		return latestFinalTag, err
 	}
@@ -145,17 +170,17 @@ func (k *KubernetesRepo) latestNonPatchFinalVersion() (semver.Version, error) {
 	return latestFinalTag, nil
 }
 
-func (k *KubernetesRepo) releaseBranchOrMasterRev(logger log.Logger, major, minor uint64) (rev string, err error) {
+func (r *Repo) releaseBranchOrMasterRev(major, minor uint64) (rev string, err error) {
 	relBranch := fmt.Sprintf("release-%d.%d", major, minor)
-	rev, err = k.RevParse(relBranch)
+	rev, err = r.RevParse(relBranch)
 	if err == nil {
-		level.Info(logger).Log("msg", "found release branch "+relBranch)
+		log.Printf("found release branch %s", relBranch)
 		return rev, nil
 	}
 
-	rev, err = k.RevParse("master")
+	rev, err = r.RevParse("master")
 	if err == nil {
-		level.Info(logger).Log("msg", "no release branch found, using master")
+		log.Println("no release branch found, using master")
 		return rev, nil
 	}
 

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -4,19 +4,15 @@ go_library(
     name = "go_default_library",
     srcs = [
         "document.go",
-        "git.go",
         "notes.go",
     ],
     importpath = "k8s.io/release/pkg/notes",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_blang_semver//:go_default_library",
         "@com_github_go_kit_kit//log:go_default_library",
         "@com_github_go_kit_kit//log/level:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This removes the `git.go` from `pkg/notes` and moves them into a dedicated package which could be re-used by krel. Afterwards we could merge it with the git.go from the utils package.