### PR TITLE
Add 'install-tools' subcommand to krel

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -4,12 +4,14 @@ go_library(
     name = "go_default_library",
     srcs = [
         "ff.go",
+        "install_tools.go",
         "push.go",
         "root.go",
     ],
     importpath = "k8s.io/release/cmd/krel/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/command:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/cmd/krel/cmd/install_tools.go
+++ b/cmd/krel/cmd/install_tools.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/command"
+)
+
+type installToolsOptions struct {
+	notFailOnOutdated bool
+}
+
+var installToolsOpts = &installToolsOptions{}
+
+var installToolsCmd = &cobra.Command{
+	Use:          "install-tools",
+	Short:        "install-tools downloads and compiles necessary release tools",
+	SilenceUsage: true,
+	RunE: func(*cobra.Command, []string) error {
+		return runInstallTools()
+	},
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	installToolsCmd.PersistentFlags().BoolVar(
+		&installToolsOpts.notFailOnOutdated,
+		"not-fail-on-outdated",
+		false,
+		"do not fail if go modules are outdated",
+	)
+	rootCmd.AddCommand(installToolsCmd)
+}
+
+var installTools = []string{
+	"k8s.io/release/cmd/blocking-testgrid-tests",
+}
+
+func runInstallTools() error {
+	setupEnv()
+
+	if err := checkDeps(installToolsOpts.notFailOnOutdated); err != nil {
+		return err
+	}
+
+	return goInstall(installTools...)
+}
+
+func setupEnv() {
+	if gobin, isSet := os.LookupEnv("GOBIN"); isSet {
+		os.Setenv("PATH", fmt.Sprintf("%s:%s", gobin, os.Getenv("PATH")))
+	}
+}
+
+func checkDeps(notFailOnOutdated bool) error {
+	goInstall("github.com/psampaz/go-mod-outdated")
+	ciFlag := "-ci"
+	if notFailOnOutdated {
+		ciFlag = ""
+	}
+	return command.Execute(
+		"go list -u -m -json all 2>/dev/null |",
+		"go-mod-outdated -update -direct", ciFlag,
+	)
+}
+
+func goInstall(tools ...string) error {
+	for _, tool := range tools {
+		log.Printf("Installing %q", tool)
+		if err := command.Execute("go install", tool); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -20,6 +20,20 @@ func TestSuccessWithWorkingDir(t *testing.T) {
 	require.Zero(t, res.ExitCode())
 }
 
+func TestSuccessWithPipe(t *testing.T) {
+	res, err := New("echo hi | cat").Run()
+	require.Nil(t, err)
+	require.True(t, res.Success())
+	require.Zero(t, res.ExitCode())
+}
+
+func TestFailureWithPipe(t *testing.T) {
+	res, err := New("echo hi | not-existing").Run()
+	require.Nil(t, err)
+	require.False(t, res.Success())
+	require.Contains(t, res.Output(), "not found")
+}
+
 func TestFailureWithWrongWorkingDir(t *testing.T) {
 	_, err := NewWithWorkDir("/should/not/exist", "ls -1").Run()
 	require.NotNil(t, err)


### PR DESCRIPTION
This adds the functionality for the `compile-release-tools` as dedicated
`install-tools` subcommand. The command functionality had to be adapted
to support pipes too. To keep things simple we spawn piped commands in a
sub-shell to not have the need for handling io.Pipes for every piped
command.
