### PR TITLE
Print the path where specs are saved if Spec-only mode is selected

### DIFF
--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -198,7 +198,9 @@ func WalkBuilds(builds []Build, architectures []string, specOnly bool) error {
 			}
 		}
 	}
-
+	if specOnly {
+		logrus.Infof("Package specs have been saved in %v", tmpDir)
+	}
 	logrus.Infof("Successfully walked builds")
 	return nil
 }


### PR DESCRIPTION
We should print the path where specs are saved if Spec-only mode is selected.
Otherwise, I can't find them at all :(

/kind bug