### PR TITLE
Add support for using arbitrary Go template when generating markdown.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,3 +133,5 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  gocyclo:
+    min-complexity: 31

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -87,7 +87,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | release-tars            | RELEASE_TARS    |                    | No       | Directory of tars to sha512 sum for display                                                                                       |
 | **OUTPUT OPTIONS**      |
 | output                  | OUTPUT          |                    | No       | The path where the release notes will be written                                                                                  |
-| format                  | FORMAT          | markdown           | Yes      | The format for notes output (options: markdown, json)                                                                             |
+| format                  | FORMAT          | markdown           | Yes      | The format for notes output (options: markdown, json, go-template:path/to/template.file)                                                                             |
 | release-version         | RELEASE_VERSION |                    | No       | The release version to tag the notes with                                                                                         |
 | **LOG OPTIONS**         |
 | debug                   | DEBUG           | false              | No       | Enable debug logging (options: true, false)                                                                                       |
@@ -125,6 +125,10 @@ cp ./bazel-bin/cmd/release-notes/darwin_amd64_stripped/release-notes /usr/local/
 
 Check out the rendering of 1.11's release notes [here](https://gist.github.com/marpaia/acfdb889f362195bb683e9e09ce196bc).
 
-### Why formats are supported?
+### What formats are supported?
 
