### PR TITLE
Fix and adapt linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,11 @@
 run:
   concurrency: 6
   deadline: 5m
+issues:
+  exclude-rules:
+    - path: fake_client\.go
+      linters:
+        - gocritic
 linters:
   disable-all: true
   enable:
@@ -44,6 +49,11 @@ linters:
     # - scopelint
     # - wsl
 linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
   errcheck:
     check-type-assertions: true
     check-blank: true

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -206,7 +206,6 @@ func runPushBuild(opts *pushBuildOptions) error {
 
 	gcsDest := opts.releaseType
 
-	//nolint
 	// TODO: is this how we want to handle gcs dest args?
 	if opts.ci {
 		gcsDest = "ci"

--- a/cmd/kubepkg/cmd/debs.go
+++ b/cmd/kubepkg/cmd/debs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package cmd // nolint: dupl
 
 import (
 	"github.com/spf13/cobra"
@@ -26,9 +26,8 @@ import (
 type debsOptions struct {
 }
 
-//nolint
 // TODO: Determine if we need debsOpts
-var debsOpts = &debsOptions{}
+var debsOpts = &debsOptions{} // nolint: deadcode,varcheck,unused
 
 // debsCmd represents the base command when called without any subcommands
 var debsCmd = &cobra.Command{

--- a/cmd/kubepkg/cmd/rpms.go
+++ b/cmd/kubepkg/cmd/rpms.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package cmd // nolint: dupl
 
 import (
 	"github.com/spf13/cobra"
@@ -26,9 +26,8 @@ import (
 type rpmsOptions struct {
 }
 
-//nolint
 // TODO: Determine if we need rpmsOpts
-var rpmsOpts = &rpmsOptions{}
+var rpmsOpts = &rpmsOptions{} // nolint: deadcode,varcheck,unused
 
 // rpmsCmd represents the base command when called without any subcommands
 var rpmsCmd = &cobra.Command{

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -167,7 +167,6 @@ func init() {
 		"Only commits from this GitHub user are considered. Set to empty string to include all users",
 	)
 	if cmd.PersistentFlags().MarkDeprecated("requiredAuthor", "use '--required-author' instead") != nil {
-		//nolint
 		//TODO: remove 'requiredAuthor' after 2020-02-01 -- ¯\_(ツ)_/¯
 		// we are in init, can't do much here
 		panic("Unknown flag 'requiredAuthor'")

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -143,7 +143,6 @@ func ConstructBuilds(buildType BuildType, packages, channels []string, kubeVersi
 	builds := []Build{}
 
 	for _, pkg := range packages {
-		// nolint
 		// TODO: Get package directory for any version once package definitions are broken out
 		packageTemplateDir := filepath.Join(templateDir, pkg)
 		_, err := os.Stat(packageTemplateDir)
@@ -307,7 +306,6 @@ func (bc *buildConfig) run() error {
 		return err
 	}
 
-	//nolint:godox
 	// TODO: keepTmp/cleanup needs to defined in kubepkg root
 	if !bc.specOnly {
 		defer os.RemoveAll(specDirWithArch)
@@ -323,7 +321,6 @@ func (bc *buildConfig) run() error {
 		return nil
 	}
 
-	//nolint:godox
 	// TODO: Move OS-specific logic into their own files
 	switch bc.Type {
 	case BuildDeb:
@@ -648,7 +645,6 @@ func getCNIDownloadLink(packageDef *PackageDefinition, arch string) (string, err
 	return fmt.Sprintf("https://github.com/containernetworking/plugins/releases/download/v%s/cni-plugins-linux-%s-v%s.tgz", packageDef.Version, arch, packageDef.Version), nil
 }
 
-//nolint:godox
 // TODO: kubepkg is failing validations when multiple options are selected
 //       It seems like StringArrayVar is treating the multiple comma-separated values as a single value.
 //

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -79,7 +79,6 @@ func TestGetPackageVersionFailure(t *testing.T) {
 	a.Error(err)
 }
 
-//nolint:godox
 // TODO: Figure out how we want to test success of this function.
 //       When channel type is provided, we return a func() (string, error), instead of (string, error).
 //       Additionally, those functions have variable output depending on when we run the test cases.

--- a/pkg/notes/client.go
+++ b/pkg/notes/client.go
@@ -34,7 +34,6 @@ type Client interface {
 	ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
 	GetPullRequest(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error)
 
-	//nolint
 	// TODO: get rid of that method, currently only used in some test case
 	GetRepoCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error)
 }

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -485,7 +485,6 @@ func matchesIncludeFilter(msg string) *regexp.Regexp {
 // given commit SHA and ending at a given commit SHA. This function is similar
 // to ListCommits except that only commits with tagged release notes are
 // returned.
-//nolint
 //TODO: This name does not make sense anymore
 //TODO: Why is that method exported?
 func (g *Gatherer) ListCommitsWithNotes(commits []*github.RepositoryCommit) (filtered []*Result, err error) {
@@ -576,7 +575,7 @@ func (g *Gatherer) notesForCommit(commit *github.RepositoryCommit) (*Result, err
 				WithField("filter", re.String()).
 				Debug("Including notes for PR based on the inclusion filter.")
 
-			//TODO is this really intentional?
+			// TODO is this really intentional?
 			// Do not test further PRs for this commmit as soon as one PR matched
 			return res, nil
 		}

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -494,6 +494,7 @@ func checkCallCount(t *testing.T, what string, expected, actual int) {
 	}
 }
 
+// nolint: unparam
 func checkOrgRepo(t *testing.T, expectedOrg, expectedRepo, actualOrg, actualRepo string) {
 	t.Helper()
 

--- a/pkg/notes/options.go
+++ b/pkg/notes/options.go
@@ -36,11 +36,11 @@ type Options struct {
 	ReleaseVersion  string
 	Format          string
 	RequiredAuthor  string
-	Debug           bool
 	DiscoverMode    string
 	ReleaseBucket   string
 	ReleaseTars     string
 	TableOfContents bool
+	Debug           bool
 	gitCloneFn      func(string, string, string, bool) (*git.Repo, error)
 }
 


### PR DESCRIPTION
We fix some reported lints from the latest release of golangci lint. Beside this we exclude generated code and adapt the godox config to not report `TODO`s.