### PR TITLE
Set start and end revisions on discovery and add unit tests

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -69,8 +69,6 @@ type changelogOptions struct {
 
 var changelogOpts = &changelogOptions{}
 
-const master = "master"
-
 func init() {
 	cobra.OnInitialize(initConfig)
 
@@ -78,7 +76,7 @@ func init() {
 		tarsFlag  = "tars"
 		tokenFlag = "token"
 	)
-	changelogCmd.PersistentFlags().StringVar(&changelogOpts.branch, "branch", master, "The target release branch. Leave it default for non-patch releases.")
+	changelogCmd.PersistentFlags().StringVar(&changelogOpts.branch, "branch", git.Master, "The target release branch. Leave it default for non-patch releases.")
 	changelogCmd.PersistentFlags().StringVar(&changelogOpts.bucket, "bucket", "kubernetes-release", "Specify gs bucket to point to in generated notes")
 	changelogCmd.PersistentFlags().StringVar(&changelogOpts.tars, tarsFlag, "", "Directory of tars to sha512 sum for display")
 	changelogCmd.PersistentFlags().StringVarP(&changelogOpts.token, tokenFlag, "t", "", "GitHub token for release notes retrieval")
@@ -94,7 +92,7 @@ func init() {
 }
 
 func runChangelog() (err error) {
-	branch := master
+	branch := git.Master
 	revisionDiscoveryMode := notes.RevisionDiscoveryModeMinorToMinor
 
 	if changelogOpts.branch != branch {

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -68,8 +68,7 @@ func runFf(opts *ffOptions) error {
 		return errors.New("Please specify valid release branch")
 	}
 	masterRef := opts.masterRef
-	master := "master"
-	remoteMaster := kgit.Remotify(master)
+	remoteMaster := kgit.Remotify(kgit.Master)
 
 	logrus.Infof("Preparing to fast-forward master@%s onto the %s branch", masterRef, branch)
 	repo, err := kgit.CloneOrOpenDefaultGitHubRepoSSH(rootOpts.repoPath, opts.org)
@@ -102,8 +101,8 @@ func runFf(opts *ffOptions) error {
 		defer repo.Cleanup() // nolint: errcheck
 	}
 
-	logrus.Infof("Finding merge base between %q and %q", master, branch)
-	mergeBase, err := repo.MergeBase(master, branch)
+	logrus.Infof("Finding merge base between %q and %q", kgit.Master, branch)
+	mergeBase, err := repo.MergeBase(kgit.Master, branch)
 	if err != nil {
 		return err
 	}

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/cmd/release-notes",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/git:go_default_library",
         "//pkg/notes:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
+	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/util"
 )
@@ -88,7 +89,7 @@ func init() {
 	cmd.PersistentFlags().StringVar(
 		&opts.Branch,
 		"branch",
-		util.EnvDefault("BRANCH", "master"),
+		util.EnvDefault("BRANCH", git.Master),
 		"Select which branch to scrape. Defaults to `master`",
 	)
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -386,18 +386,17 @@ func TestSuccessLatestPatchToPatch(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	start, end, err := testRepo.sut.LatestPatchToPatch(testRepo.branchName)
+	result, err := testRepo.sut.LatestPatchToPatch(testRepo.branchName)
 	require.Nil(t, err)
-	require.Equal(t, start, testRepo.firstBranchCommit)
-	require.Equal(t, end, testRepo.secondBranchCommit)
+	require.Equal(t, result.StartSHA(), testRepo.firstBranchCommit)
+	require.Equal(t, result.EndSHA(), testRepo.secondBranchCommit)
 }
 
 func TestFailureLatestPatchToPatchWrongBranch(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	start, end, err := testRepo.sut.LatestPatchToPatch("wrong-branch")
+	result, err := testRepo.sut.LatestPatchToPatch("wrong-branch")
 	require.NotNil(t, err)
-	require.Empty(t, start)
-	require.Empty(t, end)
+	require.Nil(t, result)
 }

--- a/pkg/notes/options.go
+++ b/pkg/notes/options.go
@@ -81,22 +81,25 @@ func (o *Options) ValidateAndFinish() error {
 			return err
 		}
 
-		var start, end string
+		var result *git.DiscoverResult
 		if o.DiscoverMode == RevisionDiscoveryModeMinorToLatest {
-			start, end, err = repo.LatestNonPatchFinalToLatest()
+			result, err = repo.LatestNonPatchFinalToLatest()
 		} else if o.DiscoverMode == RevisionDiscoveryModePatchToPatch {
-			start, end, err = repo.LatestPatchToPatch(o.Branch)
+			result, err = repo.LatestPatchToPatch(o.Branch)
 		} else if o.DiscoverMode == RevisionDiscoveryModeMinorToMinor {
-			start, end, err = repo.LatestNonPatchFinalToMinor()
+			result, err = repo.LatestNonPatchFinalToMinor()
 		}
 		if err != nil {
 			return err
 		}
 
-		o.StartSHA = start
-		o.EndSHA = end
-		logrus.Infof("discovered start SHA %s", start)
-		logrus.Infof("discovered end SHA %s", end)
+		o.StartSHA = result.StartSHA()
+		o.StartRev = result.StartRev()
+		o.EndSHA = result.EndSHA()
+		o.EndRev = result.EndRev()
+
+		logrus.Infof("discovered start %s (%s)", o.StartRev, o.StartSHA)
+		logrus.Infof("discovered end %s (%s)", o.EndRev, o.EndSHA)
 	}
 
 	// The start SHA is required.

--- a/pkg/notes/options.go
+++ b/pkg/notes/options.go
@@ -81,7 +81,7 @@ func (o *Options) ValidateAndFinish() error {
 			return err
 		}
 
-		var result *git.DiscoverResult
+		var result git.DiscoverResult
 		if o.DiscoverMode == RevisionDiscoveryModeMinorToLatest {
 			result, err = repo.LatestNonPatchFinalToLatest()
 		} else if o.DiscoverMode == RevisionDiscoveryModePatchToPatch {


### PR DESCRIPTION
This adds the missing unit tests as well as exposes the discovered revs in the notes options. This is necessary for further access of the revisions/tags in the changelog update PRs.