### PR TITLE
Update k8s-cloud-builder to use kube-cross:v1.13.9-2

### DIFF
--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -19,21 +19,21 @@ steps:
   - ${_TOOL_REPO}
   waitFor: [ '-' ]
 
-- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.9-2'
   id: prepare
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - clean
 
-- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.9-2'
   id: build
   dir: 'go/src/k8s.io/kubernetes'
   args:
   - make
   - "${_RELEASE_TYPE}"
 
-- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1'
+- name: 'gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.9-2'
   id: push-build
   dir: 'go/src/k8s.io/kubernetes'
   args:

--- a/gcb/patch-announce/cloudbuild.yaml
+++ b/gcb/patch-announce/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - "--branch=${_RELEASE_GIT_BRANCH}"
 
 - id: prepare-and-send
-  name: "gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.8-1"
+  name: "gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.13.9-2"
   env:
   - "SENDER_NAME=${_SENDER_NAME}"
   - "SENDER_EMAIL=${_SENDER_EMAIL}"

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -18,7 +18,7 @@
 ARG DEBIAN_FRONTEND=noninteractive
 
 ##------------------------------------------------------------
-FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-1
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.9-2
 
 RUN apt-get -q update
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area dependency

#### What this PR does / why we need it:
Update k8s-cloud-builder to use kube-cross:v1.13.9-2

/assign @cpanato @saschagrunert 
cc: @kubernetes/release-engineering 

#### Special notes for your reviewer:

Explicit hold until:
- v1.18.0 has been released
- All go1.13.9 PRs have merged:
   - master: https://github.com/kubernetes/kubernetes/pull/89275
   - 1.18: https://github.com/kubernetes/kubernetes/pull/89398
   - 1.17: https://github.com/kubernetes/kubernetes/pull/89399
   - 1.16: https://github.com/kubernetes/kubernetes/pull/89400

/hold

#### Does this PR introduce a user-facing change?

```release-note
Update k8s-cloud-builder to use kube-cross:v1.13.9-2
```
