### PR TITLE
Improve krel release-notes local k/sig-release repository handling

### DIFF
--- a/docs/krel/release-notes.md
+++ b/docs/krel/release-notes.md
@@ -40,9 +40,7 @@ Before running `krel release-notes` export your GitHub token to \$GITHUB_TOKEN:
       --draft-repo string                  the name of the fork of k/sig-release, the Release Notes Draft PR will be created from this repository (default "sig-release")
       --format string                      The format for notes output (options: markdown, json) (default "markdown")
   -h, --help                               help for release-notes
-      --kubernetes-sigs-fork-path string   fork kubernetes-sigs/release-notes and output a copy of the json release notes to this directory (default "/tmp/k8s-sigs")
   -o, --output-dir string                  output a copy of the release notes to this directory (default ".")
-      --sigrelease-fork-path string        fork k/sig-release and output a copy of the release notes draft to this directory (default "/tmp/k8s-sigrelease")
   -t, --tag string                         version tag for the notes
       --website-org string                 a Github organization owner of the fork of kuberntets-sigs/release-notes where the Website PR will be created
       --website-repo string                the name of the fork of kuberntets-sigs/release-notes, the Release Notes Draft PR will be created from this repository (default "release-notes")


### PR DESCRIPTION
A number of changes to allow a user to run the `krel release-notes` multiple times. You'll still get an error if you already have a branch with the expected name on your fork, but it'll correctly manage the local checkout of k/sig-release now, including checking out the `master` branch to apply changes to, setting upstreams when pushing branches, and handling unsaved changes.

This also fixes a bug where the command wouldn't work at all as it attempted to use a git repository URL without SSH configuration.

```release-note
Modify the krel release-notes subcommand to always create clean checkouts of k/sig-release and k-sigs/release-notes instead of re-using existing clones. Removed --kubernetes-sigs-fork-path and --sigrelease-fork-path flags.
```