### PR TITLE
Refactor the rest of the git methods

### DIFF
--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
+        "@in_gopkg_src_d_go_git_v4//config:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing/object:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing/transport:go_default_library",


### PR DESCRIPTION
- We now checkout the target branch after clone/open
- Added cleanup defer for repo as well
- The working directory will now contain a link to the repo
  to make the go env rewrite work
- `MergeBase` is now a method of `Repo`
- `RevParse` and `RevParseShort` are now methods of `Repo`
- The `SynchRepo` function is now obsolete since auth/clone/open works via `Repo`

I think as a next step we could refactor the rest of the `TODO`s in `ff.go` :innocent: 