### PR TITLE
Refactor kubepkg.fetchReleases into github.Releases()

### DIFF
--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -26,6 +26,24 @@ import (
 )
 
 type FakeClient struct {
+	ListReleasesStub        func(context.Context, string, string, *githuba.ListOptions) ([]*githuba.RepositoryRelease, *githuba.Response, error)
+	listReleasesMutex       sync.RWMutex
+	listReleasesArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.ListOptions
+	}
+	listReleasesReturns struct {
+		result1 []*githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}
+	listReleasesReturnsOnCall map[int]struct {
+		result1 []*githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}
 	ListTagsStub        func(context.Context, string, string, *githuba.ListOptions) ([]*githuba.RepositoryTag, *githuba.Response, error)
 	listTagsMutex       sync.RWMutex
 	listTagsArgsForCall []struct {
@@ -46,6 +64,75 @@ type FakeClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClient) ListReleases(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.ListOptions) ([]*githuba.RepositoryRelease, *githuba.Response, error) {
+	fake.listReleasesMutex.Lock()
+	ret, specificReturn := fake.listReleasesReturnsOnCall[len(fake.listReleasesArgsForCall)]
+	fake.listReleasesArgsForCall = append(fake.listReleasesArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.ListOptions
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ListReleases", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listReleasesMutex.Unlock()
+	if fake.ListReleasesStub != nil {
+		return fake.ListReleasesStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.listReleasesReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListReleasesCallCount() int {
+	fake.listReleasesMutex.RLock()
+	defer fake.listReleasesMutex.RUnlock()
+	return len(fake.listReleasesArgsForCall)
+}
+
+func (fake *FakeClient) ListReleasesCalls(stub func(context.Context, string, string, *githuba.ListOptions) ([]*githuba.RepositoryRelease, *githuba.Response, error)) {
+	fake.listReleasesMutex.Lock()
+	defer fake.listReleasesMutex.Unlock()
+	fake.ListReleasesStub = stub
+}
+
+func (fake *FakeClient) ListReleasesArgsForCall(i int) (context.Context, string, string, *githuba.ListOptions) {
+	fake.listReleasesMutex.RLock()
+	defer fake.listReleasesMutex.RUnlock()
+	argsForCall := fake.listReleasesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) ListReleasesReturns(result1 []*githuba.RepositoryRelease, result2 *githuba.Response, result3 error) {
+	fake.listReleasesMutex.Lock()
+	defer fake.listReleasesMutex.Unlock()
+	fake.ListReleasesStub = nil
+	fake.listReleasesReturns = struct {
+		result1 []*githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListReleasesReturnsOnCall(i int, result1 []*githuba.RepositoryRelease, result2 *githuba.Response, result3 error) {
+	fake.listReleasesMutex.Lock()
+	defer fake.listReleasesMutex.Unlock()
+	fake.ListReleasesStub = nil
+	if fake.listReleasesReturnsOnCall == nil {
+		fake.listReleasesReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.RepositoryRelease
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.listReleasesReturnsOnCall[i] = struct {
+		result1 []*githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeClient) ListTags(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.ListOptions) ([]*githuba.RepositoryTag, *githuba.Response, error) {
@@ -120,6 +207,8 @@ func (fake *FakeClient) ListTagsReturnsOnCall(i int, result1 []*githuba.Reposito
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.listReleasesMutex.RLock()
+	defer fake.listReleasesMutex.RUnlock()
 	fake.listTagsMutex.RLock()
 	defer fake.listTagsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/kubepkg/BUILD.bazel
+++ b/pkg/kubepkg/BUILD.bazel
@@ -10,10 +10,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/command:go_default_library",
+        "//pkg/github:go_default_library",
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
-        "@com_github_google_go_github_v29//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubepkg
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,11 +27,11 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/google/go-github/v29/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/command"
+	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/util"
 )
@@ -474,7 +473,7 @@ func getCRIToolsVersion(packageDef *PackageDefinition) (string, error) {
 
 	criToolsVersion := fmt.Sprintf("%s.%s.0", criToolsMajor, criToolsMinor)
 
-	releases, err := fetchReleases("kubernetes-sigs", "cri-tools", false)
+	releases, err := github.New().Releases("kubernetes-sigs", "cri-tools", false)
 	if err != nil {
 		return "", err
 	}
@@ -508,28 +507,6 @@ func getCRIToolsVersion(packageDef *PackageDefinition) (string, error) {
 
 	logrus.Infof("Setting CRI tools version to %s", criToolsVersion)
 	return criToolsVersion, nil
-}
-
-func fetchReleases(owner, repo string, includePrereleases bool) ([]*github.RepositoryRelease, error) {
-	ghClient := github.NewClient(nil)
-
-	allReleases, _, err := ghClient.Repositories.ListReleases(context.Background(), owner, repo, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var releases []*github.RepositoryRelease
-	for _, release := range allReleases {
-		if *release.Prerelease {
-			if includePrereleases {
-				releases = append(releases, release)
-			}
-		} else {
-			releases = append(releases, release)
-		}
-	}
-
-	return releases, nil
 }
 
 func getDownloadLinkBase(packageDef *PackageDefinition) (string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

We move the `fetchReleases` function into the `github` package to
achieve testablity and encapsulation of GitHub related functionality.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
