### PR TITLE
Sort release notes by Kind(s) instead of SIG(s)

### DIFF
--- a/pkg/notes/document_test.go
+++ b/pkg/notes/document_test.go
@@ -136,3 +136,20 @@ filename | sha512 hash
 
 `)
 }
+
+func TestSortKinds(t *testing.T) {
+	input := map[string][]string{
+		"cleanup":                       nil,
+		"api-change":                    nil,
+		"deprecation":                   nil,
+		"documentation":                 nil,
+		"Other (Bug, Cleanup or Flake)": nil,
+		"failing-test":                  nil,
+		"design":                        nil,
+		"flake":                         nil,
+		"bug":                           nil,
+		"feature":                       nil,
+	}
+	res := sortKinds(input)
+	require.Equal(t, res, kindPriority)
+}


### PR DESCRIPTION
This is a short demo how it looks like if we sort the release notes by its `kind` instead of the `SIG`.

For example:
```
> go run cmd/release-notes/main.go --start-rev v1.16.0 --end-rev v1.17.0
```

https://gist.github.com/saschagrunert/3eaf2d16b3f845fa69cf7a6661d81b05