### PR TITLE
look for version in bazel-bin

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -19,6 +19,7 @@ package release
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -47,7 +48,7 @@ const (
 	versionDirtyRE    = `(-dirty)`
 	dockerBuildPath   = "_output/release-tars"
 	bazelBuildPath    = "bazel-bin/build/release-tars"
-	bazelVersionPath  = "bazel-genfiles/version"
+	bazelVersionPath  = "bazel-bin/version"
 	dockerVersionPath = "kubernetes/version"
 	kubernetesTar     = "kubernetes.tar.gz"
 
@@ -131,6 +132,12 @@ func BuiltWithBazel(workDir string) (bool, error) {
 // ReadBazelVersion reads the version from a Bazel build.
 func ReadBazelVersion(workDir string) (string, error) {
 	version, err := ioutil.ReadFile(filepath.Join(workDir, bazelVersionPath))
+	if os.IsNotExist(err) {
+		// The check for version in bazel-genfiles can be removed once everyone is
+		// off of versions before 0.25.0.
+		// https://github.com/bazelbuild/bazel/issues/8651
+		version, err = ioutil.ReadFile(filepath.Join(workDir, "bazel-genfiles/version"))
+	}
 	return string(version), err
 }
 

--- a/push-build.sh
+++ b/push-build.sh
@@ -127,7 +127,14 @@ KUBE_ROOT=$(pwd -P)
 USE_BAZEL=false
 if release::was_built_with_bazel $KUBE_ROOT $FLAGS_release_kind; then
   USE_BAZEL=true
-  LATEST=$(cat $KUBE_ROOT/bazel-genfiles/version)
+  # The check for version in bazel-genfiles can be removed once everyone is off
+  # of versions before 0.25.0.
+  # https://github.com/bazelbuild/bazel/issues/8651
+  if [[ -r  "$KUBE_ROOT/bazel-genfiles/version" ]]; then
+    LATEST=$(cat $KUBE_ROOT/bazel-genfiles/version)
+  else
+    LATEST=$(cat $KUBE_ROOT/bazel-bin/version)
+  fi
 else
   LATEST=$(tar -O -xzf $KUBE_ROOT/_output/release-tars/$FLAGS_release_kind.tar.gz $FLAGS_release_kind/version)
 fi


### PR DESCRIPTION
bazel-bin and bazel-genfiles have pointed to the same location since
0.25. -genfiles is deprecated.

This was test running:

```
../release/push-build.sh --release-type=devel \
  --bucket=kubernetes-release-mikedanese --private-bucket --nomock \
  --version-suffix=mikedanese
```

With bazel version 2.2.0 and 0.23.2. Not sure how to test ./pkg/release but we have unit tests there.

Issue: bazelbuild/bazel#8651

/assign @justaugustus @fejta 

```release-note
NONE
```