### PR TITLE
[WIP][DO NOT MERGE] Establish Kubernetes stage/release process on Kubernetes Community Infra

### DIFF
--- a/anago
+++ b/anago
@@ -108,7 +108,7 @@ PROG=${0##*/}
 #+     [--buildversion=ver]      - Set the build version (required)
 #+     [--gcrio_path=]           - Specify the full GCR path to use.
 #+                                 defaults:
-#+                                 - gcr.io/kubernetes-release-test (mock)
+#+                                 - gcr.io/k8s-staging-kubernetes (mock)
 #+                                 - k8s.gcr.io for --nomock
 #+     [--basedir=dir]           - Specify an alternate base directory
 #+                                 (default: $HOME/anago)

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -75,7 +75,7 @@ func TestRunGcbmgrList(t *testing.T) {
 				Version:  mockVersion("v1.17.0"),
 			},
 			listJobOpts: fakeListJobs{
-				expectedProject:  "kubernetes-release-test",
+				expectedProject:  release.DefaultKubernetesStagingProject,
 				expectedLastJobs: int64(5),
 				err:              nil,
 			},
@@ -91,7 +91,7 @@ func TestRunGcbmgrList(t *testing.T) {
 				Version:  mockVersion("v1.17.0"),
 			},
 			listJobOpts: fakeListJobs{
-				expectedProject:  "kubernetes-release-test",
+				expectedProject:  release.DefaultKubernetesStagingProject,
 				expectedLastJobs: int64(10),
 				err:              errors.New("Generic Error"),
 			},

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -19,13 +19,13 @@
 ###############################################################################
 
 readonly DEFAULT_PROJECT="k8s-staging-kubernetes"
-# TODO(prototype): Need to reference test prod project here
-readonly PROD_PROJECT="k8s-staging-kubernetes"
+# TODO(prototype): Need to reference official prod project here
+readonly PROD_PROJECT="k8s-release-test-prod"
 readonly TEST_PROJECT="k8s-staging-kubernetes"
 
 readonly DEFAULT_BUCKET="k8s-staging-kubernetes"
-# TODO(prototype): Need to reference test prod project here
-readonly PROD_BUCKET="k8s-staging-kubernetes"
+# TODO(prototype): Need to reference official prod bucket here
+readonly PROD_BUCKET="k8s-release-test-prod"
 readonly TEST_BUCKET="k8s-staging-kubernetes"
 readonly CI_BUCKET="kubernetes-release-dev"
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -18,15 +18,15 @@
 # CONSTANTS
 ###############################################################################
 
-# TODO(vdf): Need to reference K8s Infra projects here
-readonly DEFAULT_PROJECT="kubernetes-release-test"
-readonly PROD_PROJECT="kubernetes-release"
-readonly TEST_PROJECT="kubernetes-release-test"
+readonly DEFAULT_PROJECT="k8s-staging-kubernetes"
+# TODO(prototype): Need to reference test prod project here
+readonly PROD_PROJECT="k8s-staging-kubernetes"
+readonly TEST_PROJECT="k8s-staging-kubernetes"
 
-# TODO(vdf): Need to reference K8s Infra buckets here
-readonly DEFAULT_BUCKET="kubernetes-release-gcb"
-readonly PROD_BUCKET="kubernetes-release"
-readonly TEST_BUCKET="kubernetes-release-gcb"
+readonly DEFAULT_BUCKET="k8s-staging-kubernetes"
+# TODO(prototype): Need to reference test prod project here
+readonly PROD_BUCKET="k8s-staging-kubernetes"
+readonly TEST_BUCKET="k8s-staging-kubernetes"
 readonly CI_BUCKET="kubernetes-release-dev"
 
 readonly GCRIO_PATH_PROD="k8s.gcr.io"

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -34,11 +34,10 @@ import (
 
 const (
 	// gcbmgr/anago defaults
-	DefaultToolRepo   = "release"
-	DefaultToolBranch = git.Master
-	DefaultToolOrg    = git.DefaultGithubOrg
-	// TODO(vdf): Need to reference K8s Infra project here
-	DefaultKubernetesStagingProject = "kubernetes-release-test"
+	DefaultToolRepo                 = "release"
+	DefaultToolBranch               = git.Master
+	DefaultToolOrg                  = git.DefaultGithubOrg
+	DefaultKubernetesStagingProject = "k8s-staging-kubernetes"
 	DefaultRelengStagingProject     = "k8s-staging-releng"
 	DefaultDiskSize                 = "300"
 	BucketPrefix                    = "kubernetes-release-"


### PR DESCRIPTION
From https://github.com/kubernetes/k8s.io/pull/624:
> As part of the [vanity image domain flip](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md), @kubernetes/release-engineering / @kubernetes/release-managers will need a new project to stage artifacts to.
> 
> Namely, the images referenced in [k/release/release-engineering/artifacts.md](https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md):
> 
>     * cloud-controller-manager
> 
>     * conformance (will likely be moved to another staging project)
> 
>     * hyperkube (will likely be removed in a future release)
> 
>     * kube-apiserver
> 
>     * kube-controller-manager
> 
>     * kube-proxy
> 
>     * kube-scheduler
> 
> 
> While we're sorting out exactly how we'd like that to work, I'd like to keep access scoped to only the @kubernetes/sig-release-admins, opening that up once the new flow is documented.
> 
> Here we add three new projects:
> 
>     * `k8s-staging-kubernetes`
> 
>     * `k8s-staging-release`
> 
>     * `k8s-release-admin`
> 
> 
> `k8s-staging-kubernetes` will be the official project for staging and releasing Kubernetes.
> 
> `k8s-staging-release` will be used to stage Release Engineering images.
> 
> `k8s-release-admin` will be a limited-scope near-prod project for Release Admins (Stephen, Tim, Caleb), which will contain KMS keys to be leveraged during staging and release.

Signed-off-by: Stephen Augustus [saugustus@vmware.com](mailto:saugustus@vmware.com)

ref: https://github.com/kubernetes/release/issues/911, https://github.com/kubernetes/release/issues/270
/hold


**Does this PR introduce a user-facing change?**:
```release-note
Establish Kubernetes stage/release process on Kubernetes Community Infra
```