### PR TITLE
[krel] gcbmgr: Dynamically retrieve build version from CI markers

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -321,7 +321,7 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 	buildVersion := o.buildVersion
 	if buildVersion == "" {
 		var versionErr error
-		buildVersion, versionErr = release.GetCIKubeVersion(o.branch)
+		buildVersion, versionErr = release.GetCIKubeVersion(o.branch, false)
 		if versionErr != nil {
 			return gcbSubs, versionErr
 		}

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -260,18 +260,14 @@ func runGcbmgr() error {
 func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 	gcbSubs := map[string]string{}
 
-	releaseToolRepo := os.Getenv("RELEASE_TOOL_REPO")
-	if releaseToolRepo == "" {
-		releaseToolRepo = release.DefaultReleaseToolRepo
-	}
+	toolOrg := release.GetToolOrg()
+	gcbSubs["TOOL_ORG"] = toolOrg
 
-	releaseToolBranch := os.Getenv("RELEASE_TOOL_BRANCH")
-	if releaseToolBranch == "" {
-		releaseToolBranch = release.DefaultReleaseToolBranch
-	}
+	toolRepo := release.GetToolRepo()
+	gcbSubs["TOOL_REPO"] = toolRepo
 
-	gcbSubs["RELEASE_TOOL_REPO"] = releaseToolRepo
-	gcbSubs["RELEASE_TOOL_BRANCH"] = releaseToolBranch
+	toolBranch := release.GetToolBranch()
+	gcbSubs["TOOL_BRANCH"] = toolBranch
 
 	gcpUser := o.gcpUser
 	if gcpUser == "" {

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,9 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 	testcases := []struct {
 		name       string
 		gcbmgrOpts gcbmgrOptions
+		toolOrg    string
+		toolRepo   string
+		toolBranch string
 		expected   map[string]string
 	}{
 		{
@@ -106,16 +110,17 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":        "--buildversion=",
-				"BUILD_AT_HEAD":       "",
-				"BUILD_POINT":         "",
-				"OFFICIAL":            "",
-				"OFFICIAL_TAG":        "",
-				"RC":                  "",
-				"RC_TAG":              "",
-				"RELEASE_BRANCH":      "master",
-				"RELEASE_TOOL_BRANCH": "master",
-				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+				"BUILDVERSION":   "--buildversion=",
+				"BUILD_AT_HEAD":  "",
+				"BUILD_POINT":    "",
+				"OFFICIAL":       "",
+				"OFFICIAL_TAG":   "",
+				"RC":             "",
+				"RC_TAG":         "",
+				"RELEASE_BRANCH": "master",
+				"TOOL_ORG":       "kubernetes",
+				"TOOL_REPO":      "release",
+				"TOOL_BRANCH":    "master",
 			},
 		},
 		{
@@ -126,16 +131,17 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":        "--buildversion=",
-				"BUILD_AT_HEAD":       "",
-				"BUILD_POINT":         "",
-				"OFFICIAL":            "",
-				"OFFICIAL_TAG":        "",
-				"RC":                  "--rc",
-				"RC_TAG":              "rc",
-				"RELEASE_BRANCH":      "release-1.14",
-				"RELEASE_TOOL_BRANCH": "master",
-				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+				"BUILDVERSION":   "--buildversion=",
+				"BUILD_AT_HEAD":  "",
+				"BUILD_POINT":    "",
+				"OFFICIAL":       "",
+				"OFFICIAL_TAG":   "",
+				"RC":             "--rc",
+				"RC_TAG":         "rc",
+				"RELEASE_BRANCH": "release-1.14",
+				"TOOL_ORG":       "kubernetes",
+				"TOOL_REPO":      "release",
+				"TOOL_BRANCH":    "master",
 			},
 		},
 		{
@@ -146,16 +152,41 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":        "--buildversion=",
-				"BUILD_AT_HEAD":       "",
-				"BUILD_POINT":         "",
-				"OFFICIAL":            "--official",
-				"OFFICIAL_TAG":        "official",
-				"RC":                  "",
-				"RC_TAG":              "",
-				"RELEASE_BRANCH":      "release-1.15",
-				"RELEASE_TOOL_BRANCH": "master",
-				"RELEASE_TOOL_REPO":   "https://github.com/kubernetes/release",
+				"BUILDVERSION":   "--buildversion=",
+				"BUILD_AT_HEAD":  "",
+				"BUILD_POINT":    "",
+				"OFFICIAL":       "--official",
+				"OFFICIAL_TAG":   "official",
+				"RC":             "",
+				"RC_TAG":         "",
+				"RELEASE_BRANCH": "release-1.15",
+				"TOOL_ORG":       "kubernetes",
+				"TOOL_REPO":      "release",
+				"TOOL_BRANCH":    "master",
+			},
+		},
+		{
+			name: "release-1.16 official with custom tool org, repo, and branch",
+			gcbmgrOpts: gcbmgrOptions{
+				branch:      "release-1.16",
+				releaseType: "official",
+				gcpUser:     "test-user",
+			},
+			toolOrg:    "honk",
+			toolRepo:   "best-tools",
+			toolBranch: "tool-branch",
+			expected: map[string]string{
+				"BUILDVERSION":   "--buildversion=",
+				"BUILD_AT_HEAD":  "",
+				"BUILD_POINT":    "",
+				"OFFICIAL":       "--official",
+				"OFFICIAL_TAG":   "official",
+				"RC":             "",
+				"RC_TAG":         "",
+				"RELEASE_BRANCH": "release-1.16",
+				"TOOL_ORG":       "honk",
+				"TOOL_REPO":      "best-tools",
+				"TOOL_BRANCH":    "tool-branch",
 			},
 		},
 	}
