### PR TITLE
Fix compile-release-tools execution for GCB builds

### DIFF
--- a/anago
+++ b/anago
@@ -397,7 +397,7 @@ check_prerequisites () {
   done
 
   logecho -n "Checking the availability of krel: "
-  logrun -s krel version || return 1
+  logrun -v -s krel version || return 1
 }
 
 ###############################################################################
@@ -406,7 +406,7 @@ PROGSTEP[generate_release_notes]="GENERATE RELEASE NOTES"
 generate_release_notes () {
   local release_tars=$TREE_ROOT/_output-$RELEASE_VERSION_PRIME/release-tars
 
-  logrun krel changelog \
+  logrun -v krel changelog \
     --repo "$TREE_ROOT" \
     --tars "$release_tars" \
     --tag "$RELEASE_VERSION_PRIME" \
@@ -1433,8 +1433,18 @@ if [[ -z "${BASEDIR}" ]]; then
   BASEDIR="$HOME/anago"
 fi
 
+BINDIR="$BASEDIR/bin"
+
+if [[ -z "$BINDIR" ]]; then
+  logrun -v mkdir -p "$BINDIR"
+fi
+
 # make sure we have the compiled bins in the path
-export PATH="${PATH}:${BASEDIR}/bin"
+export PATH="$PATH:$BINDIR"
+logecho "PATH: $PATH"
+
+# List binaries
+logrun -v ls -al "$BINDIR"
 
 ##############################################################################
 # Initialize logs
@@ -1559,7 +1569,9 @@ else
 fi
 
 # Go tools expect the kubernetes src to be under $GOPATH
-export GOPATH=$WORKDIR
+export GOPATH="$WORKDIR"
+logecho "GOPATH: $GOPATH"
+
 # TOOL_ROOT is release/
 # TREE_ROOT is working branch/tree
 TREE_ROOT=$WORKDIR/src/k8s.io/kubernetes

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -21,16 +21,21 @@ set -o pipefail
 RELEASE_TOOLS=(
   blocking-testgrid-tests
   kubepkg
-  release-notes
+  krel
 )
 
 setup_env() {
   echo "Setting up environment..."
 
-  if [ -n "${GOBIN:-}" ]
-  then
-    export PATH="${PATH}:${GOBIN}"
+  if [[ -z "${RELEASE_TOOL_BIN:-}" ]]; then
+    if [ -n "${GOBIN:-}" ]; then
+      export RELEASE_TOOL_BIN="${GOBIN}"
+    else
+      export RELEASE_TOOL_BIN="${GOPATH}/bin"
+    fi
   fi
+
+  export PATH="${PATH}:${RELEASE_TOOL_BIN}"
 }
 
 compile() {
@@ -55,23 +60,27 @@ check_deps() {
   go list -u -m -json all | go-mod-outdated "${gmo_args[@]}"
 }
 
-compile_krel() {
+compile_with_flags() {
   local git_tree_state
   local pkg
+  local tool="$1"
 
-  git_tree_state=clean
+  git_tree_state=dirty
   pkg=k8s.io/release/pkg/version
 
-  if git status --porcelain --untracked-files=no; then
-    git_tree_state=dirty
+  if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then
+    git_tree_state=clean
   fi
 
-  go build -ldflags "-s -w \
+  go build -v -ldflags "-s -w \
     -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     -X $pkg.gitCommit=$(git rev-parse HEAD) \
     -X $pkg.gitTreeState=$git_tree_state \
     -X $pkg.gitVersion=$(git describe --abbrev=0)" \
-    -o "$GOPATH"/bin/krel ./cmd/krel
+    -o "$RELEASE_TOOL_BIN/$tool" "./cmd/$tool" \
+    || return 1
+
+  echo "$tool was successfully compiled and installed to $RELEASE_TOOL_BIN/$tool"
 }
 
 main() {
@@ -82,14 +91,13 @@ main() {
 
   if [ $# -gt 0 ]; then
     for tool in "$@"; do
-      compile "k8s.io/release/cmd/${tool}"
+      compile_with_flags "${tool}"
     done
   else
     for tool in "${RELEASE_TOOLS[@]}"; do
       echo "Compiling default release tools..."
-      compile "k8s.io/release/cmd/${tool}"
+      compile_with_flags "${tool}"
     done
-    compile_krel
   fi
 }
 

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -24,6 +24,17 @@ steps:
   - "--branch=${_RELEASE_TOOL_BRANCH}"
   - "${_RELEASE_TOOL_REPO}"
 
+- name: k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}
+  dir: "go/src/k8s.io/release"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - "GO111MODULE=on"
+  - "GOPROXY=https://proxy.golang.org"
+  - "GOSUMDB=sum.golang.org"
+  args:
+  - "./compile-release-tools"
+
 - name: gcr.io/$PROJECT_ID/k8s-cloud-builder
   dir: "go/src/k8s.io/release"
   env:


### PR DESCRIPTION
- compile-release-tools: Fix execution for GCB builds
  - Update compile_with_flags to support building with version command
  - Add compile-release-tools to gcb/release/cloudbuild.yaml
- anago: Add some verbose `logrun`s and `logecho`s around changelog logic

---

I'm testing a fix to allow krel to be available to anago in GCB for `krel changelog`.
First real test is here: https://console.cloud.google.com/cloud-build/builds/b4e23b9c-b45e-4ca0-b10e-82e1211c1522?project=kubernetes-release-test

~I'll come back and update the commit messages and clean up once I get some more signal.~
cc: @saschagrunert @cpanato @hoegaarden @hasheddan 

Blocking the v1.18.0-alpha.3 release until then, although this should be solved before the call.

ref: https://github.com/kubernetes/release/pull/1049, https://github.com/kubernetes/release/pull/1044, https://github.com/kubernetes/release/pull/1056