### PR TITLE
Set authoritative changelog location and update release announcements copy

### DIFF
--- a/anago
+++ b/anago
@@ -872,13 +872,13 @@ push_git_objects () {
 # generate the announcement text to be mailed and published
 branch_announcement_text () {
   cat <<EOF
-Kubernetes team,
+Kubernetes Community,
 <P>
 Kubernetes' $RELEASE_BRANCH branch has been created.
 <P>
 The release owner will be sending updates on how to interact with this branch shortly.  The <A HREF=https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md>Cherrypick Guide</A> has some general guidance on how things will proceed.
 <P>
-Announced by <A HREF=https://github.com/kubernetes/release>$PROG</A>, the Kubernetes Release Tool
+Announced by your <A HREF=https://git.k8s.io/sig-release/release-managers.md>Kubernetes Release Managers</A>.
 EOF
 }
 
@@ -886,19 +886,19 @@ EOF
 # generate the announcement text to be mailed and published
 release_announcement_text () {
   cat <<EOF
-Kubernetes team,
+Kubernetes Community,
 <P>
 Kubernetes $RELEASE_VERSION_PRIME has been built and pushed.
 <P>
-The release notes have been updated in <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILEPATH</A> with a pointer to it on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
+The release notes have been updated in <A HREF=https://git.k8s.io/kubernetes/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A>, with a pointer to them on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
 <P>
 <HR>
 $(cat $RELEASE_NOTES_HTML)
 <HR>
 <P><BR>
-Leads, the <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILEPATH</A> has been bootstrapped with $RELEASE_VERSION_PRIME release notes and you may edit now as needed.
-<P><BR>
-Published by <A HREF=https://github.com/kubernetes/release>$PROG</A>, the Kubernetes Release Tool
+Contributors, the <A HREF=https://git.k8s.io/kubernetes/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A> has been bootstrapped with $RELEASE_VERSION_PRIME release notes and you may edit now as needed.
+<P><BR><BR>
+Published by your <A HREF=https://git.k8s.io/sig-release/release-managers.md>Kubernetes Release Managers</A>.
 EOF
 }
 
@@ -917,9 +917,9 @@ announce () {
   logecho "Creating k8s ${RELEASE_VERSION_PRIME} announcement in ${WORKDIR} ..."
 
   if [[ "$arg" == "--branch" ]]; then
-    echo "k8s ${RELEASE_BRANCH} branch has been created" > "$subject_file"
+    echo "Kubernetes ${RELEASE_BRANCH} branch has been created" > "$subject_file"
     branch_announcement_text > "$announcement_file"
-    logecho "k8s ${RELEASE_BRANCH} branch creation announcement created."
+    logecho "Kubernetes ${RELEASE_BRANCH} branch creation announcement created."
 
     # When we create a new branch, we notify the publishing-bot folks by
     # creating an issue for them
@@ -930,9 +930,9 @@ announce () {
       logecho "${OK}: publishing-bot update issue created: ${pubotIssue}"
     fi
   else
-    echo "k8s ${RELEASE_VERSION_PRIME} is live!" > "$subject_file"
+    echo "Kubernetes ${RELEASE_VERSION_PRIME} is live!" > "$subject_file"
     release_announcement_text > "$announcement_file"
-    logecho "k8s ${RELEASE_VERSION_PRIME} release announcement created."
+    logecho "Kubernetes ${RELEASE_VERSION_PRIME} release announcement created."
   fi
 
   # Only send from desktop

--- a/anago
+++ b/anago
@@ -401,7 +401,7 @@ check_prerequisites () {
 }
 
 ###############################################################################
-# Update $CHANGELOG_FILE on master
+# Update $CHANGELOG_FILEPATH on master
 PROGSTEP[generate_release_notes]="GENERATE RELEASE NOTES"
 generate_release_notes () {
   local release_tars=$TREE_ROOT/_output-$RELEASE_VERSION_PRIME/release-tars
@@ -565,9 +565,9 @@ prepare_tree () {
   # more simply readable to a maintainer?
   if [[ "$PARENT_BRANCH" == "master" && "$branch" != "master" ]]; then
     logecho -n "Remove any previous CHANGELOG-*.md files: "
-    logrun -s git rm -f CHANGELOG-*.md || return 1
-    logecho -n "Copy master $CHANGELOG_FILE to $branch branch: "
-    logrun -s git checkout master -- $CHANGELOG_FILE || return 1
+    logrun -s git rm -f "$CHANGELOG_DIR"/CHANGELOG-*.md || return 1
+    logecho -n "Copy master $CHANGELOG_FILEPATH to $branch branch: "
+    logrun -s git checkout master -- $CHANGELOG_FILEPATH || return 1
     logecho -n "Committing deleted CHANGELOG-*.md files: "
     logrun -s git commit -am "Delete extraneous CHANGELOG-*.md files on branch." || return 1
   fi
@@ -864,7 +864,7 @@ push_git_objects () {
   fi
 
   # For files created on master with new branches and
-  # for $CHANGELOG_FILE, update the master
+  # for $CHANGELOG_FILEPATH, update the master
   gitlib::push_master
 }
 
@@ -890,13 +890,13 @@ Kubernetes team,
 <P>
 Kubernetes $RELEASE_VERSION_PRIME has been built and pushed.
 <P>
-The release notes have been updated in <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILE/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A> with a pointer to it on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
+The release notes have been updated in <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILEPATH</A> with a pointer to it on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
 <P>
 <HR>
 $(cat $RELEASE_NOTES_HTML)
 <HR>
 <P><BR>
-Leads, the <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILE/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A> has been bootstrapped with $RELEASE_VERSION_PRIME release notes and you may edit now as needed.
+Leads, the <A HREF=https://github.com/kubernetes/kubernetes/blob/master/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILEPATH</A> has been bootstrapped with $RELEASE_VERSION_PRIME release notes and you may edit now as needed.
 <P><BR>
 Published by <A HREF=https://github.com/kubernetes/release>$PROG</A>, the Kubernetes Release Tool
 EOF
@@ -1039,7 +1039,7 @@ update_github_release () {
 
   # post release data
   logecho "$release_verb the $RELEASE_VERSION_PRIME release on github..."
-  local changelog_url="$K8S_GITHUB_URL/blob/master/$CHANGELOG_FILE"
+  local changelog_url="$K8S_GITHUB_URL/blob/master/$CHANGELOG_FILEPATH"
   query_tmpl='{
     "tag_name" : $tag,
     "target_commitish": $target,
@@ -1056,9 +1056,9 @@ SHA512 for `kubernetes.tar.gz`: `%s`
 Additional binary downloads are linked in the [%s](%s).'
   body="$(
     printf "$body_fmt" \
-      "$CHANGELOG_FILE" "${changelog_url}#${RELEASE_VERSION_PRIME//\./}" \
+      "$CHANGELOG_FILEPATH" "${changelog_url}#${RELEASE_VERSION_PRIME//\./}" \
       "$sha256_hash" "$sha512_hash" \
-      "$CHANGELOG_FILE" "${changelog_url}#downloads-for-${RELEASE_VERSION_PRIME//\./}"
+      "$CHANGELOG_FILEPATH" "${changelog_url}#downloads-for-${RELEASE_VERSION_PRIME//\./}"
   )"
   query_body="$( jq \
     --arg tag "$RELEASE_VERSION_PRIME" \
@@ -1583,7 +1583,8 @@ else
 fi
 
 if [[ $RELEASE_VERSION_PRIME =~ ${VER_REGEX[release]} ]]; then
-  CHANGELOG_FILE="CHANGELOG/CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+  CHANGELOG_FILE="CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+  CHANGELOG_FILEPATH="$CHANGELOG_DIR/$CHANGELOG_FILE"
 else
   common::exit 1 "Unable to set CHANGELOG file!"
 fi
@@ -1638,7 +1639,7 @@ common::printvars -p WORKDIR WORKDIR TREE_ROOT $DISPLAY_PARENT_BRANCH \
                      $DISPLAY_VERSION \
                      RELEASE_VERSION_PRIME ${ALL_RELEASE_VERSIONS[@]} \
                      RELEASE_BRANCH GCRIO_PATH RELEASE_BUCKET BUCKET_TYPE \
-                     CHANGELOG_FILE \
+                     CHANGELOG_FILEPATH \
                      FLAGS_nomock FLAGS_rc FLAGS_official \
                      LOGFILE
 

--- a/anago
+++ b/anago
@@ -1039,7 +1039,7 @@ update_github_release () {
 
   # post release data
   logecho "$release_verb the $RELEASE_VERSION_PRIME release on github..."
-  local changelog_url="$K8S_GITHUB_URL/blob/master/$CHANGELOG_FILEPATH"
+  local changelog_url="$K8S_GITHUB_URL/blob/$RELEASE_VERSION_PRIME/$CHANGELOG_FILEPATH"
   query_tmpl='{
     "tag_name" : $tag,
     "target_commitish": $target,

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -27,6 +27,10 @@ readonly PROD_BUCKET="kubernetes-release"
 readonly TEST_BUCKET="kubernetes-release-gcb"
 readonly CI_BUCKET="kubernetes-release-dev"
 
+# Set a globally usable variable for the changelog directory since we've been
+# piecemeal search/replace-ing this and missing some cases.
+readonly CHANGELOG_DIR="CHANGELOG"
+
 ###############################################################################
 # FUNCTIONS
 ###############################################################################

--- a/relnotes
+++ b/relnotes
@@ -294,6 +294,7 @@ generate_notes () {
   local tempfile=$TMPDIR/$PROG-file-1.$$
   local anchor
   local changelog_file
+  local changelog_filepath
   local -a normal_prs
   local -a action_prs
   local -a notes_normal
@@ -328,7 +329,8 @@ generate_notes () {
   range="$start_tag..$release_tag"
 
   if [[ $release_tag =~ ${VER_REGEX[release]} ]]; then
-    changelog_file="CHANGELOG/CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+    changelog_file="CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+    changelog_filepath="$CHANGELOG_DIR/$changelog_file"
   else
     logecho "Unable to set CHANGELOG file!"
     return 1
@@ -410,7 +412,7 @@ EOF+
     echo "### Previous Releases Included in $release_tag"
     while read anchor; do
       echo "$anchor"
-    done< <(git show master:$changelog_file | egrep "^- \[${release_tag}-") \
+    done< <(git show master:$changelog_filepath | egrep "^- \[${release_tag}-") \
      >> $PR_NOTES
   else
     echo "## Changelog since $start_tag" >> $PR_NOTES
@@ -458,7 +460,7 @@ EOF+
     # Make users and PRs linkable
     # Also, expand anchors (needed for email announce())
     sed -i -e "s,#\([0-9]\{5\,\}\),[#\1]($K8S_GITHUB_URL/pull/\1),g" \
-        -e "s,\(#v[0-9]\{3\}-\),$K8S_GITHUB_URL/blob/master/$changelog_file\1,g" \
+        -e "s,\(#v[0-9]\{3\}-\),$K8S_GITHUB_URL/blob/master/$changelog_filepath\1,g" \
         -e "s,@\([a-zA-Z0-9-]*\),[@\1](https://github.com/\1),g" \
      $RELEASE_NOTES_MD
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug cleanup documentation

**What this PR does / why we need it**:
- Add CHANGELOG_DIR variable to set authoritative changelog location
  Recent changes to the changelog location in kubernetes/kubernetes mean
  we need to ensure all places that reference the changelog location can
  be changed on the fly AND consistently.

  Adding this because stages on a to-be created branch fail on the removal
  of the previous changelogs. This code branch was using a wildcard, so we
  didn't pick it up in our initial search/replace.
- Update release announcements copy
  Some minor edits on the announcement copy, now that we've changed the
  changelog locations. Also, cleans up some copy nits that have been
  bugging me ever time we send an announcement.

  Deferring major changes to the branch cut announcement until I think
  more about how what advice we want to give to contributors during that
  release phase.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

**Which issue(s) this PR fixes**:
ref https://github.com/kubernetes/release/issues/1100

**Special notes for your reviewer**:
This fixes a release-blocking issue, which I'll file shortly.
A mock stage of this is running at https://console.cloud.google.com/cloud-build/builds/d086f806-812b-418c-a429-16947660370f?project=kubernetes-release-test.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Set authoritative changelog location via `CHANGELOG_DIR` variable
- Update release announcements copy
```
