### PR TITLE
Fix minor-to-latest discovery mode start revision selection

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -69,28 +69,28 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 
 ## Options
 
-| Flag | Env Variable | Default Value | Required | Description |
-| --- | --- | --- | --- | --- |
+| Flag                    | Env Variable    | Default Value      | Required | Description                                                                                                                       |
+| ----------------------- | --------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | **GITHUB REPO OPTIONS** |
-| github-token | GITHUB_TOKEN | | Yes | A personal GitHub access token |
-| github-org | GITHUB_ORG | kubernetes | Yes | Name of GitHub organization |
-| github-repo | GITHUB_REPO | kubernetes | Yes | Name of GitHub repository |
-| required-author | REQUIRED_AUTHOR | k8s-ci-robot | Yes | Only commits from this GitHub user are considered. Set to empty string to include all users |
-| branch | BRANCH | master | Yes | The GitHub repository branch to scrape |
-| start-sha | START_SHA | | Yes | The commit hash to start processing from (inclusive) |
-| end-sha | END_SHA | | Yes | The commit hash to end processing at (inclusive) |
-| repo-path | REPO_PATH | /tmp/k8s-repo | No | Path to a local Kubernetes repository, used only for tag discovery |
-| start-rev | START_REV | | No | The git revision to start at. Can be used as alternative to start-sha |
-| env-rev | END_REV | | No | The git revision to end at. Can be used as alternative to end-sha |
-| discover | DISCOVER | none | No | The revision discovery mode for automatic revision retrieval (options: none, minor-to-latest) |
-| release-bucket | RELEASE_BUCKET | kubernetes-release | No | Specify gs bucket to point to in generated notes (default "kubernetes-release") |
-| release-tars | RELEASE_TARS | | No | Directory of tars to sha512 sum for display |
-| **OUTPUT OPTIONS** |
-| output | OUTPUT | | No | The path where the release notes will be written |
-| format | FORMAT | markdown | Yes | The format for notes output (options: markdown, json) |
-| release-version | RELEASE_VERSION | | No | The release version to tag the notes with |
-| **LOG OPTIONS** |
-| debug | DEBUG | false | No | Enable debug logging (options: true, false) |
+| github-token            | GITHUB_TOKEN    |                    | Yes      | A personal GitHub access token                                                                                                    |
+| github-org              | GITHUB_ORG      | kubernetes         | Yes      | Name of GitHub organization                                                                                                       |
+| github-repo             | GITHUB_REPO     | kubernetes         | Yes      | Name of GitHub repository                                                                                                         |
+| required-author         | REQUIRED_AUTHOR | k8s-ci-robot       | Yes      | Only commits from this GitHub user are considered. Set to empty string to include all users                                       |
+| branch                  | BRANCH          | master             | Yes      | The GitHub repository branch to scrape                                                                                            |
+| start-sha               | START_SHA       |                    | Yes      | The commit hash to start processing from (inclusive)                                                                              |
+| end-sha                 | END_SHA         |                    | Yes      | The commit hash to end processing at (inclusive)                                                                                  |
+| repo-path               | REPO_PATH       | /tmp/k8s-repo      | No       | Path to a local Kubernetes repository, used only for tag discovery                                                                |
+| start-rev               | START_REV       |                    | No       | The git revision to start at. Can be used as alternative to start-sha                                                             |
+| env-rev                 | END_REV         |                    | No       | The git revision to end at. Can be used as alternative to end-sha                                                                 |
+| discover                | DISCOVER        | none               | No       | The revision discovery mode for automatic revision retrieval (options: none, mergebase-to-latest, patch-to-patch, minor-to-minor) |
+| release-bucket          | RELEASE_BUCKET  | kubernetes-release | No       | Specify gs bucket to point to in generated notes (default "kubernetes-release")                                                   |
+| release-tars            | RELEASE_TARS    |                    | No       | Directory of tars to sha512 sum for display                                                                                       |
+| **OUTPUT OPTIONS**      |
+| output                  | OUTPUT          |                    | No       | The path where the release notes will be written                                                                                  |
+| format                  | FORMAT          | markdown           | Yes      | The format for notes output (options: markdown, json)                                                                             |
+| release-version         | RELEASE_VERSION |                    | No       | The release version to tag the notes with                                                                                         |
+| **LOG OPTIONS**         |
+| debug                   | DEBUG           | false              | No       | Enable debug logging (options: true, false)                                                                                       |
 
 ## Building From Source
 

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -187,7 +187,7 @@ func init() {
 		fmt.Sprintf("The revision discovery mode for automatic revision retrieval (options: %s)",
 			strings.Join([]string{
 				notes.RevisionDiscoveryModeNONE,
-				notes.RevisionDiscoveryModeMinorToLatest,
+				notes.RevisionDiscoveryModeMergeBaseToLatest,
 				notes.RevisionDiscoveryModePatchToPatch,
 				notes.RevisionDiscoveryModeMinorToMinor,
 			}, ", "),

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -102,7 +102,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	})
 	require.Nil(t, err)
 
