### PR TITLE
Use OutputTrimNL in git package

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -512,7 +512,7 @@ func (r *Repo) DescribeTag(rev string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(result.Output()), nil
+	return result.OutputTrimNL(), nil
 }
 
 // Merge does a git merge into the current branch from the provided one


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The new API function of the result output stream should be the
preferred default and is now used by the `git` package.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
