### PR TITLE
Update CONTRIBUTING.md to reflect use of go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ kubernetes.tar.gz
 !\.drone\.sec
 
 /bazel-*
+
+# vendored go modules
+/vendor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,16 @@ read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/m
 
 ## Autogenerating Bazel Configs
 
-If you add or modify Go code, make sure to generate the necessary Bazel `BUILD` files:
+If you add or modify Go code, make sure to generate the necessary Bazel (`BUILD.bazel`) files:
 
 ```bash
 ./hack/update-all.sh
+```
+
+## Submitting a Pull Request
+
+Before submitting a pull request, please make sure to verify that all tests are passing:
+
+```bash
+./hack/verify-all.sh
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,27 +10,8 @@ read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/m
 
 ## Autogenerating Bazel Configs
 
-For Go code, this repository is currently set up with [Gazelle](https://github.com/bazelbuild/bazel-gazelle), which is a tool that can be used to generate Bazel `BUILD` files.
-
-If you add Go code which includes new dependencies, you have to update the [Dep](https://github.com/golang/dep) configs and then use Gazelle to generate the appropriate Bazel configs:
+If you add or modify Go code, make sure to generate the necessary Bazel `BUILD` files:
 
 ```bash
-# install dep
-go get -u github.com/golang/dep/cmd/dep
-
-# update Gopkg.lock
-dep ensure
-
-# generate the go_repository stanzas in WORKSPACE
-bazel run //:gazelle -- update-repos -from_file=Gopkg.lock
-
-# generate all of the BUILD files
-bazel run //:gazelle
-```
-
-If you add new Go files but do not add any dependencies, the following should be sufficient:
-
-```bash
-# generate all of the BUILD files
-bazel run //:gazelle
+./hack/update-all.sh
 ```


### PR DESCRIPTION
Now that Go modules are being used instead of `dep`, the CONTRIBUTING.md documentation for generating new `BUILD.bazel` files is out of date. This makes it current :)

Note: also added `/vendor` to `.gitignore` in case anyone is vendoring their modules.

/assign @kubernetes/release-engineering 