### PR TITLE
Default to master branch in gcbmgr

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -95,7 +95,7 @@ func init() {
 	gcbmgrCmd.PersistentFlags().StringVar(
 		&gcbmgrOpts.branch,
 		"branch",
-		"",
+		git.Master,
 		"Branch to run the specified GCB run against",
 	)
 
@@ -321,12 +321,7 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 		gcbSubs["RC"] = ""
 	}
 
-	branch := o.branch
-	if branch == "" {
-		return gcbSubs, errors.New("Release branch must be set to continue")
-	}
-
-	gcbSubs["RELEASE_BRANCH"] = branch
+	gcbSubs["RELEASE_BRANCH"] = o.branch
 
 	if o.stage {
 		// TODO: Remove once we remove support for --built-at-head.
@@ -357,8 +352,8 @@ func setGCBSubstitutions(o *gcbmgrOptions) (map[string]string, error) {
 	gcbSubs["BUILDVERSION"] = buildVersion
 
 	kubecrossBranches := []string{
-		branch,
-		"master",
+		o.branch,
+		git.Master,
 	}
 
 	kubecrossVersion, kubecrossVersionErr := release.GetKubecrossVersion(kubecrossBranches...)

--- a/docs/krel/gcbmgr.md
+++ b/docs/krel/gcbmgr.md
@@ -35,7 +35,7 @@ Simply [install krel](README.md#installation).
 
 ```
 Flags:
-      --branch string          Branch to run the specified GCB run against
+      --branch string          Branch to run the specified GCB run against (default "master")
       --build-version string   Build version
       --gcb-config string      If provided, this will be used as the name of the Google Cloud Build config file. (default "cloudbuild.yaml")
       --gcp-user string        If provided, this will be used as the GCP_USER_TAG.
@@ -56,6 +56,8 @@ Global Flags:
 ## Important notes
 
 - Default executions of `krel gcbmgr` run in mock mode. To run an actual stage or release, you **MUST** provide the `--nomock` flag.
+- Note that the default `--branch` is set to `master`, which means that it needs
+  to be set to the release branch if necessary.
 - Always execute the release process in the following order:
   - mock stage: `krel gcbmgr --stage`
   - mock release: `krel gcbmgr --release`
@@ -81,7 +83,6 @@ Global Flags:
 
 ```shell
 krel gcbmgr --stage \
-  --branch master \
   --project kubernetes-release-test
 ```
 
@@ -89,7 +90,6 @@ krel gcbmgr --stage \
 
 ```shell
 krel gcbmgr --release \
-  --branch master \
   --project kubernetes-release-test \
   --build-version <build-version>
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
A sane default for the branch in gcbmgr is the master branch, where we
can now simplify error handling paths as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Follow-up of https://github.com/kubernetes/sig-release/pull/1028

#### Special notes for your reviewer:
Handbooks may have to be updated as well.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- krel gcbmgr now defaults to the `master` branch if no `--branch` is provided
```
