### PR TITLE
Use util.EnvDefault for GetTool{Org,Repo,Branch}

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -19,7 +19,6 @@ package release
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -105,34 +104,19 @@ func GetToolRepoURL(org, repo string, useSSH bool) (string, error) {
 // GetToolOrg checks if the 'TOOL_ORG' environment variable is set.
 // If 'TOOL_ORG' is non-empty, it returns the value. Otherwise, it returns DefaultToolOrg.
 func GetToolOrg() string {
-	toolOrg := os.Getenv("TOOL_ORG")
-	if toolOrg == "" {
-		toolOrg = DefaultToolOrg
-	}
-
-	return toolOrg
+	return util.EnvDefault("TOOL_ORG", DefaultToolOrg)
 }
 
 // GetToolRepo checks if the 'TOOL_REPO' environment variable is set.
 // If 'TOOL_REPO' is non-empty, it returns the value. Otherwise, it returns DefaultToolRepo.
 func GetToolRepo() string {
-	toolRepo := os.Getenv("TOOL_REPO")
-	if toolRepo == "" {
-		toolRepo = DefaultToolRepo
-	}
-
-	return toolRepo
+	return util.EnvDefault("TOOL_REPO", DefaultToolRepo)
 }
 
 // GetToolBranch checks if the 'TOOL_BRANCH' environment variable is set.
 // If 'TOOL_BRANCH' is non-empty, it returns the value. Otherwise, it returns DefaultToolBranch.
 func GetToolBranch() string {
-	toolBranch := os.Getenv("TOOL_BRANCH")
-	if toolBranch == "" {
-		toolBranch = DefaultToolBranch
-	}
-
-	return toolBranch
+	return util.EnvDefault("TOOL_BRANCH", DefaultToolBranch)
 }
 
 // BuiltWithBazel determines whether the most recent Kubernetes release was built with Bazel.

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -101,7 +101,7 @@ func TestGetToolBranchSuccess(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
-		os.Setenv("TOOL_BRANCH", tc.branch)
+		require.Nil(t, os.Setenv("TOOL_BRANCH", tc.branch))
 
 		actual := GetToolBranch()
 		assert.Equal(t, tc.expected, actual)

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -24,7 +24,7 @@ import (
 // `key` or the default value `def` if not set.
 func EnvDefault(key, def string) string {
 	value, ok := os.LookupEnv(key)
-	if !ok {
+	if !ok || value == "" {
 		return def
 	}
 	return value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We can substitute the custom logic with the already existing utility function `util.EnvDefault()`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
We have to slightly modify the behavior of `util.EnvDefault()` to match the current implementation. I think this is more correct because I think users will expect the default if the env var is equal to `""`
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `util.EnvDefault()` to also return the default if the set value is empty (aka `""`)
```
