### PR TITLE
Make AddTagPrefix idempotent

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
     deps = [
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -310,6 +310,9 @@ func MoreRecent(a, b string) (bool, error) {
 }
 
 func AddTagPrefix(tag string) string {
+	if strings.HasPrefix(tag, TagPrefix) {
+		return tag
+	}
 	return TagPrefix + tag
 }
 

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +64,7 @@ func TestPackagesAvailableSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.True(t, actual)
+		require.True(t, actual)
 	}
 }
 
@@ -105,7 +104,7 @@ func TestPackagesAvailableFailure(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.False(t, actual)
+		require.False(t, actual)
 	}
 }
 
@@ -573,4 +572,14 @@ func TestTagStringToSemver(t *testing.T) {
 func TestSemverToTagString(t *testing.T) {
 	version := semver.Version{Major: 1, Minor: 2, Patch: 3}
 	require.Equal(t, SemverToTagString(version), "v1.2.3")
+}
+
+func TestAddTagPrefix(t *testing.T) {
+	require.Equal(t, "v0.0.0", AddTagPrefix("0.0.0"))
+	require.Equal(t, "v1.0.0", AddTagPrefix("v1.0.0"))
+}
+
+func TestTrimTagPrefix(t *testing.T) {
+	require.Equal(t, "0.0.0", TrimTagPrefix("0.0.0"))
+	require.Equal(t, "1.0.0", TrimTagPrefix("1.0.0"))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adding tag prefixes to already prefixed tags should do nothing. The same
behavior already applies to removing those tag prefixes. The test cases
have been added as well for that.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
- Changed `util.AddTagPrefix` to not add prefixes to already prefixed tags 
```
