### PR TITLE
Truly use the latest tag as default EndRev

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -95,6 +95,7 @@ func runReleaseNotes() (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "unable to find latest minor tag")
 		}
+		releaseNotesOpts.tag = tag
 	} else {
 		tag = releaseNotesOpts.tag
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
* [krel] release-notes: When using krel to generate the release notes, truly default to the latest tag found when not specified as a flag

**Which issue(s) this PR fixes**:
Relates to #1061 

**Special notes for your reviewer**:
Just a small one liner to set the latest tag as the default option

**Does this PR introduce a user-facing change?**:
```release-note
Fix to krel release-notes to default to the latest latest release tag when generating the release notes without specifying a version in the command line as a flag
```
/cc @saschagrunert @JamesLaverack 
