### PR TITLE
Add coverage to go-test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ kubernetes.tar.gz
 
 # git merge conflict originals
 *.orig
+
+# go coverage files
+coverage.*

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -u
-set -o pipefail
+set -euo pipefail
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-GO111MODULE=on go test -v -race -count=1 ./...
+GO111MODULE=on go test -v -count=1 -cover -coverprofile coverage.out ./...
+go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
This outputs a `coverage.{html,out}` file for unit test coverage
inspection. I had to disable the race detection for now since it seems
that we introduced data races in our tests with the latest changes.