### PR TITLE
[k8s-cloud-builder] Add gcc to image to support multi-arch (cross-building)

### DIFF
--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -2,6 +2,7 @@
 timeout: 7200s
 steps:
 - name: 'gcr.io/cloud-builders/git'
+  id: pull-k8s
   dir: 'go/src/k8s.io'
   args:
   - clone
@@ -9,6 +10,7 @@ steps:
   - ${_KUBERNETES_REPO}
 
 - name: 'gcr.io/cloud-builders/git'
+  id: pull-release
   dir: 'go/src/k8s.io'
   args:
   - clone
@@ -16,18 +18,21 @@ steps:
   - ${_RELEASE_TOOL_REPO}
 
 - name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  id: prepare
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - clean
 
 - name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  id: build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - "${_RELEASE_TYPE}"
 
 - name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+  id: push-build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - ../release/push-build.sh

--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
   - clone
   - --branch=${_KUBERNETES_BRANCH}
   - ${_KUBERNETES_REPO}
+  waitFor: [ '-' ]
 
 - name: 'gcr.io/cloud-builders/git'
   id: pull-release
@@ -16,6 +17,7 @@ steps:
   - clone
   - --branch=${_RELEASE_TOOL_BRANCH}
   - ${_RELEASE_TOOL_REPO}
+  waitFor: [ '-' ]
 
 - name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
   id: prepare

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/kube-cross:v1.13.4-1
 
+##------------------------------------------------------------
+# global ARGs & ENVs
 ARG DEBIAN_FRONTEND=noninteractive
+
+##------------------------------------------------------------
+FROM k8s.gcr.io/kube-cross:v1.13.4-1
 
 RUN apt-get -q update
 
@@ -90,8 +94,6 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
 
 # Cleanup a bit
 RUN apt-get -qqy remove \
-        gcc \
-        'cpp.*' \
         wget \
     && rm -rf -- \
         /var/lib/apt/lists/* \

--- a/images/k8s-cloud-builder/cloudbuild.yaml
+++ b/images/k8s-cloud-builder/cloudbuild.yaml
@@ -4,12 +4,14 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: gcr.io/cloud-builders/docker
+    id: build
     args:
     - build
-    - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}
     - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:latest
     - .
   - name: gcr.io/gcp-runtimes/container-structure-test
+    id: test
     args:
     - test
     - --image=gcr.io/$PROJECT_ID/k8s-cloud-builder:latest
@@ -20,5 +22,5 @@ substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
 images:
-  - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:latest'

--- a/images/k8s-cloud-builder/test.yaml
+++ b/images/k8s-cloud-builder/test.yaml
@@ -41,6 +41,12 @@ commandTests:
   - go
   - gsutil
   - yq
+  # for multiarch support / cross building
+  - gcc
+  - arm-linux-gnueabihf-gcc
+  - aarch64-linux-gnu-gcc
+  - powerpc64le-linux-gnu-gcc
+  - s390x-linux-gnu-gcc
   setup:
   -
     - bash


### PR DESCRIPTION
For `make release-in-a-container` to work, we need gcc and the cross build toolchains for the supported archs. As our builder image is based on the cross build image, we already got that. The only thing we need to do is not to be so strict when cleaning up the image.

One solution, as proposed here with this PR is to just not be so strict when cleaning up the images and leave the cross build toolchains from the cross build image in the k8s-cloud-builder image.

Other options:
- Maintain 2 images, one with the cross build toolchains (e.g. `k8s-cloud-builder:multiarch`), the other without (e.g. `k8s-cloud-builder:main`)
- in gcb/build use the cross build image instead of the k8s-cloud-builder
- *... probably more ...*

(I got annoyed by all the red stuff in https://console.cloud.google.com/cloud-build/builds?project=k8s-staging-release-test when checking on something else)

/kind failing-test
/area release-eng
/priority important-longterm
/cc @justaugustus 