### PR TITLE
images: Add skopeo@v0.1.41 to k8s-cloud-builder

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -46,6 +46,10 @@ RUN apt-get install -qqy \
         gnupg2 \
         grep \
         jq \
+        libassuan-dev \
+        libbtrfs-dev \
+        libdevmapper-dev \
+        libgpgme-dev \
         lsb-release \
         make \
         net-tools \
@@ -92,6 +96,14 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && apt-get -y update \
     && apt-get -qqy install \
         docker-ce-cli
+
+ARG SKOPEO_VERSION=v0.1.41
+RUN git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
+RUN cd $GOPATH/src/github.com/containers/skopeo \
+    && git checkout ${SKOPEO_VERSION} \
+    && make binary-local \
+    && cp skopeo /usr/local/bin \
+    && rm -rf $GOPATH/src/github.com/containers/skopeo
 
 # Cleanup a bit
 RUN apt-get -qqy remove \


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As part of the work to move our build/stage/release process to K8s Infra (https://github.com/kubernetes/release/pull/957#issuecomment-594153093, https://github.com/kubernetes/release/issues/911) anago will no longer be allowed to push container images to k8s.gcr.io, preferring the image promotion process instead.

I plan to make some modifications to anago to inspect manifests in `--nomock` mode using [`skopeo`](https://github.com/containers/skopeo).

Here's an example of complete output:

```shell
skopeo inspect docker://us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-1
```

```json
{
    "Name": "us.gcr.io/k8s-artifacts-prod/build-image/kube-cross",
    "Digest": "sha256:0c821cd481e9bbfc9d380290d1401a856e9c2bc0f8d0673fc1519e9bef408d1d",
    "RepoTags": [
        "v1.12.12-1",
        "v1.12.17-1",
        "v1.13.6-1",
        "v1.13.8-1"
    ],
    "Created": "2020-02-27T00:55:20.529914895Z",
    "DockerVersion": "19.03.5",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:dc65f448a2e2f2ea557e69ed9ac65aa8ac0e16f1bce68f90de910b4d5a2f1ba1",
        "sha256:346ffb2b67d7b35729673ced818325ed0ea57284e69de67f8bbc48c2bf294716",
        "sha256:dea4ecac934f71d68d4f5edb171f6cff42588edfa3f70ba8709be56e321eeddc",
        "sha256:8ac92ddf84b35dac36ef6632f8d5a0c9c2d7038f6018f2d4fa1be056d90bd366",
        "sha256:7ca6053833076bc7bd2c5666a847913b0e00163e65c5267e9f5d6e427b9f2b10",
        "sha256:f47e6cebc5126c53ef9c1635358e57ff7f11f5ad1689d43d105350519ec7531b",
        "sha256:5303501560106b7786bf68a88b0ac18bb9479fbb16233f262510188f69c61110",
        "sha256:a3a19dc1f5ddffb2d1d2f0e5f6d91afbac666f365e1077255fb29fd04c1bf3f9",
        "sha256:70657258ff41e74a811d649bc44c49ed992cdbbe9325c6fef9ecf417bf051c39",
        "sha256:18110e05b645a8e48339fa7ff4759d924291effbed95dc5e2125fed351311c83",
        "sha256:92d70c8ff0f96bfbf649fe911af2b9a23ea751b1bc734474a269d2a1e61ad9d6",
        "sha256:9a2c83fe013dba06dbe4d64275e1d487095e207711929ade8cc474db774955b4",
        "sha256:f1729024748ec72f7df3052be48f428593de71b6b2b423a1bd4b107c930d6cac",
        "sha256:c70b6cc38229a0e5ab0faca9c155751f371ca6ca10496fa27791dd999487f8c0"
    ],
    "Env": [
        "PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "GOLANG_VERSION=1.13.8",
        "GOPATH=/go",
        "GOARM=7",
        "KUBE_DYNAMIC_CROSSPLATFORMS=armhf   arm64   s390x   ppc64el",
        "KUBE_CROSSPLATFORMS=linux/386   linux/arm linux/arm64   linux/ppc64le   linux/s390x   darwin/amd64 darwin/386   windows/amd64 windows/386",
        "TMPDIR=/tmp.k8s"
    ]
}
```

...and the one-liner we might use (thanks @cblecker!):

```shell
$ skopeo inspect docker://us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-1 >/dev/null 2>&1 ; echo $?
0
$ skopeo inspect docker://us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-2 >/dev/null 2>&1 ; echo $?
1
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato 

**Does this PR introduce a user-facing change?**:
```release-note
images: Add skopeo@v0.1.41 to k8s-cloud-builder
```
