### PR TITLE
Fix gcbmgr KUBE_CROSS_VERSION env var passing

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -293,13 +293,14 @@ submit_it () {
   substitutions="_OFFICIAL_TAG=$OFFICIAL_TAG,_NOMOCK_TAG=$NOMOCK_TAG,_RC_TAG=$RC_TAG"
   substitutions+=",_BUILD_POINT=$BUILD_POINT,_GCP_USER_TAG=$GCP_USER_TAG"
 
-  [[ $COMMAND == stage ]] && substitutions+=",_BUILD_AT_HEAD=$BUILD_AT_HEAD" && substitutions+=",_KUBE_CROSS_VERSION=$KUBE_CROSS_VERSION"
+  [[ $COMMAND == stage ]] && substitutions+=",_BUILD_AT_HEAD=$BUILD_AT_HEAD"
 
   # The usual suspects
   substitutions+=",_RELEASE_BRANCH=$RELEASE_BRANCH,_OFFICIAL=$OFFICIAL,_RC=$RC"
   substitutions+=",_NOMOCK=$NOMOCK,_BUILDVERSION=$BUILDVERSION"
   substitutions+=",_RELEASE_TOOL_REPO=$RELEASE_TOOL_REPO"
   substitutions+=",_RELEASE_TOOL_BRANCH=$RELEASE_TOOL_BRANCH"
+  substitutions+=",_KUBE_CROSS_VERSION=$KUBE_CROSS_VERSION"
 
   if ! JOB_DATA=$($GCLOUD builds submit --no-source \
                           --config=$YAML_FILE $ASYNC --disk-size=$DISK_SIZE \
@@ -333,6 +334,9 @@ release_it () {
     logecho "Branch not set.  Can't continue"
     return 1
   fi
+
+  KUBE_CROSS_VERSION="$( release::kubecross_version "$RELEASE_BRANCH" 'master' )" \
+    || common::exit 1 'Exiting...' >&2
 
   # Check for mandatory buildversion
   if [[ -z $FLAGS_buildversion ]]; then


### PR DESCRIPTION
In #1053, we added a new release step to compile the release tools ahead of time, but the
container image `k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}` expects
`KUBE_CROSS_VERSION` to be supplied as an env var, which previously was
not required for the release phase.