### PR TITLE
Add tests for git.AddRemote and git.PushToRemote

### DIFF
--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -651,3 +651,43 @@ func TestOpenRepoFailure(t *testing.T) {
 	require.NotNil(t, err)
 	require.Nil(t, repo)
 }
+
+func TestAddRemoteSuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.AddRemote("remote", "owner", "repo")
+	require.Nil(t, err)
+}
+
+func TestAddRemoteFailureAlreadyExisting(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.AddRemote(git.DefaultRemote, "owner", "repo")
+	require.NotNil(t, err)
+}
+
+func TestPushToRemoteSuccessRemoteMaster(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.PushToRemote(git.DefaultRemote, git.Remotify(git.Master))
+	require.Nil(t, err)
+}
+
+func TestPushToRemoteSuccessBranchTracked(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.PushToRemote(git.DefaultRemote, testRepo.branchName)
+	require.Nil(t, err)
+}
+
+func TestPushToRemoteFailureBranchNotExisting(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.PushToRemote(git.DefaultRemote, "some-branch")
+	require.NotNil(t, err)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now add some testing around the two new API methods.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

A follow-up of https://github.com/kubernetes/release/pull/1102

**Does this PR introduce a user-facing change?**:

```release-note
None
```
