### PR TITLE
images/releng-ci-bazel: Add jq, bsdmainutils and google-cloud-sdk

### DIFF
--- a/images/releng-ci-bazel/Dockerfile
+++ b/images/releng-ci-bazel/Dockerfile
@@ -13,8 +13,19 @@
 # limitations under the License.
 
 FROM launcher.gcr.io/google/bazel:2.0.0
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
 RUN apt-get update && \
-    apt-get install -y build-essential && \
+    apt-get install -y \
+        bsdmainutils \
+        build-essential \
+        google-cloud-sdk \
+        jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Some tests require a working git executable, so we configure a pseudo-user


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

To be able to test `krel gcbmgr` we will need those binaries and
packages available in the test system.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
images/releng-ci-bazel: Add jq, bsdmainutils and google-cloud-sdk
```
