### PR TITLE
Use string builder to avoid copies on notes rendering

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -294,11 +294,14 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 			return errors.Wrapf(err, "creating release note document")
 		}
 
-		if err := notes.RenderMarkdown(
-			output, doc, opts.ReleaseBucket,
-			opts.ReleaseTars, opts.StartRev, opts.EndRev,
-		); err != nil {
+		markdown, err := notes.RenderMarkdown(
+			doc, opts.ReleaseBucket, opts.ReleaseTars, opts.StartRev, opts.EndRev,
+		)
+		if err != nil {
 			return errors.Wrapf(err, "rendering release note document to markdown")
+		}
+		if _, err := output.WriteString(markdown); err != nil {
+			return errors.Wrapf(err, "writing output file")
 		}
 
 	default:

--- a/pkg/notes/document_test.go
+++ b/pkg/notes/document_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package notes
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,6 @@ func TestPrettySIG(t *testing.T) {
 
 func TestCreateDownloadsTable(t *testing.T) {
 	// Given
-	output := &bytes.Buffer{}
 	dir, err := ioutil.TempDir("", "")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
@@ -80,8 +79,10 @@ func TestCreateDownloadsTable(t *testing.T) {
 	}
 
 	// When
-	require.Nil(t, createDownloadsTable(output, "kubernetes-release", dir,
-		"v1.16.0", "v1.16.1"))
+	output := &strings.Builder{}
+	require.Nil(t, createDownloadsTable(
+		output, "kubernetes-release", dir, "v1.16.0", "v1.16.1",
+	))
 
 	// Then
 	require.Equal(t, output.String(), `# v1.16.1


### PR DESCRIPTION
We now use the `strings.Builder` to avoid a lot of copies
during document rendering.

Beside this, we render the markdown in a temporarily buffer before
writing it into a file. This will be needed when it comes to the TOC
generation which will be an intermediate step.
