### PR TITLE
Allow only GITHUB_TOKEN env var

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -72,7 +72,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | Flag                    | Env Variable    | Default Value      | Required | Description                                                                                                                       |
 | ----------------------- | --------------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | **GITHUB REPO OPTIONS** |
-| github-token            | GITHUB_TOKEN    |                    | Yes      | A personal GitHub access token                                                                                                    |
+|                         | GITHUB_TOKEN    |                    | Yes      | A personal GitHub access token                                                                                                    |
 | github-org              | GITHUB_ORG      | kubernetes         | Yes      | Name of GitHub organization                                                                                                       |
 | github-repo             | GITHUB_REPO     | kubernetes         | Yes      | Name of GitHub repository                                                                                                         |
 | required-author         | REQUIRED_AUTHOR | k8s-ci-robot       | Yes      | Only commits from this GitHub user are considered. Set to empty string to include all users                                       |

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -51,15 +51,6 @@ var (
 )
 
 func init() {
-	// githubToken contains a personal GitHub access token. This is used to
-	// scrape the commits of the Kubernetes repo.
-	cmd.PersistentFlags().StringVar(
-		&opts.GithubToken,
-		"github-token",
-		util.EnvDefault("GITHUB_TOKEN", ""),
-		"A personal GitHub access token (required)",
-	)
-
 	// githubOrg contains name of github organization that holds the repo to scrape.
 	cmd.PersistentFlags().StringVar(
 		&opts.GithubOrg,

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -55,9 +55,9 @@ type testRepo struct {
 
 func newTestOptions(t *testing.T) *testOptions {
 	testRepo := newTestRepo(t)
+	require.Nil(t, os.Setenv(tokenKey, "token"))
 	return &testOptions{
 		Options: &Options{
-			GithubToken:  "token",
 			DiscoverMode: RevisionDiscoveryModeNONE,
 			StartSHA:     "0",
 			EndSHA:       "0",


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now remove the `--token` flag from the release notes generator and
allow only the usage of the set `GITHUB_TOKEN` environment variable.

This means that we can now auto-discover that variable in the `options`
package and can reduce the amount of env-lookups.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Removed the `--token` flag from `release-notes` in favor of the `GITHUB_TOKEN` environment variable
```
