### PR TITLE
lib/release: Parameterize GCP projects and GCS bucket names

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -386,14 +386,17 @@ logecho
 # Defaults to "list" operation
 COMMAND=${POSITIONAL_ARGV[0]:-"list"}
 ARG2=${POSITIONAL_ARGV[1]}
-PROJECT="kubernetes-release-test"
+PROJECT="${PROJECT:-$DEFAULT_PROJECT}"
 # Append $PROJECT to GCLOUD
 GCLOUD+=" --project $PROJECT"
-BUCKET="kubernetes-release"
+BUCKET="${BUCKET:-$DEFAULT_BUCKET}"
 # disk size must take base image into consideration.
 # The amount specified is not what is "free"
 DISK_SIZE="300"
 GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE --format="value(account)")
+
+# Lowercase GCP users
+GCP_USER="${GCP_USER,,}"
 # This is used as a tag so convert @ to -at- (for yaml tag field
 # where @ is invalid)
 # First, for @google.com users strip off the @domain.tld
@@ -428,7 +431,6 @@ if ((FLAGS_nomock)); then
   NOMOCK="--$NOMOCK_TAG"
 else
   USER_BUCKET=$BUCKET-$GCP_USER_TAG
-  BUCKET+="-gcb"
 fi
 
 # BUILD_POINT used in yaml tags field and is one of:

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -14,6 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+###############################################################################
+# CONSTANTS
+###############################################################################
+
+readonly DEFAULT_PROJECT="kubernetes-release-test"
+readonly PROD_PROJECT="kubernetes-release"
+readonly TEST_PROJECT="${TEST_PROJECT:-${PROJECT_ID:-$DEFAULT_PROJECT}}"
+
+readonly DEFAULT_BUCKET="kubernetes-release-gcb"
+readonly PROD_BUCKET="kubernetes-release"
+readonly TEST_BUCKET="kubernetes-release-gcb"
+readonly CI_BUCKET="kubernetes-release-dev"
+
+###############################################################################
+# FUNCTIONS
+###############################################################################
+
 ##############################################################################
 # Pulls Jenkins server job cache from GS and preprocesses it into a
 # dictionary stored in $job_path associating full job and build numbers
