### PR TITLE
Trim leading and trailing whitespace from rendered markdown

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -281,9 +281,7 @@ func writeMarkdown(repo *git.Repo, toc, markdown string, tag semver.Version) err
 	}
 
 	mergedMarkdown := fmt.Sprintf(
-		"%s\n%s",
-		strings.TrimSpace(markdown),
-		string(content[(len(tocEnd)+tocEndIndex):]),
+		"%s\n%s", markdown, string(content[(len(tocEnd)+tocEndIndex):]),
 	)
 	mergedTOC, err := notes.GenerateTOC(mergedMarkdown)
 	if err != nil {

--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -160,7 +160,7 @@ func RenderMarkdown(doc *Document, bucket, tars, prevTag, newTag string) (string
 		nlnl()
 	}
 
-	return o.String(), nil
+	return strings.TrimSpace(o.String()), nil
 }
 
 // sortKinds sorts kinds by their priority and returns the result in a string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In `krel changelog` we trimmed the markdown from trailing and leading whitespace, which can be done directly on rendering the markdown. This has the positive benefit that the `release-notes` tool benefits from it as well.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Changed release-notes markdown to be whitespace trimmed
```
