### PR TITLE
Fix latest tag retrieval for krel changelog

### DIFF
--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/command:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
+        "@com_github_google_go_github_v29//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/google/go-github/v29/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-git.v4"
@@ -690,16 +692,21 @@ func (r *Repo) PreviousTag(tag, branch string) (string, error) {
 
 // TagsForBranch returns a list of tags for the provided branch sorted by
 // creation date
-func (r *Repo) TagsForBranch(branch string) ([]string, error) {
-	if err := r.Checkout(branch); err != nil {
-		return nil, err
+func (r *Repo) TagsForBranch(branch string) (res []string, err error) {
+	previousBranch, err := r.CurrentBranch()
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving current branch")
 	}
+	if err := r.Checkout(branch); err != nil {
+		return nil, errors.Wrapf(err, "checking out %s", branch)
+	}
+	defer func() { err = r.Checkout(previousBranch) }()
 
 	status, err := command.NewWithWorkDir(
 		r.Dir(), gitExecutable, "tag", "--sort=-creatordate", "--merged",
 	).RunSilentSuccessOutput()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "retrieving merged tags for branch %s", branch)
 	}
 
 	return strings.Fields(status.Output()), nil
@@ -833,4 +840,55 @@ func (r *Repo) PushToRemote(remote, remoteBranch string) error {
 	args = append(args, remote, remoteBranch)
 
 	return command.NewWithWorkDir(r.Dir(), gitExecutable, args...).RunSuccess()
+}
+
+// TagsPerBranch is an abstraction over a simple branch to latest tag association
+type TagsPerBranch map[string]string
+
+// LatestGitHubTagsPerBranch returns the latest GitHub available tag for each
+// branch
+func LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
+	ghClient := github.NewClient(nil)
+
+	allTags, _, err := ghClient.Repositories.ListTags(
+		context.Background(), DefaultGithubOrg, DefaultGithubRepo, nil,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to retrieve GitHub releases")
+	}
+
+	releases := make(TagsPerBranch)
+	for _, t := range allTags {
+		tag := t.GetName()
+
+		// Alpha releases are only available on the master branch
+		if strings.Contains(tag, "alpha") {
+			releases.addIfNotExisting(Master, tag)
+			continue
+		}
+
+		// This should always succeed
+		semverTag, err := util.TagStringToSemver(tag)
+		if err != nil {
+			return nil, errors.Wrapf(err, "tag %s is not a vaild semver", tag)
+		}
+
+		// Latest vx.x.0 release are on both master and release branch
+		if len(semverTag.Pre) == 0 {
+			releases.addIfNotExisting(Master, tag)
+		}
+
+		branch := fmt.Sprintf("release-%d.%d", semverTag.Major, semverTag.Minor)
+		releases.addIfNotExisting(branch, tag)
+	}
+
+	return releases, nil
+}
+
+// addIfNotExisting adds a new `tag` for the `branch` if not already existing
+// in the map `TagsForBranch`
+func (t TagsPerBranch) addIfNotExisting(branch, tag string) {
+	if _, ok := t[branch]; !ok {
+		t[branch] = tag
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The issue fixed with this commit is that we cannot say if the target tag
to be built already exists in the local repository, which made it
impossible to krel to behave in an expected way. If a tag during
changelog generation already locally exists (but not remotely) seems to
differ in `anago`, which is the reason we now use a different approach:

1. We correctly chose the release branch (or master) HEAD from the
   remote as end SHA because we cannot know which branch is currently
   checked out.
2. We use a new helper function `git.LatestGitHubTagsPerBranch` which
   fetches the latest GitHub tags for each release branch and the
   master. This follows the logic that `alpha` releases are only on the
   master branch, whereas all other releases except the final tag are
   available only on `release-x.y` branches. The latest tag for the
   release branch (or master) will be our start commit for the release
   notes generation.

**Which issue(s) this PR fixes**:

Refers to https://github.com/kubernetes/sig-release/issues/999

**Special notes for your reviewer**:

The original relnotes script used this implementation to achieve the same goal:
https://github.com/kubernetes/release/blob/cadfbd5920fbee48fc7e50424f7f72dae36497af/lib/gitlib.sh#L163-L186

The general implementation has the drawback that we cannot generate changelogs for old releases any more, because we now rely on the latest tag from GitHub.

**Does this PR introduce a user-facing change?**:

```release-note
- Updated `krel changelog` to correctly choose the start tag for a release
```
