### PR TITLE
Add downloads table to minor release CHANGELOG

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -115,6 +115,8 @@ const alphaReleaseExpectedContent = `## Changes by Kind
 
 const minorReleaseExpectedTOC = `<!-- BEGIN MUNGE: GENERATED_TOC -->
 
+- [v1.17.0](#v1170)
+  - [Changelog since v1.16.0](#changelog-since-v1160)
 - [Kubernetes v1.17.0 Release Notes](#kubernetes-v1170-release-notes)
   - [What’s New (Major Themes)](#what’s-new-major-themes)
     - [Cloud Provider Labels reach General Availability](#cloud-provider-labels-reach-general-availability)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This adds the necessary downloads in case we're just downloading the
release notes from the remote resource.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Clashes with https://github.com/kubernetes/release/pull/1155

**Does this PR introduce a user-facing change?**:

```release-note
- Added downloads table for new minor releases on running `krel changelog` 
```
