### PR TITLE
[krel] gcbmgr: Disable BUILD_AT_HEAD substitution and properly set GIT_TAG

### DIFF
--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
         "//pkg/gcp/build:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/util:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/release/pkg/gcp/auth"
 	"k8s.io/release/pkg/gcp/build"
+	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/util"
 )
@@ -251,7 +252,11 @@ func runGcbmgr() error {
 
 	// TODO: Need actual values
 	var jobName, uploaded string
-	version := "FAKEVERSION"
+
+	version, err := git.GetTag()
+	if err != nil {
+		return err
+	}
 
 	return build.RunSingleJob(buildOpts, jobName, uploaded, version, gcbSubs)
 }

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -315,8 +315,10 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 
 	gcbSubs["RELEASE_BRANCH"] = branch
 
-	// TODO: Remove once we remove support for --built-at-head.
-	gcbSubs["BUILD_AT_HEAD"] = ""
+	if o.stage {
+		// TODO: Remove once we remove support for --built-at-head.
+		gcbSubs["BUILD_AT_HEAD"] = ""
+	}
 
 	buildVersion := o.buildVersion
 	if buildVersion == "" {

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/release/pkg/gcp/build"
 )
@@ -56,7 +56,7 @@ func TestRunGcbmgrSuccess(t *testing.T) {
 		gcbmgrOpts = &tc.gcbmgrOpts
 
 		err := runGcbmgr()
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestRunGcbmgrFailure(t *testing.T) {
 		gcbmgrOpts = &tc.gcbmgrOpts
 
 		err := runGcbmgr()
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -103,8 +103,9 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		expected   map[string]string
 	}{
 		{
-			name: "master prerelease",
+			name: "master prerelease - stage",
 			gcbmgrOpts: gcbmgrOptions{
+				stage:       true,
 				branch:      "master",
 				releaseType: "prerelease",
 				gcpUser:     "test-user",
@@ -122,8 +123,28 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			},
 		},
 		{
+			name: "master prerelease - release",
+			gcbmgrOpts: gcbmgrOptions{
+				release:     true,
+				branch:      "master",
+				releaseType: "prerelease",
+				gcpUser:     "test-user",
+			},
+			expected: map[string]string{
+				"OFFICIAL":       "",
+				"OFFICIAL_TAG":   "",
+				"RC":             "",
+				"RC_TAG":         "",
+				"RELEASE_BRANCH": "master",
+				"TOOL_ORG":       "kubernetes",
+				"TOOL_REPO":      "release",
+				"TOOL_BRANCH":    "master",
+			},
+		},
+		{
 			name: "release-1.14 RC",
 			gcbmgrOpts: gcbmgrOptions{
+				stage:       true,
 				branch:      "release-1.14",
 				releaseType: "rc",
 				gcpUser:     "test-user",
@@ -143,6 +164,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		{
 			name: "release-1.15 official",
 			gcbmgrOpts: gcbmgrOptions{
+				stage:       true,
 				branch:      "release-1.15",
 				releaseType: "official",
 				gcpUser:     "test-user",
@@ -162,6 +184,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		{
 			name: "release-1.16 official with custom tool org, repo, and branch",
 			gcbmgrOpts: gcbmgrOptions{
+				stage:       true,
 				branch:      "release-1.16",
 				releaseType: "official",
 				gcpUser:     "test-user",
@@ -198,7 +221,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -223,7 +246,7 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 		opts := tc.gcbmgrOpts
 
 		_, err := setGCBSubstitutions(&opts)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 

--- a/pkg/gcp/build/BUILD.bazel
+++ b/pkg/gcp/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/command:go_default_library",
+        "//pkg/git:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -26,13 +26,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/command"
+	"k8s.io/release/pkg/git"
 	"sigs.k8s.io/yaml"
 )
 
@@ -100,16 +100,6 @@ func PrepareBuilds(o *Options) error {
 	}
 
 	return nil
-}
-
-func getVersion() (string, error) {
-	cmd := exec.Command("git", "describe", "--tags", "--always", "--dirty")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	t := time.Now().Format("20060102")
-	return fmt.Sprintf("v%s-%s", t, strings.TrimSpace(string(output))), nil
 }
 
 func (o *Options) ValidateConfigDir() error {
@@ -312,9 +302,9 @@ func RunBuildJobs(o *Options) []error {
 	}
 
 	logrus.Info("Running build jobs...")
-	tag, err := getVersion()
+	tag, err := git.GetTag()
 	if err != nil {
-		return []error{errors.Wrapf(err, "failed to get current tag")}
+		return []error{err}
 	}
 
 	if !o.AllowDirty && strings.HasSuffix(tag, "-dirty") {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -53,6 +53,17 @@ const (
 	gitExecutable         = "git"
 )
 
+func GetTag() (string, error) {
+	tag, err := command.New(
+		"git", "describe", "--tags", "--always", "--dirty",
+	).RunSilentSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get current tag")
+	}
+	t := time.Now().Format("20060102")
+	return fmt.Sprintf("v%s-%s", t, tag.OutputTrimNL()), nil
+}
+
 // GetDefaultKubernetesRepoURL returns the default HTTPS repo URL for Kubernetes.
 // Expected: https://github.com/kubernetes/kubernetes
 func GetDefaultKubernetesRepoURL() (string, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-soon

**What this PR does / why we need it**:
- [krel] gcbmgr: Disable BUILD_AT_HEAD substitution unless --stage is set

  The GCB config file for the release phase does not allow the
  BUILD_AT_HEAD substitution to be set, so we only set this when the
  '--stage' flag is specified.

  This matches the intention of requiring a --build-version to be
  specified during the release phase.

- [krel] gcbmgr: Properly set GIT_TAG in GCB runs

/assign @saschagrunert @hasheddan @cpanato 

**Special notes for your reviewer**:
This _may_ be the last thing we need to do before being able to use krel gcbmgr in the release process!

**Does this PR introduce a user-facing change?**:
```release-note
[krel] gcbmgr: Properly set GIT_TAG in GCB runs
```
