### PR TITLE
Fix gcbmgr cloudbuild clone step with https remote

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -38,8 +38,9 @@ steps:
 - name: gcr.io/$PROJECT_ID/k8s-cloud-builder
   dir: "go/src/k8s.io/release"
   env:
-  - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
-  - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_BRANCH=${_TOOL_BRANCH}"
   secretEnv:
   - GITHUB_TOKEN
   args:

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -21,8 +21,8 @@ steps:
   dir: "go/src/k8s.io"
   args:
   - "clone"
-  - "--branch=${_RELEASE_TOOL_BRANCH}"
-  - "${_RELEASE_TOOL_REPO}"
+  - "--branch=${_TOOL_BRANCH}"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
 - name: k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -38,8 +38,9 @@ steps:
 - name: gcr.io/$PROJECT_ID/k8s-cloud-builder
   dir: "go/src/k8s.io/release"
   env:
-  - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
-  - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_BRANCH=${_TOOL_BRANCH}"
   secretEnv:
   - GITHUB_TOKEN
   args:
@@ -60,8 +61,9 @@ steps:
 - name: k8s.gcr.io/kube-cross:local
   dir: "go/src/k8s.io/release"
   env:
-  - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
-  - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_BRANCH=${_TOOL_BRANCH}"
   args:
   - "./anago"
   - "${_RELEASE_BRANCH}"
@@ -80,8 +82,9 @@ steps:
 - name: gcr.io/$PROJECT_ID/k8s-cloud-builder
   dir: "go/src/k8s.io/release"
   env:
-  - "RELEASE_TOOL_REPO=${_RELEASE_TOOL_REPO}"
-  - "RELEASE_TOOL_BRANCH=${_RELEASE_TOOL_BRANCH}"
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_BRANCH=${_TOOL_BRANCH}"
   secretEnv:
   - GITHUB_TOKEN
   args:

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -21,8 +21,8 @@ steps:
   dir: "go/src/k8s.io"
   args:
   - "clone"
-  - "--branch=${_RELEASE_TOOL_BRANCH}"
-  - "${_RELEASE_TOOL_REPO}"
+  - "--branch=${_TOOL_BRANCH}"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
 - name: k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"

--- a/gcbmgr
+++ b/gcbmgr
@@ -149,8 +149,6 @@ source $BASE_ROOT/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $TOOL_LIB_PATH/releaselib.sh
 
-readonly RELEASE_TOOL_REPO="${RELEASE_TOOL_REPO:-[:/]kubernetes/release}"
-readonly RELEASE_TOOL_BRANCH="${RELEASE_TOOL_BRANCH:-master}"
 readonly TOOL_ORG="${TOOL_ORG:-kubernetes}"
 readonly TOOL_REPO="${TOOL_REPO:-release}"
 readonly TOOL_BRANCH="${TOOL_BRANCH:-master}"
@@ -301,8 +299,6 @@ submit_it () {
   # The usual suspects
   substitutions+=",_RELEASE_BRANCH=$RELEASE_BRANCH,_OFFICIAL=$OFFICIAL,_RC=$RC"
   substitutions+=",_NOMOCK=$NOMOCK,_BUILDVERSION=$BUILDVERSION"
-  substitutions+=",_RELEASE_TOOL_REPO=$RELEASE_TOOL_REPO"
-  substitutions+=",_RELEASE_TOOL_BRANCH=$RELEASE_TOOL_BRANCH"
   substitutions+=",_TOOL_ORG=$TOOL_ORG"
   substitutions+=",_TOOL_REPO=$TOOL_REPO"
   substitutions+=",_TOOL_BRANCH=$TOOL_BRANCH"

--- a/gcbmgr
+++ b/gcbmgr
@@ -151,6 +151,9 @@ source $TOOL_LIB_PATH/releaselib.sh
 
 readonly RELEASE_TOOL_REPO="${RELEASE_TOOL_REPO:-[:/]kubernetes/release}"
 readonly RELEASE_TOOL_BRANCH="${RELEASE_TOOL_BRANCH:-master}"
+readonly TOOL_ORG="${TOOL_ORG:-kubernetes}"
+readonly TOOL_REPO="${TOOL_REPO:-release}"
+readonly TOOL_BRANCH="${TOOL_BRANCH:-master}"
 
 ###############################################################################
 # FUNCTIONS
@@ -300,6 +303,9 @@ submit_it () {
   substitutions+=",_NOMOCK=$NOMOCK,_BUILDVERSION=$BUILDVERSION"
   substitutions+=",_RELEASE_TOOL_REPO=$RELEASE_TOOL_REPO"
   substitutions+=",_RELEASE_TOOL_BRANCH=$RELEASE_TOOL_BRANCH"
+  substitutions+=",_TOOL_ORG=$TOOL_ORG"
+  substitutions+=",_TOOL_REPO=$TOOL_REPO"
+  substitutions+=",_TOOL_BRANCH=$TOOL_BRANCH"
   substitutions+=",_KUBE_CROSS_VERSION=$KUBE_CROSS_VERSION"
 
   if ! JOB_DATA=$($GCLOUD builds submit --no-source \

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -292,8 +292,10 @@ gitlib::push_master () {
 # Ensure TOOL_ROOT running with a synced repo.
 #
 gitlib::repo_state () {
-  local expectedRemote="${RELEASE_TOOL_REPO:-[:/]kubernetes/release}"
-  local expectedBranch="${RELEASE_TOOL_BRANCH:-master}"
+  local expectedOrg="${TOOL_ORG:-kubernetes}"
+  local expectedRepo="${TOOL_REPO:-release}"
+  local expectedRemote="[:/]${expectedOrg}/${expectedRepo}"
+  local expectedBranch="${TOOL_BRANCH:-master}"
 
   local branch
   branch=$(gitlib::current_branch "$TOOL_ROOT") || return 1


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes bug introduced by #1103 that causes `cloudbuild` clone step to fail cloning release repo.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Ref #1103 
Slack Conversation: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1582034517113800

**Special notes for your reviewer**:

I have opted to be additive with the variables used here due to the fact that `RELEASE_TOOL_REPO` and `RELEASE_TOOL_BRANCH` get passed to `anago` for the same `gitlib::repo_state` check. However, I would be happy to also update `gitlib::repo_state` with the new vars and eliminate usage of the two aforementioned ones if that is more desirable :)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @justaugustus @cpanato @saschagrunert 