### PR TITLE
OWNERS: Add approvers and reviewers for krel

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,6 +22,16 @@ aliases:
     - listx
     - ps882
     - sumitranr
+  krel-approvers:
+    - hasheddan
+    - hoegaarden
+    - justaugustus
+    - saschagrunert
+  krel-reviewers:
+    - hasheddan
+    - hoegaarden
+    - justaugustus
+    - saschagrunert
   release-notes-approvers:
     - jeefy
     - marpaia

--- a/cmd/krel/OWNERS
+++ b/cmd/krel/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - krel-approvers
+reviewers:
+  - krel-reviewers

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - krel-approvers
+reviewers:
+  - krel-reviewers


### PR DESCRIPTION
These contributors have proven to be invaluable in reviewing/approving
code around our migration to Go-based release tools (krel).

Here we add new entries in OWNERS to grant them access to officially
approve this content.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
cc: @kubernetes/release-engineering 