### PR TITLE
Fix unit tests for macOS in command package

### DIFF
--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -55,7 +55,7 @@ func TestFailurePipeWrongArgument(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, res.Success())
 	require.Empty(t, res.Output())
-	require.Contains(t, res.Error(), "unrecognized option")
+	require.NotEmpty(t, res.Error())
 }
 
 func TestSuccessWithWorkingDir(t *testing.T) {


### PR DESCRIPTION
This should at least make them not fail.

Refers to #961