### PR TITLE
Fix golangci-lint CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,9 @@ linters:
     - typecheck
     - unconvert
     - unparam
-    - unused
+    # TODO: re-enable if https://github.com/golangci/golangci-lint/issues/827
+    #       is closed
+    # - unused
     - varcheck
     - whitespace
     # - funlen


### PR DESCRIPTION
It looks like we're hitting the same issue as described in:
https://github.com/golangci/golangci-lint/issues/827

As a workaround, we now disable the unused linter for now.