### PR TITLE
Send patch release announcement mails via GCB

### DIFF
--- a/announce-patch
+++ b/announce-patch
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PROG=${0##*/}
+
+#+ NAME
+#+     $PROG - generate and send the patch release announcement mail
+#+
+#+ SYNOPSIS
+#+     $PROG --github-token=[gh-token] --sendgrid-api-key=[sendgrid-key] \
+#+       --freeze-date=[freeze-date] --cut-date=[cut-date] \
+#+       --from-name=[sender-name] --from-email=[sender-email] \
+#+       [release-branch]
+#+
+#+ DESCRIPTION
+#+     This tool generates the patch release announcement and posts it to
+#+     the 'kubernetes-dev@googlegroups.com' & 'kubernetes-dev-announce@googlegroups.com'
+#+     lists.
+#+
+#+     The mails hold the freeze date, cut date, a preview of the changelog and a
+#+     list of open cherry-pick PRs.
+#+
+#+     The mail is sent out via sendgrid, GCB does not allow to send mail directly.
+#+
+#+ OPTIONS
+#+     release-branch            - The branch we want to cut from, e.g.: 'release-1.15'.
+#+     --nomock                  - By default the mail will be sent to the mail address
+#+                                 that is set as the sender (--from-email). When this
+#+                                 flag is set, we send it to the kubernetes mailing
+#+                                 lists.
+#+     --github-token            - The github token that will be used for generating the
+#+                                 changelog.
+#+     --sendgrid-api-key        - The API key for sendgrid to send out the email.
+#+     --freeze-date             - The date we will freeze the branch and will not accept
+#+                                 cherry-picks anymore.
+#+     --cut-date                - The date we will cut and publish the release.
+#+     --from-name               - The sender's name.
+#+     --from-email              - The sender's email address. Will also be used as a
+#+                                 receiver when not in nomock mode.
+#+     [--k8s-git-url]           - The git URL to clone kubernetes/kubernetes from.
+#+     [--release-git-url]       - The git URL to clone kubernetes/release from.
+#+     [--release-git-branch]    - The branch of kubernetes/release to use.
+#+
+
+set -e
+# set -u
+set -o pipefail
+
+readonly PROG="${0##*/}"
+
+readonly BASE_ROOT="$(dirname "$(readlink -e "${BASH_SOURCE[0]}" 2>&1)")"
+# shellcheck source=./lib/common.sh
+source "${BASE_ROOT}/lib/common.sh"
+
+flag_or_env_or_default() {
+  local -r flag_name="${1//-/_}"
+  local -r default="${2:-}"
+
+  local -r flag_var_name="FLAGS_${flag_name}"
+  local -r env_var_name="${flag_name^^}"
+
+  if [ -n "${!flag_var_name:-}" ] ; then
+    echo "${!flag_var_name}"
+    return
+  fi
+
+  if [ -n "${!env_var_name:-}" ] ; then
+    echo "${!env_var_name}"
+    return
+  fi
+
+  if [ -n "$default" ] ; then
+    echo "$default"
+    return
+  fi
+
+  >&2 echo "${FATAL} flag --${flag_name//_/-} or setting '\$${env_var_name}' is mandatory"
+  return 1
+}
+
+main() {
+  local branch_name="${POSITIONAL_ARGV[0]}"
+
+  if [ -z "$branch_name" ] ; then
+    common::manpage -help
+    return 1
+  fi
+
+  local subst=()
+
+  # mandatory flags
+  subst+=( "_K8S_GIT_BRANCH=${branch_name}" )
+  subst+=( "_GITHUB_TOKEN=$( flag_or_env_or_default 'github_token' )" )
+  subst+=( "_SENDGRID_API_KEY=$( flag_or_env_or_default 'sendgrid_api_key' )" )
+  subst+=( "_FREEZE_DATE=$( flag_or_env_or_default 'freeze_date' )" )
+  subst+=( "_CUT_DATE=$( flag_or_env_or_default 'cut_date' )" )
+  subst+=( "_FROM_NAME=$( flag_or_env_or_default 'from_name' )" )
+  subst+=( "_FROM_EMAIL=$( flag_or_env_or_default 'from_email' )" )
+
+  # optional flags
+  subst+=( "_K8S_GIT_URL=$( flag_or_env_or_default 'k8s_git_url' 'https://github.com/kubernetes/kubernetes' )" )
+  subst+=( "_RELEASE_GIT_URL=$( flag_or_env_or_default 'release_git_url' 'https://github.com/kubernetes/release' )" )
+  subst+=( "_RELEASE_GIT_BRANCH=$( flag_or_env_or_default 'release_git_branch' 'master' )" )
+
+  # shellcheck disable=2154
+  # ... because that is set by magick when sourcing common.sh
+  if ((FLAGS_nomock)) ; then
+    subst+=( "_RUN_TYPE=nomock" )
+  fi
+
+  gcloud builds submit --no-source \
+    --async \
+    --config "${BASE_ROOT}/gcb/patch-announce/cloudbuild.yaml" \
+    --substitutions "$( common::join ',' "${subst[@]}" )"
+}
+
+main "$@"

--- a/announce-patch
+++ b/announce-patch
@@ -66,6 +66,15 @@ readonly BASE_ROOT="$(dirname "$(readlink -e "${BASH_SOURCE[0]}" 2>&1)")"
 # shellcheck source=./lib/common.sh
 source "${BASE_ROOT}/lib/common.sh"
 
+# For some reason, using $FLAG_xxx seems to replace ' ' with '\n'. Sendgrid
+# does not really like names with newlines in it and treats them as two
+# spearate recipients.
+# Newlines do not make too much sense for other variables, so we globally
+# replace newlines with spaces.
+replace_nl() {
+  tr -s $'\n' ' '
+}
+
 flag_or_env_or_default() {
   local -r flag_name="${1//-/_}"
   local -r default="${2:-}"
@@ -74,17 +83,17 @@ flag_or_env_or_default() {
   local -r env_var_name="${flag_name^^}"
 
   if [ -n "${!flag_var_name:-}" ] ; then
-    echo "${!flag_var_name}"
+    echo  -n "${!flag_var_name}" | replace_nl
     return
   fi
 
   if [ -n "${!env_var_name:-}" ] ; then
-    echo "${!env_var_name}"
+    echo -n "${!env_var_name}" | replace_nl
     return
   fi
 
   if [ -n "$default" ] ; then
-    echo "$default"
+    echo -n "$default" | replace_nl
     return
   fi
 

--- a/announce-patch
+++ b/announce-patch
@@ -51,6 +51,8 @@ PROG=${0##*/}
 #+     --from-name               - The sender's name.
 #+     --from-email              - The sender's email address. Will also be used as a
 #+                                 receiver when not in nomock mode.
+#+     [--tail]                  - Stays attached to the cloud build process and streams
+#+                                 in the logs
 #+     [--k8s-git-url]           - The git URL to clone kubernetes/kubernetes from.
 #+     [--release-git-url]       - The git URL to clone kubernetes/release from.
 #+     [--release-git-branch]    - The branch of kubernetes/release to use.
@@ -110,6 +112,10 @@ main() {
   fi
 
   local subst=()
+  local opts=(
+    '--no-source'
+    "--config=${BASE_ROOT}/gcb/patch-announce/cloudbuild.yaml"
+  )
 
   # mandatory flags
   subst+=( "_K8S_GIT_BRANCH=${branch_name}" )
@@ -131,9 +137,14 @@ main() {
     subst+=( "_RUN_TYPE=nomock" )
   fi
 
-  gcloud builds submit --no-source \
-    --async \
-    --config "${BASE_ROOT}/gcb/patch-announce/cloudbuild.yaml" \
+  # shellcheck disable=2154
+  # ... because that is set by magick when sourcing common.sh
+  if ! ((FLAGS_tail)) ; then
+    opts+=( '--async' )
+  fi
+
+  gcloud builds submit \
+    "${opts[@]}" \
     --substitutions "$( common::join ',' "${subst[@]}" )"
 }
 

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -35,18 +35,31 @@ steps:
   - go/src/k8s.io/release/patch-release/announce
 
 substitutions:
-  _K8S_GIT_URL:        https://github.com/kubernetes/kubernetes
-  _RELEASE_GIT_URL:    https://github.com/kubernetes/release
-  _RELEASE_GIT_BRANCH: master
-
+  # The branch of k/kubernetes to check out, the branch to announce a patch release for (e.g.: release-1.15)
   _K8S_GIT_BRANCH:     null
+  # A github token, used to collect the changelog
   _GITHUB_TOKEN:       null
+  # API key for sendgrid to send out mails
   _SENDGRID_API_KEY:   null
-  _REL_MGR_NAME:       'Kubernetes Release Managers'
-  _REL_MGR_EMAIL:      'release-managers@kubernetes.io'
-  _REL_MGR_SLACK:      'sig-release'
-  _FROM_NAME:          null
-  _FROM_EMAIL:         null
+  # Date of CP freeze, ISO 8601 (e.g.: 2019-12-06)
   _FREEZE_DATE:        null
+  # Date of planned cut, ISO 8601 (e.g.: 2019-12-11)
   _CUT_DATE:           null
+  # The mail sender's name. Will also be used as a receipient in mock mode. (e.g.: "Jane Doe")
+  _FROM_NAME:          null
+  # The mail sender's email. Will also be used as a receipient in mock mode. (e.g.: jane.doe@example.org")
+  _FROM_EMAIL:         null
+  # For the real run, set to 'nomock' (e.g.: "mock" or "nomock")
   _RUN_TYPE:           'mock'
+  # git-clone'able URL for k/kubernetes
+  _K8S_GIT_URL:        https://github.com/kubernetes/kubernetes
+  # git-clone'able URL for k/release
+  _RELEASE_GIT_URL:    https://github.com/kubernetes/release
+  # The branch of k/release to check out
+  _RELEASE_GIT_BRANCH: master
+  # For the email message: the name of the group to contact
+  _REL_MGR_NAME:       'Kubernetes Release Managers'
+  # For the email message: the email of the group to contact
+  _REL_MGR_EMAIL:      'release-managers@kubernetes.io'
+  # For the email message: the slack channel of the group to contact
+  _REL_MGR_SLACK:      'sig-release'

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -1,0 +1,52 @@
+timeout: 1200s
+
+steps:
+- id: clone-k8s
+  waitFor: [ '-' ]
+  name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "${_K8S_GIT_URL}"
+  - "--branch=${_K8S_GIT_BRANCH}"
+- id: clone-release
+  waitFor: [ '-' ]
+  name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "${_RELEASE_GIT_URL}"
+  - "--branch=${_RELEASE_GIT_BRANCH}"
+
+- id: prepare-and-send
+  name: "gcr.io/${PROJECT_ID}/k8s-cloud-builder"
+  env:
+  - "GITHUB_TOKEN=${_GITHUB_TOKEN}"
+  - "SENDGRID_API_KEY=${_SENDGRID_API_KEY}"
+  - "REL_MGR_NAME=${_REL_MGR_NAME}"
+  - "REL_MGR_EMAIL=${_REL_MGR_EMAIL}"
+  - "REL_MGR_SLACK=${_REL_MGR_SLACK}"
+  - "FROM_NAME=${_FROM_NAME}"
+  - "FROM_EMAIL=${_FROM_EMAIL}"
+  - "FREEZE_DATE=${_FREEZE_DATE}"
+  - "CUT_DATE=${_CUT_DATE}"
+  - "RUN_TYPE=${_RUN_TYPE}"
+  args:
+  - go/src/k8s.io/release/patch-release/announce
+
+substitutions:
+  _K8S_GIT_URL:        https://github.com/kubernetes/kubernetes
+  _RELEASE_GIT_URL:    https://github.com/kubernetes/release
+  _RELEASE_GIT_BRANCH: master
+
+  _K8S_GIT_BRANCH:     null
+  _GITHUB_TOKEN:       null
+  _SENDGRID_API_KEY:   null
+  _REL_MGR_NAME:       'Kubernetes Release Managers'
+  _REL_MGR_EMAIL:      'release-managers@kubernetes.io'
+  _REL_MGR_SLACK:      'sig-release'
+  _FROM_NAME:          null
+  _FROM_EMAIL:         null
+  _FREEZE_DATE:        null
+  _CUT_DATE:           null
+  _RUN_TYPE:           'mock'

--- a/patch-release/announce
+++ b/patch-release/announce
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+tmpDir="$( mktemp -d )"
+trap 'rm -rf -- "$tmpDir"' EXIT
+
+BUILD_BASE="$(pwd)"
+RELEASE_DIR="${BUILD_BASE}/go/src/k8s.io/release"
+K8S_DIR="${BUILD_BASE}/go/src/k8s.io/kubernetes"
+
+export GOPATH="${BUILD_BASE}/go"
+export PATH="${PATH}:${GOPATH}/bin"
+
+cd "${RELEASE_DIR}"
+go install k8s.io/release/cmd/blocking-testgrid-tests
+
+cd "${K8S_DIR}"
+
+md="${tmpDir}/relnotes.md"
+bash ../release/relnotes \
+  --htmlize-md \
+  --preview \
+  --markdown-file="${md}" \
+  >/dev/null
+
+# v1.13.10-beta.0-16-g48844ef5e7 -> v1.13.10
+UPCOMING_VERSION="$( git describe | cut -d- -f1 )"
+# prepend the day of week
+FREEZE_DATE="$(date -d "$FREEZE_DATE" '+%A'), ${FREEZE_DATE}"
+CUT_DATE="$(date -d "$CUT_DATE" '+%A'), ${CUT_DATE}"
+EMAIL_SUBJECT="Kubernetes ${UPCOMING_VERSION} cut planned for ${CUT_DATE}"
+
+# All vars used in the intro template (via envsubst) need to be exported.
+export UPCOMING_VERSION FREEZE_DATE CUT_DATE EMAIL_SUBJECT
+
+# by default, send the mail to yourself
+recipients="$(
+  jq -n \
+    --arg name "$FROM_NAME" --arg email "$FROM_EMAIL" \
+    '[{ "to": [{name:$name, email:$email}] }]'
+)"
+
+# if we run with nomock mode, actually send to the mailinglists
+if [ "${RUN_TYPE}" = 'nomock' ]
+then
+  echo >&2 'Running with --nomock, setting recipients to the k8s google groups'
+  recipients='[{
+    "to": [
+      {
+        "name": "Kubernetes developer/contributor discussion",
+        "email": "kubernetes-dev@googlegroups.com"
+      },{
+        "name": "kubernetes-dev-announce",
+        "email": "kubernetes-dev-announce@googlegroups.com"
+      }
+    ]
+  }]'
+fi
+
+buildEmailMd() {
+  cat "${RELEASE_DIR}/patch-release/mail-head.md.tmpl" | envsubst
+  echo '' ; echo '----' ; echo ''
+  cat "$md"
+}
+
+emailBody="$(
+  buildEmailMd \
+    | pandoc \
+        -s \
+        --metadata pagetitle="$EMAIL_SUBJECT" \
+        --columns=100000 \
+        -f gfm /dev/stdin \
+        -H "${RELEASE_DIR}/patch-release/mail-style.css" \
+        -t html5 -o -
+)"
+
+# shellcheck disable=SC2016
+# ... because that's the template we will use with jq.
+sendgridPayloadTmpl='{
+  "personalizations": $recipients,
+  "from": {"email": $fromEmail, "name": $fromName},
+  "subject": $subject,
+  "content": [
+    {"type": "text/html", "value": env.emailBody}
+  ]
+}'
+
+# Safe that in a file, in case it gets big
+sendgridPayload="${tmpDir}/sendgridPayload.json"
+
+# 'emailBody' needs to be in the env when we run jq with the
+# 'sendgridPayloadTmpl' template
+emailBody="$emailBody" \
+  jq -n \
+    --argjson recipients "$recipients" \
+    --arg fromName "$FROM_NAME" \
+    --arg fromEmail "$FROM_EMAIL" \
+    --arg subject "$EMAIL_SUBJECT" \
+    "$sendgridPayloadTmpl" \
+  > "$sendgridPayload"
+
+
+echo >&2 "Curling the sendgrid API with '$sendgridPayload'"
+curl --silent --show-error --fail \
+  --url https://api.sendgrid.com/v3/mail/send \
+  --header "Authorization: Bearer ${SENDGRID_API_KEY}" \
+  --header 'Content-Type: application/json' \
+  --data "@${sendgridPayload}"

