### PR TITLE
gcp: Update GCB and releaselib to use new k8s-staging-releng project

### DIFF
--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -19,21 +19,21 @@ steps:
   - ${_RELEASE_TOOL_REPO}
   waitFor: [ '-' ]
 
-- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
   id: prepare
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - clean
 
-- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
   id: build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - "${_RELEASE_TYPE}"
 
-- name: 'gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
   id: push-build
   dir: 'go/src/k8s.io/kubernetes'
   args:

--- a/gcb/build/variants.yaml
+++ b/gcb/build/variants.yaml
@@ -2,15 +2,15 @@ variants:
   build-ci:
     CI: '--ci'
     NOMOCK: '--nomock'
-    BUCKET: '--bucket=k8s-staging-release-test'
-    REGISTRY: '--docker-registry=gcr.io/k8s-staging-release-test'
+    BUCKET: '--bucket=k8s-staging-releng'
+    REGISTRY: '--docker-registry=gcr.io/k8s-staging-releng'
     ALLOW_DUP: '--allow-dup'
     EXTRA_PUBLISH_FILE: '--extra-publish-file=k8s-master'
     HYPERKUBE: '--hyperkube'
   build-ci-fast:
     CI: '--ci'
     NOMOCK: '--nomock'
-    BUCKET: '--bucket=k8s-staging-release-test'
+    BUCKET: '--bucket=k8s-staging-releng'
     ALLOW_DUP: '--allow-dup'
   build-ci-old:
     CI: '--ci'

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - "--branch=${_RELEASE_GIT_BRANCH}"
 
 - id: prepare-and-send
-  name: "gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1"
+  name: "gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1"
   env:
   - "SENDER_NAME=${_SENDER_NAME}"
   - "SENDER_EMAIL=${_SENDER_EMAIL}"

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - "./compile-release-tools"
 
-- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"
@@ -79,7 +79,7 @@ steps:
   - "--basedir=/workspace"
   - "--tmpdir=/workspace/tmp"
 
