### PR TITLE
[testgridshot] Fix after testgrid changed the summary endpoint

### DIFF
--- a/testgridshot
+++ b/testgridshot
@@ -109,10 +109,10 @@ get_tests_by_status() {
       return 1
     }
 
-    jq --arg status "$status" -r '
+    jq --arg status "$status" --arg board "$board" -r '
       to_entries[]
         | select(.value.overall_status==$status)
-        | .value.dashboard_name + "#" + .key
+        | $board + "#" + .key
     ' <<< "$summary"
   done
 }


### PR DESCRIPTION
`testgrid` seems to not populate the field `dashboard_name` anymore, so
we cannot rely on that.

/kind bug
/area release-eng
/assign @cpanato