### PR TITLE
Refactor CreateDownloadsTable to use fetchMetadata

### DIFF
--- a/cmd/release-notes/BUILD.bazel
+++ b/cmd/release-notes/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/notes:go_default_library",
         "//pkg/notes/document:go_default_library",
         "//pkg/notes/options:go_default_library",
+        "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
+	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/util"
 )
 
@@ -178,7 +179,7 @@ func init() {
 	cmd.PersistentFlags().StringVar(
 		&opts.ReleaseBucket,
 		"release-bucket",
-		util.EnvDefault("RELEASE_BUCKET", "kubernetes-release"),
+		util.EnvDefault("RELEASE_BUCKET", release.ProductionBucket),
 		"Specify gs bucket to point to in generated notes",
 	)
 

--- a/pkg/notes/document/BUILD.bazel
+++ b/pkg/notes/document/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/notes:go_default_library",
+        "//pkg/release:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],
 )
@@ -18,6 +19,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/notes/internal:go_default_library",
+        "//pkg/release:go_default_library",
         "@com_github_kr_pretty//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/release/pkg/notes/internal"
+	"k8s.io/release/pkg/release"
 )
 
 func TestFileMetadata(t *testing.T) {
@@ -65,8 +67,7 @@ func TestFileMetadata(t *testing.T) {
 		))
 	}
 
-	fm := FileMetadata{}
-	metadata, err := fm.FetchMetadata(dir, "http://test.com", "test-release")
+	metadata, err := fetchMetadata(dir, "http://test.com", "test-release")
 	require.Nil(t, err)
 
 	expected := &FileMetadata{
@@ -168,7 +169,7 @@ func TestRenderMarkdownTemplate(t *testing.T) {
 	require.Nil(t, err, "Reading golden file %q", goldenFile)
 	expected := string(b)
 
-	got, err := doc.RenderMarkdownTemplate("kubernetes-release", dir, internal.DefaultReleaseNotesTemplate)
+	got, err := doc.RenderMarkdownTemplate(release.ProductionBucket, dir, internal.DefaultReleaseNotesTemplate)
 	require.Nil(t, err, "Rendering document")
 
 	// Then
@@ -213,12 +214,12 @@ func TestCreateDownloadsTable(t *testing.T) {
 
 	// When
 	output := &strings.Builder{}
-	require.Nil(t, createDownloadsTable(
-		output, "kubernetes-release", dir, "v1.16.0", "v1.16.1",
+	require.Nil(t, CreateDownloadsTable(
+		output, release.ProductionBucket, dir, "v1.16.0", "v1.16.1",
 	))
 
 	// Then
-	require.Equal(t, output.String(), `# v1.16.1
+	require.Equal(t, `# v1.16.1
 
 [Documentation](https://docs.k8s.io)
 
@@ -267,7 +268,7 @@ filename | sha512 hash
 
 ## Changelog since v1.16.0
 
-`)
+`, output.String())
 }
 
 func TestSortKinds(t *testing.T) {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -73,6 +73,12 @@ const (
 	// WindowsGCSPath is the directory where Windoes GCE scripts are staged
 	// before push to GCS.
 	WindowsGCSPath = "gcs-stage/extra/gce/windows"
+
+	// ProductionBucket is the default bucket for Kubernetes releases
+	ProductionBucket = "kubernetes-release"
+
+	// ProductionBucketURL is the url for the ProductionBucket
+	ProductionBucketURL = "https://dl.k8s.io"
 )
 
 var (
@@ -256,4 +262,13 @@ func GetKubecrossVersion(branches ...string) (string, error) {
 	}
 
 	return "", errors.New("kube-cross version should not be empty; cannot continue")
+}
+
+// URLPrefixForBucket returns the URL prefix for the provided bucket string
+func URLPrefixForBucket(bucket string) string {
+	urlPrefix := fmt.Sprintf("https://storage.googleapis.com/%s/release", bucket)
+	if bucket == ProductionBucket {
+		urlPrefix = ProductionBucketURL
+	}
+	return urlPrefix
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Re-use the new `fetchMetadata` function on markdown downloads table
creation to reduce code duplication.

This also makes `CreateDownloadsTable` public, which will be needed for
creating the downloads table on remotely fetched release notes (new
final minor release).

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
