### PR TITLE
[relnotes] Add simple retry handler for AbuseRateLimit errors

### DIFF
--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/release/pkg/notes",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/notes/internal:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",
         "@com_github_nozzle_throttler//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
@@ -45,6 +46,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/notes/internal:all-srcs",
         "//pkg/notes/notesfakes:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/notes/client.go
+++ b/pkg/notes/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/google/go-github/v28/github"
+	"k8s.io/release/pkg/notes/internal"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -48,21 +49,46 @@ type githubNotesClient struct {
 var _ Client = &githubNotesClient{}
 
 func (c *githubNotesClient) GetCommit(ctx context.Context, owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
-	return c.ghc.Git.GetCommit(ctx, owner, repo, sha)
+	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
+		commit, resp, err := c.ghc.Git.GetCommit(ctx, owner, repo, sha)
+		if !shouldRetry(err) {
+			return commit, resp, err
+		}
+	}
 }
 
 func (c *githubNotesClient) ListCommits(ctx context.Context, owner, repo string, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
-	return c.ghc.Repositories.ListCommits(ctx, owner, repo, opt)
+	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
+		commits, resp, err := c.ghc.Repositories.ListCommits(ctx, owner, repo, opt)
+		if !shouldRetry(err) {
+			return commits, resp, err
+		}
+	}
 }
 
 func (c *githubNotesClient) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
-	return c.ghc.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, sha, opt)
+	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
+		prs, resp, err := c.ghc.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, sha, opt)
+		if !shouldRetry(err) {
+			return prs, resp, err
+		}
+	}
 }
 
 func (c *githubNotesClient) GetPullRequest(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error) {
-	return c.ghc.PullRequests.Get(ctx, owner, repo, number)
+	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
+		pr, resp, err := c.ghc.PullRequests.Get(ctx, owner, repo, number)
+		if !shouldRetry(err) {
+			return pr, resp, err
+		}
+	}
 }
 
 func (c *githubNotesClient) GetRepoCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error) {
-	return c.ghc.Repositories.GetCommit(ctx, owner, repo, sha)
+	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
+		commit, resp, err := c.ghc.Repositories.GetCommit(ctx, owner, repo, sha)
+		if !shouldRetry(err) {
+			return commit, resp, err
+		}
+	}
 }

--- a/pkg/notes/internal/BUILD.bazel
+++ b/pkg/notes/internal/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["retry.go"],
+    importpath = "k8s.io/release/pkg/notes/internal",
+    visibility = ["//pkg/notes:__subpackages__"],
+    deps = [
+        "@com_github_google_go_github_v28//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["retry_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_go_github_v28//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/notes/internal/retry.go
+++ b/pkg/notes/internal/retry.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"time"
+
+	"github.com/google/go-github/v28/github"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// MaxGithubRetries is the maximum amount of times we flag a GitHub error as
+	// retryable before we give up and do not flag the same call as retryable
+	// anymore.
+	MaxGithubRetries = 3
+
+	// defaultGithubSleep is the amount of time we wait between two consecutive
+	// GitHub calls in case we cannot extract that information from the error
+	// itself.
+	defaultGithubSleep = time.Minute
+)
+
+// DefaultGithubErrChecker is a GithubErrChecker set up with a default amount
+// of retries and the default sleep function.
+func DefaultGithubErrChecker() func(error) bool {
+	return GithubErrChecker(MaxGithubRetries, time.Sleep)
+}
+
+// GithubErrChecker returns a function that checks errors from GitHub and
+// decides if they can / should be retried.
+// It needs to be called with `maxTries`, a number of retries a single call
+// should be retried at max, and `sleeper`, a function which implements the
+// sleeping.
+//
+// Currently the only special error that is flagged as retryable is the
+// `AbuseRateLimitError`. If such an error occurs, we sleep for a while (the
+// amount of time the error told us to wait) and then report back that we can
+// retry.
+// Other special errors should be easy to implement too.
+//
+// It can be used like this:
+//  for shouldRetry := GithubErrChecker(10, time.Sleep); ; {
+//    commit, res, err := github_client.GetCommit(...)
+//    if !shouldRetry(err) {
+//      return commit, res, err
+//    }
+//  }
+func GithubErrChecker(maxTries int, sleeper func(time.Duration)) func(error) bool {
+	try := 0
+
+	return func(err error) bool {
+		if err == nil {
+			return false
+		}
+		if try >= maxTries {
+			logrus.Errorf("Max retries (%d) reached, not retrying anymore: %v", maxTries, err)
+			return false
+		}
+
+		try++
+
+		if aerr, ok := err.(*github.AbuseRateLimitError); ok {
+			waitDuration := defaultGithubSleep
+			if d := aerr.RetryAfter; d != nil {
+				waitDuration = *d
+			}
+			logrus.
+				WithField("err", aerr).
+				Infof("Hit the abuse rate limit on try %d, sleeping for %s", try, waitDuration)
+			sleeper(waitDuration)
+			return true
+		}
+
+		return false
+	}
+}

