### PR TITLE
Bind git branch verification to `Repo`

### DIFF
--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -31,8 +31,9 @@ var rootCmd = &cobra.Command{
 }
 
 type rootOptions struct {
-	nomock  bool
-	cleanup bool
+	nomock   bool
+	cleanup  bool
+	repoPath string
 }
 
 var rootOpts = &rootOptions{}
@@ -50,6 +51,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.nomock, "nomock", false, "nomock flag")
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.cleanup, "cleanup", false, "cleanup flag")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.repoPath, "repo", "", "the local path to the repository to be used")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -297,7 +297,12 @@ func parseOptions(args []string, logger log.Logger) (*options, error) {
 
 	// Check if we want to automatically discover the revisions
 	if opts.discoverMode == revisionDiscoveryModeMinorToLatest {
-		repo, err := git.CloneOrOpenRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
+		repo, err := git.CloneOrOpenGitHubRepo(
+			opts.repoPath,
+			opts.githubOrg,
+			opts.githubRepo,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +329,12 @@ func parseOptions(args []string, logger log.Logger) (*options, error) {
 	// Check if we have to parse a revision
 	if opts.startRev != "" || opts.endRev != "" {
 		level.Info(logger).Log("msg", "cloning/updating repository to discover start or end sha")
-		repo, err := git.CloneOrOpenRepo(opts.repoPath, opts.githubOrg, opts.githubRepo)
+		repo, err := git.CloneOrOpenGitHubRepo(
+			opts.repoPath,
+			opts.githubOrg,
+			opts.githubRepo,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -9,10 +9,10 @@ go_library(
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//config:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing/object:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//storage/memory:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//plumbing/transport:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//plumbing/transport/ssh:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This is the first part of the git refactoring. The verification if the
remote branch exists will now be done via the `Repo`, which will be
initialized by the newly added `--repo` command line option.

SSH authentication has been added on top, whereas the other functions
will be migrated in follow-up PRs.
