### PR TITLE
Repo update should persist repo state

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -169,12 +169,12 @@ func runChangelog() (err error) {
 		return err
 	}
 	defer func() {
-		if err := repo.CheckoutBranch(currentBranch); err != nil {
+		if err := repo.Checkout(currentBranch); err != nil {
 			logrus.Errorf("unable to restore branch %s: %v", currentBranch, err)
 		}
 	}()
 
-	if err := repo.CheckoutBranch(git.Master); err != nil {
+	if err := repo.Checkout(git.Master); err != nil {
 		return errors.Wrap(err, "checking out master branch")
 	}
 
@@ -386,7 +386,7 @@ func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
 	}
 
 	// Release branch modifications
-	if err := repo.CheckoutBranch(branch); err != nil {
+	if err := repo.Checkout(branch); err != nil {
 		return errors.Wrapf(err, "checking out release branch %s", branch)
 	}
 

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -92,7 +92,7 @@ func runFf(opts *ffOptions) error {
 	}
 
 	logrus.Info("Checking out release branch")
-	if err := repo.CheckoutBranch(branch); err != nil {
+	if err := repo.Checkout(branch); err != nil {
 		return err
 	}
 

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -98,7 +98,7 @@ func (c *Command) RunSuccess() (err error) {
 		return err
 	}
 	if !res.Success() {
-		return errors.Errorf("command %v did not succeed", c.String())
+		return errors.Errorf("command %v did not succeed: %v", c.String(), res.Error())
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func (c *Command) RunSilentSuccess() (err error) {
 		return err
 	}
 	if !res.Success() {
-		return errors.Errorf("command %v did not succeed", c.String())
+		return errors.Errorf("command %v did not succeed: %v", c.String(), res.Error())
 	}
 	return nil
 }

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
-        "@in_gopkg_src_d_go_git_v4//config:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing/object:go_default_library",
         "@in_gopkg_src_d_go_git_v4//plumbing/storer:go_default_library",

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -591,7 +591,7 @@ func TestCurrentBranchDefault(t *testing.T) {
 func TestCurrentBranchMaster(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
-	require.Nil(t, testRepo.sut.CheckoutBranch(git.Master))
+	require.Nil(t, testRepo.sut.Checkout(git.Master))
 
 	branch, err := testRepo.sut.CurrentBranch()
 	require.Nil(t, err)


### PR DESCRIPTION
The update of a repository will cause the issue that all local changes
will be overwritten. This is not a desired behavior and we will now
update the repo with a usual "pull --rebase --autostash". This also
changes the way how we have to checkout branches because the go-git
implementation will now work any more with that new strategy. For now we
use the simple "git checkout" shell-out command which seems to have a
more robust implementation.