### PR TITLE
Fix missing CHANGELOG/CHANGELOG* locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ For information on how to use `gcbmgr`, `anago` and `branchff`, see the [Branch 
 
 [kubernetes/kubernetes]: https://git.k8s.io/kubernetes
 [Branch Manager Handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
-[CHANGELOG.md]: https://git.k8s.io/kubernetes/blob/master/CHANGELOG.md
 [shot-issue]: https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968
 
 ## Release Notes Gathering

--- a/anago
+++ b/anago
@@ -1564,7 +1564,7 @@ else
 fi
 
 if [[ $RELEASE_VERSION_PRIME =~ ${VER_REGEX[release]} ]]; then
-  CHANGELOG_FILE="CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+  CHANGELOG_FILE="CHANGELOG/CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
 else
   common::exit 1 "Unable to set CHANGELOG file!"
 fi

--- a/cmd/kubepkg/templates/latest/deb/kubeadm/debian/changelog
+++ b/cmd/kubepkg/templates/latest/deb/kubeadm/debian/changelog
@@ -1,6 +1,6 @@
 kubeadm ({{ .Version }}-{{ .Revision }}) {{ .Channel }}; urgency=medium
 
-  * https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md
+  * https://git.k8s.io/kubernetes/CHANGELOG/README.md
 
  -- Kubernetes Authors <kubernetes-dev@googlegroups.com>  {{ date }}
 

--- a/cmd/kubepkg/templates/latest/deb/kubectl/debian/changelog
+++ b/cmd/kubepkg/templates/latest/deb/kubectl/debian/changelog
@@ -1,6 +1,6 @@
 kubectl ({{ .Version }}-{{ .Revision }}) {{ .Channel }}; urgency=medium
 
-  * https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md
+  * https://git.k8s.io/kubernetes/CHANGELOG/README.md
 
  -- Kubernetes Authors <kubernetes-dev@googlegroups.com>  {{ date }}
 

--- a/cmd/kubepkg/templates/latest/deb/kubelet/debian/changelog
+++ b/cmd/kubepkg/templates/latest/deb/kubelet/debian/changelog
@@ -1,6 +1,6 @@
 kubelet ({{ .Version }}-{{ .Revision }}) {{ .Channel }}; urgency=medium
 
-  * https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md
+  * https://git.k8s.io/kubernetes/CHANGELOG/README.md
 
  -- Kubernetes Authors <kubernetes-dev@googlegroups.com>  {{ date }}
 

--- a/cmd/kubepkg/templates/latest/deb/kubernetes-cni/debian/changelog
+++ b/cmd/kubepkg/templates/latest/deb/kubernetes-cni/debian/changelog
@@ -1,6 +1,6 @@
 kubernetes-cni ({{ .Version }}-{{ .Revision }}) {{ .Channel }}; urgency=medium
 
-  * https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md
+  * https://git.k8s.io/kubernetes/CHANGELOG/README.md
 
  -- Kubernetes Authors <kubernetes-dev@googlegroups.com>  {{ date }}
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,7 +5,7 @@ blocks)](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUE
 labels](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) with compliance across master and release- branches using [test-infra/prow](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/releasenote)
 on the main Kubernetes repository (and future repositories later).
 
-Releases are built and published by the anago tool in [this repo](https://github.com/kubernetes/release) with the release notes published in [kubernetes/CHANGELOG-x.y.md files](https://github.com/kubernetes/kubernetes).
+Releases are built and published by the anago tool in [this repo](https://github.com/kubernetes/release) with the release notes published in [kubernetes/CHANGELOG/CHANGELOG-x.y.md files](https://git.k8s.io/kubernetes/CHANGELOG/README.md).
 
 The automated release notes gathered in this way are considered complete
 for alpha, beta and official patch releases.


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup

**What this PR does / why we need it**:

We changed the default changelog location in k/k to be prefixed with
`CHANGELOG/`. We have to change them here in documentation and in anago
as well to reflect that new state.

**Which issue(s) this PR fixes**:

Fixes partially https://github.com/kubernetes/kubernetes/issues/87993

**Special notes for your reviewer**:

I may have missed other locations but I don't think so.

```release-note
- Update anago and the docs to take the new CHANGELOG/ location in k/k into acccount
```
