### PR TITLE
Apply first batch of golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,42 +6,42 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - deadcode
     - depguard
     - dogsled
     - dupl
     - goconst
+    - gocritic
     - gocyclo
     - godox
     - gofmt
     - goimports
+    - golint
     - gosimple
     - govet
+    - ineffassign
     - interfacer
+    - maligned
     - misspell
     - nakedret
+    - prealloc
+    - staticcheck
     - structcheck
+    - stylecheck
     - typecheck
     - unconvert
+    - unparam
+    - unused
     - varcheck
-    # - deadcode
+    - whitespace
     # - errcheck
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
     # - gocognit
-    # - gocritic
-    # - golint
     # - gosec
-    # - ineffassign
     # - lll
-    # - maligned
-    # - prealloc
     # - scopelint
-    # - staticcheck
-    # - stylecheck
-    # - unparam
-    # - unused
-    # - whitespace
     # - wsl
 linters-settings:
   errcheck:
@@ -68,7 +68,7 @@ linters-settings:
       - offBy1
       - sloppyReassign
       - weakCond
-      # - octalLiteral
+      - octalLiteral
 
       # Performance
       - appendCombine
@@ -90,7 +90,6 @@ linters-settings:
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
-      - ifElseChain
       - methodExprCall
       - regexpMust
       - singleCaseSwitch
@@ -106,6 +105,7 @@ linters-settings:
       - valSwap
       - wrapperFunc
       - yodaStyleExpr
+      # - ifElseChain
 
       # Opinionated
       - builtinShadow

