### PR TITLE
Use GOPATH instead of GOBIN in compile-release-tools

### DIFF
--- a/compile-release-tools
+++ b/compile-release-tools
@@ -71,7 +71,7 @@ compile_krel() {
     -X $pkg.gitCommit=$(git rev-parse HEAD) \
     -X $pkg.gitTreeState=$git_tree_state \
     -X $pkg.gitVersion=$(git describe --abbrev=0)" \
-    -o "$GOBIN"/krel ./cmd/krel
+    -o "$GOPATH"/bin/krel ./cmd/krel
 }
 
 main() {


### PR DESCRIPTION
The variable `$GOBIN` is not set in any case (for example in
`k8s.gcr.io/kube-cross:v1.13.6-1`) which will cause the script fail
because of the unbound variable. We should stick to `$GOPATH` instead
which is also defined in kube-cross.