### PR TITLE
anago: Ensure ordered releases by using a sorted release key array

### DIFF
--- a/anago
+++ b/anago
@@ -865,9 +865,9 @@ push_git_objects () {
   logrun -s git checkout master || return 1
 
   logecho "Pushing$dryrun_flag tags"
-  for b in ${!RELEASE_VERSION[@]}; do
-    logecho -n "* ${RELEASE_VERSION[$b]}: "
-    logrun -s git push$dryrun_flag origin ${RELEASE_VERSION[$b]} || return 1
+  for release_type in "${ORDERED_RELEASE_KEYS[@]}"; do
+    logecho -n "Pushing ${RELEASE_VERSION[$release_type]} tag: "
+    logrun -s git push$dryrun_flag origin ${RELEASE_VERSION[$release_type]} || return 1
   done
 
   if [[ "$RELEASE_BRANCH" =~ release- ]]; then
@@ -1684,7 +1684,7 @@ fi
 
 if [[ -z $STAGED_LOCATION ]]; then
   # Iterate over session release versions for setup, tagging and building
-  for label in ${!RELEASE_VERSION[@]}; do
+  for label in "${ORDERED_RELEASE_KEYS[@]}"; do
     common::run_stateful "prepare_tree $label" RELEASE_VERSION[$label]
     # This doesn't have to be done per label, but does need to be inserted
     # after an initial prepare_tree(), so just let the statefulness of it
@@ -1717,7 +1717,7 @@ if [[ -z $STAGED_LOCATION ]]; then
   # Complete the "build" for the gcb case
   if ((FLAGS_gcb)); then
     if ((FLAGS_stage)); then
-      for label in ${!RELEASE_VERSION[@]}; do
+      for label in "${ORDERED_RELEASE_KEYS[@]}"; do
         common::run_stateful "build_tree $label" RELEASE_VERSION[$label]
       done
     fi
@@ -1728,7 +1728,7 @@ if [[ -z $STAGED_LOCATION ]]; then
 else
   logecho
   # Force complete for these three stages
-  for label in ${!RELEASE_VERSION[@]}; do
+  for label in "${ORDERED_RELEASE_KEYS[@]}"; do
     SKIP_STEPS+=(prepare_tree+$label build_tree+$label)
     ((FLAGS_gcb)) && SKIP_STEPS+=(local_kube_cross make_cross+$label)
   done
@@ -1749,7 +1749,7 @@ else
 fi
 
 # Push for each release version of this session
-for label in ${!RELEASE_VERSION[@]}; do
+for label in "${ORDERED_RELEASE_KEYS[@]}"; do
   common::run_stateful "push_all_artifacts $label" RELEASE_VERSION[$label]
 done
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -357,6 +357,7 @@ release::set_release_version () {
   local label
   declare -A release_branch build_version
   declare -Ag RELEASE_VERSION
+  declare -ag ORDERED_RELEASE_KEYS
 
   if ! [[ $branch =~ $BRANCH_REGEX ]]; then
     logecho "Invalid branch format! $branch"
@@ -450,6 +451,40 @@ release::set_release_version () {
       logecho "RELEASE_VERSION[$label]=${RELEASE_VERSION[$label]}"
     done
     logecho "RELEASE_VERSION_PRIME=$RELEASE_VERSION_PRIME"
+  fi
+
+  # To ensure we're executing releases in the correct order, we append the keys
+  # of the RELEASE_VERSION associative array in the order that we explicitly
+  # prefer: official, rc, beta, alpha
+  #
+  # In anago, we will then iterate over the keys in the ORDERED_RELEASE_KEYS
+  # array and where necessary use these elements to access the underlying values
+  # of the RELEASE_VERSION associative array.
+  #
+  # Example:
+  #
+  # for release_type in "${ORDERED_RELEASE_KEYS[@]}"; do
+  #  echo "Doing the $release stuff (${RELEASE_VERSION[$release_type]})"
+  # done
+  #
+  #
+  # More on manipulating associative arrays:
+  # https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Arrays
+
+  if [[ ${RELEASE_VERSION[official]} ]]; then
+    ORDERED_RELEASE_KEYS+=("official")
+  fi
+
+  if [[ ${RELEASE_VERSION[rc]} ]]; then
+    ORDERED_RELEASE_KEYS+=("rc")
+  fi
+
+  if [[ ${RELEASE_VERSION[beta]} ]]; then
+    ORDERED_RELEASE_KEYS+=("beta")
+  fi
+
+  if [[ ${RELEASE_VERSION[alpha]} ]]; then
+    ORDERED_RELEASE_KEYS+=("alpha")
   fi
 
   return 0


### PR DESCRIPTION
Depending on the type of Kubernetes release we run with anago, we may be
cutting multiple releases and creating multiple tags on GitHub.

For point zero and patch releases (vx.y.z), we first run an "official"
release, followed by the next beta for that release branch
(vx.y.(z+1)-beta.0).

For the first beta of a cycle (vx.y.z-beta.0), we cut a release branch
(release-x.y) and push the next alpha tag to the master branch
(vx.(y+1).z-alpha.1).

For these activities to happen correctly, the process must run in the
correct order: official --> rc --> beta --> alpha

Prior to this commit, in several steps, we were iterating over the
RELEASE_VERSION associative array with the syntax
${!RELEASE_VERSION[@]}. Iterating over an associative array does not
guarantee ordering.

To fix this, we create a new non-associative array,
ORDERED_RELEASE_KEYS, which holds the ordered keys of RELEASE_VERSION.

From there, we then refactor each of the iterators using
${!RELEASE_VERSION[@]} to instead use ${ORDERED_RELEASE_KEYS[@]} and use
the keys therein to access the underlying values in RELEASE_VERSION.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper
cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/kubernetes/issues/86182
/priority critical-urgent
/kind bug cleanup

/hold for testing