### PR TITLE
Stop spaming rendered documents with empty downloads info

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -19,10 +19,6 @@ package cmd
 const patchReleaseExpectedTOC = `<!-- BEGIN MUNGE: GENERATED_TOC -->
 
 - [v1.16.3](#v1163)
-  - [Downloads for v1.16.3](#downloads-for-v1163)
-    - [Client Binaries](#client-binaries)
-    - [Server Binaries](#server-binaries)
-    - [Node Binaries](#node-binaries)
   - [Changelog since v1.16.2](#changelog-since-v1162)
   - [Changes by Kind](#changes-by-kind)`
 
@@ -62,10 +58,6 @@ const patchReleaseExpectedContent = `## Changes by Kind
 const alphaReleaseExpectedTOC = `<!-- BEGIN MUNGE: GENERATED_TOC -->
 
 - \[v1.18.0-alpha.3\]\(\#v1180-alpha3\)
-  - \[Downloads for v1.18.0-alpha.3\]\(\#downloads-for-v1180-alpha3\)
-    - \[Client Binaries\]\(\#client-binaries\)
-    - \[Server Binaries\]\(\#server-binaries\)
-    - \[Node Binaries\]\(\#node-binaries\)
   - \[Changelog since v.*\]\(\#changelog-since-.*\)
   - \[Changes by Kind\]\(\#changes-by-kind\)
     - \[Deprecation\]\(\#deprecation\)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Before:
* Release notes would have downloads section with no information
* TOC would have entries to downloads section that was empty.
* document.CreateDownloadsTable() could panic when fetchMetadata

After:
* Only output downloads section if there are k8s well known binaries
* TOC only has downloads section if there are downloads.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
