### PR TITLE
Restore checked out branch on krel ff

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -87,9 +87,19 @@ func runFf(opts *ffOptions, rootOpts *rootOptions) error {
 		return err
 	}
 
+	// Restore the currently checked out branch afterwards
+	currentBranch, err := repo.CurrentBranch()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve current branch")
+	}
+	defer func() {
+		if err := repo.Checkout(currentBranch); err != nil {
+			logrus.Errorf("unable to restore branch %s: %v", currentBranch, err)
+		}
+	}()
 	logrus.Info("Checking out release branch")
 	if err := repo.Checkout(branch); err != nil {
-		return err
+		return errors.Wrapf(err, "checking out branch %s", branch)
 	}
 
 	cleanup := rootOpts.cleanup


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We should restore the current repository state after the krel ff run,
what is now the default behavior.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
- Changed `krel ff` to restore the currently checked out git branch
```
