### PR TITLE
Add first part of changelog command implementation

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -12,12 +12,15 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/notes:go_default_library",
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
+        "@com_github_google_go_github_v28//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )
 

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +53,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.nomock, "nomock", false, "nomock flag")
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.cleanup, "cleanup", false, "cleanup flag")
-	rootCmd.PersistentFlags().StringVar(&rootOpts.repoPath, "repo", "", "the local path to the repository to be used")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.repoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'")
 }
 

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -187,6 +187,7 @@ func init() {
 				notes.RevisionDiscoveryModeNONE,
 				notes.RevisionDiscoveryModeMinorToLatest,
 				notes.RevisionDiscoveryModePatchToPatch,
+				notes.RevisionDiscoveryModeMinorToMinor,
 			}, ", "),
 		),
 	)

--- a/pkg/notes/options.go
+++ b/pkg/notes/options.go
@@ -49,6 +49,7 @@ const (
 	RevisionDiscoveryModeNONE          = "none"
 	RevisionDiscoveryModeMinorToLatest = "minor-to-latest"
 	RevisionDiscoveryModePatchToPatch  = "patch-to-patch"
+	RevisionDiscoveryModeMinorToMinor  = "minor-to-minor"
 )
 
 // NewOptions creates a new Options instance with the default values
@@ -83,14 +84,13 @@ func (o *Options) ValidateAndFinish() error {
 		var start, end string
 		if o.DiscoverMode == RevisionDiscoveryModeMinorToLatest {
 			start, end, err = repo.LatestNonPatchFinalToLatest()
-			if err != nil {
-				return err
-			}
 		} else if o.DiscoverMode == RevisionDiscoveryModePatchToPatch {
 			start, end, err = repo.LatestPatchToPatch(o.Branch)
-			if err != nil {
-				return err
-			}
+		} else if o.DiscoverMode == RevisionDiscoveryModeMinorToMinor {
+			start, end, err = repo.LatestNonPatchFinalToMinor()
+		}
+		if err != nil {
+			return err
 		}
 
 		o.StartSHA = start


### PR DESCRIPTION
We're now able to generate changelogs for the two needed use cases:

A patch release:

```
> go run cmd/krel/main.go changelog -t $TOKEN --tars $HOME/tars --branch release-1.16
INFO Using branch "release-1.16"
INFO Using discovery mode "patch-to-patch"
...
INFO Parsing latest tag v1.16.4
INFO Parsing previous tag v1.16.3
INFO discovered start SHA b3cbbae08ec52a7fc73d334838e18d17e8512749
INFO discovered end SHA 224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba
INFO fetching all commits. This might take a while...
INFO starting to process commit 1 of 56 (1.79%): 224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba
...
```

A minor release (no branch needed because the defalut is the `master` branch):

```
> go run cmd/krel/main.go changelog -t $TOKEN --tars $HOME/tars
INFO Using branch "master"
INFO Using discovery mode "minor-to-minor"
...
INFO latest non patch version v1.17.0
INFO previous non patch version v1.16.0
INFO discovered start SHA 2bd9643cee5b3b3a5ecbd3af49d09018f0773c77
INFO discovered end SHA 70132b0f130acc0bed193d9ba59dd186f0e634cf
INFO fetching all commits. This might take a while...
INFO starting to process commit 1 of 3065 (0.03%): a6f41a46a54c47e4225adbcca251ce8204f9bb1c
...
```

We still have to mangle the outputs together but this will be part of
another PR.