@@ -164,6 +195,9 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		opts := tc.gcbmgrOpts
+		os.Setenv("TOOL_ORG", tc.toolOrg)
+		os.Setenv("TOOL_REPO", tc.toolRepo)
+		os.Setenv("TOOL_BRANCH", tc.toolBranch)
 
 		subs, err := setGCBSubstitutions(&opts)
 		actual := dropDynamicSubstitutions(subs)

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -110,9 +110,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":   "--buildversion=",
 				"BUILD_AT_HEAD":  "",
-				"BUILD_POINT":    "",
 				"OFFICIAL":       "",
 				"OFFICIAL_TAG":   "",
 				"RC":             "",
@@ -131,9 +129,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":   "--buildversion=",
 				"BUILD_AT_HEAD":  "",
-				"BUILD_POINT":    "",
 				"OFFICIAL":       "",
 				"OFFICIAL_TAG":   "",
 				"RC":             "--rc",
@@ -152,9 +148,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				gcpUser:     "test-user",
 			},
 			expected: map[string]string{
-				"BUILDVERSION":   "--buildversion=",
 				"BUILD_AT_HEAD":  "",
-				"BUILD_POINT":    "",
 				"OFFICIAL":       "--official",
 				"OFFICIAL_TAG":   "official",
 				"RC":             "",
@@ -176,9 +170,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			toolRepo:   "best-tools",
 			toolBranch: "tool-branch",
 			expected: map[string]string{
-				"BUILDVERSION":   "--buildversion=",
 				"BUILD_AT_HEAD":  "",
-				"BUILD_POINT":    "",
 				"OFFICIAL":       "--official",
 				"OFFICIAL_TAG":   "official",
 				"RC":             "",
@@ -239,7 +231,7 @@ func dropDynamicSubstitutions(orig map[string]string) (result map[string]string)
 	result = orig
 
 	for k := range result {
-		if k == "GCP_USER_TAG" || k == "KUBE_CROSS_VERSION" {
+		if k == "BUILDVERSION" || k == "BUILD_POINT" || k == "GCP_USER_TAG" || k == "KUBE_CROSS_VERSION" {
 			delete(result, k)
 		}
 	}

--- a/pkg/kubepkg/BUILD.bazel
+++ b/pkg/kubepkg/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/command:go_default_library",
+        "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
         "@com_github_google_go_github_v29//github:go_default_library",
@@ -36,8 +37,5 @@ go_test(
     name = "go_default_test",
     srcs = ["kubepkg_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "@com_github_stretchr_testify//assert:go_default_library",
-        "@com_github_stretchr_testify//require:go_default_library",
-    ],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -60,6 +60,8 @@ const (
 	templateRootDir = "templates"
 
 	kubeadmConf = "10-kubeadm.conf"
+
+	useSemver = true
 )
 
 var (
@@ -391,12 +393,12 @@ func getKubernetesVersion(packageDef *PackageDefinition) (string, error) {
 	}
 	switch packageDef.Channel {
 	case ChannelTesting:
-		return release.GetStablePrereleaseKubeVersion()
+		return release.GetStablePrereleaseKubeVersion(useSemver)
 	case ChannelNightly:
-		return release.GetLatestCIKubeVersion()
+		return release.GetLatestCIKubeVersion(useSemver)
 	}
 
-	return release.GetStableReleaseKubeVersion()
+	return release.GetStableReleaseKubeVersion(useSemver)
 }
 
 func getCNIVersion(packageDef *PackageDefinition) (string, error) {
@@ -550,7 +552,7 @@ func getCIBuildsDownloadLinkBase(packageDef *PackageDefinition) (string, error) 
 	ciVersion := packageDef.KubernetesVersion
 	if ciVersion == "" {
 		var err error
-		ciVersion, err = release.GetLatestCIKubeVersion()
+		ciVersion, err = release.GetLatestCIKubeVersion(useSemver)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetPackageVersionSuccess(t *testing.T) {
@@ -118,57 +117,6 @@ func TestGetKubernetesVersionFailure(t *testing.T) {
 
 	_, err := getKubernetesVersion(nil)
 	a.Error(err)
-}
-
-func TestFetchVersionSuccess(t *testing.T) {
-	testcases := []struct {
-		name     string
-		url      string
-		expected string
-	}{
-		{
-			name:     "Release URL",
-			url:      "https://dl.k8s.io/release/stable-1.13.txt",
-			expected: "1.13.12",
-		},
-		{
-			name:     "CI URL",
-			url:      "https://dl.k8s.io/ci/latest-1.14.txt",
-			expected: "1.14.11-beta.1.2+c8b135d0b49c44",
-		},
-	}
-
-	for _, tc := range testcases {
-		actual, err := fetchVersion(tc.url)
-
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
-		assert.Equal(t, tc.expected, actual)
-	}
-}
-
-func TestFetchVersionFailure(t *testing.T) {
-	testcases := []struct {
-		name string
-		url  string
-	}{
-		{
-			name: "Empty URL string",
-			url:  "",
-		},
-		{
-			name: "Bad URL",
-			url:  "https://fake.url",
-		},
-	}
-
-	for _, tc := range testcases {
-		_, err := fetchVersion(tc.url)
-
-		require.Error(t, err)
-	}
 }
 
 func TestGetCNIVersionSuccess(t *testing.T) {

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/git:go_default_library",
         "//pkg/util:go_default_library",
+        "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/pkg/release",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/git:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -30,5 +31,8 @@ go_test(
     name = "go_default_test",
     srcs = ["release_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+    deps = [
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -403,24 +403,33 @@ func TestIsDirtyBuild(t *testing.T) {
 
 func TestGetKubeVersionSuccess(t *testing.T) {
 	testcases := []struct {
-		name     string
-		url      string
-		expected string
+		name      string
+		url       string
+		expected  string
+		useSemver bool
 	}{
 		{
-			name:     "Release URL",
-			url:      "https://dl.k8s.io/release/stable-1.13.txt",
-			expected: "1.13.12",
+			name:      "Release URL (semver)",
+			url:       "https://dl.k8s.io/release/stable-1.13.txt",
+			expected:  "1.13.12",
+			useSemver: true,
 		},
 		{
-			name:     "CI URL",
-			url:      "https://dl.k8s.io/ci/latest-1.14.txt",
-			expected: "1.14.11-beta.1.2+c8b135d0b49c44",
+			name:      "CI URL (semver)",
+			url:       "https://dl.k8s.io/ci/latest-1.14.txt",
+			expected:  "1.14.11-beta.1.2+c8b135d0b49c44",
+			useSemver: true,
+		},
+		{
+			name:      "CI URL (non-semver)",
+			url:       "https://dl.k8s.io/ci/latest-1.14.txt",
+			expected:  "v1.14.11-beta.1.2+c8b135d0b49c44",
+			useSemver: false,
 		},
 	}
 
 	for _, tc := range testcases {
-		actual, err := GetKubeVersion(tc.url)
+		actual, err := GetKubeVersion(tc.url, tc.useSemver)
 
 		if err != nil {
 			t.Fatalf("did not expect an error: %v", err)
@@ -432,8 +441,9 @@ func TestGetKubeVersionSuccess(t *testing.T) {
 
 func TestGetKubeVersionFailure(t *testing.T) {
 	testcases := []struct {
-		name string
-		url  string
+		name      string
+		url       string
+		useSemver bool
 	}{
 		{
 			name: "Empty URL string",
@@ -446,7 +456,7 @@ func TestGetKubeVersionFailure(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		_, err := GetKubeVersion(tc.url)
+		_, err := GetKubeVersion(tc.url, tc.useSemver)
 
 		require.Error(t, err)
 	}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -401,6 +401,57 @@ func TestIsDirtyBuild(t *testing.T) {
 	}
 }
 
+func TestGetKubeVersionSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Release URL",
+			url:      "https://dl.k8s.io/release/stable-1.13.txt",
+			expected: "1.13.12",
+		},
+		{
+			name:     "CI URL",
+			url:      "https://dl.k8s.io/ci/latest-1.14.txt",
+			expected: "1.14.11-beta.1.2+c8b135d0b49c44",
+		},
+	}
+
+	for _, tc := range testcases {
+		actual, err := GetKubeVersion(tc.url)
+
+		if err != nil {
+			t.Fatalf("did not expect an error: %v", err)
+		}
+
+		assert.Equal(t, tc.expected, actual)
+	}
+}
+
+func TestGetKubeVersionFailure(t *testing.T) {
+	testcases := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "Empty URL string",
+			url:  "",
+		},
+		{
+			name: "Bad URL",
+			url:  "https://fake.url",
+		},
+	}
+
+	for _, tc := range testcases {
+		_, err := GetKubeVersion(tc.url)
+
+		require.Error(t, err)
+	}
+}
+
 func cleanupTmps(t *testing.T, dir ...string) {
 	for _, each := range dir {
 		require.Nil(t, os.RemoveAll(each))

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -26,8 +26,85 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetDefaultToolRepoURLSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		useSSH   bool
+		expected string
+	}{
+		{
+			name:     "default HTTPS",
+			expected: "https://github.com/kubernetes/release",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		actual, err := GetDefaultToolRepoURL()
+		assert.Equal(t, tc.expected, actual)
+		assert.Nil(t, err)
+	}
+}
+
+func TestGetToolRepoURLSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		org      string
+		repo     string
+		useSSH   bool
+		expected string
+	}{
+		{
+			name:     "default HTTPS",
+			expected: "https://github.com/kubernetes/release",
+		},
+		{
+			name:     "ssh with custom org",
+			org:      "fake-org",
+			useSSH:   true,
+			expected: "git@github.com:fake-org/release",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		actual, err := GetToolRepoURL(tc.org, tc.repo, tc.useSSH)
+		assert.Equal(t, tc.expected, actual)
+		assert.Nil(t, err)
+	}
+}
+
+func TestGetToolBranchSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "default branch",
+			expected: "master",
+		},
+		{
+			name:     "custom branch",
+			branch:   "tool-branch",
+			expected: "tool-branch",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+		os.Setenv("TOOL_BRANCH", tc.branch)
+
+		actual := GetToolBranch()
+		assert.Equal(t, tc.expected, actual)
+	}
+}
 
 func TestBuiltWithBazel(t *testing.T) {
 	baseTmpDir, err := ioutil.TempDir("", "")

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,26 @@ import (
 const (
 	TagPrefix = "v"
 )
+
+func GetURLResponse(url string, trim bool) (string, error) {
+	resp, httpErr := http.Get(url)
+	if httpErr != nil {
+		return "", errors.Wrapf(httpErr, "an error occurred GET-ing %s", url)
+	}
+
+	defer resp.Body.Close()
+	respBytes, ioErr := ioutil.ReadAll(resp.Body)
+	if ioErr != nil {
+		return "", errors.Wrapf(ioErr, "could not handle the response body for %s", url)
+	}
+
+	respString := string(respBytes)
+	if trim {
+		respString = strings.TrimSpace(respString)
+	}
+
+	return respString, nil
+}
 
 // PackagesAvailable takes a slice of packages and determines if they are installed
 // on the host OS. Replaces common::check_packages.

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -46,6 +46,12 @@ func GetURLResponse(url string, trim bool) (string, error) {
 	}
 
 	defer resp.Body.Close()
+	statusOK := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if !statusOK {
+		errMsg := fmt.Sprintf("HTTP status not OK (%v) for %s", resp.StatusCode, url)
+		return "", errors.New(errMsg)
+	}
+
 	respBytes, ioErr := ioutil.ReadAll(resp.Body)
 	if ioErr != nil {
 		return "", errors.Wrapf(ioErr, "could not handle the response body for %s", url)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature cleanup

**What this PR does / why we need it**:
- pkg/release: Add getters for tools GitHub url, org, repo, and branch
- pkg/release: Refactor version marker getters
- [krel] gcbmgr: Dynamically retrieve build version from CI markers
- pkg/util: Check HTTP status code before return in GetURLResponse()
- pkg/release: Allow version getters to return [non-]SemVer-compliant 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
[krel] gcbmgr: Dynamically retrieve build version from CI markers
```
