### PR TITLE
Deprecate shell-based gcbmgr and add usage documentation for Go-based 'krel gcbmgr'

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -327,6 +327,10 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 
 	buildVersion := o.buildVersion
 	if buildVersion == "" {
+		if o.release {
+			return gcbSubs, errors.New("Build version must be specified when sending a release GCB run")
+		}
+
 		var versionErr error
 		buildVersion, versionErr = release.GetKubeVersionForBranch(
 			release.VersionTypeCILatest, o.branch,

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -125,10 +125,11 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		{
 			name: "master prerelease - release",
 			gcbmgrOpts: gcbmgrOptions{
-				release:     true,
-				branch:      "master",
-				releaseType: "prerelease",
-				gcpUser:     "test-user",
+				release:      true,
+				branch:       "master",
+				releaseType:  "prerelease",
+				buildVersion: "v1.33.7",
+				gcpUser:      "test-user",
 			},
 			expected: map[string]string{
 				"OFFICIAL":       "",
@@ -234,6 +235,14 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 		{
 			name: "no release branch",
 			gcbmgrOpts: gcbmgrOptions{
+				branch:  "",
+				gcpUser: "test-user",
+			},
+		},
+		{
+			name: "no build version",
+			gcbmgrOpts: gcbmgrOptions{
+				release: true,
 				branch:  "",
 				gcpUser: "test-user",
 			},

--- a/docs/krel/gcbmgr.md
+++ b/docs/krel/gcbmgr.md
@@ -1,0 +1,175 @@
+# gcbmgr (GCB Manager) <!-- omit in toc -->
+
+`gcbmgr` is a subcommand of `krel` for Release Managers to submit Kubernetes staging and release jobs to Google Cloud Build (GCB).
+
+`krel gcbmgr` is a wrapper around the `gcloud builds submit` command which passes a set of GCB substitutions (variables) to a GCB configuration for usage in [`anago`](/anago).
+
+**NOTE: `krel gcbmgr` is currently in development and its design may rapidly change. If you encounter errors, please file an issue in this repo.**
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Important notes](#important-notes)
+- [Alpha](#alpha)
+  - [Alpha Stage](#alpha-stage)
+  - [Alpha Release](#alpha-release)
+- [Beta](#beta)
+  - [Beta Stage](#beta-stage)
+    - [Branch cut (`x.y.0-beta.0`)](#branch-cut-xy0-beta0)
+    - [Post-branch cut (`x.y.0-beta.1` and beyond)](#post-branch-cut-xy0-beta1-and-beyond)
+  - [Beta Release](#beta-release)
+- [Release Candidate](#release-candidate)
+  - [Release Candidate (RC) Stage](#release-candidate-rc-stage)
+  - [Release Candidate (RC) Release](#release-candidate-rc-release)
+- [Official](#official)
+  - [Official Stage](#official-stage)
+  - [Official Release](#official-release)
+
+## Installation
+
+From this root of this repo:
+
+```shell
+./compile-release-tools krel
+```
+
+## Usage
+
+`krel gcbmgr [flags]`
+
+```
+Flags:
+      --branch string          Branch to run the specified GCB run against
+      --build-version string   Build version
+      --gcb-config string      If provided, this will be used as the name of the Google Cloud Build config file. (default "cloudbuild.yaml")
+      --gcp-user string        If provided, this will be used as the GCP_USER_TAG.
+  -h, --help                   help for gcbmgr
+      --project string         Branch to run the specified GCB run against (default "kubernetes-release-test")
+      --release                Submit a release run to GCB
+      --stage                  Submit a stage run to GCB
+      --stream                 If specified, GCB will run synchronously, tailing its' logs to stdout
+      --type string            Release type (must be one of: 'prerelease', 'rc', 'official') (default "prerelease")
+
+Global Flags:
+      --cleanup            cleanup flag
+      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace' (default "info")
+      --nomock             nomock flag
+      --repo string        the local path to the repository to be used (default "/tmp/k8s")
+```
+
+## Important notes
+
+- Default executions of `krel gcbmgr` run in mock mode. To run an actual stage or release, you **MUST** provide the `--nomock` flag.
+- Always execute the release process in the following order:
+  - mock stage: `krel gcbmgr --stage`
+  - mock release: `krel gcbmgr --release`
+  - nomock stage: `krel gcbmgr --stage --nomock`
+  - nomock release: `krel gcbmgr --release --nomock`
+- For release jobs, you **MUST** specify the build version that is output as a result of a successful staging run.
+- The following environment variables can be used to test the staging/release process against a contributor's fork: `TOOL_ORG`, `TOOL_REPO`, `TOOL_BRANCH`
+  
+  Example:
+
+  ```shell
+  TOOL_ORG=justaugustus \
+  TOOL_REPO=release \
+  TOOL_BRANCH=great-new-feature-branch \
+  krel gcbmgr --stage \
+    --branch release-x.y \
+    --project kubernetes-release-test \
+    --build-version $(curl -Ls https://dl.k8s.io/ci/latest-x.y.txt)
+  ```
+
+## Alpha
+
+### Alpha Stage
+
+```shell
+krel gcbmgr --stage \
+  --branch master \
+  --project kubernetes-release-test \
+  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+```
+
+### Alpha Release
+
+```shell
+krel gcbmgr --release \
+  --branch master \
+  --project kubernetes-release-test \
+  --build-version <build-version>
+```
+
+## Beta
+
+### Beta Stage
+
+#### Branch cut (`x.y.0-beta.0`)
+
+```shell
+krel gcbmgr --stage \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+```
+
+#### Post-branch cut (`x.y.0-beta.1` and beyond)
+
+```shell
+krel gcbmgr --stage \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version $(curl -Ls https://dl.k8s.io/ci/latest-x.y.txt)
+```
+
+### Beta Release
+
+```shell
+krel gcbmgr --release \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version <build-version>
+```
+
+## Release Candidate
+
+### Release Candidate (RC) Stage
+
+```shell
+krel gcbmgr --stage \
+  --type rc \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+```
+
+### Release Candidate (RC) Release
+
+```shell
+krel gcbmgr --release \
+  --type rc \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version <build-version>
+```
+
+## Official
+
+### Official Stage
+
+```shell
+krel gcbmgr --stage \
+  --type official \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+```
+
+### Official Release
+
+```shell
+krel gcbmgr --release \
+  --type official \
+  --branch release-x.y \
+  --project kubernetes-release-test \
+  --build-version <build-version>
+```

--- a/gcbmgr
+++ b/gcbmgr
@@ -332,34 +332,13 @@ submit_it () {
 }
 
 release_it () {
-  if [[ -z $RELEASE_BRANCH ]]; then
-    logecho "Branch not set.  Can't continue"
-    return 1
-  fi
-
-  KUBE_CROSS_VERSION="$( release::kubecross_version "$RELEASE_BRANCH" 'master' )" \
-    || common::exit 1 'Exiting...' >&2
-
-  # Check for mandatory buildversion
-  if [[ -z $FLAGS_buildversion ]]; then
-    logecho "--buildversion=<staged build> required for 'release' jobs."
-    return 1
-  fi
-
-  submit_it
+  logecho "The shell-based gcbmgr tool has been deprecated."
+  logecho "Please review https://git.k8s.io/release/docs/krel/gcbmgr.md for instructions on how to use 'krel gcbmgr'."
 }
 
 stage_it () {
-  if [[ -z $RELEASE_BRANCH ]]; then
-    logecho "Branch not set.  Can't continue"
-    return 1
-  fi
-
-  KUBE_CROSS_VERSION="$( release::kubecross_version "$RELEASE_BRANCH" 'master' )" \
-    || common::exit 1 'Exiting...' >&2
-
-  # Submit it
-  submit_it
+  logecho "The shell-based gcbmgr tool has been deprecated."
+  logecho "Please review https://git.k8s.io/release/docs/krel/gcbmgr.md for instructions on how to use 'krel gcbmgr'."
 }
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup deprecation documentation

**Special notes for your reviewer**:
I plan to follow-up with deduplication of the `gcbmgr` docs here and within the Branch Manager / Patch Release Team handbooks. 

**Does this PR introduce a user-facing change?**:
```release-note
Deprecate shell-based gcbmgr and add usage documentation for Go-based `krel gcbmgr`
```
