### PR TITLE
Render notes with no kind information as normal Changes by Kind

### DIFF
--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -144,7 +144,6 @@ func TestRenderMarkdownTemplate(t *testing.T) {
 
 	doc := Document{
 		NotesWithActionRequired: []string{"If an API changes and no one documented it, did it really happen?"},
-		NotesUncategorized:      []string{"Someone somewhere did the world a great justice."},
 		NotesByKind: NotesByKind{
 			KindAPIChange:       []string{"This might make people sad...or happy."},
 			KindBug:             []string{"This will likely get you promoted."},
@@ -156,6 +155,7 @@ func TestRenderMarkdownTemplate(t *testing.T) {
 			KindFeature:         []string{"This will get you promoted."},
 			KindFlake:           []string{"This *should* get you promoted."},
 			KindBugCleanupFlake: []string{"This should definitely get you promoted."},
+			KindUncategorized:   []string{"Someone somewhere did the world a great justice."},
 		},
 		PreviousRevision: "v1.16.0",
 		CurrentRevision:  "v1.16.1",
@@ -283,6 +283,7 @@ func TestSortKinds(t *testing.T) {
 		"flake":                         nil,
 		"bug":                           nil,
 		"feature":                       nil,
+		"Uncategorized":                 nil,
 	}
 	res := sortKinds(input)
 	require.Equal(t, res, kindPriority)

--- a/pkg/notes/document/testdata/document.md.golden
+++ b/pkg/notes/document/testdata/document.md.golden
@@ -64,6 +64,9 @@ filename | sha512 hash
 ### Other (Bug, Cleanup or Flake)
  - This should definitely get you promoted.
  
+### Uncategorized
+ - Someone somewhere did the world a great justice.
+ 
 ### API Change
  - This might make people sad...or happy.
  


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**What this PR does / why we need it**:

There are two main changes here:
* Bug fix: Template rendering was not rendering notes for PRs with no kinds (e.g uncategorized)
* Design change: This eliminates the need to have an explicit NotesUncategorized field. 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

This is needed to unblock [pr1148](https://github.com/kubernetes/release/pull/1148) and takes a step toward [pr1154](https://github.com/kubernetes/release/pull/1154). Both those changes and this one enhance encapsulation of the note kinds in support of simplifying template based rendering.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Uncategorized notes are now rendered under the "Change By Kind" heading. The Document struct no longer has the NotesUncategorized field (action required).
```
