### PR TITLE
Use cobra for release notes command line parser

### DIFF
--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -9,7 +9,9 @@ go_library(
         "//pkg/git:go_default_library",
         "//pkg/notes:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],
 )

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -79,6 +79,12 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | branch | BRANCH | master | Yes | The GitHub repository branch to scrape |
 | start-sha | START_SHA | | Yes | The commit hash to start processing from (inclusive) |
 | end-sha | END_SHA | | Yes | The commit hash to end processing at (inclusive) |
+| repo-path | REPO_PATH | /tmp/k8s-repo | No | Path to a local Kubernetes repository, used only for tag discovery |
+| start-rev | START_REV | | No | The git revision to start at. Can be used as alternative to start-sha |
+| env-rev | END_REV | | No | The git revision to end at. Can be used as alternative to end-sha |
+| discover | DISCOVER | none | No | The revision discovery mode for automatic revision retrieval (options: none, minor-to-latest) |
+| release-bucket | RELEASE_BUCKET | kubernetes-release | No | Specify gs bucket to point to in generated notes (default "kubernetes-release") |
+| release-tars | RELEASE_TARS | | No | Directory of tars to sha512 sum for display |
 | **OUTPUT OPTIONS** |
 | output | OUTPUT | | No | The path where the release notes will be written |
 | format | FORMAT | markdown | Yes | The format for notes output (options: markdown, json) |


### PR DESCRIPTION
This cleanup replaces the flags parser with cobra, which is already used by krel. Is also updates the error handling to correctly wrap and populate the errors to the main function. Documentation has been updated as well.

The behavior should be mainly the same, but the help output now looks a bit cleaner. Before:

```
> go run cmd/release-notes/main.go -h
Usage of release-notes:
  -branch master
        Select which branch to scrape. Defaults to master (default "master")
  -debug
        Enable debug logging
  -discover string
        The revision discovery mode for automatic revision retrieval (options: none, minor-to-latest, patch-to-patch) (default "none")
  -end-rev string
        The git revision to end at. Can be used as alternative to end-sha.
  -end-sha string
        The commit hash to end at
  -format string
        The format for notes output (options: markdown, json) (default "markdown")
  -github-org string
        Name of github organization (default "kubernetes")
  -github-repo string
        Name of github repository (default "kubernetes")
  -github-token string
        A personal GitHub access token (required)
  -output string
        The path to the where the release notes will be printed
  -release-version string
        Which release version to tag the entries as.
  -repo-path string
        Path to a the local Kubernetes repository
  -requiredAuthor string
        Only commits from this GitHub user are considered. Set to empty string to include all users (default "k8s-ci-robot")
  -start-rev string
        The git revision to start at. Can be used as alternative to start-sha.
  -start-sha string
        The commit hash to start at
ERRO parsing options: flag: help requested
```

Now:
```
release-notes - The Kubernetes Release Notes Generator

Usage:
  release-notes [flags]

Flags:
      --branch master            Select which branch to scrape. Defaults to master (default "master")
      --debug                    Enable debug logging
      --discover string          The revision discovery mode for automatic revision retrieval (options: none, minor-to-latest) (default "none")
      --end-rev string           The git revision to end at. Can be used as alternative to end-sha.
      --end-sha string           The commit hash to end at
      --format string            The format for notes output (options: markdown, json) (default "markdown")
      --github-org string        Name of github organization (default "kubernetes")
      --github-repo string       Name of github repository (default "kubernetes")
      --github-token string      A personal GitHub access token (required)
  -h, --help                     help for release-notes
      --output string            The path to the where the release notes will be printed
      --release-version string   Which release version to tag the entries as.
      --repo-path string         Path to a local Kubernetes repository, used only for tag discovery.
      --requiredAuthor string    Only commits from this GitHub user are considered. Set to empty string to include all users (default "k8s-ci-robot")
      --start-rev string         The git revision to start at. Can be used as alternative to start-sha.
      --start-sha string         The commit hash to start at
```