### PR TITLE
Fix release notes  parsing for blocks ending with 's'

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -238,10 +238,10 @@ func NoteTextFromString(s string) (string, error) {
 	exps := []*regexp.Regexp{
 		// (?s) is needed for '.' to be matching on newlines, by default that's disabled
 		// we need to match ungreedy 'U', because after the notes a `docs` block can occur
-		regexp.MustCompile("(?sU)```release-note\\r\\n(?P<note>.+)\\r\\n```"),
-		regexp.MustCompile("(?sU)```dev-release-note\\r\\n(?P<note>.+)"),
+		regexp.MustCompile("(?sU)```release-note[s]?\\r\\n(?P<note>.+)\\r\\n```"),
+		regexp.MustCompile("(?sU)```dev-release-note[s]?\\r\\n(?P<note>.+)"),
 		regexp.MustCompile("(?sU)```\\r\\n(?P<note>.+)\\r\\n```"),
-		regexp.MustCompile("(?sU)```release-note\n(?P<note>.+)\n```"),
+		regexp.MustCompile("(?sU)```release-note[s]?\n(?P<note>.+)\n```"),
 	}
 
 	for _, exp := range exps {


### PR DESCRIPTION
The release notes code block of https://github.com/kubernetes/kubernetes/pull/85733 is prefixed with `release-notes`. This is now covered by the regular expression parser as well which means that the note is now part of the generated output.

The bash script is not affected by this bug (see generated release notes of 1.16.4).