-	firstTagName := "v0.1.0"
+	firstTagName := "v1.17.0"
 	firstTagRef, err := cloneRepo.CreateTag(firstTagName, firstCommit,
 		&git.CreateTagOptions{
 			Tagger:  author,
@@ -112,7 +112,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, err)
 
 	// Create a test branch and a test commit on top
-	branchName := "first-branch"
+	branchName := "release-1.17"
 	require.Nil(t, command.NewWithWorkDir(
 		cloneTempDir, "git", "checkout", "-b", branchName,
 	).RunSuccess())
@@ -412,11 +412,11 @@ func TestSuccessDry(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestSuccessLatestNonPatchFinalToLatest(t *testing.T) {
+func TestSuccessLatestReleaseBranchMergeBaseToLatest(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	result, err := testRepo.sut.LatestNonPatchFinalToLatest()
+	result, err := testRepo.sut.LatestReleaseBranchMergeBaseToLatest()
 	require.Nil(t, err)
 	require.Equal(t, result.StartSHA(), testRepo.firstCommit)
 	require.Equal(t, result.StartRev(), testRepo.firstTagName)
@@ -424,7 +424,7 @@ func TestSuccessLatestNonPatchFinalToLatest(t *testing.T) {
 	require.Equal(t, result.EndRev(), Master)
 }
 
-func TestFailureLatestNonPatchFinalToLatestNoLatestTag(t *testing.T) {
+func TestFailureLatestReleaseBranchMergeBaseToLatestNoLatestTag(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
@@ -432,7 +432,7 @@ func TestFailureLatestNonPatchFinalToLatestNoLatestTag(t *testing.T) {
 		testRepo.sut.Dir(), "git", "tag", "-d", testRepo.firstTagName,
 	).RunSuccess())
 
-	result, err := testRepo.sut.LatestNonPatchFinalToLatest()
+	result, err := testRepo.sut.LatestReleaseBranchMergeBaseToLatest()
 	require.NotNil(t, err)
 	require.Equal(t, DiscoverResult{}, result)
 }
@@ -441,7 +441,7 @@ func TestSuccessLatestNonPatchFinalToMinor(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	nextMinorTag := "v0.2.0"
+	nextMinorTag := "v1.18.0"
 	require.Nil(t, command.NewWithWorkDir(
 		testRepo.sut.Dir(), "git", "tag", nextMinorTag,
 	).RunSuccess())


### PR DESCRIPTION
The minor to latest discovery mode had no usage because it was not
assuming the correct start revision. From a process perspective, we have
to use the first RC (code freeze) of the latest minor release, because this
is the last time that the branch got synced with the master.

This is the same commit as the merge base of the previous release
branch, which we now use to provide a more clean technical solution.

We also rename the discovery mode to `mergebase-to-latest` to reflect
the new behavior.

Refers to https://github.com/kubernetes/sig-release/pull/937#issuecomment-571494816