### PR TITLE
Remove deprecated --requiredAuthor flag

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -151,18 +151,6 @@ func init() {
 		"Only commits from this GitHub user are considered. Set to empty string to include all users",
 	)
 
-	cmd.PersistentFlags().StringVar(
-		&opts.RequiredAuthor,
-		"requiredAuthor",
-		util.EnvDefault("REQUIRED_AUTHOR", "k8s-ci-robot"),
-		"Only commits from this GitHub user are considered. Set to empty string to include all users",
-	)
-	if cmd.PersistentFlags().MarkDeprecated("requiredAuthor", "use '--required-author' instead") != nil {
-		//TODO: remove 'requiredAuthor' after 2020-02-01 -- ¯\_(ツ)_/¯
-		// we are in init, can't do much here
-		panic("Unknown flag 'requiredAuthor'")
-	}
-
 	cmd.PersistentFlags().BoolVar(
 		&opts.Debug,
 		"debug",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The flag has been deprecated long time ago and we passed the deadline to
finally remove it.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Removed `--requiredAuthor` flag from `release-notes` tool, please use `--required-author` instead
```
