### PR TITLE
Allow gcbmgr to execute with ssh remote

### DIFF
--- a/gcbmgr
+++ b/gcbmgr
@@ -149,7 +149,7 @@ source $BASE_ROOT/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 
-readonly RELEASE_TOOL_REPO="${RELEASE_TOOL_REPO:-https://github.com/kubernetes/release}"
+readonly RELEASE_TOOL_REPO="${RELEASE_TOOL_REPO:-[:/]kubernetes/release}"
 readonly RELEASE_TOOL_BRANCH="${RELEASE_TOOL_BRANCH:-master}"
 
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`gitlib::repo_state`, which is used by `branchff`, `anago`, and `gcbmgr` was updated in a previous commit to allow for `ssh` remotes. `gcbmgr` currently overrides this by setting `RELEASE_TOOL_REPO` explicitly to the `https` remote. This PR allows `gcbmgr` to execute with either a `ssh` or `https` remote.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Ref: https://github.com/kubernetes/sig-release/pull/994#issuecomment-586673659

**Special notes for your reviewer**:

The regex being used on the `git remote -v` output is `[:/]kubernetes\/release(.git)* \(fetch\)` if you want to test it out :+1: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
gcbmgr can now be run with an ssh remote
```

/assign @saschagrunert @justaugustus @cpanato
