### PR TITLE
release-notify: add --print option to print the location of the announcement file

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1145,12 +1145,6 @@ release::send_announcement () {
   ((FLAGS_nomock)) || mailto=$GCP_USER
   mailto=${FLAGS_mailto:-$mailto}
 
-  if ((FLAGS_print)); then
-    echo "You can find the Announcement file here: $archive_root/announcement.html"
-    echo "To copy to your local machine use: $GSUTIL cp $archive_root/announcement.html ."
-    return 0
-  fi
-
   # Announcement file is stored normally in WORKDIR, else check GCS.
   if [[ -f "$announcement_file" ]]; then
     announcement_text="$announcement_file"
@@ -1171,6 +1165,21 @@ release::send_announcement () {
       logecho "Unable to find an announcement subject file locally or on GCS!"
       return 1
     fi
+  fi
+
+  if ((FLAGS_print)); then
+    echo "***** Start of Subject ******"
+    logecho "$subject"
+    echo "***** End of Subject ******"
+    echo "***** Start of Announcement ******"
+    cat "$announcement_text"
+    echo "***** End of Announcement ******"
+    echo "***********"
+    echo "You can find the Subject file here: $archive_root/announcement-subject.txt"
+    echo "You can find the Announcement file here: $archive_root/announcement.html"
+    echo "***********"
+    logrun rm -f $announcement_text
+    return 0
   fi
 
   logecho

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1145,6 +1145,12 @@ release::send_announcement () {
   ((FLAGS_nomock)) || mailto=$GCP_USER
   mailto=${FLAGS_mailto:-$mailto}
 
+  if ((FLAGS_print)); then
+    echo "You can find the Announcement file here: $archive_root/announcement.html"
+    echo "To copy to your local machine use: $GSUTIL cp $archive_root/announcement.html ."
+    return 0
+  fi
+
   # Announcement file is stored normally in WORKDIR, else check GCS.
   if [[ -f "$announcement_file" ]]; then
     announcement_text="$announcement_file"

--- a/release-notify
+++ b/release-notify
@@ -41,7 +41,8 @@ PROG=${0##*/}
 #+                                 source/include:
 #+                                 FLAGS_security_layer=/path/to/script
 #+     [--mailto=]               - Useful for sending to self in --nomock mode
-#+     [--print]                 - Print the location of the annoucement file
+#+     [--print]                 - Don't send a mail, instead print the announcement email's
+#+                                 body & subject to StdOut and show their locations on GCS
 #+     [--help | -man]           - display man page for this script
 #+     [--usage | -?]            - display in-line usage
 #+

--- a/release-notify
+++ b/release-notify
@@ -24,6 +24,7 @@ PROG=${0##*/}
 #+ SYNOPSIS
 #+     $PROG  <version> [--nomock] [--mailto=<user>,...]
 #+                     [--security_layer=/path/to/pointer/to/script]
+#+                     [--print]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -40,6 +41,7 @@ PROG=${0##*/}
 #+                                 source/include:
 #+                                 FLAGS_security_layer=/path/to/script
 #+     [--mailto=]               - Useful for sending to self in --nomock mode
+#+     [--print]                 - Print the location of the annoucement file
 #+     [--help | -man]           - display man page for this script
 #+     [--usage | -?]            - display in-line usage
 #+


### PR DESCRIPTION
Adds an option to print only the location of the Announcement file for publish manually

fixes: https://github.com/kubernetes/release/issues/958

EDIT:
command output for example using the 1.17 release
```bash
root@ubuntu-s-1vcpu-1gb-fra1-01:~/release# ./release-notify v1.17.0 --print
release-notify: BEGIN main on ubuntu-s-1vcpu-1gb-fra1-01 Wed Dec 11 18:04:12 UTC 2019

Skipping security_layer::auth_check...
Checking/setting cloud tools: OK
Setting global variables: OK
You can find the Announcement file here: gs://kubernetes-release-gcb/archive/anago-v1.17.0/announcement.html
To copy to your local machine use: /usr/bin/gsutil cp gs://kubernetes-release-gcb/archive/anago-v1.17.0/announcement.html .

release-notify: DONE main on ubuntu-s-1vcpu-1gb-fra1-01 Wed Dec 11 18:04:13 UTC 2019 in 1s
```

/sig release
/area release-eng
/kind feature
/priority important-soon
/milestone v1.18
/cc @kubernetes/release-engineering
/assign @justaugustus 