### PR TITLE
Configure releng GCB jobs to use new staging project and add VDF TODOs

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -118,8 +118,8 @@ func init() {
 	gcbmgrCmd.PersistentFlags().StringVar(
 		&buildOpts.Project,
 		"project",
-		release.DefaultProject,
-		"Branch to run the specified GCB run against",
+		release.DefaultKubernetesStagingProject,
+		"GCP project to run GCB in",
 	)
 	gcbmgrCmd.PersistentFlags().BoolVar(
 		&gcbmgrOpts.stream,

--- a/cmd/patch-announce/BUILD.bazel
+++ b/cmd/patch-announce/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/log:go_default_library",
         "//pkg/patch:go_default_library",
+        "//pkg/release:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],

--- a/cmd/patch-announce/main.go
+++ b/cmd/patch-announce/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/release/pkg/log"
 	"k8s.io/release/pkg/patch"
+	"k8s.io/release/pkg/release"
 )
 
 type opts struct {
@@ -48,7 +49,6 @@ const (
 	defaultK8sBranch      = "master"
 	defaultReleaseRepoURL = "https://github.com/kubernetes/release"
 	defaultReleaseBranch  = "master"
-	defaultGCPorjectID    = "kubernetes-release-test"
 	defaultLogLevel       = "info"
 
 	// separator which hopefully never appears in any of our keys/values.
@@ -77,7 +77,7 @@ func getCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.FreezeDate, "freeze-date", "f", "", "date when no CPs are allowed anymore")
 	cmd.Flags().StringVarP(&opts.CutDate, "cut-date", "c", "", "date when the patch release is planned to be cut")
 	cmd.Flags().StringVarP(&opts.BuildConfigPath, "config", "C", "", "file path to the patch-announce cloudbuild.yaml")
-	cmd.Flags().StringVarP(&opts.ProjectID, "project-id", "p", defaultGCPorjectID, "Google Project ID")
+	cmd.Flags().StringVarP(&opts.ProjectID, "project-id", "p", release.DefaultRelengStagingProject, "Google Project ID")
 	cmd.Flags().StringVarP(&opts.K8sRepoURL, "kubernetes-repo-url", "r", defaultK8sRepoURL, `git URL for the kubernetes repo ("k/k")`)
 	cmd.Flags().StringVarP(&opts.K8sBranch, "kubernetes-branch", "b", defaultK8sBranch, `branch to checkout for the kubernetes repo ("k/k")`)
 	cmd.Flags().StringVarP(&opts.ReleaseRepoURL, "release-repo-url", "R", defaultReleaseRepoURL, `git URL for the release repo ("k/release)`)
@@ -109,6 +109,7 @@ func getCommand() *cobra.Command {
 		return nil
 	}
 
+	// TODO: Refactor to use pkg/gcp/build
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		exeName := "gcloud"
 		exe, err := exec.LookPath(exeName)

--- a/docs/krel/gcbmgr.md
+++ b/docs/krel/gcbmgr.md
@@ -32,6 +32,7 @@ From this root of this repo:
 ./compile-release-tools krel
 ```
 
+<!-- TODO(vdf): Need to reference K8s Infra projects in usage examples -->
 ## Usage
 
 `krel gcbmgr [flags]`
@@ -43,7 +44,7 @@ Flags:
       --gcb-config string      If provided, this will be used as the name of the Google Cloud Build config file. (default "cloudbuild.yaml")
       --gcp-user string        If provided, this will be used as the GCP_USER_TAG.
   -h, --help                   help for gcbmgr
-      --project string         Branch to run the specified GCB run against (default "kubernetes-release-test")
+      --project string         GCP project to run GCB in (default "kubernetes-release-test")
       --release                Submit a release run to GCB
       --stage                  Submit a stage run to GCB
       --stream                 If specified, GCB will run synchronously, tailing its' logs to stdout
@@ -75,8 +76,7 @@ Global Flags:
   TOOL_BRANCH=great-new-feature-branch \
   krel gcbmgr --stage \
     --branch release-x.y \
-    --project kubernetes-release-test \
-    --build-version $(curl -Ls https://dl.k8s.io/ci/latest-x.y.txt)
+    --project kubernetes-release-test
   ```
 
 ## Alpha
@@ -86,8 +86,7 @@ Global Flags:
 ```shell
 krel gcbmgr --stage \
   --branch master \
-  --project kubernetes-release-test \
-  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+  --project kubernetes-release-test
 ```
 
 ### Alpha Release
@@ -108,8 +107,7 @@ krel gcbmgr --release \
 ```shell
 krel gcbmgr --stage \
   --branch release-x.y \
-  --project kubernetes-release-test \
-  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+  --project kubernetes-release-test
 ```
 
 #### Post-branch cut (`x.y.0-beta.1` and beyond)
@@ -117,8 +115,7 @@ krel gcbmgr --stage \
 ```shell
 krel gcbmgr --stage \
   --branch release-x.y \
-  --project kubernetes-release-test \
-  --build-version $(curl -Ls https://dl.k8s.io/ci/latest-x.y.txt)
+  --project kubernetes-release-test
 ```
 
 ### Beta Release
@@ -138,8 +135,7 @@ krel gcbmgr --release \
 krel gcbmgr --stage \
   --type rc \
   --branch release-x.y \
-  --project kubernetes-release-test \
-  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+  --project kubernetes-release-test
 ```
 
 ### Release Candidate (RC) Release
@@ -160,8 +156,7 @@ krel gcbmgr --release \
 krel gcbmgr --stage \
   --type official \
   --branch release-x.y \
-  --project kubernetes-release-test \
-  --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt)
+  --project kubernetes-release-test
 ```
 
 ### Official Release

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -18,14 +18,21 @@
 # CONSTANTS
 ###############################################################################
 
+# TODO(vdf): Need to reference K8s Infra projects here
 readonly DEFAULT_PROJECT="kubernetes-release-test"
 readonly PROD_PROJECT="kubernetes-release"
-readonly TEST_PROJECT="${TEST_PROJECT:-${PROJECT_ID:-$DEFAULT_PROJECT}}"
+readonly TEST_PROJECT="kubernetes-release-test"
 
+# TODO(vdf): Need to reference K8s Infra buckets here
 readonly DEFAULT_BUCKET="kubernetes-release-gcb"
 readonly PROD_BUCKET="kubernetes-release"
 readonly TEST_BUCKET="kubernetes-release-gcb"
 readonly CI_BUCKET="kubernetes-release-dev"
+
+# TODO(vdf): Need to reference K8s Infra registries here
+readonly GCRIO_PATH_PROD="k8s.gcr.io"
+readonly GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
+readonly GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
 
 readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
 readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"
@@ -1297,11 +1304,6 @@ release::set_globals () {
   else
     BUCKET_TYPE="release"
   fi
-
-  GCRIO_PATH_PROD="k8s.gcr.io"
-  GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
-  # The "test" GCR path
-  GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
 
   GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
   ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -36,9 +36,11 @@ const (
 	DefaultToolRepo   = "release"
 	DefaultToolBranch = git.Master
 	DefaultToolOrg    = git.DefaultGithubOrg
-	DefaultProject    = "kubernetes-release-test"
-	DefaultDiskSize   = "300"
-	BucketPrefix      = "kubernetes-release-"
+	// TODO(vdf): Need to reference K8s Infra project here
+	DefaultKubernetesStagingProject = "kubernetes-release-test"
+	DefaultRelengStagingProject     = "k8s-staging-releng"
+	DefaultDiskSize                 = "300"
+	BucketPrefix                    = "kubernetes-release-"
 
 	versionReleaseRE  = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
 	versionBuildRE    = `([0-9]{1,})\+([0-9a-f]{5,40})`

--- a/testgridshot
+++ b/testgridshot
@@ -35,7 +35,7 @@
 #+     Change the tests you want to screenshot
 #+     Available states: FAILING, FLAKY, PASSING
 #+
-#+   BUCKET: [default: "kubernetes-release-gcb"]
+#+   BUCKET: [default: "k8s-staging-releng"]
 #+     The name of the bucket to upload the images to.
 #+     `gsutil` is used for the upload, thus it must be installed and configured correctly.
 #+     The files will be put into '/testgridshot/<release>/<datetime>_<rand>/...'
@@ -82,7 +82,7 @@ set -o pipefail
 readonly BOARDS="${BOARDS:-blocking informing}"
 # Available states: FAILING, FLAKY, PASSING
 readonly STATES="${STATES:-FAILING}"
-readonly BUCKET="${BUCKET:-kubernetes-release-gcb}"
+readonly BUCKET="${BUCKET:-k8s-staging-releng}"
 readonly BLOCK_WIDTH="${BLOCK_WIDTH:-30}"
 readonly WIDTH="${WIDTH:-3000}"
 readonly HEIGHT="${HEIGHT:-2500}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

(This splices out a few of the commits from https://github.com/kubernetes/release/pull/957 and is a follow-up to https://github.com/kubernetes/release/pull/1164.)

Here we do a few search/replaces to move GCB jobs to the following GCP projects:

- `k8s-staging-releng` - for Release Engineering jobs
- ~`k8s-staging-kubernetes` - for Kubernetes stage/release jobs~
  This is not possible until after `dl.k8s.io` is cut over, due to access restrictions on accounts that can write into `gs://kubernetes-release`

#### Special notes for your reviewer:

Related to the k8s.gcr.io vanity domain flip (https://github.com/kubernetes/release/issues/270) and the overall migration to Kubernetes Community-owned infrastructure (https://github.com/kubernetes/release/issues/911).

~/hold for https://github.com/kubernetes/release/issues/1176~

Test jobs:
- mock stage: https://console.cloud.google.com/cloud-build/builds/41c61c9d-b4a5-4bd6-8768-f20d488033c7?project=k8s-staging-kubernetes
- mock release: https://console.cloud.google.com/cloud-build/builds/0a8d3bbf-5e76-42a7-a725-0f8105602d66?project=k8s-staging-kubernetes

#### Does this PR introduce a user-facing change?

```release-note
Configure releng GCB jobs to use new staging project and add VDF TODOs
```
