### PR TITLE
images: Update k8s-cloud-builder to use the new kube-cross location

### DIFF
--- a/anago
+++ b/anago
@@ -519,8 +519,8 @@ local_kube_cross () {
   local local_image
   local docker_image
 
-  docker_image="${GCRIO_PATH_PROD}/kube-cross"
-  version="$(cat "${TREE_ROOT}/build/build-image/cross/VERSION")"
+  docker_image="${KUBE_CROSS_IMAGE}"
+  version="$(cat "${TREE_ROOT}/${KUBE_CROSS_CONFIG_LOCATION}/VERSION")"
   image="${docker_image}:${version}"
   local_image="${docker_image}:local"
 
@@ -531,7 +531,7 @@ local_kube_cross () {
   else
     logecho -n "Building docker image ${image}: "
     logrun -s docker build --cache-from "$docker_image" -t "$image" \
-                           -t "$local_image" "${TREE_ROOT}/build/build-image/cross/"
+                           -t "$local_image" "${TREE_ROOT}/${KUBE_CROSS_CONFIG_LOCATION}/"
   fi
 }
 

--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -19,21 +19,21 @@ steps:
   - ${_RELEASE_TOOL_REPO}
   waitFor: [ '-' ]
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
   id: prepare
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - clean
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
   id: build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - "${_RELEASE_TYPE}"
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder'
+- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
   id: push-build
   dir: 'go/src/k8s.io/kubernetes'
   args:

--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -19,21 +19,21 @@ steps:
   - ${_RELEASE_TOOL_REPO}
   waitFor: [ '-' ]
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
   id: prepare
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - clean
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
   id: build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - "${_RELEASE_TYPE}"
 
-- name: 'gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
   id: push-build
   dir: 'go/src/k8s.io/kubernetes'
   args:

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - "--branch=${_RELEASE_GIT_BRANCH}"
 
 - id: prepare-and-send
-  name: "gcr.io/${PROJECT_ID}/k8s-cloud-builder"
+  name: "gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1"
   env:
   - "SENDER_NAME=${_SENDER_NAME}"
   - "SENDER_EMAIL=${_SENDER_EMAIL}"

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - "--branch=${_RELEASE_GIT_BRANCH}"
 
 - id: prepare-and-send
-  name: "gcr.io/$PROJECT_ID/k8s-cloud-builder:v1.13.8-1"
+  name: "gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1"
   env:
   - "SENDER_NAME=${_SENDER_NAME}"
   - "SENDER_EMAIL=${_SENDER_EMAIL}"

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder
+- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}
+- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: k8s.gcr.io/kube-cross:${_KUBE_CROSS_VERSION}
+- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"
@@ -58,7 +58,7 @@ steps:
   - "--basedir=/workspace"
   - "--tmpdir=/workspace/tmp"
 
-- name: k8s.gcr.io/kube-cross:local
+- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:local
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"
@@ -79,7 +79,7 @@ steps:
   - "--basedir=/workspace"
   - "--tmpdir=/workspace/tmp"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder
+- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"
@@ -79,7 +79,7 @@ steps:
   - "--basedir=/workspace"
   - "--tmpdir=/workspace/tmp"
 
-- name: gcr.io/$PROJECT_ID/k8s-cloud-builder
+- name: gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -18,7 +18,7 @@
 ARG DEBIAN_FRONTEND=noninteractive
 
 ##------------------------------------------------------------
-FROM k8s.gcr.io/kube-cross:v1.13.4-1
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.12.17-1
 
 RUN apt-get -q update
 

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -18,7 +18,7 @@
 ARG DEBIAN_FRONTEND=noninteractive
 
 ##------------------------------------------------------------
-FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.12.17-1
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-1
 
 RUN apt-get -q update
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -27,6 +27,10 @@ readonly PROD_BUCKET="kubernetes-release"
 readonly TEST_BUCKET="kubernetes-release-gcb"
 readonly CI_BUCKET="kubernetes-release-dev"
 
+readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
+readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"
+readonly KUBE_CROSS_CONFIG_LOCATION="build/build-image/cross"
+
 # Set a globally usable variable for the changelog directory since we've been
 # piecemeal search/replace-ing this and missing some cases.
 readonly CHANGELOG_DIR="CHANGELOG"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area dependency
/priority important-soon

**What this PR does / why we need it**:
In https://github.com/kubernetes/release/issues/1133, we began building the kube-cross image in K8s Infra. Here we make the required adjustments to our GCB configs and Dockerfiles to point to the new location: `us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:<version>`

**Special notes for your reviewer**:
/hold until I send this for a few staging runs.

The following images were built against this PR:
- `gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.12.17-1` --> [logs](https://console.cloud.google.com/cloud-build/builds/e9fbc20a-c923-4b9d-8b33-f3bfeeca3b8c?project=k8s-staging-release-test)
- `gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1` --> [logs](https://console.cloud.google.com/cloud-build/builds/ef5faa6c-80f3-42c8-936b-43c327e34a8f?project=k8s-staging-release-test)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
images: Update k8s-cloud-builder to use the new kube-cross location
```
