### PR TITLE
Make git.GetRepoURL infallible

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -387,12 +387,7 @@ func prepareFork(branchName, repoPath, upstreamOrg, upstreamRepo, myOrg, myRepo 
 	}
 
 	// test if the fork remote is already existing
-	url, err := git.GetRepoURL(
-		myOrg, myRepo, true,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get repository URL")
-	}
+	url := git.GetRepoURL(myOrg, myRepo, true)
 	if repo.HasRemote(userForkName, url) {
 		logrus.Infof(
 			"Using already existing remote %v (%v) in repository",
@@ -549,11 +544,7 @@ func createWebsitePR(tag string, result *releaseNotesResult) error {
 
 // tryToFindPreviuousTag gets a release tag and returns the one before it
 func tryToFindPreviuousTag(tag string) (string, error) {
-	url, err := git.GetDefaultKubernetesRepoURL()
-	if err != nil {
-		return "", err
-	}
-
+	url := git.GetDefaultKubernetesRepoURL()
 	status, err := command.New(
 		"git", "ls-remote", "--sort=v:refname",
 		"--tags", url,
@@ -573,11 +564,7 @@ func tryToFindPreviuousTag(tag string) (string, error) {
 // tryToFindLatestMinorTag looks-up the default k/k remote to find the latest
 // non final version
 func tryToFindLatestMinorTag() (string, error) {
-	url, err := git.GetDefaultKubernetesRepoURL()
-	if err != nil {
-		return "", err
-	}
-
+	url := git.GetDefaultKubernetesRepoURL()
 	status, err := command.New(
 		"git", "ls-remote", "--sort=v:refname",
 		"--tags", url,

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -636,8 +636,7 @@ func TestHasRemoteSuccess(t *testing.T) {
 	require.Equal(t, "test", remotes[1].Name())
 	require.Len(t, remotes[1].URLs(), 1)
 
-	url, err := git.GetRepoURL("owner", "repo", true)
-	require.Nil(t, err)
+	url := git.GetRepoURL("owner", "repo", true)
 	require.Equal(t, url, remotes[1].URLs()[0])
 
 	// Or via the API

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -58,9 +58,8 @@ func TestGetDefaultKubernetesRepoURLSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		actual, err := git.GetDefaultKubernetesRepoURL()
+		actual := git.GetDefaultKubernetesRepoURL()
 		assert.Equal(t, tc.expected, actual)
-		assert.Nil(t, err)
 	}
 }
 
@@ -86,9 +85,8 @@ func TestGetKubernetesRepoURLSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		actual, err := git.GetKubernetesRepoURL(tc.org, tc.useSSH)
+		actual := git.GetKubernetesRepoURL(tc.org, tc.useSSH)
 		assert.Equal(t, tc.expected, actual)
-		assert.Nil(t, err)
 	}
 }
 
@@ -118,9 +116,8 @@ func TestGetRepoURLSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		actual, err := git.GetRepoURL(tc.org, tc.repo, tc.useSSH)
+		actual := git.GetRepoURL(tc.org, tc.repo, tc.useSSH)
 		assert.Equal(t, tc.expected, actual)
-		assert.Nil(t, err)
 	}
 }
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -83,7 +83,7 @@ const (
 
 // GetDefaultKubernetesRepoURL returns the default HTTPS repo URL for Release Engineering tools.
 // Expected: https://github.com/kubernetes/release
-func GetDefaultToolRepoURL() (string, error) {
+func GetDefaultToolRepoURL() string {
 	return GetToolRepoURL(DefaultToolOrg, DefaultToolRepo, false)
 }
 
@@ -92,7 +92,7 @@ func GetDefaultToolRepoURL() (string, error) {
 // Expected result is one of the following:
 // - https://github.com/<org>/release
 // - git@github.com:<org>/release
-func GetToolRepoURL(org, repo string, useSSH bool) (string, error) {
+func GetToolRepoURL(org, repo string, useSSH bool) string {
 	if org == "" {
 		org = GetToolOrg()
 	}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -47,9 +47,8 @@ func TestGetDefaultToolRepoURLSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		actual, err := GetDefaultToolRepoURL()
+		actual := GetDefaultToolRepoURL()
 		assert.Equal(t, tc.expected, actual)
-		assert.Nil(t, err)
 	}
 }
 
@@ -76,9 +75,8 @@ func TestGetToolRepoURLSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		actual, err := GetToolRepoURL(tc.org, tc.repo, tc.useSSH)
+		actual := GetToolRepoURL(tc.org, tc.repo, tc.useSSH)
 		assert.Equal(t, tc.expected, actual)
-		assert.Nil(t, err)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
The error due to parsing the `DefaultGithubURLBase` is technically not
possible and will fail every time if `DefaultGithubURLBase` is wrong. To
avoid that, we now manually create the always correct URL and let
`GetRepoURL` only return the resulting `string` type. The tests and
dependent functions have been adapted as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- The functions  `GetRepoURL`, `GetKubernetesRepoURL`, and `GetDefaultKubernetesRepoURL`
  of the `git` package are not able to error any more and return only the resulting `string`.
```
