### PR TITLE
Add command.Addwriter() support

### DIFF
--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -232,7 +231,7 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 		args = append(args, diskSizeArg)
 	}
 
-	cmd := exec.Command("gcloud", args...)
+	cmd := command.New("gcloud", args...)
 
 	if o.LogDir != "" {
 		p := path.Join(o.LogDir, strings.ReplaceAll(jobName, "/", "-")+".log")
@@ -243,16 +242,11 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 		}
 
 		defer f.Close()
-
-		cmd.Stdout = f
-		cmd.Stderr = f
-	} else {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.AddWriter(f)
 	}
 
-	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "error running %s", cmd.Args)
+	if err := cmd.RunSuccess(); err != nil {
+		return errors.Wrapf(err, "error running %s", cmd.String())
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows commands to specify additional writers, for example when
having the need for logging to files.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `Addwriter()`, `AddErrorWriter()` and  `AddOutputWriter()` to command package which allows commands to specify additional writers, for example when having the need for logging to files.
```
