### PR TITLE
Sort git.Remotes() by their name per default

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -772,6 +773,11 @@ func (r *Repo) Remotes() (res []*Remote, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list remotes")
 	}
+
+	// Sort the remotes by their name which is not always the case
+	sort.Slice(remotes, func(i, j int) bool {
+		return remotes[i].Config().Name < remotes[j].Config().Name
+	})
 
 	for _, remote := range remotes {
 		config := remote.Config()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes a flake in `git.TestHasRemoteSuccess` by always ensuring
alphabetically sorted remotes.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Change `git.Remotes` to always return the remotes sorted alphabetically
```
