### PR TITLE
Enable errcheck linter and fix lints

### DIFF
--- a/.errcheck-excludes
+++ b/.errcheck-excludes
@@ -1,0 +1,1 @@
+(github.com/go-kit/kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - errcheck
     - goconst
     - gocritic
     - gocyclo
@@ -34,7 +35,6 @@ linters:
     - unused
     - varcheck
     - whitespace
-    # - errcheck
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
@@ -47,6 +47,7 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+    exclude: .errcheck-excludes
   gocritic:
     enabled-checks:
       # Diagnostic

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -101,7 +101,7 @@ func runFf(opts *ffOptions) error {
 
 	cleanup := rootOpts.cleanup
 	if cleanup {
-		defer repo.Cleanup() //nolint: errcheck
+		defer repo.Cleanup() // nolint: errcheck
 	}
 
 	log.Printf("Finding merge base between %q and %q", master, branch)

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -244,7 +244,10 @@ func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history not
 	// Contextualized release notes can be printed in a variety of formats
 	switch o.format {
 	case "json":
-		byteValue, _ := ioutil.ReadAll(output)
+		byteValue, err := ioutil.ReadAll(output)
+		if err != nil {
+			return err
+		}
 
 		if len(byteValue) > 0 {
 			if err := json.Unmarshal(byteValue, &existingNotes); err != nil {
@@ -254,8 +257,12 @@ func (o *options) WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history not
 		}
 
 		if len(existingNotes) > 0 {
-			output.Truncate(0)
-			output.Seek(0, 0)
+			if err := output.Truncate(0); err != nil {
+				return err
+			}
+			if _, err := output.Seek(0, 0); err != nil {
+				return err
+			}
 
 			for i := 0; i < len(existingNotes); i++ {
 				_, ok := releaseNotes[existingNotes[i].PrNumber]

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -66,8 +66,9 @@ func TestSuccessWithWorkingDir(t *testing.T) {
 }
 
 func TestFailureWithWrongWorkingDir(t *testing.T) {
-	_, err := NewWithWorkDir("/should/not/exist", "ls", "-1").Run()
+	res, err := NewWithWorkDir("/should/not/exist", "ls", "-1").Run()
 	require.NotNil(t, err)
+	require.Nil(t, res)
 }
 
 func TestSuccessSilent(t *testing.T) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -175,8 +175,12 @@ func (r *Repo) Cleanup() error {
 // RevParse parses a git revision and returns a SHA1 on success, otherwise an
 // error.
 func (r *Repo) RevParse(rev string) (string, error) {
-	// Prefix all non-tags the default remote "origin"
-	if isVersion, _ := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev); !isVersion {
+	matched, err := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev)
+	if err != nil {
+		return "", err
+	}
+	if !matched {
+		// Prefix all non-tags the default remote "origin"
 		rev = Remotify(rev)
 	}
 
@@ -234,7 +238,7 @@ func (r *Repo) latestNonPatchFinalVersion() (semver.Version, error) {
 	}
 
 	found := false
-	_ = tags.ForEach(func(t *plumbing.Reference) error {
+	_ = tags.ForEach(func(t *plumbing.Reference) error { // nolint: errcheck
 		tag := strings.TrimPrefix(t.Name().Short(), "v")
 		ver, err := semver.Make(tag)
 


### PR DESCRIPTION
We also err an `.errcheck-excludes` configuration file which excludes
the logging error messages for now.