### PR TITLE
Add git -rm CHANGELOG-*.md to krel changelog

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -62,7 +62,9 @@ the golang based 'release-notes' tool:
    announcement is done by another subcommand of 'krel', not "changelog'.
 
 3. Commit the modified CHANGELOG-x.y.md into the master branch as well as the
-   corresponding release-branch of kubernetes/kubernetes.
+   corresponding release-branch of kubernetes/kubernetes. The release branch
+   will be pruned from all other CHANGELOG-*.md files which do not belong to
+   this release branch.
 `,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -401,6 +403,11 @@ func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
 	// Release branch modifications
 	if err := repo.CheckoutBranch(branch); err != nil {
 		return errors.Wrapf(err, "checking out release branch %s", branch)
+	}
+
+	// Remove all other changelog files
+	if err := repo.Rm(true, "CHANGELOG-*.md"); err != nil {
+		return errors.Wrap(err, "unable to remove CHANGELOG-*.md files")
 	}
 
 	logrus.Info("Checking out changelog from master branch")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -693,3 +693,16 @@ func (r *Repo) CurrentBranch() (branch string, err error) {
 
 	return branch, nil
 }
+
+// Rm removes files from the repository
+func (r *Repo) Rm(force bool, files ...string) error {
+	args := []string{"rm"}
+	if force {
+		args = append(args, "-f")
+	}
+	args = append(args, files...)
+
+	return command.
+		NewWithWorkDir(r.Dir(), gitExecutable, args...).
+		RunSilentSuccess()
+}


### PR DESCRIPTION
The anago script removes all unrelated CHANGELOG-*.md files so krel
changelog needs to have this feature as well.

Testing in the git repo has been adapted as well.
