### PR TITLE
anago: Unconditionally add an empty commit prior to release tagging

### DIFF
--- a/anago
+++ b/anago
@@ -625,11 +625,14 @@ prepare_tree () {
   # Ensure a common name for label in case we're using the special beta indexes
   [[ "$label" =~ ^beta ]] && label_common="beta"
 
-  # Ensure any beta tag is on a unique commit by making a commit here:
-  if [[ "$label_common" == "beta" ]]; then
-    logecho "Making a unique commit for tag ${RELEASE_VERSION[$label]}"
-    logrun git commit --allow-empty -m "k/release issue #1020 workaround: ${RELEASE_VERSION[$label]}" || return 1
-  fi
+  # Ensure all release types are tagged on a unique commit
+  # Instead of only creating a release commit when we tag a beta, we should do it unconditionally.
+  # This removes any ambiguity about when an empty commit is or isn't added.
+  #
+  # ref: kubernetes/release#1020, kubernetes/release#1030
+  logecho "Creating an empty release commit for tag ${RELEASE_VERSION[$label]}"
+  logrun git commit --allow-empty -m "Release commit for Kubernetes ${RELEASE_VERSION[$label]}" \
+    || return 1
 
   # Tagging
   commit_string="Kubernetes $label_common release ${RELEASE_VERSION[$label]}"


### PR DESCRIPTION
Ensure all release types are tagged on a unique commit.
Instead of only creating a release commit when we tag a beta, we should 
do it unconditionally.

This removes any ambiguity about when an empty commit is or isn't added.

Follow-up to #1021 
ref: #1020 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>