### PR TITLE
Makefile: Add targets for running krel gcbmgr in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,26 @@ test-go: ## Runs all golang tests
 test-sh: ## Runs all shellscript tests
 	./hack/test-sh.sh
 
+##@ Tools
+
+RELEASE_TOOLS ?=
+
+.PHONY: release-tools
+
+release-tools: ## Compiles a set of release tools, specified by $RELEASE_TOOLS
+	./compile-release-tools $(RELEASE_TOOLS)
+
+##@ GCB Jobs
+
+.PHONY: stage-ci
+
+stage-ci: ## Compiles/installs krel and submits a MOCK streamed stage build to GCB (used for Prow)
+	RELEASE_TOOLS="krel" $(MAKE) release-tools
+	krel gcbmgr --stage \
+		--branch master \
+		--build-version=$$(curl -Ls https://dl.k8s.io/ci/latest.txt) \
+		--stream
+
 ##@ Images
 
 .PHONY: update-images


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Follow-up to #1081, adding a `stage-ci` Make target, to allow running `krel gcbmgr --stage` in CI.

/assign @saschagrunert @cpanato 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/release/pull/1052, https://github.com/kubernetes/test-infra/pull/16074

**Does this PR introduce a user-facing change?**:
```release-note
Makefile: Add targets for running krel gcbmgr in CI
```
