### PR TITLE
Change CHANGELOG url back to master branch

### DIFF
--- a/anago
+++ b/anago
@@ -1039,7 +1039,7 @@ update_github_release () {
 
   # post release data
   logecho "$release_verb the $RELEASE_VERSION_PRIME release on github..."
-  local changelog_url="$K8S_GITHUB_URL/blob/$RELEASE_VERSION_PRIME/$CHANGELOG_FILEPATH"
+  local changelog_url="$K8S_GITHUB_URL/blob/master/$CHANGELOG_FILEPATH"
   query_tmpl='{
     "tag_name" : $tag,
     "target_commitish": $target,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In 089f53411a7484c743db2ee773565b7b7426f1c6, we changed the URL to match the tag for the release notes. This now causes that the release notes are not available on that location because they are generated one commit ahead of the actual tag.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

See the links at: https://github.com/kubernetes/kubernetes/releases/tag/v1.18.0-beta.1

**Does this PR introduce a user-facing change?**:

```release-note
- Fixed wrong CHANGELOG link not targeting to the release tag any more
```

/assign @justaugustus 