@@ -905,7 +922,8 @@ release::gcs::publish () {
   local publish_file_dst="gs://$bucket/$publish_file"
   local contents
   local public_link="https://storage.googleapis.com/$bucket/$publish_file"
-  if [[ "$bucket" == "kubernetes-release" ]]; then
+
+  if [[ "$bucket" == "$PROD_BUCKET" ]]; then
     public_link="https://dl.k8s.io/$publish_file"
   fi
 
@@ -1202,20 +1220,12 @@ release::send_announcement () {
 #                            contains k8s.gcr.io so we can check access in mock
 #                            mode before an actual release occurs
 release::set_globals () {
-  # Define the placeholder/"role" user for GCB
-  local gcb_user="gcb@google.com"
-
   logecho -n "Setting global variables: "
 
   # Default disk requirements per version - Modified in found_staged_location()
   RELEASE_GB="75"
 
-  if ((FLAGS_gcb)); then
-    # a placeholder that satisfies @google.com conditional below
-    GCP_USER="$gcb_user"
-  else
-    # Nothing should work without this.  The entire release workflow depends
-    # on it whether running from the desktop or GCB
+  if ! ((FLAGS_gcb)); then
     GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE \
                                  --format="value(account)" 2>/dev/null)
     if [[ -z "$GCP_USER" ]]; then
@@ -1223,12 +1233,9 @@ release::set_globals () {
       logecho "Unable to set a valid GCP credential!"
       return 1
     fi
-  fi
 
-  RELEASE_BUCKET="kubernetes-release"
-  if [[ $GCP_USER =~ "@google.com" ]]; then
-    WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
-    READ_RELEASE_BUCKETS=("$RELEASE_BUCKET")
+    # Lowercase GCP user
+    GCP_USER="${GCP_USER,,}"
   fi
 
   if ((FLAGS_stage)); then
@@ -1237,50 +1244,46 @@ release::set_globals () {
     BUCKET_TYPE="release"
   fi
 
-  # The "production" GCR path is now multi-region alias
   GCRIO_PATH_PROD="k8s.gcr.io"
   GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
   # The "test" GCR path
-  GCRIO_PATH_TEST="gcr.io/kubernetes-release-test"
+  GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
+
+  GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
+  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   if ((FLAGS_nomock)); then
+    RELEASE_BUCKET="$PROD_BUCKET"
+
     GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_PROD}"
-    ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
+  elif ((FLAGS_gcb)); then
+    RELEASE_BUCKET="$TEST_BUCKET"
+
+    # This is passed to logrun() where appropriate when we want to mock
+    # specific activities like pushes
+    LOGRUN_MOCK="-m"
   else
     # GCS buckets cannot contain @ or "google", so for those users, just use
-    # the "$USER" portion of $GCP_USER/$gcb_user
+    # the "$USER" portion of $GCP_USER
     RELEASE_BUCKET_USER="$RELEASE_BUCKET-${GCP_USER%%@google.com}"
-    RELEASE_BUCKET_GCB="$RELEASE_BUCKET-${gcb_user%%@google.com}"
     RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/@/-at-}"
-    RELEASE_BUCKET_GCB="${RELEASE_BUCKET_GCB/@/-at-}"
+
     # GCP also doesn't like anything even remotely looking like a domain name
     # in the bucket name so convert . to -
     RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/\./-}"
-    RELEASE_BUCKET_GCB="${RELEASE_BUCKET_GCB/\./-}"
     RELEASE_BUCKET="$RELEASE_BUCKET_USER"
 
-    # All the RELEASE_BUCKETS we could possibly write to
-    WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET_USER")
-    # All the RELEASE_BUCKETS we could possibly read from (for staging)
-    READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET_USER")
-    # If a regular user is running mocks, also look in the GCB mock bucket for
-    # releases
-    ((FLAGS_gcb)) || READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET_GCB")
-
-    # Set GCR values
-    GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
-    ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
-    # During GCB runs also check access to $GCRIO_PATH_PROD
-    # This is not needed for command-line/desktop as --nomock is no
-    # longer valid
-    if ((FLAGS_gcb)) && [[ $GCP_USER =~ "@google.com" ]]; then
-      ALL_CONTAINER_REGISTRIES+=("$GCRIO_PATH_PROD")
-    fi
+    READ_RELEASE_BUCKETS=("$TEST_BUCKET")
 
     # This is passed to logrun() where appropriate when we want to mock
     # specific activities like pushes
     LOGRUN_MOCK="-m"
   fi
+
+  WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
+  READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET")
+
+  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   # TODO:
   # These KUBE_ globals extend beyond the scope of the new release refactored

--- a/push-build.sh
+++ b/push-build.sh
@@ -112,7 +112,8 @@ common::timestamp begin
 ###############################################################################
 # MAIN
 ###############################################################################
-RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
+RELEASE_BUCKET="${FLAGS_bucket:-"$CI_BUCKET"}"
+
 # Compatibility with incoming global args
 [[ $KUBE_GCS_UPDATE_LATEST == "n" ]] && FLAGS_noupdatelatest=1
 

--- a/release-notify
+++ b/release-notify
@@ -46,7 +46,7 @@ PROG=${0##*/}
 #+ EXAMPLES
 #+
 #+ FILES
-#+     gs://kubernetes-release{,-$USER,-gcb}/archive/<version/announcement.html
+#+     gs://kubernetes-release{,-$USER,-gcb}/archive/<version>/announcement.html
 #+
 #+ SEE ALSO
 #+     common.sh                 - common function definitions

--- a/relnotes
+++ b/relnotes
@@ -96,6 +96,7 @@ PROG=${0##*/}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
+source $TOOL_LIB_PATH/releaselib.sh
 
 # Validate command-line
 common::argc_validate 1
@@ -181,7 +182,7 @@ create_downloads_table () {
   local heading=$1
   shift
   local url_prefix
-  if [[ "$release_bucket" == "kubernetes-release" ]]; then
+  if [[ "$release_bucket" == "$PROD_BUCKET" ]]; then
     url_prefix="https://dl.k8s.io"
   else
     url_prefix="https://storage.googleapis.com/$release_bucket/release"
@@ -207,7 +208,7 @@ create_body () {
   local release_tars=$1
   local start_tag=$2
   local release_tag=$3
-  local release_bucket=${FLAGS_release_bucket:-"kubernetes-release"}
+  local release_bucket="${FLAGS_release_bucket:-"$PROD_BUCKET"}"
   local title
 
   ((FLAGS_preview)) && title="Branch "


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Parameterize GCP projects and GCS bucket names

**Special notes for your reviewer**:
This is an attempt at extracting some useful commits from the `prototype` feature branch.
They're roughly equivalent to what was already reviewed in https://github.com/kubernetes/release/pull/909 and https://github.com/kubernetes/release/pull/919, without the references to the K8s Infra staging project. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
lib/release: Parameterize GCP projects and GCS bucket names
```
