### PR TITLE
Fix changelog generation for anago usage

### DIFF
--- a/anago
+++ b/anago
@@ -408,6 +408,7 @@ generate_release_notes () {
 
   logrun -v krel changelog \
     --repo "$TREE_ROOT" \
+    --branch="${PARENT_BRANCH:-$RELEASE_BRANCH}" \
     --tars "$release_tars" \
     --tag "$RELEASE_VERSION_PRIME" \
     --html-file "$RELEASE_NOTES_HTML" \

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -145,7 +145,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 		if err != nil {
 			return err
 		}
-		if o.StartRev != "" {
+		if o.StartRev != "" && o.StartSHA == "" {
 			sha, err := repo.RevParse(o.StartRev)
 			if err != nil {
 				return err
@@ -153,7 +153,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			logrus.Infof("using found start SHA: %s", sha)
 			o.StartSHA = sha
 		}
-		if o.EndRev != "" {
+		if o.EndRev != "" && o.EndSHA == "" {
 			sha, err := repo.RevParse(o.EndRev)
 			if err != nil {
 				return err


### PR DESCRIPTION
- We now use the branch specified from anago to not assume a release branch in any case.
- The tag does not exist when generating the notes, so we have to use the HEAD as end rev and the latest tag as start rev.
- If we're not on a release branch, we also do not touch the CHANGELOG-x.y.md files of other releases
- When start or end sha is provided, we do not discover them any more