### PR TITLE
Remove leftovers from the godep image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ test-sh: ## Runs all shellscript tests
 .PHONY: update-images
 
 images := \
-	godep \
 	k8s-cloud-builder
 
 update-images: $(addprefix image-,$(images)) ## Update all images in ./images/

--- a/images/README.md
+++ b/images/README.md
@@ -32,6 +32,5 @@ bit more on that [in the cloud-build docs][gcb_images].
 Image                                     | used in/by
 :---:                                     | --
 [k8s-cloud-builder](./k8s-cloud-builder/) | The "main" image, [`anago`](../anago) runs with on cloud-build (submitted via [`gcbmgr`](../gcbmgr))
-[godep](./godep/)                         | ?
 
 [gcb_images]: https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts#storing_images_in


### PR DESCRIPTION
Remove some more leftovers after 1e536cbf984ed487a4fc42932dab2eab0925649f.

/assign @justaugustus 
cc: @kubernetes/release-engineering
/kind cleanup
