### PR TITLE
kubepkg: Update inputs and expected values for TestFetchVersionSuccess

### DIFF
--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -128,13 +128,13 @@ func TestFetchVersionSuccess(t *testing.T) {
 	}{
 		{
 			name:     "Release URL",
-			url:      "https://dl.k8s.io/release/stable-1.14.txt",
-			expected: "1.14.10",
+			url:      "https://dl.k8s.io/release/stable-1.13.txt",
+			expected: "1.13.12",
 		},
 		{
 			name:     "CI URL",
 			url:      "https://dl.k8s.io/ci/latest-1.14.txt",
-			expected: "1.14.11-beta.1",
+			expected: "1.14.11-beta.1.2+c8b135d0b49c44",
 		},
 	}
 


### PR DESCRIPTION
The test was targeted against what we thought was going to be an
entirely out of support Kubernetes version (1.14), but we needed to
push additional no-op content to release-1.14 in order to cut another
1.14 release to fix skew tests on the release-1.15 branch.

We update the final CI versions here.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper 
/priority critical-urgent
ref: https://github.com/kubernetes/release/pull/1021, https://github.com/kubernetes/kubernetes/issues/86182