--- a/cmd/blocking-testgrid-tests/main.go
+++ b/cmd/blocking-testgrid-tests/main.go
@@ -65,14 +65,14 @@ func readConfFromURL(ctx context.Context, url string) (*config.Configuration, er
 	ctx, cancel := context.WithTimeout(ctx, DownloadTimeout)
 	defer cancel()
 
-	if err := downloadFile(ctx, tmpFile.Name(), TestgridConfigURL); err != nil {
+	if err := downloadFile(ctx, tmpFile.Name(), url); err != nil {
 		return nil, err
 	}
 
 	return config.ReadPath(tmpFile.Name())
 }
 
-func downloadFile(ctx context.Context, filepath string, url string) error {
+func downloadFile(ctx context.Context, filePath, url string) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func downloadFile(ctx context.Context, filepath string, url string) error {
 	}
 	defer res.Body.Close()
 
-	out, err := os.Create(filepath)
+	out, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -120,10 +120,12 @@ func runFf(opts *ffOptions) error {
 		return err
 	}
 	if masterTag != mergeBaseTag {
-		log.Fatalf(
+		err := errors.Errorf(
 			"Unable to fast forward: tag %q does not match %q",
 			masterTag, mergeBaseTag,
 		)
+		log.Print(err)
+		return err
 	}
 	log.Printf("Last tag is: %s", masterTag)
 

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -40,18 +40,18 @@ push --bucket=kubernetes-release-$USER
                            - Do a developer push to kubernetes-release-$USER`
 
 type pushBuildOptions struct {
-	allowDup         bool
 	bucket           string
-	ci               bool
 	dockerRegistry   string
 	extraPublishFile string
-	federation       bool
 	gcsSuffix        string
-	noUpdateLatest   bool
-	privateBucket    bool
 	releaseKind      string
 	releaseType      string
 	versionSuffix    string
+	allowDup         bool
+	ci               bool
+	federation       bool
+	noUpdateLatest   bool
+	privateBucket    bool
 }
 
 var pushBuildOpts = &pushBuildOptions{}

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -17,9 +17,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -56,20 +54,4 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-}
-
-func cleanupTmpDir(dir string) error {
-	log.Printf("Deleting %s...", dir)
-	err := os.RemoveAll(dir)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func exitWithHelp(cmd *cobra.Command, err string) {
-	fmt.Fprintln(os.Stderr, err)
-	cmd.Help()
-	os.Exit(1)
 }

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -184,7 +184,7 @@ func (o *options) GetReleaseNotes() (notes.ReleaseNotes, notes.ReleaseNotesHisto
 	// Fetch a list of fully-contextualized release notes
 	level.Info(o.logger).Log("msg", "fetching all commits. this might take a while...")
 
-	opts := []notes.GithubApiOption{notes.WithContext(ctx)}
+	opts := []notes.GitHubAPIOption{notes.WithContext(ctx)}
 	if o.githubOrg != "" {
 		opts = append(opts, notes.WithOrg(o.githubOrg))
 	}
@@ -318,12 +318,12 @@ func parseOptions(args []string, logger log.Logger) (*options, error) {
 
 	// The start SHA is required.
 	if opts.startSHA == "" && opts.startRev == "" {
-		return nil, errors.New("The starting commit hash must be set via -start-sha, $START_SHA, -start-rev or $START_REV")
+		return nil, errors.New("the starting commit hash must be set via -start-sha, $START_SHA, -start-rev or $START_REV")
 	}
 
 	// The end SHA is required.
 	if opts.endSHA == "" && opts.endRev == "" {
-		return nil, errors.New("The ending commit hash must be set via -end-sha, $END_SHA, -end-rev or $END_REV")
+		return nil, errors.New("the ending commit hash must be set via -end-sha, $END_SHA, -end-rev or $END_REV")
 	}
 
 	// Check if we have to parse a revision

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -108,7 +108,7 @@ func (c *Command) RunSilentSuccess() (err error) {
 }
 
 // run is the internal run method
-func (c *Command) run(print bool) (res *Status, err error) {
+func (c *Command) run(printOutput bool) (res *Status, err error) {
 	log.Printf("Running command: %v", c.cmd)
 	outBuffer := bytes.Buffer{}
 
@@ -121,7 +121,7 @@ func (c *Command) run(print bool) (res *Status, err error) {
 	}
 
 	var writer io.Writer
-	if print {
+	if printOutput {
 		writer = io.MultiWriter(os.Stdout, &outBuffer)
 	} else {
 		writer = io.MultiWriter(&outBuffer)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -111,16 +111,13 @@ func CloneOrOpenRepo(repoPath, url string, useSSH bool) (*Repo, error) {
 		if err == nil {
 			// The file or directory exists, just try to update the repo
 			return updateRepo(repoPath, useSSH)
-
 		} else if os.IsNotExist(err) {
 			// The directory does not exists, we still have to clone it
 			targetDir = repoPath
-
 		} else {
 			// Something else bad happened
 			return nil, err
 		}
-
 	} else {
 		// No repoPath given, use a random temp dir instead
 		t, err := ioutil.TempDir("", "k8s-")
@@ -335,7 +332,7 @@ func (r *Repo) MergeBase(from, to string) (string, error) {
 	commitRevs := []string{masterRef, releaseRef}
 	var res []*object.Commit
 
-	var hashes []*plumbing.Hash
+	hashes := []*plumbing.Hash{}
 	for _, rev := range commitRevs {
 		hash, err := r.inner.ResolveRevision(plumbing.Revision(rev))
 		if err != nil {
@@ -344,7 +341,7 @@ func (r *Repo) MergeBase(from, to string) (string, error) {
 		hashes = append(hashes, hash)
 	}
 
-	var commits []*object.Commit
+	commits := []*object.Commit{}
 	for _, hash := range hashes {
 		commit, err := r.inner.CommitObject(*hash)
 		if err != nil {

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -73,6 +73,7 @@ func TestReleaseNoteParsing(t *testing.T) {
 		commit, _, err := client.Repositories.GetCommit(ctx, "kubernetes", "kubernetes", sha)
 		require.NoError(t, err)
 		prs, err := PRsFromCommit(client, nil, commit)
+		require.NoError(t, err)
 		_, err = ReleaseNoteFromCommit(&Result{commit: commit, pullRequest: prs[0]}, client, "0.1")
 		require.NoError(t, err)
 	}
@@ -173,21 +174,21 @@ func TestDocumentationFromString(t *testing.T) {
 
 func TestClassifyURL(t *testing.T) {
 	// A KEP
-	url, err := url.Parse("http://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kubectl-staging.md")
+	u, err := url.Parse("http://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kubectl-staging.md")
 	require.Equal(t, err, nil)
-	result := classifyURL(url)
+	result := classifyURL(u)
 	require.Equal(t, result, DocTypeKEP)
 
 	// An official documentation
-	url, err = url.Parse("https://kubernetes.io/docs/concepts/#kubernetes-objects")
+	u, err = url.Parse("https://kubernetes.io/docs/concepts/#kubernetes-objects")
 	require.Equal(t, err, nil)
-	result = classifyURL(url)
+	result = classifyURL(u)
 	require.Equal(t, result, DocTypeOfficial)
 
 	// An external documentation
-	url, err = url.Parse("https://google.com/")
+	u, err = url.Parse("https://google.com/")
 	require.Equal(t, err, nil)
-	result = classifyURL(url)
+	result = classifyURL(u)
 	require.Equal(t, result, DocTypeExternal)
 }
 
@@ -222,5 +223,4 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -61,9 +61,8 @@ common::askyorn () {
 }
 */
 
-func Ask(question, expectedResponse string, retries int) (string, bool, error) {
+func Ask(question, expectedResponse string, retries int) (answer string, success bool, err error) {
 	attempts := 1
-	answer := ""
 
 	if retries < 0 {
 		log.Printf("Retries was set to a number less than zero (%d). Please specify a positive number of retries or zero, if you want to ask unconditionally.", retries)
@@ -86,7 +85,7 @@ func Ask(question, expectedResponse string, retries int) (string, bool, error) {
 	}
 
 	log.Printf("Expected response was not provided. Retries exceeded.")
-	return answer, false, errors.New("Expected response was not input. Retries exceeded.")
+	return answer, false, errors.New("expected response was not input. Retries exceeded")
 }
 
 // FakeGOPATH creates a temp directory, links the base directory into it and


### PR DESCRIPTION
We enable and fix the reports of the following linters:

- deadcode
- gocritic
- golint
- ineffassign
- maligned
- prealloc
- staticcheck
- unparam
- unused
- whitepsace
