### PR TITLE
[krel] gcbmgr: Enable retrieving current GCP user via gcloud auth list

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "//cmd/release-notes:all-srcs",
         "//lib:all-srcs",
         "//pkg/command:all-srcs",
+        "//pkg/gcp/auth:all-srcs",
         "//pkg/gcp/build:all-srcs",
         "//pkg/git:all-srcs",
         "//pkg/kubepkg:all-srcs",

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     importpath = "k8s.io/release/cmd/krel/cmd",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/command:go_default_library",
+        "//pkg/gcp/auth:go_default_library",
         "//pkg/gcp/build:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/log:go_default_library",

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "k8s.io/release/cmd/krel/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/command:go_default_library",
         "//pkg/gcp/build:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/log:go_default_library",

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/gcp/build"
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/util"
@@ -50,8 +51,7 @@ const (
 	defaultReleaseToolRepo   = "https://github.com/kubernetes/release"
 	defaultReleaseToolBranch = "master"
 	defaultProject           = "kubernetes-release-test"
-	//nolint
-	defaultDiskSize = "300"
+	defaultDiskSize          = "300"
 
 	bucketPrefix = "kubernetes-release-"
 )
@@ -140,8 +140,10 @@ func runGcbmgr() error {
 		logrus.Fatal("Cannot specify both the 'stage' and 'release' flag. Please resubmit with only one of those flags selected.")
 	}
 
-	gcbSubs, gcbSubsErr := setGCBSubstitutions()
-	if gcbSubsErr != nil {
+	gcbSubs := map[string]string{}
+	var gcbSubsErr error
+	gcbSubs, gcbSubsErr = setGCBSubstitutions(gcbSubs)
+	if gcbSubs == nil || gcbSubsErr != nil {
 		return gcbSubsErr
 	}
 
@@ -182,6 +184,11 @@ func runGcbmgr() error {
 		return err
 	}
 
+	logrus.Info("Listing GCB substitutions prior to build submission...")
+	for k, v := range gcbSubs {
+		logrus.Infof("%s: %s", k, v)
+	}
+
 	switch {
 	case gcbmgrOpts.stage:
 		return submitStage(toolRoot, gcbSubs)
@@ -214,8 +221,10 @@ func submitRelease() error {
 	return nil // build.RunSingleJob(buildOpts, jobName, uploaded, version, subs)
 }
 
-func setGCBSubstitutions() (map[string]string, error) {
-	gcbSubs := make(map[string]string)
+func setGCBSubstitutions(gcbSubs map[string]string) (map[string]string, error) {
+	if gcbSubs == nil {
+		return nil, errors.New("GCB substitutions map must be initialized (non-nil) prior to populating")
+	}
 
 	releaseToolRepo := os.Getenv("RELEASE_TOOL_REPO")
 	if releaseToolRepo == "" {
@@ -230,24 +239,27 @@ func setGCBSubstitutions() (map[string]string, error) {
 	gcbSubs["RELEASE_TOOL_REPO"] = releaseToolRepo
 	gcbSubs["RELEASE_TOOL_BRANCH"] = releaseToolBranch
 
-	// TODO: Need to find out if command.Execute supports capturing the command output
-	gcpUser := "FAKEUSER"
-	//nolint
-	/*
-		gcpUser := command.Execute(
-			"gcloud",
-			"auth",
-			"list",
-			"--filter=status:ACTIVE",
-			`--format="value(account)"`,
-		)
-		if gcpUser != nil {
-			return nil, gcpUserErr
-		}
-	*/
+	authListCmd := command.New(
+		"gcloud",
+		"auth",
+		"list",
+		"--filter=status:ACTIVE",
+		"--format=value(account)",
+		"--verbosity=debug",
+	)
+	authListStatus, authListErr := authListCmd.RunSilent()
+	if authListErr != nil {
+		return nil, errors.Wrapf(authListErr, "'gcloud auth list' was not successful")
+	}
+	if !authListStatus.Success() {
+		return nil, errors.Errorf("'gcloud auth list' was not successful: %s", authListStatus.Error())
+	}
 
+	gcpUser := authListStatus.Output()
+	gcpUser = strings.TrimSuffix(gcpUser, "\n")
 	gcpUser = strings.ReplaceAll(gcpUser, "@", "-at-")
 	gcpUser = strings.ReplaceAll(gcpUser, ".", "-")
+	gcpUser = strings.ToLower(gcpUser)
 	gcbSubs["GCP_USER_TAG"] = gcpUser
 
 	// TODO: The naming for these env vars is clumsy/confusing, but we're bound by anago right now.

--- a/pkg/gcp/auth/BUILD.bazel
+++ b/pkg/gcp/auth/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["auth.go"],
+    importpath = "k8s.io/release/pkg/gcp/auth",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/command:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/release/pkg/command"
+)
+
+func GetCurrentGCPUser() (string, error) {
+	authListCmd := command.New(
+		"gcloud",
+		"auth",
+		"list",
+		"--filter=status:ACTIVE",
+		"--format=value(account)",
+		"--verbosity=debug",
+	)
+	authListStatus, authListErr := authListCmd.RunSilent()
+	if authListErr != nil {
+		return "", errors.Wrapf(authListErr, "'gcloud auth list' was not successful")
+	}
+	if !authListStatus.Success() {
+		return "", errors.Errorf("'gcloud auth list' was not successful: %s", authListStatus.Error())
+	}
+
+	gcpUser := authListStatus.Output()
+
+	if gcpUser == "" {
+		return "", errors.New("the GCP user name should not be empty")
+	}
+
+	gcpUser = strings.TrimSuffix(gcpUser, "\n")
+	gcpUser = strings.ReplaceAll(gcpUser, "@", "-at-")
+	gcpUser = strings.ReplaceAll(gcpUser, ".", "-")
+	gcpUser = strings.ToLower(gcpUser)
+
+	return gcpUser, nil
+}

--- a/pkg/gcp/build/BUILD.bazel
+++ b/pkg/gcp/build/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/pkg/gcp/build",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/command:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
- [krel] gcbmgr: Enable retrieving current GCP user via gcloud auth list
- pkg/gcp/build: Switch to using pkg/command for command execution

/assign @saschagrunert @hasheddan @cpanato 

**Does this PR introduce a user-facing change?**:
```release-note
[krel] gcbmgr: Enable retrieving current GCP user via gcloud auth list
```
