### PR TITLE
[krel] gcbmgr: Address bartsmykla review comments

### DIFF
--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -43,10 +43,16 @@ func GetCurrentGCPUser() (string, error) {
 		return "", errors.New("the GCP user name should not be empty")
 	}
 
+	gcpUser = NormalizeGCPUser(gcpUser)
+
+	return gcpUser, nil
+}
+
+func NormalizeGCPUser(gcpUser string) string {
 	gcpUser = strings.TrimSpace(gcpUser)
 	gcpUser = strings.ReplaceAll(gcpUser, "@", "-at-")
 	gcpUser = strings.ReplaceAll(gcpUser, ".", "-")
 	gcpUser = strings.ToLower(gcpUser)
 
-	return gcpUser, nil
+	return gcpUser
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Update function descriptions
- Initialize buildOpts.Async as 'true'
- Fail even earlier if both '--stage' and '--release' are specified
- Use NormalizeGCPUser() to encapsulate normalizing the GCP_USER_TAG
- Simplify check for release branch

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes**:
Addresses @bartsmykla's [review comments](https://github.com/kubernetes/release/pull/1101#pullrequestreview-359504196) from https://github.com/kubernetes/release/pull/1101

**Special notes for your reviewer**:
~/hold I'm adding one more thing to this for readability~

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
