### PR TITLE
Add GO111MODULE environment variable to example

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -7,7 +7,7 @@ This directory contains a tool called `release-notes` and a set of library utili
 The simplest way to install the `release-notes` CLI is via `go get`:
 
 ```
-go get k8s.io/release/cmd/release-notes
+GO111MODULE=on go get k8s.io/release/cmd/release-notes
 ```
 
 This will install `release-notes` to `$(go env GOPATH)/bin/release-notes`.


### PR DESCRIPTION
Without this enabled, current versions of Go will give an error when following these instructions.