### PR TITLE
[krel] gcbmgr: Add support for 'release' workflow

### DIFF
--- a/cmd/gcbuilder/cmd/root.go
+++ b/cmd/gcbuilder/cmd/root.go
@@ -17,9 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -61,7 +58,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&buildOpts.ConfigDir, "config-dir", "", "Configuration directory")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.BuildDir, "build-dir", "", "If provided, this directory will be uploaded as the source for the Google Cloud Build run.")
-	rootCmd.PersistentFlags().StringVar(&buildOpts.CloudbuildFile, "gcb-config", "cloudbuild.yaml", "If provided, this will be used as the name of the Google Cloud Build config file.")
+	rootCmd.PersistentFlags().StringVar(&buildOpts.CloudbuildFile, "gcb-config", build.DefaultCloudbuildFile, "If provided, this will be used as the name of the Google Cloud Build config file.")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.LogDir, "log-dir", "", "If provided, build logs will be sent to files in this directory instead of to stdout/stderr.")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.ScratchBucket, "scratch-bucket", "", "The complete GCS path for Cloud Build to store scratch files (sources, logs).")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.Project, "project", "", "If specified, use a non-default GCP project.")
@@ -74,48 +71,10 @@ func init() {
 	buildOpts.ConfigDir = strings.TrimSuffix(buildOpts.ConfigDir, "/")
 }
 
-// TODO: Clean up error handling
 func run() error {
-	if buildOpts.ConfigDir == "" {
-		logrus.Info("expected a config directory to be provided")
-		// TODO: Should return error
-		//nolint:gocritic
-		return nil // errors.New("expected a config directory to be provided")
-	}
-
-	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
-		if err := os.Chdir(bazelWorkspace); err != nil {
-			logrus.Fatalf("Failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
-		}
-	}
-
-	if buildOpts.BuildDir == "" {
-		buildOpts.BuildDir = buildOpts.ConfigDir
-	}
-
-	logrus.Infof("Build directory: %s\n", buildOpts.BuildDir)
-
-	// Canonicalize the config directory to be an absolute path.
-	// As we're about to cd into the build directory, we need a consistent way to reference the config files
-	// when the config directory is not the same as the build directory.
-	absConfigDir, absErr := filepath.Abs(buildOpts.ConfigDir)
-	if absErr != nil {
-		logrus.Fatalf("Could not resolve absolute path for config directory: %v", absErr)
-	}
-
-	buildOpts.ConfigDir = absConfigDir
-	buildOpts.CloudbuildFile = path.Join(buildOpts.ConfigDir, buildOpts.CloudbuildFile)
-
-	configDirErr := buildOpts.ValidateConfigDir()
-	if configDirErr != nil {
-		logrus.Fatalf("Could not validate config directory: %v", configDirErr)
-	}
-
-	logrus.Infof("Config directory: %s\n", buildOpts.ConfigDir)
-
-	logrus.Infof("cd-ing to build directory: %s\n", buildOpts.BuildDir)
-	if err := os.Chdir(buildOpts.BuildDir); err != nil {
-		logrus.Fatalf("Failed to chdir to build directory (%s): %v", buildOpts.BuildDir, err)
+	prepareBuildErr := build.PrepareBuilds(buildOpts)
+	if prepareBuildErr != nil {
+		return prepareBuildErr
 	}
 
 	buildErrors := build.RunBuildJobs(buildOpts)

--- a/cmd/gcbuilder/cmd/root.go
+++ b/cmd/gcbuilder/cmd/root.go
@@ -56,7 +56,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&buildOpts.ConfigDir, "config-dir", "", "Configuration directory")
+	rootCmd.PersistentFlags().StringVar(&buildOpts.ConfigDir, "config-dir", ".", "Configuration directory")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.BuildDir, "build-dir", "", "If provided, this directory will be uploaded as the source for the Google Cloud Build run.")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.CloudbuildFile, "gcb-config", build.DefaultCloudbuildFile, "If provided, this will be used as the name of the Google Cloud Build config file.")
 	rootCmd.PersistentFlags().StringVar(&buildOpts.LogDir, "log-dir", "", "If provided, build logs will be sent to files in this directory instead of to stdout/stderr.")

