### PR TITLE
Add Run{Silent}SuccessOutput API to command

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -131,16 +131,10 @@ func tryToFindLatestMinorTag() (string, error) {
 	).
 		Pipe("grep", "-Eo", "v[0-9].[0-9]+.0-.*.[0-9]$").
 		Pipe("tail", "-1").
-		RunSilent()
+		RunSilentSuccessOutput()
 
 	if err != nil {
-		return "", errors.Wrapf(err, "git ls-remote command failed")
-	}
-
-	if !status.Success() {
-		return "", errors.Errorf(
-			"git ls-remote command not successful: %v", status.Error(),
-		)
+		return "", err
 	}
 
 	return strings.TrimSpace(status.Output()), nil

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -167,3 +167,27 @@ func TestSuccessRunSilentSuccess(t *testing.T) {
 func TestFailureRunSuccessSilent(t *testing.T) {
 	require.NotNil(t, New("cat", "/not/available").RunSilentSuccess())
 }
+
+func TestSuccessRunSuccessOutput(t *testing.T) {
+	res, err := New("echo", "-n", "hi").RunSuccessOutput()
+	require.Nil(t, err)
+	require.Equal(t, "hi", res.Output())
+}
+
+func TestFailureRunSuccessOutput(t *testing.T) {
+	res, err := New("cat", "/not/available").RunSuccessOutput()
+	require.NotNil(t, err)
+	require.Nil(t, res)
+}
+
+func TestSuccessRunSilentSuccessOutput(t *testing.T) {
+	res, err := New("echo", "-n", "hi").RunSilentSuccessOutput()
+	require.Nil(t, err)
+	require.Equal(t, "hi", res.Output())
+}
+
+func TestFailureRunSilentSuccessOutput(t *testing.T) {
+	res, err := New("cat", "/not/available").RunSilentSuccessOutput()
+	require.NotNil(t, err)
+	require.Nil(t, res)
+}

--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -25,20 +25,16 @@ import (
 )
 
 func GetCurrentGCPUser() (string, error) {
-	authListCmd := command.New(
+	authListStatus, authListErr := command.New(
 		"gcloud",
 		"auth",
 		"list",
 		"--filter=status:ACTIVE",
 		"--format=value(account)",
 		"--verbosity=debug",
-	)
-	authListStatus, authListErr := authListCmd.RunSilent()
+	).RunSilentSuccessOutput()
 	if authListErr != nil {
-		return "", errors.Wrapf(authListErr, "'gcloud auth list' was not successful")
-	}
-	if !authListStatus.Success() {
-		return "", errors.Errorf("'gcloud auth list' was not successful: %s", authListStatus.Error())
+		return "", authListErr
 	}
 
 	gcpUser := authListStatus.Output()

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -505,17 +505,14 @@ func (r *Repo) DescribeTag(rev string) (string, error) {
 	// go git seems to have no implementation for `git describe`
 	// which means that we fallback to a shell command for sake of
 	// simplicity
-	status, err := command.NewWithWorkDir(
+	result, err := command.NewWithWorkDir(
 		r.Dir(), gitExecutable, "describe", "--abbrev=0", "--tags", rev,
-	).RunSilent()
+	).RunSilentSuccessOutput()
 	if err != nil {
 		return "", err
 	}
-	if !status.Success() {
-		return "", errors.Errorf("git describe command failed: %s", status.Error())
-	}
 
-	return strings.TrimSpace(status.Output()), nil
+	return strings.TrimSpace(result.Output()), nil
 }
 
 // Merge does a git merge into the current branch from the provided one
@@ -645,12 +642,9 @@ func (r *Repo) TagsForBranch(branch string) ([]string, error) {
 
 	status, err := command.NewWithWorkDir(
 		r.Dir(), gitExecutable, "tag", "--sort=-creatordate", "--merged",
-	).RunSilent()
+	).RunSilentSuccessOutput()
 	if err != nil {
 		return nil, err
-	}
-	if !status.Success() {
-		return nil, errors.Errorf("git tag command failed: %s", status.Error())
 	}
 
 	return strings.Fields(status.Output()), nil


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This gives us the possibility to conveniently access the outputs for the
command by assuming that is was successful. Tests have been adapted as
well as all other places where the API fits in.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
```release-note
- Add `RunSuccessOutput()`/`RunSilentSuccessOutput()` API to command to still access the outputs of a command which should succeed
```
