### PR TITLE
Remove `owner` from git.CloneOrOpenDefaultGitHubRepoSSH function

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -30,7 +30,6 @@ import (
 type ffOptions struct {
 	branch    string
 	masterRef string
-	org       string
 }
 
 var ffOpts = &ffOptions{}
@@ -54,7 +53,6 @@ var ffCmd = &cobra.Command{
 func init() {
 	ffCmd.PersistentFlags().StringVar(&ffOpts.branch, "branch", "", "branch")
 	ffCmd.PersistentFlags().StringVar(&ffOpts.masterRef, "ref", kgit.DefaultMasterRef, "ref on master")
-	ffCmd.PersistentFlags().StringVar(&ffOpts.org, "org", kgit.DefaultGithubOrg, "org to run tool against")
 
 	rootCmd.AddCommand(ffCmd)
 }
@@ -68,7 +66,7 @@ func runFf(opts *ffOptions) error {
 	remoteMaster := kgit.Remotify(kgit.Master)
 
 	logrus.Infof("Preparing to fast-forward master@%s onto the %s branch", masterRef, branch)
-	repo, err := kgit.CloneOrOpenDefaultGitHubRepoSSH(rootOpts.repoPath, opts.org)
+	repo, err := kgit.CloneOrOpenDefaultGitHubRepoSSH(rootOpts.repoPath)
 	if err != nil {
 		return err
 	}
@@ -137,7 +135,7 @@ func runFf(opts *ffOptions) error {
 		return err
 	}
 
-	prepushMessage(repo.Dir(), kgit.DefaultRemote, branch, opts.org, releaseRev, headRev)
+	prepushMessage(repo.Dir(), kgit.DefaultRemote, branch, kgit.DefaultGithubOrg, releaseRev, headRev)
 
 	_, pushUpstream, err := util.Ask("Are you ready to push the local branch fast-forward changes upstream? Please only answer after you have validated the changes.", "yes", 3)
 	if err != nil {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -179,9 +179,12 @@ func (r *Repo) SetInnerRepo(repo Repository) {
 }
 
 // CloneOrOpenDefaultGitHubRepoSSH clones the default Kubernetes GitHub
-// repository into the path or updates it.
-func CloneOrOpenDefaultGitHubRepoSSH(repoPath, owner string) (*Repo, error) {
-	return CloneOrOpenGitHubRepo(repoPath, owner, DefaultGithubRepo, true)
+// repository via SSH if the repoPath is empty, otherwise updates it at the
+// expected repoPath.
+func CloneOrOpenDefaultGitHubRepoSSH(repoPath string) (*Repo, error) {
+	return CloneOrOpenGitHubRepo(
+		repoPath, DefaultGithubOrg, DefaultGithubRepo, true,
+	)
 }
 
 // CloneOrOpenGitHubRepo creates a temp directory containing the provided


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We added the variable owner for test reasons, but since we test via a
local bare-copy we do not have a need to set the owner any more.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Remove `owner` from `git.CloneOrOpenDefaultGitHubRepoSSH` and use the default one (`kubernetes`)
```
