### PR TITLE
gcb: Move KMS keys to k8s-releng-prod GCP project

### DIFF
--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -12,10 +12,10 @@ timeout: 1200s
 #
 # (Please do not remove this security notice.)
 secrets:
-- kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+- kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
-# TODO: move to the kubernetes-release-test
+    GITHUB_TOKEN: CiQAIkWjMKxKm2TA5DQNxwDfoAvnT/MQvfwlaxFUiFfyCmplqHESUQBLz1D+nejo8OWfiQF2DW+1QJXcb/XCWb9uPtBvcBdR9a9MwadgS2P85IseuBmqYVgSDvgdEVP3Zj9MXaHj60towEGlaRonA2uNYAgxRWhD6Q==
+# TODO: move to the k8s-releng-prod
 - kmsKeyName: projects/cf-london-servces-k8s/locations/global/keyRings/hhorl-k8s-release/cryptoKeys/sendgrid
   secretEnv:
     SENDGRID_API_KEY: CiQAkn5y0WUR0kZIqj1v4UW2McFdlceel2zptSa468+Ir/gDeh0SbwDMTYRJdFtqt2x2hGPN7oOoMs2lCLFoY+oh4Mb1b/nQehooMYQuNwupxOpnwE+d/GbEFhwtMg9wbA5zhOMYPe0OLsSAXvt4w/IC1Z701Ev3CMdT6ZjicillZoBlFYhVlFPQLWcm8jtobdQcDj91eg==

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -12,9 +12,9 @@ timeout: 14400s
 #
 # (Please do not remove this security notice.)
 secrets:
-- kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+- kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
+    GITHUB_TOKEN: CiQAIkWjMKxKm2TA5DQNxwDfoAvnT/MQvfwlaxFUiFfyCmplqHESUQBLz1D+nejo8OWfiQF2DW+1QJXcb/XCWb9uPtBvcBdR9a9MwadgS2P85IseuBmqYVgSDvgdEVP3Zj9MXaHj60towEGlaRonA2uNYAgxRWhD6Q==
 
 steps:
 - name: gcr.io/cloud-builders/git

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -12,9 +12,9 @@ timeout: 14400s
 #
 # (Please do not remove this security notice.)
 secrets:
-- kmsKeyName: projects/kubernetes-release-test/locations/global/keyRings/anago/cryptoKeys/k8s-release-robot
+- kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAveh8wGJqpEkcVluO3tBntlehynOxiOPDD9u1XCONx3vuozoSUgCMoh/IJuNkqhcDTP2om2tyOStft8myMSrvnGd7NvTo+H+fI0EkLMNzkVOHxl/C0piktBm74uN70QVE+e4TTa9wwA//qpiSm/UuqYmEYeMIpyY=
+    GITHUB_TOKEN: CiQAIkWjMKxKm2TA5DQNxwDfoAvnT/MQvfwlaxFUiFfyCmplqHESUQBLz1D+nejo8OWfiQF2DW+1QJXcb/XCWb9uPtBvcBdR9a9MwadgS2P85IseuBmqYVgSDvgdEVP3Zj9MXaHj60towEGlaRonA2uNYAgxRWhD6Q==
 
 steps:
 - name: gcr.io/cloud-builders/git


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup feature

**What this PR does / why we need it**:
Now that KMS usage has been documented in https://github.com/kubernetes/sig-release/pull/1016, we should cutover our GCB configs to use KMS assets in the `k8s-releng-prod` GCP project.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/release/issues/911, https://github.com/kubernetes/k8s.io/pull/641

**Special notes for your reviewer**:
KMS decrypter access granted to the `kubernetes-release-test` GCB service account:

```shell
$ gcloud kms keys add-iam-policy-binding \
    encrypt-0 --location=global --keyring=release \
    --member=serviceAccount:648026197307@cloudbuild.gserviceaccount.com \
    --role=roles/cloudkms.cryptoKeyDecrypter
```

```shell
Updated IAM policy for key [encrypt-0].
bindings:
- members:
  - serviceAccount:117157742389@cloudbuild.gserviceaccount.com
  - serviceAccount:615281671549@cloudbuild.gserviceaccount.com
  - serviceAccount:648026197307@cloudbuild.gserviceaccount.com
  role: roles/cloudkms.cryptoKeyDecrypter
etag: BwWgakJY2PQ=
version: 1
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
gcb: Move KMS keys to k8s-releng-prod GCP project
```
