### PR TITLE
krel changelog: remove other CHANGELOG-*.md only on first RC

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -1222,3 +1222,7 @@ are trying to monitor for whether iptables updates are failing, the
 
   </body>
 </html>`
+
+const rcReleaseExpectedTOC = `<!-- BEGIN MUNGE: GENERATED_TOC -->
+
+- [v1.16.0-rc.1](#v1160-rc1)`

--- a/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/GetCommit-0.json
+++ b/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/GetCommit-0.json
@@ -1,0 +1,34 @@
+{
+ "Result": {
+  "sha": "571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+  "author": {
+   "date": "2020-03-12T20:51:36Z",
+   "name": "Anago GCB",
+   "email": "nobody@k8s.io"
+  },
+  "committer": {
+   "date": "2020-03-12T20:51:36Z",
+   "name": "Anago GCB",
+   "email": "nobody@k8s.io"
+  },
+  "message": "Release commit for Kubernetes v1.16.9-beta.0",
+  "tree": {
+   "sha": "fb22510b1c2105e736af8e9242cbc65ec5dea885"
+  },
+  "parents": [
+   {
+    "sha": "ec6eb119b81be488b030e849b9e64fda4caaf33c",
+    "html_url": "https://github.com/kubernetes/kubernetes/commit/ec6eb119b81be488b030e849b9e64fda4caaf33c",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/ec6eb119b81be488b030e849b9e64fda4caaf33c"
+   }
+  ],
+  "html_url": "https://github.com/kubernetes/kubernetes/commit/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+  "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+  "verification": {
+   "verified": false,
+   "reason": "unsigned"
+  },
+  "node_id": "MDY6Q29tbWl0MjA1ODA0OTg6NTcxYmRjZjhlMjhjZjc5NTliZmI0YzdlYTgyYThiMmE3MzcyOTYyNQ=="
+ },
+ "LastPage": 0
+}

--- a/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/GetCommit-1.json
+++ b/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/GetCommit-1.json
@@ -1,0 +1,34 @@
+{
+ "Result": {
+  "sha": "92e71139aa16398e5c1aa4195cdec98891cc44fc",
+  "author": {
+   "date": "2020-03-12T22:26:18Z",
+   "name": "Anago GCB",
+   "email": "nobody@k8s.io"
+  },
+  "committer": {
+   "date": "2020-03-12T22:26:18Z",
+   "name": "Anago GCB",
+   "email": "nobody@k8s.io"
+  },
+  "message": "Update CHANGELOG/CHANGELOG-1.16.md for v1.16.8",
+  "tree": {
+   "sha": "33dc2cd3cbb3f6609a51dc39b33c916586f08aac"
+  },
+  "parents": [
+   {
+    "sha": "571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+    "html_url": "https://github.com/kubernetes/kubernetes/commit/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625"
+   }
+  ],
+  "html_url": "https://github.com/kubernetes/kubernetes/commit/92e71139aa16398e5c1aa4195cdec98891cc44fc",
+  "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/92e71139aa16398e5c1aa4195cdec98891cc44fc",
+  "verification": {
+   "verified": false,
+   "reason": "unsigned"
+  },
+  "node_id": "MDY6Q29tbWl0MjA1ODA0OTg6OTJlNzExMzlhYTE2Mzk4ZTVjMWFhNDE5NWNkZWM5ODg5MWNjNDRmYw=="
+ },
+ "LastPage": 0
+}

--- a/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListCommits-0.json
+++ b/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListCommits-0.json
@@ -1,0 +1,77 @@
+{
+ "Result": [
+  {
+   "node_id": "MDY6Q29tbWl0MjA1ODA0OTg6OTJlNzExMzlhYTE2Mzk4ZTVjMWFhNDE5NWNkZWM5ODg5MWNjNDRmYw==",
+   "sha": "92e71139aa16398e5c1aa4195cdec98891cc44fc",
+   "commit": {
+    "author": {
+     "date": "2020-03-12T22:26:18Z",
+     "name": "Anago GCB",
+     "email": "nobody@k8s.io"
+    },
+    "committer": {
+     "date": "2020-03-12T22:26:18Z",
+     "name": "Anago GCB",
+     "email": "nobody@k8s.io"
+    },
+    "message": "Update CHANGELOG/CHANGELOG-1.16.md for v1.16.8",
+    "tree": {
+     "sha": "33dc2cd3cbb3f6609a51dc39b33c916586f08aac"
+    },
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/92e71139aa16398e5c1aa4195cdec98891cc44fc",
+    "verification": {
+     "verified": false,
+     "reason": "unsigned"
+    },
+    "comment_count": 0
+   },
+   "parents": [
+    {
+     "sha": "571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+     "html_url": "https://github.com/kubernetes/kubernetes/commit/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+     "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625"
+    }
+   ],
+   "html_url": "https://github.com/kubernetes/kubernetes/commit/92e71139aa16398e5c1aa4195cdec98891cc44fc",
+   "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/92e71139aa16398e5c1aa4195cdec98891cc44fc",
+   "comments_url": "https://api.github.com/repos/kubernetes/kubernetes/commits/92e71139aa16398e5c1aa4195cdec98891cc44fc/comments"
+  },
+  {
+   "node_id": "MDY6Q29tbWl0MjA1ODA0OTg6NTcxYmRjZjhlMjhjZjc5NTliZmI0YzdlYTgyYThiMmE3MzcyOTYyNQ==",
+   "sha": "571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+   "commit": {
+    "author": {
+     "date": "2020-03-12T20:51:36Z",
+     "name": "Anago GCB",
+     "email": "nobody@k8s.io"
+    },
+    "committer": {
+     "date": "2020-03-12T20:51:36Z",
+     "name": "Anago GCB",
+     "email": "nobody@k8s.io"
+    },
+    "message": "Release commit for Kubernetes v1.16.9-beta.0",
+    "tree": {
+     "sha": "fb22510b1c2105e736af8e9242cbc65ec5dea885"
+    },
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/git/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+    "verification": {
+     "verified": false,
+     "reason": "unsigned"
+    },
+    "comment_count": 0
+   },
+   "parents": [
+    {
+     "sha": "ec6eb119b81be488b030e849b9e64fda4caaf33c",
+     "html_url": "https://github.com/kubernetes/kubernetes/commit/ec6eb119b81be488b030e849b9e64fda4caaf33c",
+     "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/ec6eb119b81be488b030e849b9e64fda4caaf33c"
+    }
+   ],
+   "html_url": "https://github.com/kubernetes/kubernetes/commit/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+   "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625",
+   "comments_url": "https://api.github.com/repos/kubernetes/kubernetes/commits/571bdcf8e28cf7959bfb4c7ea82a8b2a73729625/comments"
+  }
+ ],
+ "LastPage": 0
+}

--- a/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListPullRequestsWithCommit-0.json
+++ b/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListPullRequestsWithCommit-0.json
@@ -1,0 +1,4 @@
+{
+ "Result": [],
+ "LastPage": 0
+}

--- a/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListPullRequestsWithCommit-1.json
+++ b/cmd/krel/cmd/testdata/changelog-v1.16.0-rc.1/ListPullRequestsWithCommit-1.json
@@ -1,0 +1,4 @@
+{
+ "Result": [],
+ "LastPage": 0
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We should remove other changelog files only on the first release
candidate to avoid merge conflicts on branch fast forward. An
integration test for this case has been added as well.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
/cc @justaugustus @cpanato @liggitt 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Change `krel changelog` to remove non release branch related `CHANGELOG/CHANGELOG-*.md` only on the first release candidate (for example `v1.18.0-rc.1`)
```
