### PR TITLE
Add changelog remote lookup feature

### DIFF
--- a/pkg/notes/options_test.go
+++ b/pkg/notes/options_test.go
@@ -357,6 +357,11 @@ func TestValidateAndFinishSuccessDiscoveryModePatchToPatch(t *testing.T) {
 	options := newTestOptions(t)
 	defer options.testRepo.cleanup(t)
 
+	nextMinorTag := "v1.17.1"
+	require.Nil(t, command.NewWithWorkDir(
+		options.testRepo.sut.Dir(), "git", "tag", nextMinorTag,
+	).RunSuccess())
+
 	options.Branch = options.testRepo.branchName
 	options.DiscoverMode = RevisionDiscoveryModePatchToPatch
 	require.Nil(t, options.ValidateAndFinish())


### PR DESCRIPTION
:tada: With this change we're pretty close to be able to replace the relnotes script and parts of anago with the `krel changelog` subcommand. Just one `TODO` left. :innocent: 

#### Description

We now correctly assume that a non-patch final version needs to have a
remote changelog available and failure if this one does not exist.

We also have to provide the target tag to the changelog subcommand to be
able to find the right release notes generation approach.

The git package has been adapted to contain a more robust way to
retrieve tags for a dedicated branch.

#### Demo

```bash
# A beta version provided. We now expect to generate the notes to the previous tag on the same branch (alpha, beta, rc)
> go run cmd/krel/main.go changelog -t $TOKEN --tars $TARS --tag v1.16.0-beta.2
# ...
INFO Found previous tag v1.16.0-beta.1
INFO Generating release notes
INFO cloning/updating repository to discover start or end sha
INFO using found start SHA: 92639f719ee353219fa2cd19128a93409bb3a1e3
INFO using found end SHA: 48ca054daba9e610f13c6d6bfcedf6c7de12b138
# ...

# A final version provided. We now expect to download the remote notes
> go run cmd/krel/main.go changelog -t $TOKEN --tars $TARS --tag v1.16.0
# ...
INFO Assuming new minor release
INFO Found release notes
# ...

# A patch release provided. We now expect to generate the notes to the previous patch on the same branch
> go run cmd/krel/main.go changelog -t $TOKEN --tars $TARS --tag v1.16.3
# ...
INFO Assuming new patch release
INFO cloning/updating repository to discover start or end sha
INFO using found start SHA: c97fe5036ef3df2967d086711e6c0c405941e14b
INFO using found end SHA: b3cbbae08ec52a7fc73d334838e18d17e8512749
# ...
```

All three runs will be merged together in one single `CHANGELOG-1.16.md` file, which looks like this:
https://gist.github.com/saschagrunert/b04e87ebfd7d4e632f91ecd61ed478b7#kubernetes-v1160-release-notes