### PR TITLE
anago: remove repo from krel changelog command

### DIFF
--- a/anago
+++ b/anago
@@ -407,7 +407,6 @@ generate_release_notes () {
   local release_tars=$TREE_ROOT/_output-$RELEASE_VERSION_PRIME/release-tars
 
   logrun -v krel changelog \
-    --repo "$TREE_ROOT" \
     --branch="${PARENT_BRANCH:-$RELEASE_BRANCH}" \
     --tars "$release_tars" \
     --tag "$RELEASE_VERSION_PRIME" \


### PR DESCRIPTION
To checkout a clean repo

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
When building stack mock for release-1.18 we got this error
```
Step #4: ================================================================================
Step #4: GENERATE RELEASE NOTES  (9/11)
Step #4: ================================================================================
Step #4: 
Step #4: 
Step #4: anago::generate_release_notes(): krel changelog --repo /workspace/anago-v1.18.0-beta.0.175+60790dbb519fd0/src/k8s.io/kubernetes --branch=release-1.18 --tars /workspace/anago-v1.18.0-beta.0.175+60790dbb519fd0/src/k8s.io/kubernetes/_output-v1.18.0-beta.1/release-tars --tag v1.18.0-beta.1 --html-file /workspace/anago-v1.18.0-beta.0.175+60790dbb519fd0/src/release-notes.html --bucket=kubernetes-release-gcb
Step #4: level=info msg="Using release branch release-1.18"
Step #4: level=info msg="Using local repository path /workspace/anago-v1.18.0-beta.0.175+60790dbb519fd0/src/k8s.io/kubernetes"
Step #4: level=info msg="Found HEAD commit fe9073b8c14bbf6bbe42a2259f01d3d3a853a6a3"
Step #4: level=info msg="Found latest tag 1.18.0-beta.1"
Step #4: level=info msg="Generating release notes"
Step #4: level=info msg="re-using local repo /workspace/anago-v1.18.0-beta.0.175+60790dbb519fd0/src/k8s.io/kubernetes"
Step #4: level=info msg="using found start SHA: 2b3a77c9b086e6327623e578a49ec086647561fc"
Step #4: level=fatal msg="listing release notes: GET https://api.github.com/repos/kubernetes/kubernetes/git/commits/2b3a77c9b086e6327623e578a49ec086647561fc: 404 Not Found []"
Step #4: [2020-Feb-25 19:15:11 UTC] generate_release_notes in 3s
Step #4: FAILED in generate_release_notes.
Step #4: 
Step #4: RELEASE INCOMPLETE! Exiting...
```
The existing repo already have a tag for the release and the `krel changelog` expected to get a previous one and not the new tag.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
anago: remove --repo from the krel changelog command to get a clean repo
```
/cc @saschagrunert @kubernetes/release-managers 
/priority critical-urgent
