### PR TITLE
util/common: add new line when printing to std out to avoid messages in the same line

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -200,12 +200,12 @@ func Ask(question, expectedResponse string, retries int) (answer string, success
 	attempts := 1
 
 	if retries < 0 {
-		fmt.Printf("Retries was set to a number less than zero (%d). Please specify a positive number of retries or zero, if you want to ask unconditionally.", retries)
+		fmt.Printf("Retries was set to a number less than zero (%d). Please specify a positive number of retries or zero, if you want to ask unconditionally.\n", retries)
 	}
 
 	for attempts <= retries {
 		scanner := bufio.NewScanner(os.Stdin)
-		fmt.Printf("%s (%d/%d) ", question, attempts, retries)
+		fmt.Printf("%s (%d/%d) \n", question, attempts, retries)
 
 		scanner.Scan()
 		answer = scanner.Text()
@@ -214,7 +214,7 @@ func Ask(question, expectedResponse string, retries int) (answer string, success
 			return answer, true, nil
 		}
 
-		fmt.Printf("Expected '%s', but got '%s'", expectedResponse, answer)
+		fmt.Printf("Expected '%s', but got '%s'\n", expectedResponse, answer)
 
 		attempts++
 	}


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Add new line when printing to stdout

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
util/common: new line when printing to stdout added
```

/cc @saschagrunert 