### PR TITLE
Default release notes fork repo to 'sig-release'

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -103,13 +103,13 @@ func init() {
 		&releaseNotesOpts.draftOrg,
 		"draft-org",
 		"",
-		"a Github organization ownwer of the fork of k/sig-release where the Release Notes Draft PR will be created",
+		"a Github organization owner of the fork of k/sig-release where the Release Notes Draft PR will be created",
 	)
 
 	releaseNotesCmd.PersistentFlags().StringVar(
 		&releaseNotesOpts.draftRepo,
 		"draft-repo",
-		"",
+		git.DefaultGithubReleaseRepo,
 		"the name of the fork of k/sig-release, the Release Notes Draft PR will be created from this repository",
 	)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The default repo name when forking k/sig-release is `my-username/sig-release`, so we can also default to `sig-release` for the release notes fork name.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

A follow-up of https://github.com/kubernetes/release/pull/1102

**Does this PR introduce a user-facing change?**:
```release-note
None
```
