### PR TITLE
WIP: Add GITHUB_TOKEN to releng-ci-bazel container image

### DIFF
--- a/images/releng-ci-bazel/cloudbuild.yaml
+++ b/images/releng-ci-bazel/cloudbuild.yaml
@@ -1,10 +1,30 @@
 ---
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 1200s
+
+#### SECURITY NOTICE ####
+# Google Cloud Build (GCB) supports the usage of secrets for build requests.
+# Secrets appear within GCB configs as base64-encoded strings.
+# These secrets are GCP Cloud KMS-encrypted and cannot be decrypted by any
+# human or system outside of GCP Cloud KMS for the GCP project this encrypted
+# resource was created for.  Seeing the base64-encoded encrypted blob here is
+# not a security event for the project.
+# More details on using encrypted resources on Google Cloud Build can be found
+# here:
+# https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials
+#
+# (Please do not remove this security notice.)
+secrets:
+  - kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+    secretEnv:
+      GITHUB_TOKEN: <TOKEN>
+
 options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: gcr.io/cloud-builders/docker
+    secretEnv:
+      - GITHUB_TOKEN
     args:
       - build
       - --tag=gcr.io/$PROJECT_ID/releng-ci-bazel:$_GIT_TAG


### PR DESCRIPTION
This is needed to run changelog e2e/integration tests within the CI.

Needed by: https://github.com/kubernetes/release/pull/1023