### PR TITLE
Use testify require instead of assert

### DIFF
--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/git/gitfakes:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@in_gopkg_src_d_go_git_v4//:go_default_library",
         "@in_gopkg_src_d_go_git_v4//config:go_default_library",

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -19,7 +19,6 @@ package git_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/git/gitfakes"
@@ -59,7 +58,7 @@ func TestGetDefaultKubernetesRepoURLSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		actual := git.GetDefaultKubernetesRepoURL()
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -86,7 +85,7 @@ func TestGetKubernetesRepoURLSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		actual := git.GetKubernetesRepoURL(tc.org, tc.useSSH)
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -117,7 +116,7 @@ func TestGetRepoURLSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		actual := git.GetRepoURL(tc.org, tc.repo, tc.useSSH)
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 

--- a/pkg/kubepkg/BUILD.bazel
+++ b/pkg/kubepkg/BUILD.bazel
@@ -37,5 +37,5 @@ go_test(
     name = "go_default_test",
     srcs = ["kubepkg_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+    deps = ["@com_github_stretchr_testify//require:go_default_library"],
 )

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -19,7 +19,7 @@ package kubepkg
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPackageVersionSuccess(t *testing.T) {
@@ -72,15 +72,13 @@ func TestGetPackageVersionSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetPackageVersionFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getPackageVersion(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 // TODO: Figure out how we want to test success of this function.
@@ -113,15 +111,13 @@ func TestGetKubernetesVersionSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetKubernetesVersionFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getKubernetesVersion(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetCNIVersionSuccess(t *testing.T) {
@@ -162,15 +158,13 @@ func TestGetCNIVersionSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCNIVersionFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getCNIVersion(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetCRIToolsVersionSuccess(t *testing.T) {
@@ -204,15 +198,13 @@ func TestGetCRIToolsVersionSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCRIToolsVersionFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getCRIToolsVersion(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetDownloadLinkBaseSuccess(t *testing.T) {
@@ -247,15 +239,13 @@ func TestGetDownloadLinkBaseSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetDownloadLinkBaseFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getDownloadLinkBase(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetCIBuildsDownloadLinkBaseSuccess(t *testing.T) {
@@ -282,15 +272,13 @@ func TestGetCIBuildsDownloadLinkBaseSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCIBuildsDownloadLinkBaseFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getCIBuildsDownloadLinkBase(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetDefaultReleaseDownloadLinkBaseSuccess(t *testing.T) {
@@ -322,15 +310,13 @@ func TestGetDefaultReleaseDownloadLinkBaseSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetDefaultReleaseDownloadLinkBaseFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getDefaultReleaseDownloadLinkBase(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetDependenciesSuccess(t *testing.T) {
@@ -369,15 +355,13 @@ func TestGetDependenciesSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetDependenciesFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getDependencies(nil)
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestGetCNIDownloadLinkSuccess(t *testing.T) {
@@ -413,15 +397,13 @@ func TestGetCNIDownloadLinkSuccess(t *testing.T) {
 			t.Fatalf("did not expect an error: %v", err)
 		}
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCNIDownloadLinkFailure(t *testing.T) {
-	a := assert.New(t)
-
 	_, err := getCNIDownloadLink(nil, "amd64")
-	a.Error(err)
+	require.NotNil(t, err)
 }
 
 func TestIsSupportedSuccess(t *testing.T) {
@@ -459,7 +441,7 @@ func TestIsSupportedSuccess(t *testing.T) {
 	for _, tc := range testcases {
 		actual := IsSupported(tc.input, tc.check)
 
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -484,6 +466,6 @@ func TestIsSupportedFailure(t *testing.T) {
 	for _, tc := range testcases {
 		actual := IsSupported(tc.input, tc.check)
 
-		assert.NotEqual(t, tc.expected, actual)
+		require.NotEqual(t, tc.expected, actual)
 	}
 }

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
         "//pkg/http:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +47,7 @@ func TestGetDefaultToolRepoURLSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		actual := GetDefaultToolRepoURL()
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -76,7 +75,7 @@ func TestGetToolRepoURLSuccess(t *testing.T) {
 		t.Logf("Test case: %s", tc.name)
 
 		actual := GetToolRepoURL(tc.org, tc.repo, tc.useSSH)
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -102,7 +101,7 @@ func TestGetToolBranchSuccess(t *testing.T) {
 		require.Nil(t, os.Setenv("TOOL_BRANCH", tc.branch))
 
 		actual := GetToolBranch()
-		assert.Equal(t, tc.expected, actual)
+		require.Equal(t, tc.expected, actual)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Require stops execution when a test fails which is the more used package
in our repository. To have a unique look and feel of the tests we now
stick to the require package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
