### PR TITLE
Make git.Remotify idempotent

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -541,6 +541,10 @@ func (r *Repo) MergeBase(from, to string) (string, error) {
 
 // Remotify returns the name prepended with the default remote
 func Remotify(name string) string {
+	split := strings.Split(name, "/")
+	if len(split) > 1 {
+		return name
+	}
 	return fmt.Sprintf("%s/%s", DefaultRemote, name)
 }
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -123,3 +123,15 @@ func TestGetRepoURLSuccess(t *testing.T) {
 		assert.Nil(t, err)
 	}
 }
+
+func TestRemotify(t *testing.T) {
+	testcases := []struct{ provided, expected string }{
+		{provided: git.Master, expected: git.DefaultRemote + "/" + git.Master},
+		{provided: "origin/ref", expected: "origin/ref"},
+		{provided: "base/another_ref", expected: "base/another_ref"},
+	}
+
+	for _, tc := range testcases {
+		require.Equal(t, git.Remotify(tc.provided), tc.expected)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Already remotified remotes should not be remotified any more, which is
now the default behavior.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- The function `git.Remotify` does not remotify remotes which have been already remotified
```
