### PR TITLE
gcbmr: missing replace the release branch in the confirmation msg

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -190,7 +190,7 @@ func runGcbmgr() error {
 	if rootOpts.nomock {
 		// TODO: Consider a '--yes' flag so we can mock this
 		_, nomockSubmit, askErr := util.Ask(
-			"Really submit a --nomock release job against the $RELEASE_BRANCH branch?",
+			fmt.Sprintf("Really submit a --nomock release job against the %s branch?", gcbmgrOpts.branch),
 			"yes",
 			3,
 		)


### PR DESCRIPTION
#### What type of PR is this?
When running the release cut for 1.18.0-rc.1 observed when running the `--nomock` the message was missing the substitution of the branch

```
krel gcbmgr --stage --type rc --branch release-1.18 --build-version $(curl -Ls https://dl.k8s.io/ci/latest-1.18.txt) --nomock --stream
INFO Running gcbmgr with the following options: {true false true release-1.18 rc v1.18.0-beta.2.74+9205645b8cbc8f }
INFO Build options: {  cloudbuild.yaml   kubernetes-release-test false false false   }
INFO Trying to get the kube-cross version for release-1.18...
INFO Found the following kube-cross version: v1.13.8-1
Really submit a --nomock release job against the $RELEASE_BRANCH branch? (1/3)
```
it shows `$RELEASE_BRANCH` and should show the `release-1.18`

This PR address that

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/cc @saschagrunert 
