### PR TITLE
Update krel changelog docs to mention GITHUB_TOKEN and repo path

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -44,7 +44,13 @@ import (
 var changelogCmd = &cobra.Command{
 	Use:   "changelog",
 	Short: "changelog maintains the lifecycle of CHANGELOG-x.y.{md,html} files",
-	Long: `krel changelog
+	Long: fmt.Sprintf(`krel changelog
+
+To let this tool work, please point '--repo' to a local copy of the target k/k
+repository. This local checkout will be modified during the run of 'krel
+changelog' and should contain all changes from the remote location. Beside this,
+a valid %s=<TOKEN> environment variable has to be exported to let the generation
+of the release notes work.
 
 The 'changelog' subcommand of 'krel' does the following things by utilizing
 the golang based 'release-notes' tool:
@@ -65,7 +71,7 @@ the golang based 'release-notes' tool:
    corresponding release-branch of kubernetes/kubernetes. The release branch
    will be pruned from all other CHANGELOG-*.md files which do not belong to
    this release branch.
-`,
+`, options.GitHubToken),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -121,7 +127,9 @@ func runChangelog() (err error) {
 	logrus.Infof("Using local repository path %s", rootOpts.repoPath)
 	repo, err := git.OpenRepo(rootOpts.repoPath)
 	if err != nil {
-		return err
+		return errors.Wrapf(err,
+			"unable to open expected k/k repository %q", rootOpts.repoPath,
+		)
 	}
 
 	head, err := repo.RevParse("HEAD")

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -57,7 +57,7 @@ The 'release-notes' subcommand of krel has been developed to:
 
 To use the tool, please set the %v environment variable which needs write
 permissions to your fork of k/sig-release and k-sigs/release-notes.`,
-		options.TokenKey),
+		options.GitHubToken),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -61,7 +61,7 @@ const (
 	RevisionDiscoveryModeMergeBaseToLatest = "mergebase-to-latest"
 	RevisionDiscoveryModePatchToPatch      = "patch-to-patch"
 	RevisionDiscoveryModeMinorToMinor      = "minor-to-minor"
-	TokenKey                               = "GITHUB_TOKEN"
+	GitHubToken                            = "GITHUB_TOKEN"
 )
 
 // New creates a new Options instance with the default values
@@ -95,13 +95,13 @@ func (o *Options) ValidateAndFinish() (err error) {
 	}
 
 	// The GitHub Token is required if replay is not specified
-	token, ok := os.LookupEnv(TokenKey)
+	token, ok := os.LookupEnv(GitHubToken)
 	if ok {
 		o.githubToken = token
 	} else if o.ReplayDir == "" {
 		return errors.Errorf(
 			"neither environment variable `%s` nor `replay` option is set",
-			TokenKey,
+			GitHubToken,
 		)
 	}
 

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -55,7 +55,7 @@ type testRepo struct {
 
 func newTestOptions(t *testing.T) *testOptions {
 	testRepo := newTestRepo(t)
-	require.Nil(t, os.Setenv(TokenKey, "token"))
+	require.Nil(t, os.Setenv(GitHubToken, "token"))
 	return &testOptions{
 		Options: &Options{
 			DiscoverMode: RevisionDiscoveryModeNONE,


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The documentation now indicates that an GITHUB_TOKEN has to be exported
as well as we require a local checkout of a k/k working copy via `--repo`.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Update krel changelog docs to include required GITHUB_TOKEN and a local k/k working copy
```