-- name: gcr.io/k8s-staging-release-test/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -975,7 +975,7 @@ release::gcs::publish () {
     "$publish_file_dst" || return 1
 
   if ((FLAGS_nomock)) && ! ((FLAGS_private_bucket)); then
-    # New Kubernetes infra buckets, like k8s-staging-release-test, have a
+    # New Kubernetes infra buckets, like k8s-staging-releng, have a
     # bucket-only ACL policy set, which means attempting to set the ACL on an
     # object will fail. We should skip this ACL change in those instances, as
     # new buckets already default to being publicly readable.
@@ -983,7 +983,7 @@ release::gcs::publish () {
     # Ref:
     # - https://cloud.google.com/storage/docs/bucket-policy-only
     # - https://github.com/kubernetes/release/issues/904
-    if [[ "$bucket" != "k8s-staging-release-test" ]]; then
+    if [[ "$bucket" != "k8s-staging-releng" ]]; then
       logecho -n "Making uploaded version file public: "
       logrun -s $GSUTIL acl ch -R -g all:R $publish_file_dst || return 1
     fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup deprecation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Now that the [official releng staging project](https://github.com/kubernetes/k8s.io/pull/624) exists, we move image references to point to `k8s-staging-releng`.

ref: https://github.com/kubernetes/release/issues/1161, https://github.com/kubernetes/k8s.io/pull/624, https://github.com/kubernetes/release/issues/911, https://github.com/kubernetes/test-infra/pull/16679

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Special notes for your reviewer**:
~/hold until I backfill the latest images to the new project~
Image backfill:

<details>

```shell
$ docker image prune -af
<snip>

$ docker pull gcr.io/k8s-staging-release-test/kubepkg:latest
latest: Pulling from k8s-staging-release-test/kubepkg
50e431f79093: Pull complete 
458c4832ca7f: Pull complete 
802c02f9bf17: Pull complete 
7847d2f503c2: Pull complete 
6014ab3076a7: Pull complete 
c4e5db903383: Pull complete 
ac4363819782: Pull complete 
Digest: sha256:ee90e2c3d9307d13f0b50dafebd67cbaf6e3ff1a5aed793b0a0916517179411c
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/kubepkg:latest
gcr.io/k8s-staging-release-test/kubepkg:latest
$ docker pull gcr.io/k8s-staging-release-test/kubepkg-rpm:latest
latest: Pulling from k8s-staging-release-test/kubepkg-rpm
401909e6e2aa: Pull complete 
7110593f0d19: Pull complete 
e35481e86264: Pull complete 
296f383b9b23: Pull complete 
a5e9a7542ba0: Pull complete 
e74bcdf4eb14: Pull complete 
fed6469eb16a: Pull complete 
Digest: sha256:1baaa46d7cd3b24f20483a9ced2762afbafc42caca92d8de659eaaf26469b814
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/kubepkg-rpm:latest
gcr.io/k8s-staging-release-test/kubepkg-rpm:latest
$ docker pull gcr.io/k8s-staging-release-test/releng-ci-bazel:latest
latest: Pulling from k8s-staging-release-test/releng-ci-bazel
86ead3408d04: Pull complete 
431889374a38: Pull complete 
3c2cba919283: Pull complete 
fe666a4ec244: Pull complete 
e1f203a11eaa: Pull complete 
66a0d0f2b476: Pull complete 
fd404befecb5: Pull complete 
Digest: sha256:dece8119fa73eb1fc3284d51faa3eb19138915e6db3a9f4b338ec5b020b6cbf2
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/releng-ci-bazel:latest
gcr.io/k8s-staging-release-test/releng-ci-bazel:latest
$ docker pull gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1
v1.13.8-1: Pulling from k8s-staging-release-test/k8s-cloud-builder
dc65f448a2e2: Already exists 
346ffb2b67d7: Already exists 
dea4ecac934f: Already exists 
8ac92ddf84b3: Already exists 
7ca605383307: Already exists 
f47e6cebc512: Already exists 
530350156010: Already exists 
a3a19dc1f5dd: Already exists 
70657258ff41: Already exists 
18110e05b645: Already exists 
92d70c8ff0f9: Already exists 
9a2c83fe013d: Already exists 
f1729024748e: Already exists 
c70b6cc38229: Already exists 
f67432fbc2c7: Pull complete 
67025fcd53ac: Pull complete 
e2fdd4062c70: Pull complete 
ae50f7d4808c: Pull complete 
2234dd691bc6: Pull complete 
b5661a345fb9: Pull complete 
12993cf84643: Pull complete 
d5c6a653edb6: Pull complete 
ee73437ba836: Pull complete 
Digest: sha256:53cf2294947e345d64be2c4c5078c8611c98fca10577233190e99fa4af33c404
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1
gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1
$ docker pull gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.12.17-1
v1.12.17-1: Pulling from k8s-staging-release-test/k8s-cloud-builder
dc65f448a2e2: Already exists 
346ffb2b67d7: Already exists 
dea4ecac934f: Already exists 
8ac92ddf84b3: Already exists 
7ca605383307: Already exists 
020f524b99dd: Pull complete 
06036b0307c9: Pull complete 
45e3537b3201: Pull complete 
9db62c6de27c: Pull complete 
a4c036f35817: Pull complete 
8b8cd699b2dd: Pull complete 
ba55a2dd5134: Pull complete 
484b4a59ea35: Pull complete 
f95eeb66fe5a: Pull complete 
178526d0b139: Pull complete 
dd28a51502e2: Pull complete 
531a500042e6: Pull complete 
a51a9a0cbcf8: Pull complete 
b2f9627fc1bb: Pull complete 
c18194cb6762: Pull complete 
236b9d4484ff: Pull complete 
Digest: sha256:edc0af8ad77cd72da28518016803889dee40140705f2db1fd7efcb6a7526344b
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.12.17-1
gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.12.17-1
$ docker tag gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.12.17-1 gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.12.17-1
$ docker tag gcr.io/k8s-staging-release-test/k8s-cloud-builder:v1.13.8-1 gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1
$ docker push gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.12.17-1
The push refers to repository [gcr.io/k8s-staging-releng/k8s-cloud-builder]
8dc82b31bdcb: Mounted from k8s-staging-release-test/k8s-cloud-builder 
34cabc9a17cf: Mounted from k8s-staging-release-test/k8s-cloud-builder 
4d5f4f1f2e57: Mounted from k8s-staging-release-test/k8s-cloud-builder 
90fbe74518d4: Mounted from k8s-staging-release-test/k8s-cloud-builder 
ee3088fb0621: Mounted from k8s-staging-release-test/k8s-cloud-builder 
da7c477beb35: Mounted from k8s-staging-release-test/k8s-cloud-builder 
eba4d2bf0c4f: Mounted from k8s-staging-release-test/k8s-cloud-builder 
1141ef73942c: Mounted from k8s-staging-release-test/k8s-cloud-builder 
ffaf7eb885be: Mounted from k8s-staging-release-test/k8s-cloud-builder 
f07bd38f70c0: Mounted from k8s-staging-release-test/k8s-cloud-builder 
cb6f218fdf9d: Mounted from k8s-staging-release-test/k8s-cloud-builder 
2695e40066e1: Mounted from k8s-staging-release-test/k8s-cloud-builder 
0611327306a7: Mounted from k8s-staging-release-test/k8s-cloud-builder 
3410c31c1747: Mounted from k8s-staging-release-test/k8s-cloud-builder 
2b91982b1a06: Mounted from k8s-staging-release-test/k8s-cloud-builder 
709502c58bd4: Mounted from k8s-staging-release-test/k8s-cloud-builder 
8378cd889737: Mounted from k8s-staging-release-test/k8s-cloud-builder 
5c813a85f7f0: Layer already exists 
bdca38f94ff0: Layer already exists 
faac394a1ad3: Layer already exists 
ce8168f12337: Layer already exists 
v1.12.17-1: digest: sha256:edc0af8ad77cd72da28518016803889dee40140705f2db1fd7efcb6a7526344b size: 4755
$ docker push gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1
The push refers to repository [gcr.io/k8s-staging-releng/k8s-cloud-builder]
d34693df8284: Mounted from k8s-staging-release-test/k8s-cloud-builder 
5c163a7385a9: Mounted from k8s-staging-release-test/k8s-cloud-builder 
7bceda38d522: Mounted from k8s-staging-release-test/k8s-cloud-builder 
a5716c84c5e0: Mounted from k8s-staging-release-test/k8s-cloud-builder 
cbdc833df546: Mounted from k8s-staging-release-test/k8s-cloud-builder 
920cab79346a: Mounted from k8s-staging-release-test/k8s-cloud-builder 
224cfdfd1d0a: Mounted from k8s-staging-release-test/k8s-cloud-builder 
98140e870df8: Mounted from k8s-staging-release-test/k8s-cloud-builder 
0df685bec679: Mounted from k8s-staging-release-test/k8s-cloud-builder 
9116d8ff08f4: Mounted from k8s-staging-release-test/k8s-cloud-builder 
386a8bbe36d5: Mounted from k8s-staging-release-test/k8s-cloud-builder 
a5bead104f10: Mounted from k8s-staging-release-test/k8s-cloud-builder 
0cca9057181d: Mounted from k8s-staging-release-test/k8s-cloud-builder 
1520648d34ba: Mounted from k8s-staging-release-test/k8s-cloud-builder 
bc4efb5ebb9f: Mounted from k8s-staging-release-test/k8s-cloud-builder 
b5d031bfbc0a: Mounted from k8s-staging-release-test/k8s-cloud-builder 
cae11887bc90: Mounted from k8s-staging-release-test/k8s-cloud-builder 
729c3ac48990: Mounted from k8s-staging-release-test/k8s-cloud-builder 
8378cd889737: Layer already exists 
5c813a85f7f0: Layer already exists 
bdca38f94ff0: Layer already exists 
faac394a1ad3: Layer already exists 
ce8168f12337: Layer already exists 
v1.13.8-1: digest: sha256:53cf2294947e345d64be2c4c5078c8611c98fca10577233190e99fa4af33c404 size: 5179
$ docker pull gcr.io/k8s-staging-release-test/kubepkg:v20200307-v0.2.5-23-g11eb80c
v20200307-v0.2.5-23-g11eb80c: Pulling from k8s-staging-release-test/kubepkg
Digest: sha256:ee90e2c3d9307d13f0b50dafebd67cbaf6e3ff1a5aed793b0a0916517179411c
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/kubepkg:v20200307-v0.2.5-23-g11eb80c
gcr.io/k8s-staging-release-test/kubepkg:v20200307-v0.2.5-23-g11eb80c
$ docker tag gcr.io/k8s-staging-release-test/kubepkg:v20200307-v0.2.5-23-g11eb80c gcr.io/k8s-staging-releng/kubepkg:v20200307-v0.2.5-23-g11eb80c
$ docker tag gcr.io/k8s-staging-release-test/kubepkg:v20200307-v0.2.5-23-g11eb80c gcr.io/k8s-staging-releng/kubepkg:latest
$ docker push gcr.io/k8s-staging-releng/kubepkg:latest
The push refers to repository [gcr.io/k8s-staging-releng/kubepkg]
13e86b7f6202: Mounted from k8s-staging-release-test/kubepkg 
9a20a22cfc34: Mounted from k8s-staging-release-test/kubepkg 
0f0108e96cc0: Mounted from k8s-staging-release-test/kubepkg 
3c827c54adc6: Mounted from k8s-staging-release-test/kubepkg 
369459075bf1: Mounted from k8s-staging-release-test/kubepkg 
713a1690460e: Mounted from k8s-staging-release-test/kubepkg 
1c76bd0dc325: Layer already exists 
latest: digest: sha256:ee90e2c3d9307d13f0b50dafebd67cbaf6e3ff1a5aed793b0a0916517179411c size: 1783
$ docker push gcr.io/k8s-staging-releng/kubepkg:v20200307-v0.2.5-23-g11eb80c 
The push refers to repository [gcr.io/k8s-staging-releng/kubepkg]
13e86b7f6202: Layer already exists 
9a20a22cfc34: Layer already exists 
0f0108e96cc0: Layer already exists 
3c827c54adc6: Layer already exists 
369459075bf1: Layer already exists 
713a1690460e: Layer already exists 
1c76bd0dc325: Layer already exists 
v20200307-v0.2.5-23-g11eb80c: digest: sha256:ee90e2c3d9307d13f0b50dafebd67cbaf6e3ff1a5aed793b0a0916517179411c size: 1783
$ docker pull gcr.io/k8s-staging-releng/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c
Error response from daemon: manifest for gcr.io/k8s-staging-releng/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c not found: manifest unknown: Failed to fetch "v20200307-v0.2.5-23-g11eb80c" from request "/v2/k8s-staging-releng/kubepkg-rpm/manifests/v20200307-v0.2.5-23-g11eb80c".
$ docker pull gcr.io/k8s-staging-release-test/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c
v20200307-v0.2.5-23-g11eb80c: Pulling from k8s-staging-release-test/kubepkg-rpm
Digest: sha256:1baaa46d7cd3b24f20483a9ced2762afbafc42caca92d8de659eaaf26469b814
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c
gcr.io/k8s-staging-release-test/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c
$ docker tag gcr.io/k8s-staging-release-test/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c gcr.io/k8s-staging-releng/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c
$ docker tag gcr.io/k8s-staging-release-test/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c gcr.io/k8s-staging-releng/kubepkg-rpm:latest
$ docker push gcr.io/k8s-staging-releng/kubepkg-rpm:v20200307-v0.2.5-23-g11eb80c 
The push refers to repository [gcr.io/k8s-staging-releng/kubepkg-rpm]
3cf634a4ff1d: Mounted from k8s-staging-release-test/kubepkg-rpm 
c1f35d24b589: Mounted from k8s-staging-release-test/kubepkg-rpm 
b0e95fd87632: Mounted from k8s-staging-release-test/kubepkg-rpm 
2136e78712a1: Mounted from k8s-staging-release-test/kubepkg-rpm 
e93d03d46dd8: Mounted from k8s-staging-release-test/kubepkg-rpm 
6735fa4eb6d0: Mounted from k8s-staging-release-test/kubepkg-rpm 
a061a1fe0040: Mounted from k8s-staging-release-test/kubepkg-rpm 
v20200307-v0.2.5-23-g11eb80c: digest: sha256:1baaa46d7cd3b24f20483a9ced2762afbafc42caca92d8de659eaaf26469b814 size: 1782
$ docker push gcr.io/k8s-staging-releng/kubepkg-rpm:latest
The push refers to repository [gcr.io/k8s-staging-releng/kubepkg-rpm]
3cf634a4ff1d: Layer already exists 
c1f35d24b589: Layer already exists 
b0e95fd87632: Layer already exists 
2136e78712a1: Layer already exists 
e93d03d46dd8: Layer already exists 
6735fa4eb6d0: Layer already exists 
a061a1fe0040: Layer already exists 
latest: digest: sha256:1baaa46d7cd3b24f20483a9ced2762afbafc42caca92d8de659eaaf26469b814 size: 1782
$ docker pull gcr.io/k8s-staging-release-test/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c
v20200304-v0.2.5-4-gb6a280c: Pulling from k8s-staging-release-test/releng-ci-bazel
Digest: sha256:dece8119fa73eb1fc3284d51faa3eb19138915e6db3a9f4b338ec5b020b6cbf2
Status: Downloaded newer image for gcr.io/k8s-staging-release-test/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c
gcr.io/k8s-staging-release-test/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c
$ docker tag gcr.io/k8s-staging-release-test/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c gcr.io/k8s-staging-releng/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c
$ docker tag gcr.io/k8s-staging-release-test/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c gcr.io/k8s-staging-releng/releng-ci-bazel:latest
$ docker push gcr.io/k8s-staging-releng/releng-ci-bazel:v20200304-v0.2.5-4-gb6a280c
The push refers to repository [gcr.io/k8s-staging-releng/releng-ci-bazel]
fb4c29f79059: Mounted from k8s-staging-release-test/releng-ci-bazel 
3d0f6e3e579f: Mounted from k8s-staging-release-test/releng-ci-bazel 
84ff92691f90: Mounted from k8s-staging-release-test/releng-ci-bazel 
eda6e4780b47: Mounted from k8s-staging-release-test/releng-ci-bazel 
bb71035a3ce5: Mounted from k8s-staging-release-test/releng-ci-bazel 
55fb363bca7c: Mounted from k8s-staging-release-test/releng-ci-bazel 
1e544f80d77b: Mounted from k8s-staging-release-test/releng-ci-bazel 
v20200304-v0.2.5-4-gb6a280c: digest: sha256:dece8119fa73eb1fc3284d51faa3eb19138915e6db3a9f4b338ec5b020b6cbf2 size: 1998
$ docker push gcr.io/k8s-staging-releng/releng-ci-bazel:latest
The push refers to repository [gcr.io/k8s-staging-releng/releng-ci-bazel]
fb4c29f79059: Layer already exists 
3d0f6e3e579f: Layer already exists 
84ff92691f90: Layer already exists 
eda6e4780b47: Layer already exists 
bb71035a3ce5: Layer already exists 
55fb363bca7c: Layer already exists 
1e544f80d77b: Layer already exists 
latest: digest: sha256:dece8119fa73eb1fc3284d51faa3eb19138915e6db3a9f4b338ec5b020b6cbf2 size: 1998
```

</details>

**Does this PR introduce a user-facing change?**:
```release-note
gcp: Update GCB and releaselib to use new k8s-staging-releng project
```
