### PR TITLE
[VDF] anago: Publish container images on K8s Infra (k8s-staging-kubernetes)

### DIFF
--- a/anago
+++ b/anago
@@ -259,12 +259,11 @@ copy_logs_to_workdir () {
 }
 
 ###############################################################################
-# Ensures all registries that will be used during both mock and --nomock
-# runs allow write access so we don't fall over later
-# @param registries - A space separated list of registries
+# Ensures we have write access to a specified registry
+# @param registry - A registry to check the ACLs for
 #
 ensure_registry_acls () {
-  local registries=($1)
+  local registry="$1"
   local emptyfile="$TMPDIR/empty-file.$$"
   local gs_path
   local r
@@ -276,27 +275,29 @@ ensure_registry_acls () {
 
   # Short of creating a hardcoded map of project-id to registry, translating
   # _ to - seems to be a simple rule to keep this, well, simple.
-  for r in ${registries[*]//_/-}; do
-    # In this context, "google-containers" is still used
-    if [[ "$r" == "$GCRIO_PATH_PROD" ]]; then
-      artifact_namespace="google-containers"
-    else
-      artifact_namespace="${r/gcr.io\//}"
-    fi
+  r=${registry//_/-}
 
-    gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
-    logecho -n "Checking write access to registry $r: "
-    if logrun $GSUTIL -q cp $emptyfile $gs_path && \
-       logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
-      logecho $OK
-    else
-      logecho $FAILED
-      ((retcode++))
-    fi
+  # When we are no-mock mode we need to perform an image promotion, so it's
+  # unnecessary to check for write access to the production container registry.
+  if ((FLAGS_nomock)); then
+    logecho "Skipping registry ACL check on $GCRIO_PATH_PROD in no-mock mode"
+    return 0
+  else
+    artifact_namespace="${r/gcr.io\//}"
+  fi
 
-    # Always reset back to $USER
-    ((FLAGS_gcb)) || logrun $GCLOUD config set account $GCP_USER
-  done
+  gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
+  logecho -n "Checking write access to registry $r: "
+  if logrun $GSUTIL -q cp $emptyfile $gs_path && \
+      logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
+    logecho $OK
+  else
+    logecho $FAILED
+    ((retcode++))
+  fi
+
+  # Always reset back to $USER
+  ((FLAGS_gcb)) || logrun $GCLOUD config set account $GCP_USER
 
   logrun rm -f $emptyfile
 
@@ -378,7 +379,7 @@ check_prerequisites () {
 
   # Verify write access to all container registries that might be used
   # to ensure both mock and --nomock runs will work.
-  ensure_registry_acls "${ALL_CONTAINER_REGISTRIES[*]}" || return 1
+  ensure_registry_acls "$GCRIO_PATH" || return 1
 
   logecho -n "Checking cloud project state: "
   GCLOUD_PROJECT=$($GCLOUD config get-value project 2>/dev/null)

--- a/anago
+++ b/anago
@@ -280,7 +280,8 @@ ensure_registry_acls () {
   # When we are no-mock mode we need to perform an image promotion, so it's
   # unnecessary to check for write access to the production container registry.
   if ((FLAGS_nomock)); then
-    logecho "Skipping registry ACL check on $GCRIO_PATH_PROD in no-mock mode"
+    logecho -n "Skipping container registry ACL check on $GCRIO_PATH_PROD in no-mock mode: "
+    logecho $OK
     return 0
   else
     artifact_namespace="${r/gcr.io\//}"
@@ -1445,8 +1446,18 @@ push_all_artifacts () {
        gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
 
-    common::runstep release::docker::release \
-     $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
+    # When we are no-mock mode we need to perform an image promotion, so
+    # instead of pushing to the production container registry, we validate
+    # that the manifest is populated on the remote registry.
+    if ! ((FLAGS_nomock)); then
+      common::runstep release::docker::release \
+      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
+    fi
+
+    # TODO(vdf): Add image manifest validation logic
+    #            Maybe consider adding this to release::docker::release
+    #            and renaming that function.
+    logecho "Validating image manifests (# TODO(vdf): currently a no-op)..." || return 1
 
     common::runstep release::gcs::publish_version \
      $BUCKET_TYPE $version $BUILD_OUTPUT-$version $RELEASE_BUCKET || return 1

--- a/anago
+++ b/anago
@@ -1454,10 +1454,8 @@ push_all_artifacts () {
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
     fi
 
-    # TODO(vdf): Add image manifest validation logic
-    #            Maybe consider adding this to release::docker::release
-    #            and renaming that function.
-    logecho "Validating image manifests (# TODO(vdf): currently a no-op)..." || return 1
+    common::runstep release::docker::validate_remote_manifests \
+      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
 
     common::runstep release::gcs::publish_version \
      $BUCKET_TYPE $version $BUILD_OUTPUT-$version $RELEASE_BUCKET || return 1

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -32,7 +32,7 @@ readonly CI_BUCKET="kubernetes-release-dev"
 # TODO(vdf): Need to reference K8s Infra registries here
 readonly GCRIO_PATH_PROD="k8s.gcr.io"
 readonly GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
-readonly GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
+readonly GCRIO_PATH_TEST="gcr.io/k8s-staging-kubernetes"
 
 readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
 readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1277,9 +1277,6 @@ release::send_announcement () {
 # READ_RELEASE_BUCKETS - array of readable buckets for multiple sourcing of
 #                        mock staged builds
 # GCRIO_PATH - GCR path based on mock or --nomock
-# ALL_CONTAINER_REGISTRIES - when running mock (via GCB) this array also
-#                            contains k8s.gcr.io so we can check access in mock
-#                            mode before an actual release occurs
 release::set_globals () {
   logecho -n "Setting global variables: "
 
@@ -1306,7 +1303,6 @@ release::set_globals () {
   fi
 
   GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
-  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"
@@ -1338,8 +1334,6 @@ release::set_globals () {
 
   WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
   READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET")
-
-  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   # TODO:
   # These KUBE_ globals extend beyond the scope of the new release refactored


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
As part of the [vanity domain flip](https://github.com/kubernetes/release/issues/270), we need to be able to publish container images on K8s Infra.
As a [domain restriction organization policy is in place on the Google Infra projects](https://github.com/kubernetes/release/issues/1176#issuecomment-597790833), we cannot
completely move staging to K8s Infra until dl.k8s.io is moved as well (both the redirect AND the GCS bucket contents).

So in the meantime, we will instead run the GCB stage/release jobs within the current `kubernetes-release-test` GCP project and grant its GCB service account access to write container images into the new `k8s-staging-kubernetes` staging project.

_(Part of the larger effort to move to the stage/release process to K8s Infra: https://github.com/kubernetes/release/issues/911)_

#### Special notes for your reviewer:
~Blocked on https://github.com/kubernetes/k8s.io/pull/673.~

#### Does this PR introduce a user-facing change?

```release-note
[VDF] anago: Publish container images on K8s Infra (k8s-staging-kubernetes)
```
