### PR TITLE
krel/ff: print a shorter git commit hash

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -179,5 +179,5 @@ Once the branch fast-forward is complete, the diff will be available after push 
 
 	https://github.com/%s/%s/compare/%s...%s"
 
-`, gitRoot, remote, branch, org, kgit.DefaultGithubRepo, releaseRev, headRev)
+`, gitRoot, remote, branch, org, kgit.DefaultGithubRepo, releaseRev[0:11], headRev[0:11])
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
print the short git commit hash instead of the full

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
- Changed `krel ff` to print a short git commit hash instead of the full one
```
