### PR TITLE
Remove unnecessary double-init of the logger

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -68,7 +68,6 @@ the golang based 'release-notes' tool:
 `,
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PreRunE:       initLogging,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runChangelog()
 	},

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -46,7 +46,6 @@ var ffCmd = &cobra.Command{
 	Example:       "krel ff --branch release-1.17 --ref HEAD --cleanup",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PreRunE:       initLogging,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runFf(ffOpts)
 	},

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -62,7 +62,6 @@ var gcbmgrCmd = &cobra.Command{
 	Short:         "Run gcbmgr",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PreRunE:       initLogging,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGcbmgr()
 	},

--- a/cmd/krel/cmd/version.go
+++ b/cmd/krel/cmd/version.go
@@ -37,7 +37,6 @@ var versionCmd = &cobra.Command{
 	Short:         "output version information",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PreRunE:       initLogging,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runVersion(versionOpts)
 	},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The call to `PersistentPreRunE: initLogging` already initialized the
loggers for every subcommand, so we do not have to do this twice.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
