### PR TITLE
Use real comments for `kind` in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,14 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 -->
 
 **What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
->
-> /kind bug
-> /kind cleanup
-> /kind deprecation
-> /kind design
-> /kind documentation
-> /kind feature
+<!-- Choose only one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind feature
+-->
 
 **What this PR does / why we need it**:
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Please see this PR more as a kickoff for a discussion. I think If we use real HTML comments for the kind block, then it feels easier to apply a Kind because we just have to uncomment that line. This would also reflect the note above in a more correct way:

> Uncomment only one ` /kind <>` line…

We probably want to apply this to k/k as well. WDYT?

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

/hold 

For starting the discussion here.

**Does this PR introduce a user-facing change?**:

```release-note
None
```
