### PR TITLE
Test for available fork remotes before adding them

### DIFF
--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -612,6 +612,45 @@ func TestRmSuccessForce(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
+func TestHasRemoteSuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	err := testRepo.sut.AddRemote("test", "owner", "repo")
+	require.Nil(t, err)
+
+	remotes, err := testRepo.sut.Remotes()
+	require.Nil(t, err)
+
+	require.Len(t, remotes, 2)
+
+	// The origin remote
+	require.Equal(t, git.DefaultRemote, remotes[0].Name())
+	require.Len(t, remotes[0].URLs(), 1)
+	require.Equal(t, testRepo.dir, remotes[0].URLs()[0])
+
+	// Or via the API
+	require.True(t, testRepo.sut.HasRemote("origin", testRepo.dir))
+
+	// The added test remote
+	require.Equal(t, "test", remotes[1].Name())
+	require.Len(t, remotes[1].URLs(), 1)
+
+	url, err := git.GetRepoURL("owner", "repo", true)
+	require.Nil(t, err)
+	require.Equal(t, url, remotes[1].URLs()[0])
+
+	// Or via the API
+	require.True(t, testRepo.sut.HasRemote("test", url))
+}
+
+func TestHasRemoteFailure(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	require.False(t, testRepo.sut.HasRemote("name", "some-url.com"))
+}
+
 func TestRmFailureForce(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)

--- a/pkg/git/gitfakes/fake_repository.go
+++ b/pkg/git/gitfakes/fake_repository.go
@@ -78,6 +78,18 @@ type FakeRepository struct {
 		result1 *gita.Remote
 		result2 error
 	}
+	RemotesStub        func() ([]*gita.Remote, error)
+	remotesMutex       sync.RWMutex
+	remotesArgsForCall []struct {
+	}
+	remotesReturns struct {
+		result1 []*gita.Remote
+		result2 error
+	}
+	remotesReturnsOnCall map[int]struct {
+		result1 []*gita.Remote
+		result2 error
+	}
 	ResolveRevisionStub        func(plumbing.Revision) (*plumbing.Hash, error)
 	resolveRevisionMutex       sync.RWMutex
 	resolveRevisionArgsForCall []struct {
@@ -343,6 +355,61 @@ func (fake *FakeRepository) RemoteReturnsOnCall(i int, result1 *gita.Remote, res
 	}{result1, result2}
 }
 
+func (fake *FakeRepository) Remotes() ([]*gita.Remote, error) {
+	fake.remotesMutex.Lock()
+	ret, specificReturn := fake.remotesReturnsOnCall[len(fake.remotesArgsForCall)]
+	fake.remotesArgsForCall = append(fake.remotesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Remotes", []interface{}{})
+	fake.remotesMutex.Unlock()
+	if fake.RemotesStub != nil {
+		return fake.RemotesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.remotesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) RemotesCallCount() int {
+	fake.remotesMutex.RLock()
+	defer fake.remotesMutex.RUnlock()
+	return len(fake.remotesArgsForCall)
+}
+
+func (fake *FakeRepository) RemotesCalls(stub func() ([]*gita.Remote, error)) {
+	fake.remotesMutex.Lock()
+	defer fake.remotesMutex.Unlock()
+	fake.RemotesStub = stub
+}
+
+func (fake *FakeRepository) RemotesReturns(result1 []*gita.Remote, result2 error) {
+	fake.remotesMutex.Lock()
+	defer fake.remotesMutex.Unlock()
+	fake.RemotesStub = nil
+	fake.remotesReturns = struct {
+		result1 []*gita.Remote
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) RemotesReturnsOnCall(i int, result1 []*gita.Remote, result2 error) {
+	fake.remotesMutex.Lock()
+	defer fake.remotesMutex.Unlock()
+	fake.RemotesStub = nil
+	if fake.remotesReturnsOnCall == nil {
+		fake.remotesReturnsOnCall = make(map[int]struct {
+			result1 []*gita.Remote
+			result2 error
+		})
+	}
+	fake.remotesReturnsOnCall[i] = struct {
+		result1 []*gita.Remote
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeRepository) ResolveRevision(arg1 plumbing.Revision) (*plumbing.Hash, error) {
 	fake.resolveRevisionMutex.Lock()
 	ret, specificReturn := fake.resolveRevisionReturnsOnCall[len(fake.resolveRevisionArgsForCall)]
@@ -472,6 +539,8 @@ func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	defer fake.headMutex.RUnlock()
 	fake.remoteMutex.RLock()
 	defer fake.remoteMutex.RUnlock()
+	fake.remotesMutex.RLock()
+	defer fake.remotesMutex.RUnlock()
 	fake.resolveRevisionMutex.RLock()
 	defer fake.resolveRevisionMutex.RUnlock()
 	fake.tagsMutex.RLock()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We can test if the fork remote already exists and leave it untouched
if its location matches our expected URL. This requires two new API
methods for the git package: `git.HasRemote` and `git.Remotes`.

The `krel release-notes` subcommand has been adapted accordingly and
tests have been added as well.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Follow-up of https://github.com/kubernetes/release/pull/1102

**Does this PR introduce a user-facing change?**:
```release-note
- Added `git.HasRemote` and `git.Remotes` API
- Added pre-check in `krel release-notes` if the fork remote is already available
```

/cc @puerco