### PR TITLE
Configure git user for releng-ci-bazel test image

### DIFF
--- a/images/releng-ci-bazel/Dockerfile
+++ b/images/releng-ci-bazel/Dockerfile
@@ -16,3 +16,7 @@ FROM launcher.gcr.io/google/bazel:2.0.0
 RUN apt-get update && \
     apt-get install -y build-essential && \
     rm -rf /var/lib/apt/lists/*
+
+# Some tests require a working git executable, so we configure a pseudo-user
+RUN git config --global user.name releng-ci-user && \
+    git config --global user.email nobody@k8s.io


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Some tests will require a valid configured git user, which we now ensure
globally inside the test image.

**Which issue(s) this PR fixes**:

Should help https://github.com/kubernetes/release/pull/1111 to successfully run the tests

**Special notes for your reviewer**:

We could also configure that on a per-test level but I thought it would not hurt to do this inside the container image. 

**Does this PR introduce a user-facing change?**:

```release-note
None
```
