### PR TITLE
Make github package client token capable

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -74,7 +74,7 @@ the golang based 'release-notes' tool:
    corresponding release-branch of kubernetes/kubernetes. The release branch
    will be pruned from all other CHANGELOG-*.md files which do not belong to
    this release branch.
-`, options.GitHubToken),
+`, github.TokenEnvKey),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/krel/cmd/patch-announce.go
+++ b/cmd/krel/cmd/patch-announce.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/log"
 	"k8s.io/release/pkg/patch"
 	"k8s.io/release/pkg/util"
@@ -50,7 +51,7 @@ func patchAnnounceCommand() *cobra.Command {
 
 	// TODO: figure out, how we can read env vars and also be able to set the flags to required in a cobra-native way
 	cmd.PersistentFlags().StringVarP(&opts.SendgridAPIKey, "sendgrid-api-key", "s", util.EnvDefault("SENDGRID_API_KEY", ""), "API key for sendgrid")
-	cmd.PersistentFlags().StringVarP(&opts.GithubToken, "github-token", "g", util.EnvDefault("GITHUB_TOKEN", ""), "a GitHub token, used r/o for generating the release notes")
+	cmd.PersistentFlags().StringVarP(&opts.GithubToken, "github-token", "g", util.EnvDefault(github.TokenEnvKey, ""), "a GitHub token, used r/o for generating the release notes")
 
 	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		// TODO: make github-token & sendgrid-api-key required too

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
@@ -66,7 +67,7 @@ The 'release-notes' subcommand of krel has been developed to:
 
 To use the tool, please set the %v environment variable which needs write
 permissions to your fork of k/sig-release and k-sigs/release-notes.`,
-		options.GitHubToken),
+		github.TokenEnvKey),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/github/BUILD.bazel
+++ b/pkg/github/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//pkg/util:go_default_library",
         "@com_github_google_go_github_v29//github:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )
 

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/github:go_default_library",
         "//pkg/notes/client:go_default_library",
         "//pkg/notes/client/clientfakes:go_default_library",
         "@com_github_google_go_github_v29//github:go_default_library",

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -27,13 +27,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	kgithub "k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/notes/client"
 )
 
 func githubClient(t *testing.T) (client.Client, context.Context) {
-	token, tokenSet := os.LookupEnv("GITHUB_TOKEN")
+	token, tokenSet := os.LookupEnv(kgithub.TokenEnvKey)
 	if !tokenSet {
-		t.Skip("GITHUB_TOKEN is not set")
+		t.Skipf("%s is not set", kgithub.TokenEnvKey)
 	}
 
 	ctx := context.Background()

--- a/pkg/notes/options/BUILD.bazel
+++ b/pkg/notes/options/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/git:go_default_library",
+        "//pkg/github:go_default_library",
         "//pkg/notes/client:go_default_library",
         "//pkg/notes/internal:go_default_library",
         "@com_github_google_go_github_v29//github:go_default_library",
@@ -23,6 +24,7 @@ go_test(
     deps = [
         "//pkg/command:go_default_library",
         "//pkg/git:go_default_library",
+        "//pkg/github:go_default_library",
         "//pkg/notes/internal:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -29,8 +29,10 @@ import (
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
+
 	"k8s.io/release/pkg/command"
 	kgit "k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/notes/internal"
 )
 
@@ -69,7 +71,7 @@ func newTestTemplate(t *testing.T, fileName, contents string) string {
 
 func newTestOptions(t *testing.T) *testOptions {
 	testRepo := newTestRepo(t)
-	require.Nil(t, os.Setenv(GitHubToken, "token"))
+	require.Nil(t, os.Setenv(github.TokenEnvKey, "token"))
 	return &testOptions{
 		Options: &Options{
 			DiscoverMode: RevisionDiscoveryModeNONE,

--- a/pkg/patch/internal/BUILD.bazel
+++ b/pkg/patch/internal/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/github:go_default_library",
         "//pkg/patch/internal/internalfakes:go_default_library",
         "//pkg/patch/internal/testing:go_default_library",
         "@com_github_sendgrid_rest//:go_default_library",

--- a/pkg/patch/internal/release_notes_test.go
+++ b/pkg/patch/internal/release_notes_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/patch/internal"
 	"k8s.io/release/pkg/patch/internal/internalfakes"
 	it "k8s.io/release/pkg/patch/internal/testing"
@@ -89,7 +90,7 @@ func TestReleaseNoter(t *testing.T) {
 			it.CheckErrSub(t, err, tc.expectedErr)
 			require.Equal(t, tc.expectedOutput, output, "output")
 			require.Equal(t, tc.k8sDir, command.SetDirArgsForCall(0), "Command#SetDir arg")
-			require.Contains(t, command.SetEnvArgsForCall(0), "GITHUB_TOKEN="+tc.githubToken)
+			require.Contains(t, command.SetEnvArgsForCall(0), github.TokenEnvKey+"="+tc.githubToken)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The GitHub client inside the `github` package is now capable of
retrieving the token from the current environment. This makes `kubepkg`
a possible token consumer as well and fixes the issue of the low limit
of unauthenticated requests.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1175

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed kubepkg to take GITHUB_TOKEN into account for doing authenticated GitHub requests
```
