### PR TITLE
Add dedicated HTTP package to be testable

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,7 @@ filegroup(
         "//pkg/gcp/build:all-srcs",
         "//pkg/git:all-srcs",
         "//pkg/github:all-srcs",
+        "//pkg/http:all-srcs",
         "//pkg/kubepkg:all-srcs",
         "//pkg/log:all-srcs",
         "//pkg/notes:all-srcs",

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/gcp/build:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/github:go_default_library",
+        "//pkg/http:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/notes:go_default_library",
         "//pkg/notes/document:go_default_library",

--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +35,7 @@ import (
 
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/github"
+	"k8s.io/release/pkg/http"
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
@@ -376,27 +376,14 @@ func lookupRemoteReleaseNotes(branch string) (string, error) {
 		"https://raw.githubusercontent.com/kubernetes/sig-release/master/"+
 			"releases/%s/release-notes-draft.md", branch,
 	)
-	resp, err := http.Get(remote)
+	response, err := http.GetURLResponse(remote, false)
 	if err != nil {
 		return "", errors.Wrapf(err,
 			"fetching release notes from remote: %s", remote,
 		)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf(
-			"remote release notes not found at: %s", remote,
-		)
-	}
 	logrus.Info("Found release notes")
-
-	content, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	return string(content), nil
+	return response, nil
 }
 
 func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {

--- a/pkg/http/BUILD.bazel
+++ b/pkg/http/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["http.go"],
+    importpath = "k8s.io/release/pkg/http",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_pkg_errors//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["http_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// GetURLResponse returns the HTTP response for the provided URL if the request succeeds
+func GetURLResponse(url string, trim bool) (string, error) {
+	resp, httpErr := http.Get(url)
+	if httpErr != nil {
+		return "", errors.Wrapf(httpErr, "an error occurred GET-ing %s", url)
+	}
+
+	defer resp.Body.Close()
+	statusOK := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if !statusOK {
+		errMsg := fmt.Sprintf("HTTP status not OK (%v) for %s", resp.StatusCode, url)
+		return "", errors.New(errMsg)
+	}
+
+	respBytes, ioErr := ioutil.ReadAll(resp.Body)
+	if ioErr != nil {
+		return "", errors.Wrapf(ioErr, "could not handle the response body for %s", url)
+	}
+
+	respString := string(respBytes)
+	if trim {
+		respString = strings.TrimSpace(respString)
+	}
+
+	return respString, nil
+}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	khttp "k8s.io/release/pkg/http"
+)
+
+func TestGetURLResponseSuccess(t *testing.T) {
+	// Given
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, err := io.WriteString(w, "")
+			require.Nil(t, err)
+		}))
+	defer server.Close()
+
+	// When
+	actual, err := khttp.GetURLResponse(server.URL, false)
+
+	// Then
+	require.Nil(t, err)
+	require.Empty(t, actual)
+}
+
+func TestGetURLResponseSuccessTrimmed(t *testing.T) {
+	// Given
+	const expected = "     some test     "
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, err := io.WriteString(w, expected)
+			require.Nil(t, err)
+		}))
+	defer server.Close()
+
+	// When
+	actual, err := khttp.GetURLResponse(server.URL, true)
+
+	// Then
+	require.Nil(t, err)
+	require.Equal(t, strings.TrimSpace(expected), actual)
+}
+
+func TestGetURLResponseFailedStatus(t *testing.T) {
+	// Given
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+	defer server.Close()
+
+	// When
+	_, err := khttp.GetURLResponse(server.URL, true)
+
+	// Then
+	require.NotNil(t, err)
+}

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/http:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/http"
 	"k8s.io/release/pkg/util"
 )
 
@@ -217,7 +218,7 @@ func GetCIKubeVersion(branch string, useSemver bool) (string, error) {
 
 func GetKubeVersion(markerURL string, useSemver bool) (string, error) {
 	logrus.Infof("Retrieving Kubernetes build version from %s...", markerURL)
-	version, httpErr := util.GetURLResponse(markerURL, true)
+	version, httpErr := http.GetURLResponse(markerURL, true)
 	if httpErr != nil {
 		return "", httpErr
 	}
@@ -246,7 +247,7 @@ func GetKubecrossVersion(branches ...string) (string, error) {
 
 		versionURL := fmt.Sprintf("https://raw.githubusercontent.com/kubernetes/kubernetes/%s/build/build-image/cross/VERSION", branch)
 
-		version, httpErr := util.GetURLResponse(versionURL, true)
+		version, httpErr := http.GetURLResponse(versionURL, true)
 		if httpErr != nil {
 			if i < len(branches)-1 {
 				logrus.Infof("Error retrieving the kube-cross version for the '%s': %v", branch, httpErr)

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,32 +37,6 @@ import (
 const (
 	TagPrefix = "v"
 )
-
-func GetURLResponse(url string, trim bool) (string, error) {
-	resp, httpErr := http.Get(url)
-	if httpErr != nil {
-		return "", errors.Wrapf(httpErr, "an error occurred GET-ing %s", url)
-	}
-
-	defer resp.Body.Close()
-	statusOK := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !statusOK {
-		errMsg := fmt.Sprintf("HTTP status not OK (%v) for %s", resp.StatusCode, url)
-		return "", errors.New(errMsg)
-	}
-
-	respBytes, ioErr := ioutil.ReadAll(resp.Body)
-	if ioErr != nil {
-		return "", errors.Wrapf(ioErr, "could not handle the response body for %s", url)
-	}
-
-	respString := string(respBytes)
-	if trim {
-		respString = strings.TrimSpace(respString)
-	}
-
-	return respString, nil
-}
 
 // PackagesAvailable takes a slice of packages and determines if they are installed
 // on the host OS. Replaces common::check_packages.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now use a dedicated, mock-able http package which is used by the
changelog retrieval and the release package. Tests have been added as
well.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
