### PR TITLE
OWNERS: Release Managers updates

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,11 +12,11 @@ aliases:
     - feiskyer # Patch Release Team
     - hoegaarden # Patch Release Team
     - idealhack # Patch Release Team
-    - justaugustus # subproject owner
+    - justaugustus # subproject owner / Patch Release Team
     - tpepper # subproject owner / Patch Release Team
   branch-managers:
-    - bubblemelon
-    - justaugustus
+    - cpanato
+    - saschagrunert
   build-admins:
     - aleksandra-malinowska
     - listx


### PR DESCRIPTION
- Promote Stephen Augustus to Patch Release Team
- Retroactively add Carlos Panato as Branch Manager
- Promote Sascha Grunert as Branch Manager
- Remove Cheryl Fong as Branch Manager

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**On hold until https://github.com/kubernetes/sig-release/pull/868 merges**
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup