### PR TITLE
branchff: Remove hack/update-openapi-spec.sh run from tool

### DIFF
--- a/branchff
+++ b/branchff
@@ -187,49 +187,6 @@ if ! logrun -s git merge -X ours $MASTER_OBJECT; then
   logrun -s git commit -m "Merge remote-tracking branch 'origin/master' into $RELEASE_BRANCH.  Deleting ${DELETED_FILES[*]}" || common::exit 1 "Exiting..."
 fi
 
-# TODO: This should use update-all again when
-# - run-time returns to reasonable levels
-# - it doesn't run update-generated-docs.sh which creates placeholder docs
-#   for *master* only
-# - it doesn't result in failures like this:
-# <snip>
-# Running update-staging-godeps
-#
-#Unexpected dirty working directory:
-#
-# M api/openapi-spec/swagger.json
-# M docs/admin/cloud-controller-manager.md
-# M docs/admin/kube-apiserver.md
-# M docs/admin/kube-controller-manager.md
-# M docs/admin/kube-proxy.md
-# <snip>
-# Commit your changes in another terminal and then continue here by pressing enter.
-
-USEFUL_UPDATES=(update-openapi-spec)
-
-logecho -n "Ensure etcd is up to date: "
-logrun -s hack/install-etcd.sh
-export PATH="$TREE_ROOT/third_party/etcd:$PATH"
-
-logecho "Run 'useful' (the list may be out of date) hack/update* scripts..."
-for script in ${USEFUL_UPDATES[*]}; do
-  fullscript="hack/$script.sh"
-  if ! [[ -f $fullscript ]]; then
-    logecho "Skipping non-existent $script..."
-    continue
-  fi
-  logecho -n "Running $fullscript: "
-  logrun -s $fullscript
-done
-
-if [[ -n "$(git status -s)" ]]; then
-  logecho -n "Commit changes: "
-  logrun git add -A
-  logrun -s git commit -am \
-                "Results of running update scripts: ${USEFUL_UPDATES[*]}" \
-    || common::exit 1 "Exiting..."
-fi
-
 ##############################################################################
 common::stepheader "PUSH UPSTREAM"
 ##############################################################################


### PR DESCRIPTION
This is an optimization, which also allows us to perform a true branch
fast-forward using "branchff".

Prior to this commit, we were running hack/update-openapi-spec.sh,
which:
- installs a bunch of prerequisites, including etcd
- builds the apiserver
- runs an apiserver to retrieve the OpenAPI spec
- rewrites a version field within the resulting swagger.json to match
   the targeted release branch

And then we commit the result before pushing to the upstream release
branch.

This is obviously wasteful and runs contrary to the definition of a
fast-forward.

A fix to "null" the version field in the swagger.json has been
submitted, so this commit removes that script logic to match.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Until https://github.com/kubernetes/kubernetes/pull/84654 merges: 
/hold

/assign @liggitt @cpanato @Katharine @tpepper 
/priority important-soon
/kind cleanup
/milestone v1.17

ref: https://kubernetes.slack.com/archives/C1TU9EB9S/p1572627769216100