### PR TITLE
Refactor release package kube version retrieval

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -328,7 +328,9 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 	buildVersion := o.buildVersion
 	if buildVersion == "" {
 		var versionErr error
-		buildVersion, versionErr = release.GetCIKubeVersion(o.branch, false)
+		buildVersion, versionErr = release.GetKubeVersionForBranch(
+			release.VersionTypeCILatest, o.branch,
+		)
 		if versionErr != nil {
 			return gcbSubs, versionErr
 		}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -505,6 +505,8 @@ func (r *Repo) Checkout(rev string, args ...string) error {
 		RunSilentSuccess()
 }
 
+// IsReleaseBranch returns true if the provided branch is a Kubernetes release
+// branch
 func IsReleaseBranch(branch string) bool {
 	re := regexp.MustCompile(branchRE)
 	if !re.MatchString(branch) {

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -59,8 +59,6 @@ const (
 	templateRootDir = "templates"
 
 	kubeadmConf = "10-kubeadm.conf"
-
-	useSemver = true
 )
 
 var (
@@ -392,12 +390,12 @@ func getKubernetesVersion(packageDef *PackageDefinition) (string, error) {
 	}
 	switch packageDef.Channel {
 	case ChannelTesting:
-		return release.GetStablePrereleaseKubeVersion(useSemver)
+		return release.GetKubeVersion(release.VersionTypeStablePreRelease)
 	case ChannelNightly:
-		return release.GetLatestCIKubeVersion(useSemver)
+		return release.GetKubeVersion(release.VersionTypeCILatest)
 	}
 
-	return release.GetStableReleaseKubeVersion(useSemver)
+	return release.GetKubeVersion(release.VersionTypeStable)
 }
 
 func getCNIVersion(packageDef *PackageDefinition) (string, error) {
@@ -529,13 +527,13 @@ func getCIBuildsDownloadLinkBase(packageDef *PackageDefinition) (string, error) 
 	ciVersion := packageDef.KubernetesVersion
 	if ciVersion == "" {
 		var err error
-		ciVersion, err = release.GetLatestCIKubeVersion(useSemver)
+		ciVersion, err = release.GetKubeVersion(release.VersionTypeCILatest)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	return fmt.Sprintf("https://dl.k8s.io/ci/v%s", ciVersion), nil
+	return fmt.Sprintf("https://dl.k8s.io/ci/%s", util.AddTagPrefix(ciVersion)), nil
 }
 
 func getDefaultReleaseDownloadLinkBase(packageDef *PackageDefinition) (string, error) {

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -2,14 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["release.go"],
+    srcs = [
+        "release.go",
+        "version.go",
+    ],
     importpath = "k8s.io/release/pkg/release",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
         "//pkg/http:go_default_library",
         "//pkg/util:go_default_library",
-        "@com_github_blang_semver//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
@@ -31,9 +33,15 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["release_test.go"],
+    srcs = [
+        "release_test.go",
+        "version_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/http:go_default_library",
+        "//pkg/util:go_default_library",
+        "@com_github_blang_semver//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -400,67 +400,6 @@ func TestIsDirtyBuild(t *testing.T) {
 	}
 }
 
-func TestGetKubeVersionSuccess(t *testing.T) {
-	testcases := []struct {
-		name      string
-		url       string
-		expected  string
-		useSemver bool
-	}{
-		{
-			name:      "Release URL (semver)",
-			url:       "https://dl.k8s.io/release/stable-1.13.txt",
-			expected:  "1.13.12",
-			useSemver: true,
-		},
-		{
-			name:      "CI URL (semver)",
-			url:       "https://dl.k8s.io/ci/latest-1.14.txt",
-			expected:  "1.14.11-beta.1.2+c8b135d0b49c44",
-			useSemver: true,
-		},
-		{
-			name:      "CI URL (non-semver)",
-			url:       "https://dl.k8s.io/ci/latest-1.14.txt",
-			expected:  "v1.14.11-beta.1.2+c8b135d0b49c44",
-			useSemver: false,
-		},
-	}
-
-	for _, tc := range testcases {
-		actual, err := GetKubeVersion(tc.url, tc.useSemver)
-
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
-		assert.Equal(t, tc.expected, actual)
-	}
-}
-
-func TestGetKubeVersionFailure(t *testing.T) {
-	testcases := []struct {
-		name      string
-		url       string
-		useSemver bool
-	}{
-		{
-			name: "Empty URL string",
-			url:  "",
-		},
-		{
-			name: "Bad URL",
-			url:  "https://fake.url",
-		},
-	}
-
-	for _, tc := range testcases {
-		_, err := GetKubeVersion(tc.url, tc.useSemver)
-
-		require.Error(t, err)
-	}
-}
-
 func cleanupTmps(t *testing.T, dir ...string) {
 	for _, each := range dir {
 		require.Nil(t, os.RemoveAll(each))

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/http"
+)
+
+// VersionType is a simple wrapper around a Kubernetes release version
+type VersionType string
+
+const (
+	// VersionStable references the latest stable Kubernetes version,
+	// for example `v1.17.3`
+	VersionTypeStable VersionType = "release/stable"
+
+	// VersionStablePreRelease references the latest stable pre release
+	// Kubernetes version, for example `v1.19.0-alpha.0`
+	VersionTypeStablePreRelease VersionType = "release/latest"
+
+	// VersionStable references the latest CI Kubernetes version,
+	// for example `v1.19.0-alpha.0.721+f8ff8f44206ff4`
+	VersionTypeCILatest VersionType = "ci/latest"
+
+	// baseURL is the base URL for every release version retrieval
+	baseURL = "https://dl.k8s.io/"
+)
+
+// url retrieves the full URL of the Kubernetes release version
+func (t VersionType) url(version string) string {
+	url := baseURL + string(t)
+
+	if version != "" {
+		url += "-" + version
+	}
+	url += ".txt"
+
+	return url
+}
+
+// GetKubeVersion retrieves the version of the provided Kubernetes version type
+func GetKubeVersion(versionType VersionType) (string, error) {
+	logrus.Infof("Retrieving Kubernetes release version for %s", versionType)
+	return kubeVersionFromURL(versionType.url(""))
+}
+
+// GetKubeVersionForBranch returns the remote Kubernetes release version for
+// the provided branch
+func GetKubeVersionForBranch(versionType VersionType, branch string) (string, error) {
+	logrus.Infof(
+		"Retrieving Kubernetes release version for %s on branch %s",
+		versionType, branch,
+	)
+
+	version := ""
+	if branch != git.Master {
+		if !git.IsReleaseBranch(branch) {
+			return "", errors.Errorf("%s is not a valid release branch", branch)
+		}
+		version = strings.TrimPrefix(branch, "release-")
+	}
+	url := versionType.url(version)
+
+	return kubeVersionFromURL(url)
+}
+
+// kubeVersionFromURL retrieves the Kubernetes version from the provided URL
+// ans strips the tag prefix if `stripTagPrefix` is `true`
+func kubeVersionFromURL(url string) (string, error) {
+	logrus.Infof("Retrieving Kubernetes build version from %s...", url)
+	version, httpErr := http.GetURLResponse(url, true)
+	if httpErr != nil {
+		return "", errors.Wrap(httpErr, "retrieving kube version")
+	}
+
+	logrus.Infof("Retrieved Kubernetes version: %s", version)
+	return version, nil
+}

--- a/pkg/release/version_test.go
+++ b/pkg/release/version_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/http"
+	"k8s.io/release/pkg/util"
+)
+
+func TestGetKubeVersionSuccess(t *testing.T) {
+	testcases := []struct {
+		versionType VersionType
+		assertion   func(semver.Version)
+	}{
+		{
+			// for example: v1.17.3
+			versionType: VersionTypeStable,
+			assertion:   func(s semver.Version) { require.Empty(t, s.Pre) },
+		},
+		{
+			// for example: v1.19.0-alpha.0.721+f8ff8f44206ff4
+			versionType: VersionTypeCILatest,
+			assertion:   func(s semver.Version) { require.Len(t, s.Pre, 3) },
+		},
+		{
+			// for example: v1.19.0-alpha.0
+			versionType: VersionTypeStablePreRelease,
+			assertion:   func(s semver.Version) { require.Len(t, s.Pre, 2) },
+		},
+	}
+
+	for _, tc := range testcases {
+		tag, err := GetKubeVersion(tc.versionType)
+		require.Nil(t, err)
+
+		s, err := util.TagStringToSemver(tag)
+		require.Nil(t, err)
+
+		require.EqualValues(t, s.Major, 1)
+		tc.assertion(s)
+	}
+}
+
+func TestGetKubeVersionForBranchSuccess(t *testing.T) {
+	testcases := []struct {
+		versionType VersionType
+		branch      string
+		expected    string
+	}{
+		{
+			versionType: VersionTypeStable,
+			branch:      "release-1.13",
+			expected:    "v1.13.12",
+		},
+		{
+			versionType: VersionTypeCILatest,
+			branch:      "release-1.14",
+			expected:    "v1.14.11-beta.1.2+c8b135d0b49c44",
+		},
+		{
+			versionType: VersionTypeStablePreRelease,
+			branch:      "release-1.14",
+			expected:    "v1.14.11-beta.0",
+		},
+	}
+
+	for _, tc := range testcases {
+		actual, err := GetKubeVersionForBranch(tc.versionType, tc.branch)
+		require.Nil(t, err, string(tc.versionType))
+		require.Equal(t, tc.expected, actual)
+	}
+}
+
+func TestGetKubeVersionForBranchFailure(t *testing.T) {
+	testcases := []struct {
+		versionType VersionType
+		branch      string
+	}{
+		{
+			versionType: VersionTypeStable,
+			branch:      "wrong-branch",
+		},
+	}
+
+	for _, tc := range testcases {
+		_, err := GetKubeVersionForBranch(tc.versionType, tc.branch)
+		require.NotNil(t, err, string(tc.versionType))
+	}
+}
+
+func TestURL(t *testing.T) {
+	testcases := []struct {
+		versionType VersionType
+		version     string
+		expected    string
+	}{
+		{
+			versionType: VersionTypeStable,
+			version:     "1.13",
+			expected:    "https://dl.k8s.io/release/stable-1.13.txt",
+		},
+		{
+			versionType: VersionTypeStable,
+			expected:    "https://dl.k8s.io/release/stable.txt",
+		},
+		{
+			versionType: VersionTypeCILatest,
+			version:     "1.14",
+			expected:    "https://dl.k8s.io/ci/latest-1.14.txt",
+		},
+		{
+			versionType: VersionTypeCILatest,
+			expected:    "https://dl.k8s.io/ci/latest.txt",
+		},
+		{
+			versionType: VersionTypeStablePreRelease,
+			version:     "1.15",
+			expected:    "https://dl.k8s.io/release/latest-1.15.txt",
+		},
+		{
+			versionType: VersionTypeStablePreRelease,
+			expected:    "https://dl.k8s.io/release/latest.txt",
+		},
+	}
+
+	for _, tc := range testcases {
+		url := tc.versionType.url(tc.version)
+		require.Equal(t, tc.expected, url)
+
+		response, err := http.GetURLResponse(url, true)
+		require.Nil(t, err)
+		require.NotEmpty(t, response)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now use a dedicated type (`VersionType`) for kube version retrieval.
This allows us to retrieve the final url via a simple call to `url()`,
whereas the public function `GetKubeVersionForBranch()` verifies that
the provided branch is a valid release branch.

I removed the tag stripping and put that logic into the consumers of the
API to have a more dedicated responsiblity in `GetKubeVersionForBranch()`
and `GetKubeVersion()`.

Tests have been adapted as well as the API consumers
`pkg/kubepkg/kubepkg.go` and `cmd/krel/cmd/gcbmgr.go`.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
