### PR TITLE
Uppercase the first character for each markdown note

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -356,6 +356,9 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*Releas
 		markdown = fmt.Sprintf("%s [%s]", markdown, noteSuffix)
 	}
 
+	// Uppercase the first character of the markdown to make it look uniform
+	markdown = strings.ToUpper(string(markdown[0])) + markdown[1:]
+
 	return &ReleaseNote{
 		Commit:         result.commit.GetSHA(),
 		Text:           text,


### PR DESCRIPTION


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Since we sort the markdown notes now alphabetically, we should take care
that the overall look of the notes is looking homogeneously and not:

```markdown
- Fixed something really cool
- Updated the latest dependency
- fixed another thing
- updated something else
```

To achieve this we now automatically uppercase the first character of
each markdown note, which results in:

```markdown
- Fixed another thing
- Fixed something really cool
- Updated something else
- Updated the latest dependency
```

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Automatically uppercase the first character for each release notes entry to have a better sorting layout
```
