### PR TITLE
[krel] changelog: Include CHANGELOG/README.md in master commit logic

### DIFF
--- a/anago
+++ b/anago
@@ -405,6 +405,8 @@ check_prerequisites () {
 PROGSTEP[generate_release_notes]="GENERATE RELEASE NOTES"
 generate_release_notes () {
   local release_tars=$TREE_ROOT/_output-$RELEASE_VERSION_PRIME/release-tars
+  local git_status_output
+  local repo_state
 
   logrun -v krel changelog \
     --repo "$TREE_ROOT" \
@@ -414,6 +416,16 @@ generate_release_notes () {
     --html-file "$RELEASE_NOTES_HTML" \
     --bucket="$RELEASE_BUCKET" \
     || return 1
+
+  git_status_output=$(git status -s)
+  repo_state=$([[ -z $git_status_output ]] || echo "dirty")
+
+  if [[ $repo_state == "dirty" ]]; then
+    logecho "Repo state was dirty after generating release notes. Cannot continue."
+    logecho "'git status -s' output:"
+    logecho "$git_status_output"
+    return 1
+  fi
 }
 
 ##############################################################################

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -280,10 +280,12 @@ gitlib::push_master () {
 
   logecho -n "Checkout master branch to push objects: "
   logrun -s git checkout master || return 1
+  logrun -v git status -s || return 1
+  logrun -v git show || return 1
 
   logecho -n "Rebase master branch: "
-  logrun git fetch origin || return 1
-  logrun -s git rebase origin/master || return 1
+  logrun -v git fetch origin || return 1
+  logrun -s -v git rebase origin/master || return 1
   logecho -n "Pushing$dryrun_flag master branch: "
   logrun -s git push$dryrun_flag origin master || return 1
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- anago: Add repo state check after release notes generation
- [krel] changelog: Include CHANGELOG/README.md in master commit logic

The repo state check allows us to fail during the staging (instead of release) phase when `krel changelog` does not cleanly commit to the repo.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/release/issues/1144

**Does this PR introduce a user-facing change?**:
```release-note
[krel] changelog: Include CHANGELOG/README.md in master commit logic
```
