### PR TITLE
Fix low performance on repo.Add()

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -725,10 +725,12 @@ func (r *Repo) TagsForBranch(branch string) (res []string, err error) {
 
 // Add adds a file to the staging area of the repo
 func (r *Repo) Add(filename string) error {
-	if _, err := r.worktree.Add(filename); err != nil {
-		return err
-	}
-	return nil
+	return errors.Wrapf(
+		command.NewWithWorkDir(
+			r.Dir(), gitExecutable, "add", filename,
+		).RunSilentSuccess(),
+		"adding file %s to repository", filename,
+	)
 }
 
 // UserCommit makes a commit using the local user's config

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -560,7 +560,7 @@ func TestAddFailureWrongPath(t *testing.T) {
 
 	err := testRepo.sut.Add("wrong")
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "entry not found")
+	require.Contains(t, err.Error(), "adding file wrong to repository")
 }
 
 func TestCommitSuccess(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
There is an open regression in go-git about the slow performance of
repo.Add(): https://github.com/src-d/go-git/issues/1260

I measured the time during the release building, whereas we call this
method two times during changelog generation. This took round about 10
minutes for each `git.Add()` which seems not acceptable in my viewpoint.

So we're now switching to the `git add` shell command to increase the
performance back to normal.
#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed very slow performance of `repo.Add()` method within the `git` package
```
