### PR TITLE
jenkins.sh: fix race condition against process substitution

### DIFF
--- a/debian/jenkins.sh
+++ b/debian/jenkins.sh
@@ -14,4 +14,4 @@ docker build -t "${IMG_NAME}" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 docker run --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}" $@
 
 gsutil -m cp -nrc bin "${DEB_RELEASE_BUCKET}/${BUILD_TAG}"
-gsutil -m cp <(printf "${BUILD_TAG}") "${DEB_RELEASE_BUCKET}/latest"
+printf "%s" "${BUILD_TAG}" | gsutil cp - "${DEB_RELEASE_BUCKET}/latest"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Sometimes, the gsutil command fails with

    CommandException: No URLs matched: /dev/fd/63

where /dev/fd/63 is most likely the file handle used by Bash's process
substitution. So, use STDIN instead.

We also remove the -m (multithreaded) flag because gsutil's help page
warns that it is incompatible:

    Note: Streaming transfers are not allowed when the top-level gsutil -m flag
    is used.

(this is for gsutil version 4.47).

/priority critical-urgent
/assign @tpepper @listx @hoegaarden 
cc: @kubernetes/release-engineering 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Note that this is a merge to a special feature branch, `build-admins` to rev the tag that @kubernetes/build-admins currently work off of.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
jenkins.sh: fix race condition against process substitution
```
