### PR TITLE
Do not pull changes before changelog generation

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -127,7 +127,7 @@ func runChangelog() (err error) {
 	logrus.Infof("Using release branch %s", branch)
 
 	logrus.Infof("Using local repository path %s", rootOpts.repoPath)
-	repo, err := git.CloneOrOpenDefaultGitHubRepoSSH(rootOpts.repoPath, git.DefaultGithubOrg)
+	repo, err := git.OpenRepo(rootOpts.repoPath)
 	if err != nil {
 		return err
 	}
@@ -206,6 +206,7 @@ func generateReleaseNotes(branch, startRev, endRev string) (string, error) {
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.RecordDir = changelogOpts.recordDir
 	notesOptions.ReplayDir = changelogOpts.replayDir
+	notesOptions.Pull = false
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return "", err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -233,6 +233,26 @@ func updateRepo(repoPath string, useSSH bool) (*Repo, error) {
 	}, nil
 }
 
+// OpenRepo tries to open the provided repoPath
+func OpenRepo(repoPath string) (*Repo, error) {
+	r, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	worktree, err := r.Worktree()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Repo{
+		inner:    r,
+		worktree: worktree,
+		auth:     nil,
+		dir:      repoPath,
+	}, nil
+}
+
 func (r *Repo) Cleanup() error {
 	logrus.Debugf("Deleting %s", r.dir)
 	return os.RemoveAll(r.dir)

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -635,3 +635,18 @@ func TestRmFailureModified(t *testing.T) {
 	)
 	require.NotNil(t, testRepo.sut.Rm(false, testRepo.testFileName))
 }
+
+func TestOpenRepoSuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	repo, err := git.OpenRepo(testRepo.sut.Dir())
+	require.Nil(t, err)
+	require.Equal(t, testRepo.sut.Dir(), repo.Dir())
+}
+
+func TestOpenRepoFailure(t *testing.T) {
+	repo, err := git.OpenRepo("invalid")
+	require.NotNil(t, err)
+	require.Nil(t, repo)
+}

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -61,6 +61,7 @@ func newTestOptions(t *testing.T) *testOptions {
 			DiscoverMode: RevisionDiscoveryModeNONE,
 			StartSHA:     "0",
 			EndSHA:       "0",
+			Pull:         true,
 			gitCloneFn: func(string, string, string, bool) (*kgit.Repo, error) {
 				return testRepo.sut, nil
 			},


### PR DESCRIPTION
We do not need to pull changes before generating the changelog so we now
use a new option to disable it per default.