### PR TITLE
Revert common and command pkg to using go1.12 compatible vars

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -243,7 +243,7 @@ func writeMarkdown(repo *git.Repo, toc, markdown string, tag semver.Version) err
 		return ioutil.WriteFile(
 			changelogPath, []byte(strings.Join(
 				[]string{addTocMarkers(t), strings.TrimSpace(m)}, "\n",
-			)), 0o644,
+			)), os.FileMode(0644),
 		)
 	}
 
@@ -342,7 +342,7 @@ func writeHTML(tag semver.Version, markdown string) error {
 		return err
 	}
 	logrus.Infof("Writing single HTML to %s", absOutputPath)
-	return ioutil.WriteFile(absOutputPath, output.Bytes(), 0o644)
+	return ioutil.WriteFile(absOutputPath, output.Bytes(), os.FileMode(0644))
 }
 
 func lookupRemoteReleaseNotes(branch string) (string, error) {
@@ -444,7 +444,7 @@ func adaptChangelogReadmeFile(repo *git.Repo, tag semver.Version) error {
 
 	const nl = "\n"
 	if err := ioutil.WriteFile(
-		targetFile, []byte(strings.Join(res, nl)+nl), 0o644); err != nil {
+		targetFile, []byte(strings.Join(res, nl)+nl), os.FileMode(0644)); err != nil {
 		return errors.Wrap(err, "unable to write changelog README.md")
 	}
 	return nil

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -240,7 +240,7 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 	var existingNotes notes.ReleaseNotes
 
 	if opts.Output != "" {
-		output, err = os.OpenFile(opts.Output, os.O_RDWR|os.O_CREATE, 0o644)
+		output, err = os.OpenFile(opts.Output, os.O_RDWR|os.O_CREATE, os.FileMode(0644))
 		if err != nil {
 			return errors.Wrapf(err, "opening the supplied output file")
 		}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -107,7 +107,15 @@ func (c *Command) RunSuccess() (err error) {
 func (c *Command) String() string {
 	str := []string{}
 	for _, x := range c.cmds {
-		str = append(str, x.String())
+		// Note: the following logic can be replaced with x.String(), which was
+		// implemented in go1.13
+		b := new(strings.Builder)
+		b.WriteString(x.Path)
+		for _, a := range x.Args[1:] {
+			b.WriteByte(' ')
+			b.WriteString(a)
+		}
+		str = append(str, b.String())
 	}
 	return strings.Join(str, " | ")
 }

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -86,7 +86,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	worktree, err := cloneRepo.Worktree()
@@ -123,7 +123,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 	_, err = worktree.Add(branchTestFileName)
 	require.Nil(t, err)
@@ -147,7 +147,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 	_, err = worktree.Add(secondBranchTestFileName)
 	require.Nil(t, err)
@@ -507,7 +507,7 @@ func TestCheckoutSuccess(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		testRepo.testFileName,
 		[]byte("hello world"),
-		0o644,
+		os.FileMode(0644),
 	))
 	res, err := command.NewWithWorkDir(
 		testRepo.sut.Dir(), "git", "diff", "--name-only").Run()
@@ -602,7 +602,7 @@ func TestRmSuccessForce(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 	require.Nil(t, ioutil.WriteFile(testRepo.testFileName,
-		[]byte("test"), 0o755),
+		[]byte("test"), os.FileMode(0755)),
 	)
 
 	require.Nil(t, testRepo.sut.Rm(true, testRepo.testFileName))
@@ -631,7 +631,7 @@ func TestRmFailureModified(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 	require.Nil(t, ioutil.WriteFile(testRepo.testFileName,
-		[]byte("test"), 0o755),
+		[]byte("test"), os.FileMode(0755)),
 	)
 	require.NotNil(t, testRepo.sut.Rm(false, testRepo.testFileName))
 }

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -346,7 +346,7 @@ func (bc *buildConfig) run() error {
 		dstParts := []string{"bin", string(bc.Channel), fileName}
 
 		dstPath := filepath.Join(dstParts...)
-		if mkdirErr := os.MkdirAll(dstPath, 0o777); mkdirErr != nil {
+		if mkdirErr := os.MkdirAll(dstPath, os.FileMode(0777)); mkdirErr != nil {
 			return err
 		}
 

--- a/pkg/notes/client/record.go
+++ b/pkg/notes/client/record.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -149,7 +150,7 @@ func (c *githubNotesRecordClient) recordAPICall(
 		return err
 	}
 	if err := ioutil.WriteFile(
-		filepath.Join(c.recordDir, fileName), file, 0o644,
+		filepath.Join(c.recordDir, fileName), file, os.FileMode(0644),
 	); err != nil {
 		return err
 	}

--- a/pkg/notes/document_test.go
+++ b/pkg/notes/document_test.go
@@ -74,7 +74,7 @@ func TestCreateDownloadsTable(t *testing.T) {
 		"kubernetes.tar.gz",
 	} {
 		require.Nil(t, ioutil.WriteFile(
-			filepath.Join(dir, file), []byte{1, 2, 3}, 0o644,
+			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
 		))
 	}
 

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -173,7 +173,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	// Create the record dir
 	if o.RecordDir != "" {
 		logrus.Info("using record mode")
-		if err := os.MkdirAll(o.RecordDir, 0o755); err != nil {
+		if err := os.MkdirAll(o.RecordDir, os.FileMode(0755)); err != nil {
 			return err
 		}
 	}

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -107,7 +107,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	worktree, err := cloneRepo.Worktree()
@@ -144,7 +144,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 	_, err = worktree.Add(branchTestFileName)
 	require.Nil(t, err)
@@ -168,7 +168,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
-		0o644,
+		os.FileMode(0644),
 	))
 	_, err = worktree.Add(secondBranchTestFileName)
 	require.Nil(t, err)

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -51,13 +51,13 @@ func TestBuiltWithBazel(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		baseBazelFile,
 		[]byte("test"),
-		0o644,
+		os.FileMode(0644),
 	))
 	bazelFile := filepath.Join(bazelTmpDir, "bazel-bin/build/release-tars/kubernetes.tar.gz")
 	require.Nil(t, ioutil.WriteFile(
 		bazelFile,
 		[]byte("test"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	time.Sleep(1 * time.Second)
@@ -66,13 +66,13 @@ func TestBuiltWithBazel(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		baseDockerFile,
 		[]byte("test"),
-		0o644,
+		os.FileMode(0644),
 	))
 	dockerFile := filepath.Join(dockerTmpDir, "_output/release-tars/1.1.1.tar.gz")
 	require.Nil(t, ioutil.WriteFile(
 		dockerFile,
 		[]byte("test"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	defer cleanupTmps(t, baseTmpDir, bazelTmpDir, dockerTmpDir)
@@ -143,7 +143,7 @@ func TestReadBazelVersion(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		bazelVersionFile,
 		[]byte(version),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	defer cleanupTmps(t, baseTmpDir)
@@ -206,7 +206,7 @@ func TestReadDockerVersion(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		filepath.Join(baseTmpDir, dockerBuildPath, "kubernetes.tar.gz"),
 		b.Bytes(),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	defer cleanupTmps(t, baseTmpDir)

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -111,7 +111,7 @@ func FakeGOPATH(srcDir string) (string, error) {
 	logrus.Debugf("GOPATH: %s", os.Getenv("GOPATH"))
 
 	gitRoot := fmt.Sprintf("%s/src/k8s.io", baseDir)
-	if err := os.MkdirAll(gitRoot, 0o755); err != nil {
+	if err := os.MkdirAll(gitRoot, os.FileMode(0755)); err != nil {
 		return "", err
 	}
 	gitRoot = filepath.Join(gitRoot, "kubernetes")

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -39,7 +39,7 @@ func TestMoreRecent(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		testFileOne,
 		[]byte("file-one-contents"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	time.Sleep(1 * time.Second)
@@ -48,7 +48,7 @@ func TestMoreRecent(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		testFileTwo,
 		[]byte("file-two-contents"),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	notFile := filepath.Join(baseTmpDir, "noexist.txt")
@@ -152,7 +152,7 @@ func TestReadFileFromGzippedTar(t *testing.T) {
 	require.Nil(t, ioutil.WriteFile(
 		testTarPath,
 		b.Bytes(),
-		0o644,
+		os.FileMode(0644),
 	))
 
 	defer cleanupTmp(t, baseTmpDir)


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Allows 1.15 stages using `gcbmgr` to pass in kube-cross container, which uses go1.12.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1089 

**Special notes for your reviewer**:

/assign @justaugustus @saschagrunert @cpanato

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
