### PR TITLE
Set ReleaseVersion for generated notes

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -596,6 +596,7 @@ func releaseNotesFor(tag string) (*releaseNotesResult, error) {
 	notesOptions.StartRev = startTag
 	notesOptions.EndRev = tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
+	notesOptions.ReleaseVersion = util.TrimTagPrefix(tag)
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err
@@ -649,6 +650,7 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	notesOptions.StartRev = startTag
 	notesOptions.EndRev = releaseNotesOpts.tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
+	notesOptions.ReleaseVersion = util.TrimTagPrefix(releaseNotesOpts.tag)
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We need to set the ReleaseVersion within the JSON for the generated
notes to display them correctly on relnotes.k8s.io.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/cc @evillgenius75 @JamesLaverack @reylejano-rxm @jluk @puerco
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed missing `release_version` field in generated `krel release-notes` JSON output
```
