### PR TITLE
[testgridshot] Print comment, even if no failing dashboards where found

### DIFF
--- a/testgridshot
+++ b/testgridshot
@@ -54,6 +54,12 @@
 #+     Change the amount of time we want to wait between consecutive API call
 #+     retries.
 #+
+#+   LOCAL_IMG_DIR: [default: '']
+#+     Set this to a local path to skip the upload to the GCS bucket and
+#+     instead move the resulting files to the specified local path.
+#+     The directory specified must not exist yet or testgridshot will fail
+#+     to ensure we don't override files unintentionally.
+#+
 #+   Example:
 #+     $ BUCKET='kubeimages' BOARDS='all informing' STATES='FAILING FLAKY' BLOCK_WIDTH=10 ./testgridshot 1.15
 #+         Creates dense screenshots of all the 'sig-release-1.15-{all,informing}'
@@ -82,10 +88,11 @@ readonly WIDTH="${WIDTH:-3000}"
 readonly HEIGHT="${HEIGHT:-2500}"
 readonly RETRY_COUNT="${RETRY_COUNT:-3}"
 readonly RETRY_SLEEP="${RETRY_SLEEP:-2}"
+readonly LOCAL_IMG_DIR="${LOCAL_IMG_DIR:-}"
 
 readonly TESTGRID='https://testgrid.k8s.io'
 readonly RENDER_TRON='https://render-tron.appspot.com/screenshot'
-readonly ISSUE_STUB_SUFFIX='issue.'
+readonly ISSUE_STUB_SUFFIX='issue_comment_part.'
 readonly SHRUG='‾\_(ツ)_/‾'
 
 
@@ -207,6 +214,13 @@ shoot() {
   local idx=0
   local img_bucket_dir
   local pids=()
+  local comment
+
+  if [ -n "$LOCAL_IMG_DIR" ] && [ -e "$LOCAL_IMG_DIR" ]
+  then
+    log "Directory '${LOCAL_IMG_DIR}' must be empty"
+    return 1
+  fi
 
   tmp_dir="$( mktemp -d )"
   trap 'rm -rf -- "$tmp_dir"' EXIT
@@ -276,14 +290,22 @@ shoot() {
     return
   fi
 
-  log "Starting upload to '$BUCKET'"
-  upload_and_publish_images "$img_dir" "$img_bucket_dir"
-  log "Upload finished successfully"
+  comment="$( combine_issue_stubs "${tmp_dir}" | tee "${tmp_dir}/issue_comment.txt" )"
+
+  if [ -n "$LOCAL_IMG_DIR" ]
+  then
+    log "Skipping upload, moving results to '$LOCAL_IMG_DIR'"
+    mv "${tmp_dir}" "${LOCAL_IMG_DIR}"
+  else
+    log "Starting upload to '$BUCKET'"
+    upload_and_publish_images "$img_dir" "$img_bucket_dir"
+    log "Upload finished successfully"
+  fi
 
   echo
 
   echo '<!-- ----[ issue comment ]---- -->'
-  combine_issue_stubs "${tmp_dir}"
+  echo "$comment"
   echo '<!-- ----[ issue comment ]---- -->'
 }
 

--- a/testgridshot
+++ b/testgridshot
@@ -93,7 +93,6 @@ readonly LOCAL_IMG_DIR="${LOCAL_IMG_DIR:-}"
 readonly TESTGRID='https://testgrid.k8s.io'
 readonly RENDER_TRON='https://render-tron.appspot.com/screenshot'
 readonly ISSUE_STUB_SUFFIX='issue_comment_part.'
-readonly SHRUG='‾\_(ツ)_/‾'
 
 
 get_tests_by_status() {
@@ -286,8 +285,10 @@ shoot() {
   wait_for_all "${pids[@]}"
 
   if [ "$idx" -lt 1 ]; then
-    log "No screenshots captured for ${target_release} ... ${SHRUG}"
-    return
+    {
+      echo
+      echo "**NO $(comma_sep "${STATES}") TESTS**"
+    } > "$( get_issue_stub_name "${tmp_dir}" $((idx + 1)) )"
   fi
 
   comment="$( combine_issue_stubs "${tmp_dir}" | tee "${tmp_dir}/issue_comment.txt" )"

--- a/testgridshot
+++ b/testgridshot
@@ -94,15 +94,20 @@ get_tests_by_status() {
   shift
 
   local board
+  local summary
 
   for board in "$@"
   do
-    curl_with_retry --retry 0 "${TESTGRID}/${board}/summary" 2>/dev/null \
-      | jq --arg status "$status" -r '
-        to_entries[]
-          | select(.value.overall_status==$status)
-          | .value.dashboard_name + "#" + .key
-      '
+    summary="$( curl_with_retry --retry 0 "${TESTGRID}/${board}/summary" 2>/dev/null )" || {
+      log "Could not get summary for board '${board}'"
+      return 1
+    }
+
+    jq --arg status "$status" -r '
+      to_entries[]
+        | select(.value.overall_status==$status)
+        | .value.dashboard_name + "#" + .key
+    ' <<< "$summary"
   done
 }
 
@@ -188,12 +193,20 @@ usage() {
   awk -vRE="$usage_marker" "$awk_prog" <"$0" >&2
 }
 
+wait_for_all() {
+  for pid in "$@"
+  do
+    wait "$pid"
+  done
+}
+
 shoot() {
   local target_release="$1"
   local boards
-  local tests t s
+  local tests t s raw_tests
   local idx=0
   local img_bucket_dir
+  local pids=()
 
   tmp_dir="$( mktemp -d )"
   trap 'rm -rf -- "$tmp_dir"' EXIT
@@ -213,7 +226,8 @@ shoot() {
 
   for s in ${STATES}
   do
-    mapfile -t tests <<< "$(get_tests_by_status "$s" "${boards[@]}")"
+    raw_tests="$( get_tests_by_status "$s" "${boards[@]}" )"
+    mapfile -t tests <<< "$raw_tests"
     for t in "${tests[@]}"
     do
       [ -n "${t}" ] || continue
@@ -251,10 +265,11 @@ shoot() {
 
         local_log "done, image will be available at ${image_url}"
       )&
+      pids+=( $! )
     done
   done
 
-  wait
+  wait_for_all "${pids[@]}"
 
   if [ "$idx" -lt 1 ]; then
     log "No screenshots captured for ${target_release} ... ${SHRUG}"


### PR DESCRIPTION
When we find no tests of state configured in [`STATE`](https://github.com/kubernetes/release/blob/f033a8215f94913277976c4a3cc6f130a4e24cb7/testgridshot#L34-L36) we still generate a issue comment which now e.g. says:
> NO FAILING TEST

Also, a new feature has been added to not fill the bucket with useless testing screenshots:
When [`LOCAL_IMG_DIR`](https://github.com/kubernetes/release/blob/0f672f28855083d51528534abc5ef9b3da134447/testgridshot#L57-L61) is set, the images won't be uploaded but all the results will kept in a local directory.

Fixes: #965
/kind cleanup
/milestone v1.18