### PR TITLE
Replace log package with logrus

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
     ],

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -17,21 +17,22 @@ limitations under the License.
 package cmd
 
 import (
-	"log"
-
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "krel",
-	Short: "krel",
+	Use:     "krel",
+	Short:   "krel",
+	PreRunE: initLogging,
 }
 
 type rootOptions struct {
 	nomock   bool
 	cleanup  bool
 	repoPath string
+	logLevel string
 }
 
 var rootOpts = &rootOptions{}
@@ -40,7 +41,7 @@ var rootOpts = &rootOptions{}
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }
 
@@ -50,8 +51,20 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.nomock, "nomock", false, "nomock flag")
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.cleanup, "cleanup", false, "cleanup flag")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.repoPath, "repo", "", "the local path to the repository to be used")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'")
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+}
+
+func initLogging(*cobra.Command, []string) error {
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	lvl, err := logrus.ParseLevel(rootOpts.logLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(lvl)
+	logrus.Debugf("Using log level %q", lvl)
+	return nil
 }

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -168,7 +168,7 @@ func (o *options) BindFlags() *flag.FlagSet {
 		"Only commits from this GitHub user are considered. Set to empty string to include all users",
 	)
 
-	debug, _ := strconv.ParseBool(envDefault("DEBUG", "false"))
+	debug, _ := strconv.ParseBool(envDefault("DEBUG", "false")) // nolint: errcheck
 	flags.BoolVar(
 		&o.debug,
 		"debug",

--- a/pkg/command/BUILD.bazel
+++ b/pkg/command/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["command.go"],
     importpath = "k8s.io/release/pkg/command",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_pkg_errors//:go_default_library"],
+    deps = [
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -19,7 +19,6 @@ package command
 import (
 	"bytes"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -27,6 +26,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // A generic command abstraction
@@ -136,7 +136,7 @@ func (c *Command) RunSilentSuccess() (err error) {
 
 // run is the internal run method
 func (c *Command) run(printOutput bool) (res *Status, err error) {
-	log.Printf("Running command: %v", c.String())
+	logrus.Debugf("Running command: %v", c.String())
 	var runErr error
 	stdOutBuffer := &bytes.Buffer{}
 	stdErrBuffer := &bytes.Buffer{}
@@ -167,10 +167,10 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 			go func() {
 				defer waitGroup.Done()
 				if _, err := io.Copy(stdOutWriter, stdout); err != nil {
-					log.Println("unable to copy command stdout")
+					logrus.Warn("unable to copy command stdout")
 				}
 				if _, err := io.Copy(stdErrWriter, stderr); err != nil {
-					log.Println("unable to copy command stderr")
+					logrus.Warn("unable to copy command stderr")
 				}
 			}()
 		}
@@ -254,7 +254,7 @@ func Available(commands ...string) (ok bool) {
 	ok = true
 	for _, command := range commands {
 		if _, err := exec.LookPath(command); err != nil {
-			log.Printf("Unable to %v", err)
+			logrus.Warnf("Unable to %v", err)
 			ok = false
 		}
 	}

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/command:go_default_library",
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//config:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["common.go"],
     importpath = "k8s.io/release/pkg/util",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
 )
 
 filegroup(

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -24,10 +24,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 /*
@@ -69,12 +70,12 @@ func Ask(question, expectedResponse string, retries int) (answer string, success
 	attempts := 1
 
 	if retries < 0 {
-		log.Printf("Retries was set to a number less than zero (%d). Please specify a positive number of retries or zero, if you want to ask unconditionally.", retries)
+		fmt.Printf("Retries was set to a number less than zero (%d). Please specify a positive number of retries or zero, if you want to ask unconditionally.", retries)
 	}
 
 	for attempts <= retries {
 		scanner := bufio.NewScanner(os.Stdin)
-		log.Printf("%s (%d/%d) ", question, attempts, retries)
+		fmt.Printf("%s (%d/%d) ", question, attempts, retries)
 
 		scanner.Scan()
 		answer = scanner.Text()
@@ -83,28 +84,27 @@ func Ask(question, expectedResponse string, retries int) (answer string, success
 			return answer, true, nil
 		}
 
-		log.Printf("Expected '%s', but got '%s'", expectedResponse, answer)
+		fmt.Printf("Expected '%s', but got '%s'", expectedResponse, answer)
 
 		attempts++
 	}
 
-	log.Printf("Expected response was not provided. Retries exceeded.")
 	return answer, false, errors.New("expected response was not input. Retries exceeded")
 }
 
 // FakeGOPATH creates a temp directory, links the base directory into it and
 // sets the GOPATH environment variable to it.
 func FakeGOPATH(srcDir string) (string, error) {
-	log.Printf("Linking repository into temp dir")
+	logrus.Debug("Linking repository into temp dir")
 	baseDir, err := ioutil.TempDir("", "ff-")
 	if err != nil {
 		return "", err
 	}
 
-	log.Printf("New working directory is %q", baseDir)
+	logrus.Infof("New working directory is %q", baseDir)
 
 	os.Setenv("GOPATH", baseDir)
-	log.Printf("GOPATH: %s", os.Getenv("GOPATH"))
+	logrus.Debugf("GOPATH: %s", os.Getenv("GOPATH"))
 
 	gitRoot := fmt.Sprintf("%s/src/k8s.io", baseDir)
 	if err := os.MkdirAll(gitRoot, os.FileMode(int(0755))); err != nil {
@@ -113,12 +113,12 @@ func FakeGOPATH(srcDir string) (string, error) {
 	gitRoot = filepath.Join(gitRoot, "kubernetes")
 
 	// link the repo into the working directory
-	log.Printf("Creating symlink from %q to %q", srcDir, gitRoot)
+	logrus.Debugf("Creating symlink from %q to %q", srcDir, gitRoot)
 	if err := os.Symlink(srcDir, gitRoot); err != nil {
 		return "", err
 	}
 
-	log.Printf("Changing working directory to %s", gitRoot)
+	logrus.Infof("Changing working directory to %s", gitRoot)
 	if err := os.Chdir(gitRoot); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We now introduce a new `--log-level` flag to set the appropriate level, whereas the usage of the internal log package has been replaces with logrus.