### PR TITLE
testgrishot: remove canned_acl

### DIFF
--- a/testgridshot
+++ b/testgridshot
@@ -185,10 +185,7 @@ upload_and_publish_images() {
   local img_bucket_dir="${2}"
   local bucket_path="gs://${BUCKET}/${img_bucket_dir}/"
 
-  # https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
-  local canned_acl='public-read'
-
-  gsutil -m -q cp -a "$canned_acl" -r "${local_path}/." "${bucket_path}"
+  gsutil -m -q cp -r "${local_path}/." "${bucket_path}"
 }
 
 usage() {


### PR DESCRIPTION
The new K8s Infra buckets are public read at the top-level, so it'll
reject attempts to set the ACL on individual objects

per discussion and Stephen suggestion here: https://kubernetes.slack.com/archives/C2C40FMNF/p1585051364297800?thread_ts=1584999272.250400&cid=C2C40FMNF

#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
testgridshot: removed canned_acl option when uploading to K8s Infra
```

cc @justaugustus @saschagrunert 