### PR TITLE
Add log filename hook to krel/release-notes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "//pkg/command:all-srcs",
         "//pkg/git:all-srcs",
         "//pkg/kubepkg:all-srcs",
+        "//pkg/log:all-srcs",
         "//pkg/notes:all-srcs",
         "//pkg/release:all-srcs",
         "//pkg/util:all-srcs",

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/log:go_default_library",
         "//pkg/notes:go_default_library",
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -68,6 +70,7 @@ func initLogging(*cobra.Command, []string) error {
 		return err
 	}
 	logrus.SetLevel(lvl)
+	logrus.AddHook(log.NewFilenameHook())
 	logrus.Debugf("Using log level %q", lvl)
 	return nil
 }

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/log:go_default_library",
         "//pkg/notes:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/log"
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/util"
 )
@@ -344,6 +345,7 @@ func run(*cobra.Command, []string) error {
 
 func main() {
 	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logrus.AddHook(log.NewFilenameHook())
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/log/BUILD.bazel
+++ b/pkg/log/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hooks.go"],
+    importpath = "k8s.io/release/pkg/log",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/log/hooks.go
+++ b/pkg/log/hooks.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type FileNameHook struct {
+	field      string
+	skipPrefix []string
+	formatter  logrus.Formatter
+	Formatter  func(file, function string, line int) string
+}
+
+type wrapper struct {
+	old  logrus.Formatter
+	hook *FileNameHook
+}
+
+// NewFilenameHook creates a new default FileNameHook
+func NewFilenameHook() *FileNameHook {
+	return &FileNameHook{
+		field:      "file",
+		skipPrefix: []string{"log/", "logrus/", "logrus@"},
+		Formatter: func(file, function string, line int) string {
+			return fmt.Sprintf("%s:%d", file, line)
+		},
+	}
+}
+
+// Levels returns the levels for which the hook is activated. This contains
+// currently only the DebugLevel
+func (f *FileNameHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire executes the hook for every logrus entry
+func (f *FileNameHook) Fire(entry *logrus.Entry) error {
+	if f.formatter != entry.Logger.Formatter {
+		f.formatter = &wrapper{entry.Logger.Formatter, f}
+	}
+	entry.Logger.Formatter = f.formatter
+	return nil
+}
+
+// Format returns the log format including the caller as field
+func (w *wrapper) Format(entry *logrus.Entry) ([]byte, error) {
+	field := entry.WithField(
+		w.hook.field,
+		w.hook.Formatter(w.hook.findCaller()),
+	)
+	field.Level = entry.Level
+	field.Message = entry.Message
+	return w.old.Format(field)
+}
+
+// findCaller returns the file, function and line number for the current call
+func (f *FileNameHook) findCaller() (file, function string, line int) {
+	var pc uintptr
+	// The maximum amount of frames to be iterated
+	const maxFrames = 10
+	for i := 0; i < maxFrames; i++ {
+		// The amount of frames to be skipped to land at the actual caller
+		const skipFrames = 5
+		pc, file, line = caller(skipFrames + i)
+		if !f.shouldSkipPrefix(file) {
+			break
+		}
+	}
+	if pc != 0 {
+		frames := runtime.CallersFrames([]uintptr{pc})
+		frame, _ := frames.Next()
+		function = frame.Function
+	}
+
+	return file, function, line
+}
+
+// caller reports file and line number information about function invocations
+// on the calling goroutine's stack. The argument skip is the number of stack
+// frames to ascend, with 0 identifying the caller of Caller.
+func caller(skip int) (pc uintptr, file string, line int) {
+	ok := false
+	pc, file, line, ok = runtime.Caller(skip)
+	if !ok {
+		return 0, "", 0
+	}
+
+	n := 0
+	for i := len(file) - 1; i > 0; i-- {
+		if file[i] == '/' {
+			n++
+			if n >= 2 {
+				file = file[i+1:]
+				break
+			}
+		}
+	}
+
+	return pc, file, line
+}
+
+// shouldSkipPrefix returns true if the hook should be skipped, otherwise false
+func (f *FileNameHook) shouldSkipPrefix(file string) bool {
+	for i := range f.skipPrefix {
+		if strings.HasPrefix(file, f.skipPrefix[i]) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The log filename hook adds a new field to every log indicating the file
location of the log:

```
INFO my message  file="notes/notes.go:520"
```