--- a/patch-release/mail-head.md.tmpl
+++ b/patch-release/mail-head.md.tmpl
@@ -1,0 +1,7 @@
+Below is a draft of the generated changelog for ${UPCOMING_VERSION}. If you submitted a cherrypick, please make sure it's listed and has an **accurate release note**.
+
+If you have a pending cherrypick for ${UPCOMING_VERSION}, make sure it merges by end of day on **${FREEZE_DATE}**.
+Please tag `@kubernetes/patch-release-team` on the GitHub issue/PR, email [${REL_MGR_NAME}](mailto:${REL_MGR_EMAIL}), or reach out in [#${REL_MGR_SLACK}](https://kubernetes.slack.com/messages/${REL_MGR_SLACK}/) on Slack if your cherrypick appears to be blocked on something out of your control.
+
+If you've already spoken to the patch release team about PRs that are not yet merged or listed below, don't worry, we're tracking them.
+

--- a/patch-release/mail-style.css
+++ b/patch-release/mail-style.css
@@ -1,0 +1,27 @@
+<style type="text/css">
+body {
+  font-family: "Verdana"
+}
+code, pre {
+  background-color: #f2f2f2;
+}
+code {
+  display: inline-block;
+  padding: 2px;
+}
+pre {
+  padding: 1em;
+}
+tr:nth-child(even) td {
+  background-color: #f2f2f2;
+}
+td {
+  padding: 1em;
+}
+hr {
+  border: 4px solid #f2f2f2;
+  margin-left: 1em;
+  margin-right: 1em;
+  border-radius: 2px;
+}
+</style>


### PR DESCRIPTION
I have the assumption that sending out the [patch release announcement mails][mail] is pretty much done on individuals' machines. We could change that if we'd want to, and run it on GCB.

This is pretty much a c&p of the thing I have running in my private concourse to send out [the mails][mail], therefor its is not implemented in go / `krel`.
However, I am opening this PR to get some feedback. Do people want that?

Notes:
- It "proves" that we could use sendgrid for sending mail
- The top-level tool `announce-patch` is pretty much just to submit the job and, same as `gcbmgr`, should eventually go away maybe and replaced by prow/builder
- The github token and sendgrid API key should be stored in KMS as `secretEnv`, right now those two vars will show up in the console

TODOs, merge blocking:
- [ ] move secrets to KMS

TODOs, maybe as follow-up PRs:
- [ ] reimplement the tool in go / as part of krel
- [ ] submit GCB things via prow/builder and not via `gcbmgr` / `announce-patch`

cc: @kubernetes/patch-release-team 
cc: @kubernetes/release-engineering 

/assign @tpepper @idealhack 

[mail]: https://groups.google.com/d/msg/kubernetes-dev/9oXvqwVbeU0/Fin5CT3HBQAJ