### PR TITLE
pkg/git: Add getters for GitHub URLs

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -125,9 +125,14 @@ func runReleaseNotes() (err error) {
 // tryToFindLatestMinorTag looks-up the default k/k remote to find the latest
 // non final version
 func tryToFindLatestMinorTag() (string, error) {
+	url, err := git.GetDefaultKubernetesRepoURL()
+	if err != nil {
+		return "", err
+	}
+
 	status, err := command.New(
 		"git", "ls-remote", "--sort=v:refname",
-		"--tags", git.DefaultGithubRepoURL,
+		"--tags", url,
 	).
 		Pipe("grep", "-Eo", "v[0-9].[0-9]+.0-.*.[0-9]$").
 		Pipe("tail", "-1").

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/git/gitfakes:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//config:go_default_library",

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -19,6 +19,7 @@ package git_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/git/gitfakes"
@@ -39,4 +40,86 @@ func TestCommit(t *testing.T) {
 	repo, _, worktreeMock := newSUT()
 	require.Nil(t, repo.Commit("msg"))
 	require.Equal(t, worktreeMock.CommitCallCount(), 1)
+}
+
+func TestGetDefaultKubernetesRepoURLSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		org      string
+		useSSH   bool
+		expected string
+	}{
+		{
+			name:     "default HTTPS",
+			expected: "https://github.com/kubernetes/kubernetes",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		actual, err := git.GetDefaultKubernetesRepoURL()
+		assert.Equal(t, tc.expected, actual)
+		assert.Nil(t, err)
+	}
+}
+
+func TestGetKubernetesRepoURLSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		org      string
+		useSSH   bool
+		expected string
+	}{
+		{
+			name:     "default HTTPS",
+			expected: "https://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "ssh with custom org",
+			org:      "fake-org",
+			useSSH:   true,
+			expected: "git@github.com:fake-org/kubernetes",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		actual, err := git.GetKubernetesRepoURL(tc.org, tc.useSSH)
+		assert.Equal(t, tc.expected, actual)
+		assert.Nil(t, err)
+	}
+}
+
+func TestGetRepoURLSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		org      string
+		repo     string
+		useSSH   bool
+		expected string
+	}{
+		{
+			name:     "default Kubernetes HTTPS",
+			org:      "kubernetes",
+			repo:     "kubernetes",
+			expected: "https://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "ssh with custom org",
+			org:      "fake-org",
+			repo:     "repofoo",
+			useSSH:   true,
+			expected: "git@github.com:fake-org/repofoo",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("Test case: %s", tc.name)
+
+		actual, err := git.GetRepoURL(tc.org, tc.repo, tc.useSSH)
+		assert.Equal(t, tc.expected, actual)
+		assert.Nil(t, err)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Here we add some simple getters to retrieve/construct the git URLs for org repos.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
/priority important-soon

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