--- a/pkg/notes/internal/retry_test.go
+++ b/pkg/notes/internal/retry_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v28/github"
+	"github.com/sirupsen/logrus"
+	"k8s.io/release/pkg/notes/internal"
+)
+
+func TestMain(m *testing.M) {
+	// logrus, shut up
+	logrus.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}
+
+func TestGithubRetryer(t *testing.T) {
+	tests := map[string]struct {
+		maxTries        int
+		sleeper         func(time.Duration)
+		errs            []error
+		expectedResults []bool
+	}{
+		"never retry": {
+			maxTries: 0,
+		},
+		"when error is nil, don't retry": {
+			maxTries:        1,
+			sleeper:         nilSleeper,
+			errs:            []error{nil},
+			expectedResults: []bool{false},
+		},
+		"when error is a random error, don't retry": {
+			maxTries:        1,
+			sleeper:         nilSleeper,
+			errs:            []error{fmt.Errorf("some randm error")},
+			expectedResults: []bool{false},
+		},
+		"when the error is a github abuse rate limit error, retry": {
+			maxTries:        1,
+			sleeper:         nilSleeper,
+			errs:            []error{&github.AbuseRateLimitError{}},
+			expectedResults: []bool{true},
+		},
+		"when the error is a github abuse rate limit error but max tries have been reached, don't retry": {
+			maxTries: 2,
+			sleeper:  nilSleeper,
+			errs: []error{
+				&github.AbuseRateLimitError{},
+				&github.AbuseRateLimitError{},
+				&github.AbuseRateLimitError{},
+			},
+			expectedResults: []bool{
+				true, true, false,
+			},
+		},
+		"when no RetryAfter is specified on the abuse rate limit error, sleep the default amount of time": {
+			maxTries:        1,
+			sleeper:         sleepChecker(t, 1*time.Minute),
+			errs:            []error{&github.AbuseRateLimitError{}},
+			expectedResults: []bool{true},
+		},
+		"when a RetryAfter is specified on the abuse rate limit error, sleep that amount of time": {
+			maxTries:        1,
+			sleeper:         sleepChecker(t, 42*time.Minute),
+			errs:            []error{&github.AbuseRateLimitError{RetryAfter: durPtr(42 * time.Minute)}},
+			expectedResults: []bool{true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
+			shouldRetry := internal.GithubErrChecker(tc.maxTries, nilSleeper)
+
+			for i, err := range tc.errs {
+				if a, e := shouldRetry(err), tc.expectedResults[i]; e != a {
+					t.Errorf("Expected to get %t, got: %t", e, a)
+				}
+			}
+		})
+	}
+}
+
+func sleepChecker(t *testing.T, expectedSleep time.Duration) func(time.Duration) {
+	return func(d time.Duration) {
+		if d != expectedSleep {
+			t.Errorf("Expected the sleeper to be called with a duration %s, got called with %s", expectedSleep, d)
+		}
+		return
+	}
+}
+
+func nilSleeper(_ time.Duration) {
+	return
+}
+
+func durPtr(d time.Duration) *time.Duration {
+	return &d
+}

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -35,7 +35,7 @@ import (
 const (
 	// maxParallelRequests is the maximum parallel requests we shall make to the
 	// GitHub API
-	maxParallelRequests = 20
+	maxParallelRequests = 10
 )
 
 // ReleaseNote is the type that represents the total sum of all the information


### PR DESCRIPTION
This is just a hot-fix/workaround. If we want a faster relnotes tool
which makes thousands of API requests, we need a better solution on the
long run.

This at least allows us to max out the 5000reqs/h with a bit of waiting. It should still be faster then the original implementation.

I briefly checked on https://git.k8s.io/test-infra/ghproxy & https://git.k8s.io/test-infra/ghproxy/ghcache which didn't bring any improvement. However, I might also just used them wrong. I will check further what test-infra has done, as they sure have the same issue.

<details>

<summary>shell session</summary>

```shell
hhoerl@pfah[±|notes-rate-limit-retry U:2 ?:1 ✗]:~/go/src/k8s.io/release $ time go run cmd/release-notes/main.go --branch release-1.17 --start-sha 2bd9643cee5b3b3a5ecbd3af49d09018f0773c77 --end-sha 70132b0f130acc0bed193d9ba59dd186f0e634cf
INFO fetching all commits. This might take a while...
INFO starting to process commit 1 of 2682 (0.04%): 70132b0f130acc0bed193d9ba59dd186f0e634cf
INFO starting to process commit 2 of 2682 (0.07%): 1a8a2c81a8bd73fca0c4ce791338b2c0de493236
   [...]
INFO starting to process commit 281 of 2682 (10.48%): 204fc6bd28a338e2473e8b3568481b31d6ede983
INFO starting to process commit 282 of 2682 (10.51%): 303de85dd188d16db808baba5857b7f0e6ecc1db
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84873: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84748: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO starting to process commit 283 of 2682 (10.55%): ca836256c4234fd82b463ab03a857976141c6692
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84750: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84834: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84844: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO starting to process commit 284 of 2682 (10.59%): 1b4155804cccf5484a59f5e553905f5f76a71723
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84573: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84622: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84772: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84378: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO Hit the abuse rate limit on try 1, sleeping for 1m0s  err="GET https://api.github.com/repos/kubernetes/kubernetes/pulls/84669: 403 You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
INFO starting to process commit 285 of 2682 (10.63%): c97d90546a72146b871db1a43a8a613a4742a6a5
INFO starting to process commit 286 of 2682 (10.66%): 3ba4c686a4a3d81343e741052ea964562989f043
   [...]
INFO starting to process commit 2681 of 2682 (99.96%): 926bd4ddbbee7afbb52e15afd890fccb6e1e69cf
INFO starting to process commit 2682 of 2682 (100.00%): b1dfd2491a650a9c14daa8567ab23c5b824137b5
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=c97d90546a72146b871db1a43a8a613a4742a6a5
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=0c0408c790c64d9105a85ae702c73d0714bdb850
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=814ebe7678a2caed27b370ea2637278945b310d1
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=c6c7e8b8070c56de4a84655f01c49c65a43e9744
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=0f7873ad5c92e90020bb1708af850f442a7c277a
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=457fa6b40d708a823bf5a0557f0c36faa532394b
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=c9f8b8b52526a7b396479875725fd447de7b63a8
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=07e26d9bfc3c5d680d7588abf0675d0947c81da2
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=a7bd7a925ddf5ff909bfc3ead6eb1bbdcd524c13
ERRO getting the release note from commit while listing release notes  err="no matches found when parsing note text from commit string" sha=c9d50135740bae0002615dbd46b88755444fe866
INFO got the commits, performing rendering
INFO release notes written to file                 format=markdown path=/tmp/release-notes-605597618

real    11m56.441s
user    0m11.618s
sys     0m1.753s
hhoerl@pfah[±|notes-rate-limit-retry S:2 ?:1 ✗]:~/go/src/k8s.io/release $
```

</details>

Alternatively, I'd be also happy to roll back #973.

re: #979
/priority important-soon
/kind bug
/milestone v1.18
/assign @saschagrunert 