### PR TITLE
Add markdown creation support for krel changelog

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/notes:go_default_library",
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
+        "@com_github_blang_semver//:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -320,7 +320,7 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 		}
 
 		if _, err := output.WriteString(markdown); err != nil {
-			return errors.Wrapf(err, "writing output file")
+			return errors.Wrap(err, "writing output file")
 		}
 
 	default:


### PR DESCRIPTION
We're now able to create the CHANGELOG-x.y.md file for generated release
notes. If the file already exists, then we re-generate the table of
contents and merge them together.

#### Demo

Running:
```
> go run cmd/krel/main.go changelog -t $TOKEN --tars $HOME/downloads --branch release-1.16 -o $HOME/downloads
```
Results in the following markdown file:
````markdown
<!-- BEGIN MUNGE: GENERATED_TOC -->

- [v1.16.4](#v1164)
  - [Downloads for v1.16.4](#downloads-for-v1164)
    - [Client Binaries](#client-binaries)
    - [Server Binaries](#server-binaries)
    - [Node Binaries](#node-binaries)
  - [Changelog since v1.16.3](#changelog-since-v1163)
    - [API Changes](#api-changes)
    - [Notes from Multiple SIGs](#notes-from-multiple-sigs)
      - [SIG API Machinery, SIG Cloud Provider, and SIG Scalability](#sig-api-machinery-sig-cloud-provider-and-sig-scalability)
      - [SIG Apps, and SIG Network](#sig-apps-and-sig-network)
    - [Notes from Individual SIGs](#notes-from-individual-sigs)
      - [SIG API Machinery](#sig-api-machinery)
      - [SIG Cloud Provider](#sig-cloud-provider)
      - [SIG Cluster Lifecycle](#sig-cluster-lifecycle)
      - [SIG Network](#sig-network)

<!-- END MUNGE: GENERATED_TOC -->

# v1.16.4

[Documentation](https://docs.k8s.io)

## Downloads for v1.16.4

filename | sha512 hash
-------- | -----------

### Client Binaries

filename | sha512 hash
-------- | -----------

### Server Binaries

filename | sha512 hash
-------- | -----------

### Node Binaries

filename | sha512 hash
-------- | -----------

## Changelog since v1.16.3

### API Changes

...
````

Running it again merges contents correctly:
````markdown
<!-- BEGIN MUNGE: GENERATED_TOC -->

- [v1.16.4](#v1164)
  - [Downloads for v1.16.4](#downloads-for-v1164)
    - [Client Binaries](#client-binaries)
    - [Server Binaries](#server-binaries)
    - [Node Binaries](#node-binaries)
  - [Changelog since v1.16.3](#changelog-since-v1163)
    - [API Changes](#api-changes)
    - [Notes from Multiple SIGs](#notes-from-multiple-sigs)
      - [SIG API Machinery, SIG Cloud Provider, and SIG Scalability](#sig-api-machinery-sig-cloud-provider-and-sig-scalability)
      - [SIG Apps, and SIG Network](#sig-apps-and-sig-network)
    - [Notes from Individual SIGs](#notes-from-individual-sigs)
      - [SIG API Machinery](#sig-api-machinery)
      - [SIG Cloud Provider](#sig-cloud-provider)
      - [SIG Cluster Lifecycle](#sig-cluster-lifecycle)
      - [SIG Network](#sig-network)
- [v1.16.4](#v1164-1)
  - [Downloads for v1.16.4](#downloads-for-v1164-1)
    - [Client Binaries](#client-binaries-1)
    - [Server Binaries](#server-binaries-1)
    - [Node Binaries](#node-binaries-1)
  - [Changelog since v1.16.3](#changelog-since-v1163-1)
    - [API Changes](#api-changes-1)
    - [Notes from Multiple SIGs](#notes-from-multiple-sigs-1)
      - [SIG API Machinery, SIG Cloud Provider, and SIG Scalability](#sig-api-machinery-sig-cloud-provider-and-sig-scalability-1)
      - [SIG Apps, and SIG Network](#sig-apps-and-sig-network-1)
    - [Notes from Individual SIGs](#notes-from-individual-sigs-1)
      - [SIG API Machinery](#sig-api-machinery-1)
      - [SIG Cloud Provider](#sig-cloud-provider-1)
      - [SIG Cluster Lifecycle](#sig-cluster-lifecycle-1)
      - [SIG Network](#sig-network-1)

<!-- END MUNGE: GENERATED_TOC -->

# v1.16.4

[Documentation](https://docs.k8s.io)

...
````