-Right now the tool can output release notes in Markdown and JSON.
+Right now the tool can output release notes in Markdown and JSON. The tool
+also supports arbitrary formats using go-templates. The template has access
+to fields in the `Document` struct. For an example, see the default markdown
+template (`pkg/notes/internal/template.go`) used to render the stock format.
+

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.13
 require (
 	cloud.google.com/go v0.44.3
 	github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.4
+	github.com/bazelbuild/rules_go v0.22.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golangci/golangci-lint v1.23.3
 	github.com/google/go-github/v29 v29.0.3
 	github.com/google/uuid v1.1.1
+	github.com/kr/pretty v0.1.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bazelbuild/rules_go v0.22.1 h1:GRtyhztX3PNl4lhPhhn+eORpNfrFvygcVCQKgMv8lG8=
+github.com/bazelbuild/rules_go v0.22.1/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -188,6 +190,7 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a h1:GmsqmapfzSJkm28dhRoHz2tLRbJmqhU86IPgBtN3mmk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=

--- a/pkg/notes/document/BUILD.bazel
+++ b/pkg/notes/document/BUILD.bazel
@@ -14,8 +14,14 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["document_test.go"],
+    data = ["testdata/document.md.golden"],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+    deps = [
+        "//pkg/notes/internal:go_default_library",
+        "@com_github_kr_pretty//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -23,8 +23,157 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
+	"k8s.io/release/pkg/notes/internal"
 )
+
+func TestFileMetadata(t *testing.T) {
+	// Given
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	for _, file := range []string{
+		"kubernetes-client-darwin-386.tar.gz",
+		"kubernetes-client-darwin-amd64.tar.gz",
+		"kubernetes-client-linux-386.tar.gz",
+		"kubernetes-client-linux-amd64.tar.gz",
+		"kubernetes-client-linux-arm.tar.gz",
+		"kubernetes-client-linux-arm64.tar.gz",
+		"kubernetes-client-linux-ppc64le.tar.gz",
+		"kubernetes-client-linux-s390x.tar.gz",
+		"kubernetes-client-windows-386.tar.gz",
+		"kubernetes-client-windows-amd64.tar.gz",
+		"kubernetes-node-linux-amd64.tar.gz",
+		"kubernetes-node-linux-arm.tar.gz",
+		"kubernetes-node-linux-arm64.tar.gz",
+		"kubernetes-node-linux-ppc64le.tar.gz",
+		"kubernetes-node-linux-s390x.tar.gz",
+		"kubernetes-node-windows-amd64.tar.gz",
+		"kubernetes-server-linux-amd64.tar.gz",
+		"kubernetes-server-linux-arm.tar.gz",
+		"kubernetes-server-linux-arm64.tar.gz",
+		"kubernetes-server-linux-ppc64le.tar.gz",
+		"kubernetes-server-linux-s390x.tar.gz",
+		"kubernetes-src.tar.gz",
+		"kubernetes.tar.gz",
+	} {
+		require.Nil(t, ioutil.WriteFile(
+			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
+		))
+	}
+
+	fm := FileMetadata{}
+	metadata, err := fm.FetchMetadata(dir, "http://test.com", "test-release")
+	require.Nil(t, err)
+
+	expected := &FileMetadata{
+		Source: []File{
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes.tar.gz", URL: "http://test.com/test-release/kubernetes.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-src.tar.gz", URL: "http://test.com/test-release/kubernetes-src.tar.gz"},
+		},
+		Client: []File{
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-darwin-386.tar.gz", URL: "http://test.com/test-release/kubernetes-client-darwin-386.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-darwin-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-client-darwin-amd64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-386.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-386.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-amd64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-arm.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-arm.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-arm64.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-arm64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-ppc64le.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-ppc64le.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-linux-s390x.tar.gz", URL: "http://test.com/test-release/kubernetes-client-linux-s390x.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-windows-386.tar.gz", URL: "http://test.com/test-release/kubernetes-client-windows-386.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-client-windows-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-client-windows-amd64.tar.gz"},
+		},
+		Server: []File{
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-server-linux-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-server-linux-amd64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-server-linux-arm.tar.gz", URL: "http://test.com/test-release/kubernetes-server-linux-arm.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-server-linux-arm64.tar.gz", URL: "http://test.com/test-release/kubernetes-server-linux-arm64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-server-linux-ppc64le.tar.gz", URL: "http://test.com/test-release/kubernetes-server-linux-ppc64le.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-server-linux-s390x.tar.gz", URL: "http://test.com/test-release/kubernetes-server-linux-s390x.tar.gz"},
+		},
+		Node: []File{
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-linux-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-node-linux-amd64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-linux-arm.tar.gz", URL: "http://test.com/test-release/kubernetes-node-linux-arm.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-linux-arm64.tar.gz", URL: "http://test.com/test-release/kubernetes-node-linux-arm64.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-linux-ppc64le.tar.gz", URL: "http://test.com/test-release/kubernetes-node-linux-ppc64le.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-linux-s390x.tar.gz", URL: "http://test.com/test-release/kubernetes-node-linux-s390x.tar.gz"},
+			{Checksum: "27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29", Name: "kubernetes-node-windows-amd64.tar.gz", URL: "http://test.com/test-release/kubernetes-node-windows-amd64.tar.gz"},
+		},
+	}
+	require.Nil(t, pretty.Diff(metadata, expected))
+}
+
+func TestRenderMarkdownTemplate(t *testing.T) {
+	// Given
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	for _, file := range []string{
+		"kubernetes-client-darwin-386.tar.gz",
+		"kubernetes-client-darwin-amd64.tar.gz",
+		"kubernetes-client-linux-386.tar.gz",
+		"kubernetes-client-linux-amd64.tar.gz",
+		"kubernetes-client-linux-arm.tar.gz",
+		"kubernetes-client-linux-arm64.tar.gz",
+		"kubernetes-client-linux-ppc64le.tar.gz",
+		"kubernetes-client-linux-s390x.tar.gz",
+		"kubernetes-client-windows-386.tar.gz",
+		"kubernetes-client-windows-amd64.tar.gz",
+		"kubernetes-node-linux-amd64.tar.gz",
+		"kubernetes-node-linux-arm.tar.gz",
+		"kubernetes-node-linux-arm64.tar.gz",
+		"kubernetes-node-linux-ppc64le.tar.gz",
+		"kubernetes-node-linux-s390x.tar.gz",
+		"kubernetes-node-windows-amd64.tar.gz",
+		"kubernetes-server-linux-amd64.tar.gz",
+		"kubernetes-server-linux-arm.tar.gz",
+		"kubernetes-server-linux-arm64.tar.gz",
+		"kubernetes-server-linux-ppc64le.tar.gz",
+		"kubernetes-server-linux-s390x.tar.gz",
+		"kubernetes-src.tar.gz",
+		"kubernetes.tar.gz",
+	} {
+		require.Nil(t, ioutil.WriteFile(
+			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
+		))
+	}
+
+	doc := Document{
+		NotesWithActionRequired: []string{"If an API changes and no one documented it, did it really happen?"},
+		NotesUncategorized:      []string{"Someone somewhere did the world a great justice."},
+		NotesByKind: NotesByKind{
+			KindAPIChange:       []string{"This might make people sad...or happy."},
+			KindBug:             []string{"This will likely get you promoted."},
+			KindCleanup:         []string{"This usually does not get you promoted but it should."},
+			KindDeprecation:     []string{"Delorted."},
+			KindDesign:          []string{"Change the world."},
+			KindDocumentation:   []string{"There was  a library in Alexandria, Egypt once."},
+			KindFailingTest:     []string{"Please run presubmit test!"},
+			KindFeature:         []string{"This will get you promoted."},
+			KindFlake:           []string{"This *should* get you promoted."},
+			KindBugCleanupFlake: []string{"This should definitely get you promoted."},
+		},
+		PreviousRevision: "v1.16.0",
+		CurrentRevision:  "v1.16.1",
+	}
+
+	// When
+	goldenFile, err := bazel.Runfile(filepath.Join("testdata", "document.md.golden"))
+	require.Nil(t, err, "Locating runfiles are you using bazel test?")
+
+	b, err := ioutil.ReadFile(goldenFile)
+	require.Nil(t, err, "Reading golden file %q", goldenFile)
+	expected := string(b)
+
+	got, err := doc.RenderMarkdownTemplate("kubernetes-release", dir, internal.DefaultReleaseNotesTemplate)
+	require.Nil(t, err, "Rendering document")
+
+	// Then
+	require.Nil(t, pretty.Diff(expected, got), "Unexpected diff")
+}
 
 func TestCreateDownloadsTable(t *testing.T) {
 	// Given

--- a/pkg/notes/document/testdata/document.md.golden
+++ b/pkg/notes/document/testdata/document.md.golden
@@ -1,0 +1,93 @@
+# Release notes for v1.16.1
+
+[Documentation](https://docs.k8s.io/docs/home)
+
+## Downloads for v1.16.1
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-src.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-darwin-386.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-darwin-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-386.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-arm.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-arm64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-ppc64le.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-s390x.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-windows-386.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-windows-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-arm.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-arm64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-ppc64le.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-s390x.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-arm.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-arm64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-ppc64le.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-s390x.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-windows-amd64.tar.gz) | 27864cc5219a951a7a6e52b8c8dddf6981d098da1658d96258c870b2c88dfbcb51841aea172a28bafa6a79731165584677066045c959ed0f9929688d04defc29
+
+
+# Changelog since v1.16.0
+
+## Urgent Upgrade Notes 
+
+### (No, really, you MUST read this before you upgrade)
+
+ - If an API changes and no one documented it, did it really happen?
+ 
+## Changes by Kind
+
+### Other (Bug, Cleanup or Flake)
+ - This should definitely get you promoted.
+ 
+### API Change
+ - This might make people sad...or happy.
+ 
+### Bug
+ - This will likely get you promoted.
+ 
+### Cleanup
+ - This usually does not get you promoted but it should.
+ 
+### Deprecation
+ - Delorted.
+ 
+### Design
+ - Change the world.
+ 
+### Documentation
+ - There was  a library in Alexandria, Egypt once.
+ 
+### Failing Test
+ - Please run presubmit test!
+ 
+### Feature
+ - This will get you promoted.
+ 
+### Flake
+ - This *should* get you promoted.
+ 

--- a/pkg/notes/internal/BUILD.bazel
+++ b/pkg/notes/internal/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["retry.go"],
+    srcs = [
+        "retry.go",
+        "template.go",
+    ],
     importpath = "k8s.io/release/pkg/notes/internal",
     visibility = ["//pkg/notes:__subpackages__"],
     deps = [

--- a/pkg/notes/internal/template.go
+++ b/pkg/notes/internal/template.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+// DefaultReleaseNotesTemplate is the text template for the default release notes.
+// k8s/release/cmd/release-notes uses text/template to render markdown
+// templates.
+const DefaultReleaseNotesTemplate = `
+{{- $CurrentRevision := .CurrentRevision -}}
+{{- $PreviousRevision := .PreviousRevision -}}
+# Release notes for {{$CurrentRevision}}
+
+[Documentation](https://docs.k8s.io/docs/home)
+
+{{- with .Downloads}}
+
+## Downloads for {{$CurrentRevision}}
+
+{{- with .Source}}
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+{{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
+{{end}}
+
+{{- with .Client}}
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+{{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
+{{end}}
+
+{{- with .Server}}
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+{{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
+{{end}}
+
+{{- with .Node}}
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+{{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
+{{end}}
+{{end -}}
+
+# Changelog since {{$PreviousRevision}}
+
+{{with .NotesWithActionRequired -}}
+## Urgent Upgrade Notes 
+
+### (No, really, you MUST read this before you upgrade)
+
+{{range .}} {{println "-" .}} {{end}}
+{{end}}
+
+{{- with .NotesByKind -}}
+## Changes by Kind
+{{ range $kind, $notes := .}}
+### {{$kind | prettyKind}}
+{{range $note := $notes}} {{println "-" $note}} {{end -}}
+{{end -}}
+{{end -}}
+`

--- a/pkg/notes/options/BUILD.bazel
+++ b/pkg/notes/options/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/git:go_default_library",
         "//pkg/notes/client:go_default_library",
+        "//pkg/notes/internal:go_default_library",
         "@com_github_google_go_github_v29//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -22,6 +23,7 @@ go_test(
     deps = [
         "//pkg/command:go_default_library",
         "//pkg/git:go_default_library",
+        "//pkg/notes/internal:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",

--- a/repos.bzl
+++ b/repos.bzl
@@ -2045,3 +2045,11 @@ def go_repositories():
         sum = "h1:QtHYUjIdgXTtJVdYQhWIQZZoXa32aF3O9BNX2up2plE=",
         version = "v0.0.0-20190816221834-a9f1d8a9c101",
     )
+    go_repository(
+        name = "com_github_bazelbuild_rules_go",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/bazelbuild/rules_go",
+        sum = "h1:GRtyhztX3PNl4lhPhhn+eORpNfrFvygcVCQKgMv8lG8=",
+        version = "v0.22.1",
+    )


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
Adds the ability to render notes in markdown using a user-supplied template. A default template is supplied with this PR and is used by default when neither a template string or template file are specified.

This makes the tool less opinionated about the output format and gives the user a bit more control over the output. Wanting to customize the markdown output seems like a common use-case for this tool.

Additionally, users would not need to create wrappers around `kubernetes/release` just to customize their output (e.g. release-notes -> JSON -> Go template -> Desired output).

## Which issue(s) this PR fixes:

Partially addresses https://github.com/urfave/cli/issues/965

## Special notes for your reviewer:

Was hoping to get some guidance on the following:

1. The test keep failing due to cyclomatic complexity score of 31. Code seems to be okay where it's at and trying to lower this score doesn't seem to be adding much value. **Any suggestion on how to make this better and make the test pass?**
1. I'd like to delete all the old code for `RenderMarkdown` as it's redundant but that might break importers of that code. **How can we get rid of that code?**
2.  I'd like to add a test flag (say --update_golden_files) that would automatically update the `document.md.golden` file so we can keep the test update. I wasn't able to figure out how to get the flag through to the test case. **Do you think this is worth doing? If so, do you have an example of passing a flag into a test with bazel?**

This idea was originally [suggested](https://github.com/urfave/cli/issues/965#issuecomment-564713233) by @saschagrunert. 

## Does this PR introduce a user-facing change?:
```release-note
Adds a new option for the `--format=go-template:path/to/template.file` which allows a user to specify an arbitrary go-template file. If `--format` is `markdown` or `go-template:default` a default template is used to render the notes.
```
