### PR TITLE
Add `krel version` precheck to anago

### DIFF
--- a/anago
+++ b/anago
@@ -395,6 +395,9 @@ check_prerequisites () {
   for rb in ${WRITE_RELEASE_BUCKETS[*]}; do
     release::gcs::check_release_bucket $rb || return 1
   done
+
+  logecho -n "Checking the availability of krel: "
+  logrun -s krel version || return 1
 }
 
 ###############################################################################


### PR DESCRIPTION
To verify which version of krel we are using in anago, we now add a
`krel version` precheck to it.

Question: Do we have to rebuild the container images to have krel available?