### PR TITLE
push build: initial migration to krel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "//pkg/command:all-srcs",
         "//pkg/git:all-srcs",
         "//pkg/notes:all-srcs",
+        "//pkg/release:all-srcs",
         "//pkg/util:all-srcs",
     ],
     tags = ["automanaged"],

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -11,9 +11,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
     ],
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module k8s.io/release
 go 1.13
 
 require (
-	cloud.google.com/go v0.38.0 // indirect
+	cloud.google.com/go v0.38.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-kit/kit v0.9.0
 	github.com/google/go-github/v28 v28.1.1

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["release.go"],
+    importpath = "k8s.io/release/pkg/release",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"k8s.io/release/pkg/util"
+)
+
+const (
+	versionReleaseRE  = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
+	versionDotZeroRE  = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.0$`
+	versionBuildRE    = `([0-9]{1,})\+([0-9a-f]{5,40})`
+	versionDirtyRE    = `(-dirty)`
+	dockerBuildPath   = "/_output/release-tars/"
+	bazelBuildPath    = "/bazel-bin/build/release-tars/"
+	bazelVersionPath  = "/bazel-genfiles/version"
+	dockerVersionPath = "/version"
+	tarballExtension  = ".tar.gz"
+)
+
+// BuiltWithBazel determines whether the most recent release was built with Bazel.
+func BuiltWithBazel(path string, releaseKind string) (bool, error) {
+	bazelBuild := path + bazelBuildPath + releaseKind + tarballExtension
+	dockerBuild := path + dockerBuildPath + releaseKind + tarballExtension
+	return util.MoreRecent(bazelBuild, dockerBuild)
+}
+
+// ReadBazelVersion reads the version from a Bazel build.
+func ReadBazelVersion(path string) (string, error) {
+	version, err := ioutil.ReadFile(path + bazelVersionPath)
+	return string(version), err
+}
+
+// ReadDockerizedVersion reads the version from a Dockerized
+func ReadDockerizedVersion(path, releaseKind string) (string, error) {
+	dockerTarball := path + dockerBuildPath + releaseKind + tarballExtension
+	return util.UntarAndRead(dockerTarball, releaseKind+dockerVersionPath)
+}
+
+// IsValidReleaseBuild checks if build version is valid for release.
+func IsValidReleaseBuild(build string) (bool, error) {
+	return regexp.MatchString("("+versionReleaseRE+`(\.`+versionBuildRE+")?"+versionDirtyRE+"?)", build)
+}
+
+// IsDirtyBuild checks if build version is dirty.
+func IsDirtyBuild(build string) bool {
+	return strings.Contains(build, "dirty")
+}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -17,13 +17,17 @@ limitations under the License.
 package util
 
 import (
+	"archive/tar"
 	"bufio"
+	"compress/gzip"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 /*
@@ -104,7 +108,7 @@ func FakeGOPATH(srcDir string) (string, error) {
 	log.Printf("GOPATH: %s", os.Getenv("GOPATH"))
 
 	gitRoot := fmt.Sprintf("%s/src/k8s.io", baseDir)
-	if err := os.MkdirAll(gitRoot, 0o755); err != nil {
+	if err := os.MkdirAll(gitRoot, os.FileMode(int(0755))); err != nil {
 		return "", err
 	}
 	gitRoot = filepath.Join(gitRoot, "kubernetes")
@@ -121,4 +125,48 @@ func FakeGOPATH(srcDir string) (string, error) {
 	}
 
 	return gitRoot, nil
+}
+
+// UntarAndRead opens a tarball and reads contents of a file inside.
+func UntarAndRead(tarPath, filePath string) (string, error) {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return "", err
+	}
+
+	archive, err := gzip.NewReader(file)
+	if err != nil {
+		return "", err
+	}
+	tr := tar.NewReader(archive)
+
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+
+		if h.Name == filePath {
+			file, err := ioutil.ReadAll(tr)
+			return strings.TrimSuffix(string(file), "\n"), err
+		}
+	}
+
+	return "", errors.New("unable to find file in tarball")
+}
+
+// MoreRecent determines if file at path a was modified more recently than file at path b.
+func MoreRecent(a, b string) (bool, error) {
+	// TODO: default to existing file if only one exists?
+	fileA, err := os.Stat(a)
+	if err != nil {
+		return false, err
+	}
+
+	fileB, err := os.Stat(b)
+	if err != nil {
+		return false, err
+	}
+
+	return (fileA.ModTime().Unix() > fileB.ModTime().Unix()), nil
 }


### PR DESCRIPTION
Initial steps to move `push-build.sh` to `krel push`. Steps to still be completed include:

- [ ] Implement remainder of push logic (do we feel the need to use `bazel` to push the build? If not then we can likely do it in a cleaner fashion using gcloud sdk rather than executing bazel using `os.Exec`.)
- [ ] Add unit tests for new pkg functions

Please feel free to review and give any immediate thoughts or feedback!

/cc @saschagrunert @justaugustus 