### PR TITLE
Fix CHANGELOG-x.y.md paths for new subpath

### DIFF
--- a/relnotes
+++ b/relnotes
@@ -327,7 +327,7 @@ generate_notes () {
   range="$start_tag..$release_tag"
 
   if [[ $release_tag =~ ${VER_REGEX[release]} ]]; then
-    changelog_file="CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+    changelog_file="CHANGELOG/CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
   else
     logecho "Unable to set CHANGELOG file!"
     return 1


### PR DESCRIPTION
Since we're moving CHANGELOG’s into a new subpath on k/k we have to
adapt the krel changelog tooling as well.

Needs https://github.com/kubernetes/kubernetes/pull/87879