### PR TITLE
Remove automatic word split from command

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -41,23 +40,14 @@ type Status struct {
 }
 
 // New creates a new command from the provided arguments.
-func New(cmd ...string) *Command {
-	return NewWithWorkDir("", cmd...)
+func New(cmd string, args ...string) *Command {
+	return NewWithWorkDir("", cmd, args...)
 }
 
-// New creates a new command from the provided workDir and the command
+// NewWithWorkDir creates a new command from the provided workDir and the command
 // arguments.
-func NewWithWorkDir(workDir string, cmd ...string) *Command {
-	args := strings.Fields(strings.Join(cmd, " "))
-
-	command := func() *Command {
-		if len(args) == 0 {
-			return &Command{exec.Command(cmd[0])}
-		} else if len(args) > 1 {
-			return &Command{exec.Command(args[0], args[1:]...)}
-		}
-		return &Command{exec.Command(args[0])}
-	}()
+func NewWithWorkDir(workDir, cmd string, args ...string) *Command {
+	command := &Command{exec.Command(cmd, args...)}
 
 	if workDir != "" {
 		command.cmd.Dir = workDir
@@ -183,8 +173,8 @@ func (s *Status) Output() string {
 
 // Execute is a convenience function which creates a new Command, executes it
 // and evaluates its status.
-func Execute(cmd ...string) error {
-	status, err := New(cmd...).Run()
+func Execute(cmd string, args ...string) error {
+	status, err := New(cmd, args...).Run()
 	if err != nil {
 		return errors.Wrapf(err, "command %q is not executable", cmd)
 	}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -7,26 +7,26 @@ import (
 )
 
 func TestSuccess(t *testing.T) {
-	res, err := New("echo hi").Run()
+	res, err := New("echo", "hi").Run()
 	require.Nil(t, err)
 	require.True(t, res.Success())
 	require.Zero(t, res.ExitCode())
 }
 
 func TestSuccessWithWorkingDir(t *testing.T) {
-	res, err := NewWithWorkDir("/", "ls -1").Run()
+	res, err := NewWithWorkDir("/", "ls", "-1").Run()
 	require.Nil(t, err)
 	require.True(t, res.Success())
 	require.Zero(t, res.ExitCode())
 }
 
 func TestFailureWithWrongWorkingDir(t *testing.T) {
-	_, err := NewWithWorkDir("/should/not/exist", "ls -1").Run()
+	_, err := NewWithWorkDir("/should/not/exist", "ls", "-1").Run()
 	require.NotNil(t, err)
 }
 
 func TestSuccessSilent(t *testing.T) {
-	res, err := New("echo hi").RunSilent()
+	res, err := New("echo", "hi").RunSilent()
 	require.Nil(t, err)
 	require.True(t, res.Success())
 }
@@ -50,9 +50,9 @@ func TestSuccessNoArgument(t *testing.T) {
 }
 
 func TestSuccessOutput(t *testing.T) {
-	res, err := New("echo -n 'hello world'").Run()
+	res, err := New("echo", "-n", "hello world").Run()
 	require.Nil(t, err)
-	require.Equal(t, "'hello world'", res.Output())
+	require.Equal(t, "hello world", res.Output())
 }
 
 func TestSuccessOutputSeparated(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSuccessOutputSeparated(t *testing.T) {
 }
 
 func TestFailureStdErr(t *testing.T) {
-	res, err := New("cat /not/valid").Run()
+	res, err := New("cat", "/not/valid").Run()
 	require.Nil(t, err)
 	require.False(t, res.Success())
 	require.Equal(t, res.ExitCode(), 1)
@@ -75,7 +75,7 @@ func TestFailureNotExisting(t *testing.T) {
 }
 
 func TestSuccessExecute(t *testing.T) {
-	err := Execute("echo -n hi", "ho")
+	err := Execute("echo", "-n", "hi", "ho")
 	require.Nil(t, err)
 }
 
@@ -100,17 +100,17 @@ func TestAvailableFailure(t *testing.T) {
 }
 
 func TestSuccessRunSuccess(t *testing.T) {
-	require.Nil(t, New("echo hi").RunSuccess())
+	require.Nil(t, New("echo", "hi").RunSuccess())
 }
 
 func TestFailureRunSuccess(t *testing.T) {
-	require.NotNil(t, New("cat /not/available").RunSuccess())
+	require.NotNil(t, New("cat", "/not/available").RunSuccess())
 }
 
 func TestSuccessRunSilentSuccess(t *testing.T) {
-	require.Nil(t, New("echo hi").RunSilentSuccess())
+	require.Nil(t, New("echo", "hi").RunSilentSuccess())
 }
 
 func TestFailureRunSuccessSilent(t *testing.T) {
-	require.NotNil(t, New("cat /not/available").RunSilentSuccess())
+	require.NotNil(t, New("cat", "/not/available").RunSilentSuccess())
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -105,7 +105,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	// Create a test branch and a test commit on top
 	branchName := "first-branch"
 	require.Nil(t, command.NewWithWorkDir(
-		cloneTempDir, "git checkout -b", branchName,
+		cloneTempDir, "git", "checkout", "-b", branchName,
 	).RunSuccess())
 
 	const branchTestFileName = "branch-test-file"


### PR DESCRIPTION
To provide an idiomatic way for handling arguments and the command we
now do not auto-split them any more.

Refers to: https://github.com/kubernetes/release/pull/951#discussion_r353288514

/cc @hoegaarden 