### PR TITLE
Restore checked out branch in krel changelog

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -159,6 +159,17 @@ func runChangelog() (err error) {
 		return err
 	}
 
+	// Restore the currently checked out branch
+	currentBranch, err := repo.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := repo.CheckoutBranch(currentBranch); err != nil {
+			logrus.Errorf("unable to restore branch %s: %v", currentBranch, err)
+		}
+	}()
+
 	if err := repo.CheckoutBranch(git.Master); err != nil {
 		return errors.Wrap(err, "checking out master branch")
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -639,3 +639,30 @@ func (r *Repo) Commit(msg string) error {
 	}
 	return nil
 }
+
+// CurrentBranch returns the current branch of the repository or an error in
+// case of any failure
+func (r *Repo) CurrentBranch() (branch string, err error) {
+	branches, err := r.inner.Branches()
+	if err != nil {
+		return "", err
+	}
+
+	head, err := r.inner.Head()
+	if err != nil {
+		return "", err
+	}
+
+	if err := branches.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Hash() == head.Hash() {
+			branch = ref.Name().Short()
+			return nil
+		}
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return branch, nil
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -577,3 +577,22 @@ func TestCommitSuccess(t *testing.T) {
 	require.Contains(t, res.Output(), "Author: Anago GCB <nobody@k8s.io>")
 	require.Contains(t, res.Output(), commitMessage)
 }
+
+func TestCurrentBranchDefault(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	branch, err := testRepo.sut.CurrentBranch()
+	require.Nil(t, err)
+	require.Equal(t, testRepo.branchName, branch)
+}
+
+func TestCurrentBranchMaster(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+	require.Nil(t, testRepo.sut.CheckoutBranch(Master))
+
+	branch, err := testRepo.sut.CurrentBranch()
+	require.Nil(t, err)
+	require.Equal(t, Master, branch)
+}


### PR DESCRIPTION
Since we cannot know which checked out branch the user expects after the
usage of `krel changelog` we now restore the initially set branch.