### PR TITLE
pkg/command: leave the underlying WaitStatus type opaque

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -41,7 +41,7 @@ type command struct {
 
 // A generic command exit status
 type Status struct {
-	exitCode syscall.WaitStatus
+	waitStatus syscall.WaitStatus
 	*Stream
 }
 
@@ -237,8 +237,8 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 	status.stdErr = stdErrBuffer.String()
 
 	if exitErr, ok := runErr.(*exec.ExitError); ok {
-		if exitCode, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-			status.exitCode = exitCode
+		if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			status.waitStatus = waitStatus
 			return status, nil
 		}
 	}
@@ -248,12 +248,12 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 
 // Success returns if a Status was successful
 func (s *Status) Success() bool {
-	return s.exitCode == 0
+	return s.waitStatus.ExitStatus() == 0
 }
 
 // ExitCode returns the exit status of the command status
 func (s *Status) ExitCode() int {
-	return s.exitCode.ExitStatus()
+	return s.waitStatus.ExitStatus()
 }
 
 // Output returns stdout of the command status


### PR DESCRIPTION
**What this PR does / why we need it**:

WaitStatus is not a uint32 on Windows:
https://github.com/golang/go/blob/master/src/syscall/syscall_windows.go#L943-L945

- Rename "exitCode" to "waitStatus"
- For Success() use ExitStatus() == 0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Special notes for your reviewer**:
i was on a Windows box and wanted to test the release-notes tool, but it failed building with an error:
```
...\pkg\command\command.go:222:20: invalid operation: s.exitCode == 0 (mismatched types syscall.WaitStatus and int)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @saschagrunert 
/priority backlog
/kind bug
