### PR TITLE
[krel] add options for release notes draft PR automation

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/blang/semver"
@@ -66,7 +67,11 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 }
 
 type releaseNotesOptions struct {
-	tag string
+	tag           string
+	draftOrg      string
+	draftRepo     string
+	createDraftPR bool
+	outputDir     string
 }
 
 type releaseNotesResult struct {
@@ -83,6 +88,38 @@ func init() {
 		"t",
 		"",
 		"version tag for the notes",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVarP(
+		&releaseNotesOpts.draftOrg,
+		"draft-org",
+		"",
+		"",
+		"a Github organization or user where the Release Notes PR will be created",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVarP(
+		&releaseNotesOpts.draftRepo,
+		"draft-repo",
+		"",
+		"",
+		"the name of a Github repository where the Release Notes PR will be created",
+	)
+
+	releaseNotesCmd.PersistentFlags().BoolVarP(
+		&releaseNotesOpts.createDraftPR,
+		"create-draft-pr",
+		"",
+		false,
+		"create the Release Notes draft PR. --draft-org and --draft-repo muste be set along with this option",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVarP(
+		&releaseNotesOpts.outputDir,
+		"output-dir",
+		"o",
+		"",
+		"output a copy of the release notes to this directory",
 	)
 
 	rootCmd.AddCommand(releaseNotesCmd)
@@ -113,12 +150,116 @@ func runReleaseNotes() (err error) {
 	logrus.Infof("Using start tag %v", start)
 	logrus.Infof("Using end tag %v", tag)
 
-	_, err = releaseNotesFrom(start)
+	if releaseNotesOpts.createDraftPR {
+		err = validateDraftPROptions()
+		if err != nil {
+			return errors.Wrap(err, "validating PR command line options")
+		}
+	}
+
+	result, err := releaseNotesFrom(start)
 	if err != nil {
 		return errors.Wrapf(err, "generating release notes")
 	}
 
-	//TODO: implement PR creation for k-sigs/release-notes and k/sig-release
+	// Create RN draft PR
+	if releaseNotesOpts.createDraftPR {
+		err = createDraftPR(tag, result)
+		if err != nil {
+			return errors.Wrap(err, "Failed to create release notes draft PR")
+		}
+	}
+
+	if releaseNotesOpts.outputDir != "" {
+		err = ioutil.WriteFile(releaseNotesOpts.outputDir+"release-notes.json", []byte(result.json), 0644)
+		if err != nil {
+			return errors.Wrap(err, "writing release notes JSON file")
+		}
+
+		err = ioutil.WriteFile(releaseNotesOpts.outputDir+"release-notes.md", []byte(result.json), 0644)
+		if err != nil {
+			return errors.Wrap(err, "writing release notes markdown file")
+		}
+	}
+
+	// TODO: implement PR creation for k-sigs/release-notes
+	return nil
+}
+
+// validateDraftPROptions checks if we have all needed parameters to create the Release Notes PR
+func validateDraftPROptions() error {
+	if releaseNotesOpts.createDraftPR {
+		// Check if --draft-org is set
+		if releaseNotesOpts.draftOrg == "" {
+			return errors.New("cannot generate Release Notes draft PR without --draft-org")
+		}
+
+		// Check if --draft-repo is set
+		if releaseNotesOpts.draftRepo == "" {
+			return errors.New("cannot generate Release Notes draft PR without --draft-repo")
+		}
+	}
+	return nil
+}
+
+// createDraftPR pushes the release notes draft to the users fork
+func createDraftPR(tag string, result *releaseNotesResult) error {
+	s, err := util.TagStringToSemver(tag)
+	if err != nil {
+		return errors.Wrapf(err, "no valid tag: %v", tag)
+	}
+
+	// checkout kubernetes/sig-release
+	sigReleaseRepo, err := git.CloneOrOpenGitHubRepo("", "kubernetes", "sig-release", true)
+	if err != nil {
+		return errors.Wrap(err, "cloning k/sig-release")
+	}
+
+	// add the user's fork as a remote
+	err = sigReleaseRepo.AddRemote("userfork", releaseNotesOpts.draftOrg, releaseNotesOpts.draftRepo)
+	if err != nil {
+		return errors.Wrap(err, "adding users fork as remote repository")
+	}
+
+	// verify the branch doesn't already exist on the user's fork
+	err = sigReleaseRepo.HasRemoteBranch("release-notes-draft-" + tag)
+	if err == nil {
+		return errors.New(fmt.Sprintf("Remote repo already has a branch named release-notes-draft-%s", tag))
+	}
+
+	// checkout the new branch
+	err = sigReleaseRepo.Checkout("-b", "release-notes-draft-"+tag)
+	if err != nil {
+		return errors.Wrapf(err, "creating new branch %s", "release-notes-draft-"+tag)
+	}
+
+	// generate the notes
+	targetdir := sigReleaseRepo.Dir() + fmt.Sprintf("/releases/release-%d.%d", s.Major, s.Minor)
+	logrus.Debugf("Release notes markdown will be written to %s", targetdir)
+	err = ioutil.WriteFile(targetdir+"/release-notes-draft.md", []byte(result.markdown), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "writing release notes draft")
+	}
+
+	// commit the results
+	err = sigReleaseRepo.Add(fmt.Sprintf("releases/release-%d.%d", s.Major, s.Minor) + "/release-notes-draft.md")
+	if err != nil {
+		return errors.Wrap(err, "adding release notes draft to staging area")
+	}
+
+	err = sigReleaseRepo.Commit("Release Notes draft for k/k " + tag)
+	if err != nil {
+		return errors.Wrapf(err, "Error creating commit in %s/%s", releaseNotesOpts.draftOrg, releaseNotesOpts.draftRepo)
+	}
+
+	// push to fork
+	logrus.Infof("Pushing release notes draft to %s/%s", releaseNotesOpts.draftOrg, releaseNotesOpts.draftRepo)
+	err = sigReleaseRepo.PushToRemote("userfork", "release-notes-draft-"+tag)
+	if err != nil {
+		return errors.Wrapf(err, "pushing changes to %s/%s", releaseNotesOpts.draftOrg, releaseNotesOpts.draftRepo)
+	}
+
+	// TODO: Call github API and create PR against k/sig-release
 	return nil
 }
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -535,6 +535,19 @@ func (r *Repo) Push(remoteBranch string) error {
 	return command.NewWithWorkDir(r.Dir(), gitExecutable, args...).RunSuccess()
 }
 
+// PushToRemote push the current branch to a spcified remote, but only if the
+// repository is not in dry run mode
+func (r *Repo) PushToRemote(remote, remoteBranch string) error {
+	args := []string{"push"}
+	if r.dryRun {
+		logrus.Infof("Won't push due to dry run repository")
+		args = append(args, "--dry-run")
+	}
+	args = append(args, remote, remoteBranch)
+
+	return command.NewWithWorkDir(r.Dir(), gitExecutable, args...).RunSuccess()
+}
+
 // Head retrieves the current repository HEAD as a string
 func (r *Repo) Head() (string, error) {
 	ref, err := r.inner.Head()
@@ -706,6 +719,16 @@ func (r *Repo) Rm(force bool, files ...string) error {
 		args = append(args, "-f")
 	}
 	args = append(args, files...)
+
+	return command.
+		NewWithWorkDir(r.Dir(), gitExecutable, args...).
+		RunSilentSuccess()
+}
+
+// AddRemote adds a new remote to the current working tree
+func (r *Repo) AddRemote(name, owner, repo string) error {
+	args := []string{"remote", "add"}
+	args = append(args, name, fmt.Sprintf("%s%s/%s.git", defaultGithubAuthRoot, owner, repo))
 
 	return command.
 		NewWithWorkDir(r.Dir(), gitExecutable, args...).


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR adds the flags needed to automate the creation of the release notes draft. It adds three flags: --create-draft-pr --draft-org and --draft-repo to determine the repository where the PR will be opened.

In addition, it adds a new flag: --output-dir to output a copy of the release notes.

**Which issue(s) this PR fixes**:

Relates to #1061

**Special notes for your reviewer**:

This PR is a rewrite of the code sent in PR #1102 incorporating @justaugustus  suggestions
 
**Does this PR introduce a user-facing change?**:
```release-note
Add --create-draft-pr --draft-org and --draft-repo flags to automate the creation of the release notes draft
Add --output-dir to output a copy of the release notes.
```
/cc @justaugustus @JamesLaverack 