### PR TITLE
Make SIG list more compact

### DIFF
--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -208,7 +208,7 @@ func prettySIG(sig string) string {
 	return strings.Join(parts, " ")
 }
 
-func prettifySigList(sigs []string) string {
+func prettifySIGList(sigs []string) string {
 	sigList := ""
 
 	// sort the list so that any group of SIGs with the same content gives us the
@@ -219,9 +219,9 @@ func prettifySigList(sigs []string) string {
 		if i == 0 {
 			sigList = fmt.Sprintf("SIG %s", prettySIG(sig))
 		} else if i == len(sigs)-1 {
-			sigList = fmt.Sprintf("%s, and SIG %s", sigList, prettySIG(sig))
+			sigList = fmt.Sprintf("%s and %s", sigList, prettySIG(sig))
 		} else {
-			sigList = fmt.Sprintf("%s, SIG %s", sigList, prettySIG(sig))
+			sigList = fmt.Sprintf("%s, %s", sigList, prettySIG(sig))
 		}
 	}
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -336,7 +336,7 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*Releas
 		g.options.GithubOrg, g.options.GithubRepo, pr.GetNumber(),
 	)
 	isFeature := HasString(LabelsWithPrefix(pr, "kind"), "feature")
-	noteSuffix := prettifySigList(LabelsWithPrefix(pr, "sig"))
+	noteSuffix := prettifySIGList(LabelsWithPrefix(pr, "sig"))
 
 	isDuplicateSIG := false
 	if len(LabelsWithPrefix(pr, "sig")) > 1 {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

We do not have to repeat the word `SIG` every time at the end of every
note. This clean-up the verbosity of the overall release notes document.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Changed the SIG list on every release note to be more compact
```
