### PR TITLE
Add DescribeTag method for Repo

### DIFF
--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/pkg/git",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/command:go_default_library",
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",


### PR DESCRIPTION
The added `DescribeTag` method for `Repo` can now be used by the branch
fast-forward logic to check if the latest tag of the merge base matches
the latest master tag.