--- a/cmd/gcbuilder/cmd/root_test.go
+++ b/cmd/gcbuilder/cmd/root_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestRootCommand(t *testing.T) {
-	err := rootCmd.Execute()
+	err := rootCmd.Usage()
 	require.Nil(t, err)
 }

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -39,10 +39,14 @@ go_test(
     name = "go_default_test",
     srcs = [
         "changelog_test.go",
+        "gcbmgr_test.go",
         "root_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+    deps = [
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/gcp/build:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -59,16 +59,6 @@ var (
 	}
 )
 
-const (
-	// TODO: This should maybe be in pkg/release
-	defaultReleaseToolRepo   = "https://github.com/kubernetes/release"
-	defaultReleaseToolBranch = "master"
-	defaultProject           = "kubernetes-release-test"
-	defaultDiskSize          = "300"
-
-	bucketPrefix = "kubernetes-release-"
-)
-
 // gcbmgrCmd is the command when calling `krel version`
 var gcbmgrCmd = &cobra.Command{
 	Use:           "gcbmgr",
@@ -122,7 +112,7 @@ func init() {
 	gcbmgrCmd.PersistentFlags().StringVar(
 		&buildOpts.Project,
 		"project",
-		defaultProject,
+		release.DefaultProject,
 		"Branch to run the specified GCB run against",
 	)
 	gcbmgrCmd.PersistentFlags().BoolVar(
@@ -162,7 +152,7 @@ func runGcbmgr() error {
 	logrus.Infof("Build options: %v", *buildOpts)
 
 	buildOpts.NoSource = true
-	buildOpts.DiskSize = defaultDiskSize
+	buildOpts.DiskSize = release.DefaultDiskSize
 
 	if gcbmgrOpts.stream {
 		buildOpts.Async = false
@@ -197,6 +187,8 @@ func runGcbmgr() error {
 		// TODO: Remove once cloudbuild.yaml doesn't strictly require vars to be set.
 		gcbSubs["NOMOCK_TAG"] = ""
 		gcbSubs["NOMOCK"] = ""
+
+		bucketPrefix := release.BucketPrefix
 
 		userBucket := fmt.Sprintf("%s%s", bucketPrefix, gcbSubs["GCP_USER_TAG"])
 		userBucketSetErr := os.Setenv("USER_BUCKET", userBucket)
@@ -252,12 +244,12 @@ func setGCBSubstitutions() (map[string]string, error) {
 
 	releaseToolRepo := os.Getenv("RELEASE_TOOL_REPO")
 	if releaseToolRepo == "" {
-		releaseToolRepo = defaultReleaseToolRepo
+		releaseToolRepo = release.DefaultReleaseToolRepo
 	}
 
 	releaseToolBranch := os.Getenv("RELEASE_TOOL_BRANCH")
 	if releaseToolBranch == "" {
-		releaseToolBranch = defaultReleaseToolBranch
+		releaseToolBranch = release.DefaultReleaseToolBranch
 	}
 
 	gcbSubs["RELEASE_TOOL_REPO"] = releaseToolRepo

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -150,6 +150,8 @@ func runGcbmgr() error {
 		return errors.New("binaries required to run gcbmgr are not present; cannot continue")
 	}
 
+	// TODO: Add gitlib::repo_state check
+
 	logrus.Infof("Running gcbmgr with the following options: %v", *gcbmgrOpts)
 	logrus.Infof("Build options: %v", *buildOpts)
 
@@ -217,12 +219,14 @@ func runGcbmgr() error {
 	case gcbmgrOpts.stage:
 		return submitStage(toolRoot, gcbSubs)
 	case gcbmgrOpts.release:
-		return submitRelease()
+		return submitRelease(toolRoot, gcbSubs)
 	default:
 		return listJobs()
 	}
 }
 
+// TODO: We may consider pushing stage and release into the runGcbmgr() function
+//       Seems to be a bit of duplication without a lot of benefit.
 func submitStage(toolRoot string, substitutions map[string]string) error {
 	logrus.Infof("Submitting a stage to GCB")
 
@@ -236,14 +240,18 @@ func submitStage(toolRoot string, substitutions map[string]string) error {
 	return build.RunSingleJob(buildOpts, jobName, uploaded, version, substitutions)
 }
 
-// TODO: Populate logic once we're happy with the flow for the submitStage() function.
-func submitRelease() error {
+func submitRelease(toolRoot string, substitutions map[string]string) error {
 	logrus.Infof("Submitting a release to GCB")
 
+	// TODO: Fail if the file doesn't exist
+	buildOpts.CloudbuildFile = filepath.Join(toolRoot, "gcb/stage/cloudbuild.yaml")
 	buildOpts.DiskSize = "100"
 
-	//nolint:gocritic
-	return nil // build.RunSingleJob(buildOpts, jobName, uploaded, version, subs)
+	// TODO: Need actual values
+	var jobName, uploaded string
+	version := "FAKEVERSION"
+
+	return build.RunSingleJob(buildOpts, jobName, uploaded, version, substitutions)
 }
 
 func setGCBSubstitutions() (map[string]string, error) {

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -280,7 +280,7 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 		}
 	} else {
 		// TODO: Consider removing this once the 'gcloud auth' is testable in CI
-		gcpUser = strings.TrimSuffix(gcpUser, "\n")
+		gcpUser = strings.TrimSpace(gcpUser)
 		gcpUser = strings.ReplaceAll(gcpUser, "@", "-at-")
 		gcpUser = strings.ReplaceAll(gcpUser, ".", "-")
 		gcpUser = strings.ToLower(gcpUser)

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -314,14 +314,24 @@ func setGCBSubstitutions() (map[string]string, error) {
 	buildVersion = fmt.Sprintf("--buildversion=%s", buildVersion)
 	gcbSubs["BUILDVERSION"] = buildVersion
 
-	if gcbmgrOpts.branch != "" {
-		gcbSubs["RELEASE_BRANCH"] = gcbmgrOpts.branch
+	branch := gcbmgrOpts.branch
+
+	if branch != "" {
+		gcbSubs["RELEASE_BRANCH"] = branch
 	} else {
 		return gcbSubs, errors.New("Release branch must be set to continue")
 	}
 
-	// TODO: Ensure release.GetKubecrossVersion() isn't hardcoded.
-	gcbSubs["KUBE_CROSS_VERSION"] = release.GetKubecrossVersion()
+	kubecrossBranches := []string{
+		branch,
+		"master",
+	}
+
+	kubecrossVersion, kubecrossVersionErr := release.GetKubecrossVersion(kubecrossBranches...)
+	if kubecrossVersionErr != nil {
+		return gcbSubs, kubecrossVersionErr
+	}
+	gcbSubs["KUBE_CROSS_VERSION"] = kubecrossVersion
 
 	return gcbSubs, nil
 }

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -161,7 +161,7 @@ func runGcbmgr() error {
 	}
 
 	if gcbmgrOpts.stage && gcbmgrOpts.release {
-		logrus.Fatal("Cannot specify both the 'stage' and 'release' flag. Please resubmit with only one of those flags selected.")
+		return errors.New("cannot specify both the 'stage' and 'release' flag; resubmit with only one build type selected")
 	}
 
 	gcbSubs, gcbSubsErr := setGCBSubstitutions(gcbmgrOpts)
@@ -170,6 +170,7 @@ func runGcbmgr() error {
 	}
 
 	if rootOpts.nomock {
+		// TODO: Consider a '--yes' flag so we can mock this
 		_, nomockSubmit, askErr := util.Ask(
 			"Really submit a --nomock release job against the $RELEASE_BRANCH branch?",
 			"yes",
@@ -215,6 +216,7 @@ func runGcbmgr() error {
 
 	var jobType string
 	switch {
+	// TODO: Consider a '--validate' flag to validate the GCB config without submitting
 	case gcbmgrOpts.stage:
 		jobType = "stage"
 	case gcbmgrOpts.release:

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -164,7 +164,7 @@ func runGcbmgr() error {
 		logrus.Fatal("Cannot specify both the 'stage' and 'release' flag. Please resubmit with only one of those flags selected.")
 	}
 
-	gcbSubs, gcbSubsErr := setGCBSubstitutions()
+	gcbSubs, gcbSubsErr := setGCBSubstitutions(gcbmgrOpts)
 	if gcbSubs == nil || gcbSubsErr != nil {
 		return gcbSubsErr
 	}
@@ -237,7 +237,7 @@ func runGcbmgr() error {
 	return build.RunSingleJob(buildOpts, jobName, uploaded, version, gcbSubs)
 }
 
-func setGCBSubstitutions() (map[string]string, error) {
+func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 	gcbSubs := map[string]string{}
 
 	releaseToolRepo := os.Getenv("RELEASE_TOOL_REPO")
@@ -261,7 +261,7 @@ func setGCBSubstitutions() (map[string]string, error) {
 	gcbSubs["GCP_USER_TAG"] = gcpUser
 
 	// TODO: The naming for these env vars is clumsy/confusing, but we're bound by anago right now.
-	releaseType := gcbmgrOpts.releaseType
+	releaseType := o.releaseType
 	switch releaseType {
 	case "official":
 		gcbSubs["OFFICIAL_TAG"] = releaseType
@@ -288,16 +288,16 @@ func setGCBSubstitutions() (map[string]string, error) {
 	// TODO: Remove once we remove support for --built-at-head.
 	gcbSubs["BUILD_AT_HEAD"] = ""
 
-	buildpoint := gcbmgrOpts.buildVersion
+	buildpoint := o.buildVersion
 	buildpoint = strings.ReplaceAll(buildpoint, "+", "-")
 	gcbSubs["BUILD_POINT"] = buildpoint
 
 	// TODO: Add conditionals for find_green_build
-	buildVersion := gcbmgrOpts.buildVersion
+	buildVersion := o.buildVersion
 	buildVersion = fmt.Sprintf("--buildversion=%s", buildVersion)
 	gcbSubs["BUILDVERSION"] = buildVersion
 
-	branch := gcbmgrOpts.branch
+	branch := o.branch
 
 	if branch != "" {
 		gcbSubs["RELEASE_BRANCH"] = branch

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -215,8 +215,6 @@ func runGcbmgr() error {
 
 	var jobType string
 	switch {
-	case gcbmgrOpts.stage && gcbmgrOpts.release:
-		return errors.New("The '--stage' and '--release' flags cannot be used together")
 	case gcbmgrOpts.stage:
 		jobType = "stage"
 	case gcbmgrOpts.release:

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetGCBSubstitutionsSuccess(t *testing.T) {
+	testcases := []struct {
+		name       string
+		gcbmgrOpts gcbmgrOptions
+		expected   map[string]string
+	}{
+		{
+			name: "master prerelease",
+			gcbmgrOpts: gcbmgrOptions{
+				branch:      "master",
+				releaseType: "prerelease",
+			},
+			expected: map[string]string{
+				"BUILDVERSION":        "--buildversion=",
+				"BUILD_AT_HEAD":       "",
+				"BUILD_POINT":         "",
+				"OFFICIAL":            "",
+				"OFFICIAL_TAG":        "",
+				"RC":                  "",
+				"RC_TAG":              "",
+				"RELEASE_BRANCH":      "master",
+				"RELEASE_TOOL_BRANCH": "master",
+				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+			},
+		},
+		{
+			name: "release-1.14 RC",
+			gcbmgrOpts: gcbmgrOptions{
+				branch:      "release-1.14",
+				releaseType: "rc",
+			},
+			expected: map[string]string{
+				"BUILDVERSION":        "--buildversion=",
+				"BUILD_AT_HEAD":       "",
+				"BUILD_POINT":         "",
+				"OFFICIAL":            "",
+				"OFFICIAL_TAG":        "",
+				"RC":                  "--rc",
+				"RC_TAG":              "rc",
+				"RELEASE_BRANCH":      "release-1.14",
+				"RELEASE_TOOL_BRANCH": "master",
+				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+			},
+		},
+		{
+			name: "release-1.15 official",
+			gcbmgrOpts: gcbmgrOptions{
+				branch:      "release-1.15",
+				releaseType: "official",
+			},
+			expected: map[string]string{
+				"BUILDVERSION":        "--buildversion=",
+				"BUILD_AT_HEAD":       "",
+				"BUILD_POINT":         "",
+				"OFFICIAL":            "--official",
+				"OFFICIAL_TAG":        "official",
+				"RC":                  "",
+				"RC_TAG":              "",
+				"RELEASE_BRANCH":      "release-1.15",
+				"RELEASE_TOOL_BRANCH": "master",
+				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		opts := tc.gcbmgrOpts
+
+		subs, err := setGCBSubstitutions(&opts)
+		actual := dropDynamicSubstitutions(subs)
+
+		if err != nil {
+			t.Fatalf("did not expect an error: %v", err)
+		}
+
+		assert.Equal(t, tc.expected, actual)
+	}
+}
+
+func TestSetGCBSubstitutionsFailure(t *testing.T) {
+	testcases := []struct {
+		name       string
+		gcbmgrOpts gcbmgrOptions
+		expected   map[string]string
+	}{
+		{
+			name: "no release branch",
+			gcbmgrOpts: gcbmgrOptions{
+				branch: "",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		opts := tc.gcbmgrOpts
+
+		_, err := setGCBSubstitutions(&opts)
+		assert.Error(t, err)
+	}
+}
+
+func dropDynamicSubstitutions(orig map[string]string) (result map[string]string) {
+	result = orig
+
+	for k := range result {
+		if k == "GCP_USER_TAG" || k == "KUBE_CROSS_VERSION" {
+			delete(result, k)
+		}
+	}
+
+	return result
+}

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -17,10 +17,76 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/release/pkg/gcp/build"
 )
+
+func TestRunGcbmgrSuccess(t *testing.T) {
+	testcases := []struct {
+		name       string
+		gcbmgrOpts gcbmgrOptions
+		buildOpts  build.Options
+		expected   map[string]string
+	}{
+		{
+			name: "list only",
+			gcbmgrOpts: gcbmgrOptions{
+				branch: "master",
+			},
+		},
+		{
+			name: "stream the job",
+			gcbmgrOpts: gcbmgrOptions{
+				branch: "master",
+				stream: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		gcbmgrOpts = &tc.gcbmgrOpts
+
+		err := runGcbmgr()
+		assert.Nil(t, err)
+	}
+}
+
+func TestRunGcbmgrFailure(t *testing.T) {
+	testcases := []struct {
+		name       string
+		gcbmgrOpts gcbmgrOptions
+		expected   map[string]string
+	}{
+		{
+			name: "no release branch",
+			gcbmgrOpts: gcbmgrOptions{
+				branch: "",
+			},
+		},
+		{
+			name: "specify stage and release",
+			gcbmgrOpts: gcbmgrOptions{
+				stage:   true,
+				release: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		fmt.Printf("Test case: %s", tc.name)
+
+		gcbmgrOpts = &tc.gcbmgrOpts
+
+		err := runGcbmgr()
+		assert.Error(t, err)
+	}
+}
 
 func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 	testcases := []struct {
@@ -88,6 +154,8 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
 		opts := tc.gcbmgrOpts
 
 		subs, err := setGCBSubstitutions(&opts)
@@ -116,6 +184,8 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
 		opts := tc.gcbmgrOpts
 
 		_, err := setGCBSubstitutions(&opts)

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -35,14 +35,16 @@ func TestRunGcbmgrSuccess(t *testing.T) {
 		{
 			name: "list only",
 			gcbmgrOpts: gcbmgrOptions{
-				branch: "master",
+				branch:  "master",
+				gcpUser: "test-user",
 			},
 		},
 		{
 			name: "stream the job",
 			gcbmgrOpts: gcbmgrOptions{
-				branch: "master",
-				stream: true,
+				branch:  "master",
+				stream:  true,
+				gcpUser: "test-user",
 			},
 		},
 	}
@@ -66,7 +68,8 @@ func TestRunGcbmgrFailure(t *testing.T) {
 		{
 			name: "no release branch",
 			gcbmgrOpts: gcbmgrOptions{
-				branch: "",
+				branch:  "",
+				gcpUser: "test-user",
 			},
 		},
 		{
@@ -74,6 +77,7 @@ func TestRunGcbmgrFailure(t *testing.T) {
 			gcbmgrOpts: gcbmgrOptions{
 				stage:   true,
 				release: true,
+				gcpUser: "test-user",
 			},
 		},
 	}
@@ -99,6 +103,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			gcbmgrOpts: gcbmgrOptions{
 				branch:      "master",
 				releaseType: "prerelease",
+				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
 				"BUILDVERSION":        "--buildversion=",
@@ -118,6 +123,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			gcbmgrOpts: gcbmgrOptions{
 				branch:      "release-1.14",
 				releaseType: "rc",
+				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
 				"BUILDVERSION":        "--buildversion=",
@@ -137,6 +143,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			gcbmgrOpts: gcbmgrOptions{
 				branch:      "release-1.15",
 				releaseType: "official",
+				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
 				"BUILDVERSION":        "--buildversion=",
@@ -178,7 +185,8 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 		{
 			name: "no release branch",
 			gcbmgrOpts: gcbmgrOptions{
-				branch: "",
+				branch:  "",
+				gcpUser: "test-user",
 			},
 		},
 	}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -261,9 +261,10 @@ func (s *Stream) Output() string {
 	return s.stdOut
 }
 
-// Output returns stdout of the command status with the newline trimmed
+// OutputTrimNL returns stdout of the command status with newlines trimmed
+// Use only when output is expected to be a single "word", like a version string.
 func (s *Stream) OutputTrimNL() string {
-	return strings.TrimSuffix(s.stdOut, "\n")
+	return strings.TrimSpace(s.stdOut)
 }
 
 // Error returns the stderr of the command status

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -261,6 +261,11 @@ func (s *Stream) Output() string {
 	return s.stdOut
 }
 
+// Output returns stdout of the command status with the newline trimmed
+func (s *Stream) OutputTrimNL() string {
+	return strings.TrimSuffix(s.stdOut, "\n")
+}
+
 // Error returns the stderr of the command status
 func (s *Stream) Error() string {
 	return s.stdErr

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -101,6 +101,12 @@ func TestSuccessOutput(t *testing.T) {
 	require.Equal(t, "hello world", res.Output())
 }
 
+func TestSuccessOutputTrimNL(t *testing.T) {
+	res, err := New("echo", "-n", "hello world\n").Run()
+	require.Nil(t, err)
+	require.Equal(t, "hello world", res.OutputTrimNL())
+}
+
 func TestSuccessError(t *testing.T) {
 	res, err := New("cat", "/not/valid").Run()
 	require.Nil(t, err)

--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -43,7 +43,7 @@ func GetCurrentGCPUser() (string, error) {
 		return "", errors.New("the GCP user name should not be empty")
 	}
 
-	gcpUser = strings.TrimSuffix(gcpUser, "\n")
+	gcpUser = strings.TrimSpace(gcpUser)
 	gcpUser = strings.ReplaceAll(gcpUser, "@", "-at-")
 	gcpUser = strings.ReplaceAll(gcpUser, ".", "-")
 	gcpUser = strings.ToLower(gcpUser)

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["release.go"],
     importpath = "k8s.io/release/pkg/release",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util:go_default_library"],
+    deps = [
+        "//pkg/util:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -31,6 +31,13 @@ import (
 )
 
 const (
+	// gcbmgr/anago defaults
+	DefaultReleaseToolRepo   = "https://github.com/kubernetes/release"
+	DefaultReleaseToolBranch = "master"
+	DefaultProject           = "kubernetes-release-test"
+	DefaultDiskSize          = "300"
+	BucketPrefix             = "kubernetes-release-"
+
 	versionReleaseRE  = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
 	versionBuildRE    = `([0-9]{1,})\+([0-9a-f]{5,40})`
 	versionDirtyRE    = `(-dirty)`

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -72,7 +72,7 @@ func ReadDockerizedVersion(path, releaseKind string) (string, error) {
 		return "", err
 	}
 	file, err := ioutil.ReadAll(reader)
-	return strings.TrimSuffix(string(file), "\n"), err
+	return strings.TrimSpace(string(file)), err
 }
 
 // IsValidReleaseBuild checks if build version is valid for release.
@@ -106,7 +106,7 @@ func GetKubecrossVersion(branches ...string) (string, error) {
 			return "", errors.Wrapf(ioErr, "could not handle the response body for %s", versionURL)
 		}
 
-		version = strings.TrimSuffix(string(body), "\n")
+		version = strings.TrimSpace(string(body))
 
 		if version != "" {
 			logrus.Infof("Found the following kube-cross version: %s", version)

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/release/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/command:go_default_library",
         "@com_github_blang_semver//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
@@ -37,6 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@com_github_blang_semver//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -97,6 +97,9 @@ func PackagesAvailable(packages ...string) (bool, error) {
 				ok = false
 			}
 		}
+	default:
+		ok = false
+		return ok, errors.New("cannot continue; running tool on an unsupported OS")
 	}
 
 	installInstructionsPrefix := fmt.Sprintf("sudo %s install ", pkgMgr)

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -28,8 +28,85 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPackagesAvailableSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		packages []string
+	}{
+		{
+			name: "single package",
+			packages: []string{
+				"bash",
+			},
+		},
+		{
+			name: "multiple packages",
+			packages: []string{
+				"bash",
+				"curl",
+				"grep",
+			},
+		},
+		{
+			name:     "no packages",
+			packages: []string{},
+		},
+	}
+
+	for _, tc := range testcases {
+		actual, err := PackagesAvailable(tc.packages...)
+
+		if err != nil {
+			t.Fatalf("did not expect an error: %v", err)
+		}
+
+		assert.True(t, actual)
+	}
+}
+
+func TestPackagesAvailableFailure(t *testing.T) {
+	testcases := []struct {
+		name     string
+		packages []string
+	}{
+		{
+			name: "single unavailable package",
+			packages: []string{
+				"fakepackagefoo",
+			},
+		},
+		{
+			name: "multiple unavailable packages",
+			packages: []string{
+				"fakepackagefoo",
+				"fakepackagebar",
+				"fakepackagebaz",
+			},
+		},
+		{
+			name: "available and unavailable packages",
+			packages: []string{
+				"bash",
+				"fakepackagefoo",
+				"fakepackagebar",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		actual, err := PackagesAvailable(tc.packages...)
+
+		if err != nil {
+			t.Fatalf("did not expect an error: %v", err)
+		}
+
+		assert.False(t, actual)
+	}
+}
 
 func TestMoreRecent(t *testing.T) {
 	baseTmpDir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup feature

**What this PR does / why we need it**:
- [krel] gcbmgr: Add check for installed packages/commands before running
- [krel] gcbmgr: Add support for 'release' workflow
- [krel] gcbmgr: Populate GetKubecrossVersion() logic
- pkg/gcp/build: Move build preparation logic to PrepareBuilds()
- [krel] gcbmgr: De-dupe stage/release logic using build.PrepareBuilds
- gcbuilder: Default config directory to current working directory
- pkg/release: Add defaults for gcbmgr/anago execution
- [krel] gcbmgr: Remove redundant case in job submission selection
- [krel] gcbmgr: Add test cases for setGCBSubstitutions()
- [krel] gcbmgr: Add test cases for runGcbmgr()
- pkg/util: Clean up log messages for PackagesAvailable() and getOS()
- [krel] gcbmgr: Temporarily bypass package checks to not fail tests in CI
- pkg/util: Add default case failure for PackagesAvailable()

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Does this PR introduce a user-facing change?**:
```release-note
[krel] gcbmgr: Add support for 'release' workflow
```
