### PR TITLE
Add dedicated types for Kind and Notes

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/git:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/notes:go_default_library",
+        "//pkg/notes/document:go_default_library",
         "//pkg/notes/options:go_default_library",
         "//pkg/patch:go_default_library",
         "//pkg/release:go_default_library",

--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -36,6 +36,7 @@ import (
 
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/notes"
+	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
 	"k8s.io/release/pkg/util"
 )
@@ -227,7 +228,7 @@ func generateReleaseNotes(branch, startRev, endRev string) (string, error) {
 	}
 
 	// Create the markdown
-	doc, err := notes.CreateDocument(releaseNotes, history)
+	doc, err := document.CreateDocument(releaseNotes, history)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating release note document")
 	}

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/notes"
+	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
 	"k8s.io/release/pkg/util"
 )
@@ -161,7 +162,7 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 		return nil, errors.Wrapf(err, "listing release notes")
 	}
 
-	doc, err := notes.CreateDocument(releaseNotes, history)
+	doc, err := document.CreateDocument(releaseNotes, history)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating release note document")
 	}

--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/git:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/notes:go_default_library",
+        "//pkg/notes/document:go_default_library",
         "//pkg/notes/options:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/log"
 	"k8s.io/release/pkg/notes"
+	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
 	"k8s.io/release/pkg/util"
 )
@@ -275,7 +276,7 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 			return errors.Wrapf(err, "encoding JSON output")
 		}
 	case "markdown":
-		doc, err := notes.CreateDocument(releaseNotes, history)
+		doc, err := document.CreateDocument(releaseNotes, history)
 		if err != nil {
 			return errors.Wrapf(err, "creating release note document")
 		}

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "document.go",
         "notes.go",
         "toc.go",
     ],
@@ -22,7 +21,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "document_test.go",
         "notes_gatherer_test.go",
         "notes_test.go",
         "toc_test.go",
@@ -51,6 +49,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/notes/client:all-srcs",
+        "//pkg/notes/document:all-srcs",
         "//pkg/notes/internal:all-srcs",
         "//pkg/notes/options:all-srcs",
     ],

--- a/pkg/notes/document/BUILD.bazel
+++ b/pkg/notes/document/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["document.go"],
+    importpath = "k8s.io/release/pkg/notes/document",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/notes:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["document_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package notes
+package document
 
 import (
 	"io/ioutil"
@@ -25,22 +25,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestPrettySIG(t *testing.T) {
-	cases := map[string]string{
-		"scheduling":        "Scheduling",
-		"cluster-lifecycle": "Cluster Lifecycle",
-		"cli":               "CLI",
-		"aws":               "AWS",
-		"api-machinery":     "API Machinery",
-		"vsphere":           "vSphere",
-		"openstack":         "OpenStack",
-	}
-
-	for input, expected := range cases {
-		require.Equal(t, expected, (prettySIG(input)))
-	}
-}
 
 func TestCreateDownloadsTable(t *testing.T) {
 	// Given
@@ -138,7 +122,7 @@ filename | sha512 hash
 }
 
 func TestSortKinds(t *testing.T) {
-	input := map[string][]string{
+	input := NotesByKind{
 		"cleanup":                       nil,
 		"api-change":                    nil,
 		"deprecation":                   nil,

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -230,3 +230,18 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 		})
 	}
 }
+func TestPrettySIG(t *testing.T) {
+	cases := map[string]string{
+		"scheduling":        "Scheduling",
+		"cluster-lifecycle": "Cluster Lifecycle",
+		"cli":               "CLI",
+		"aws":               "AWS",
+		"api-machinery":     "API Machinery",
+		"vsphere":           "vSphere",
+		"openstack":         "OpenStack",
+	}
+
+	for input, expected := range cases {
+		require.Equal(t, expected, (prettySIG(input)))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

This makes the overall code more semantic and readable. We also move the
`document` logic into a dedicated package to not mix types with the
`notes` package.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
