### PR TITLE
Make git.Describe more flexible

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -125,11 +125,22 @@ func runFf(opts *ffOptions, rootOpts *rootOptions) error {
 	}
 
 	// Verify the tags
-	masterTag, err := repo.DescribeTag(kgit.Remotify(kgit.Master))
+	masterTag, err := repo.Describe(
+		kgit.NewDescribeOptions().
+			WithRevision(kgit.Remotify(kgit.Master)).
+			WithAbbrev(0).
+			WithTags(),
+	)
+
 	if err != nil {
 		return err
 	}
-	mergeBaseTag, err := repo.DescribeTag(mergeBase)
+	mergeBaseTag, err := repo.Describe(
+		kgit.NewDescribeOptions().
+			WithRevision(mergeBase).
+			WithAbbrev(0).
+			WithTags(),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -253,9 +253,9 @@ func runGcbmgr() error {
 	// TODO: Need actual values
 	var jobName, uploaded string
 
-	version, err := git.GetTag()
+	version, err := release.GetTag()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting current tag")
 	}
 
 	return build.RunSingleJob(buildOpts, jobName, uploaded, version, gcbSubs)

--- a/pkg/gcp/build/BUILD.bazel
+++ b/pkg/gcp/build/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/command:go_default_library",
-        "//pkg/git:go_default_library",
+        "//pkg/release:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_olekukonko_tablewriter//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/api/option"
 
 	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/release"
 	"sigs.k8s.io/yaml"
 )
 
@@ -300,7 +300,7 @@ func RunBuildJobs(o *Options) []error {
 	}
 
 	logrus.Info("Running build jobs...")
-	tag, err := git.GetTag()
+	tag, err := release.GetTag()
 	if err != nil {
 		return []error{err}
 	}

--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["git.go"],
+    srcs = [
+        "describe.go",
+        "git.go",
+    ],
     importpath = "k8s.io/release/pkg/git",
     visibility = ["//visibility:public"],
     deps = [
@@ -38,6 +41,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "describe_test.go",
         "git_integration_test.go",
         "git_test.go",
     ],

--- a/pkg/git/describe.go
+++ b/pkg/git/describe.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/release/pkg/command"
+)
+
+// DescribeOptions is the type for the argument passed to repo.Describe
+type DescribeOptions struct {
+	revision string
+	abbrev   int16
+	always   bool
+	dirty    bool
+	tags     bool
+}
+
+// NewDescribeOptions creates new repository describe options
+func NewDescribeOptions() *DescribeOptions {
+	return &DescribeOptions{
+		revision: "",
+		abbrev:   -1,
+		always:   false,
+		dirty:    false,
+		tags:     false,
+	}
+}
+
+// WithRevision sets the revision in the DescribeOptions
+func (d *DescribeOptions) WithRevision(rev string) *DescribeOptions {
+	d.revision = rev
+	return d
+}
+
+// WithAbbrev sets the --abbrev=<parameter> in the DescribeOptions
+func (d *DescribeOptions) WithAbbrev(abbrev uint8) *DescribeOptions {
+	d.abbrev = int16(abbrev)
+	return d
+}
+
+// WithAlways sets always to true in the DescribeOptions
+func (d *DescribeOptions) WithAlways() *DescribeOptions {
+	d.always = true
+	return d
+}
+
+// WithDirty sets dirty to true in the DescribeOptions
+func (d *DescribeOptions) WithDirty() *DescribeOptions {
+	d.dirty = true
+	return d
+}
+
+// WithTags sets tags to true in the DescribeOptions
+func (d *DescribeOptions) WithTags() *DescribeOptions {
+	d.tags = true
+	return d
+}
+
+// toArgs converts DescribeOptions to string arguments
+func (d *DescribeOptions) toArgs() (args []string) {
+	if d.tags {
+		args = append(args, "--tags")
+	}
+	if d.dirty {
+		args = append(args, "--dirty")
+	}
+	if d.always {
+		args = append(args, "--always")
+	}
+	if d.abbrev >= 0 {
+		args = append(args, fmt.Sprintf("--abbrev=%d", d.abbrev))
+	}
+	if d.revision != "" {
+		args = append(args, d.revision)
+	}
+	return args
+}
+
+// Describe runs `git describe` with the provided arguments
+func (r *Repo) Describe(opts *DescribeOptions) (string, error) {
+	if opts == nil {
+		return "", errors.New("provided describe options are nil")
+	}
+	output, err := command.NewWithWorkDir(
+		r.Dir(), gitExecutable, append([]string{"describe"}, opts.toArgs()...)...,
+	).RunSilentSuccessOutput()
+	if err != nil {
+		return "", err
+	}
+	return output.OutputTrimNL(), nil
+}

--- a/pkg/git/describe_test.go
+++ b/pkg/git/describe_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeOptionsEmpty(t *testing.T) {
+	sut := NewDescribeOptions()
+	require.NotNil(t, sut)
+	require.Nil(t, sut.toArgs())
+}
+
+func TestDescribeOptionsArguments(t *testing.T) {
+	sut := NewDescribeOptions().
+		WithTags().
+		WithDirty().
+		WithAbbrev(3).
+		WithAlways().
+		WithRevision("rev")
+	require.NotNil(t, sut)
+	require.Equal(t, []string{
+		"--tags",
+		"--dirty",
+		"--always",
+		"--abbrev=3",
+		"rev",
+	}, sut.toArgs())
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -52,17 +52,6 @@ const (
 	gitExecutable         = "git"
 )
 
-func GetTag() (string, error) {
-	tag, err := command.New(
-		"git", "describe", "--tags", "--always", "--dirty",
-	).RunSilentSuccessOutput()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get current tag")
-	}
-	t := time.Now().Format("20060102")
-	return fmt.Sprintf("v%s-%s", t, tag.OutputTrimNL()), nil
-}
-
 // GetDefaultKubernetesRepoURL returns the default HTTPS repo URL for Kubernetes.
 // Expected: https://github.com/kubernetes/kubernetes
 func GetDefaultKubernetesRepoURL() string {
@@ -553,21 +542,6 @@ func Remotify(name string) string {
 		return name
 	}
 	return fmt.Sprintf("%s/%s", DefaultRemote, name)
-}
-
-// DescribeTag can be used to retrieve the latest tag for a provided revision
-func (r *Repo) DescribeTag(rev string) (string, error) {
-	// go git seems to have no implementation for `git describe`
-	// which means that we fallback to a shell command for sake of
-	// simplicity
-	result, err := command.NewWithWorkDir(
-		r.Dir(), gitExecutable, "describe", "--abbrev=0", "--tags", rev,
-	).RunSilentSuccessOutput()
-	if err != nil {
-		return "", err
-	}
-
-	return result.OutputTrimNL(), nil
 }
 
 // Merge does a git merge into the current branch from the provided one

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -221,20 +221,30 @@ func TestSuccessCloneOrOpen(t *testing.T) {
 	require.Nil(t, secondRepo.Cleanup())
 }
 
-func TestSuccessDescribeTag(t *testing.T) {
+func TestSuccessDescribeTags(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	tag, err := testRepo.sut.DescribeTag(testRepo.firstTagCommit)
+	tag, err := testRepo.sut.Describe(
+		git.NewDescribeOptions().
+			WithRevision(testRepo.firstTagCommit).
+			WithAbbrev(0).
+			WithTags(),
+	)
 	require.Nil(t, err)
 	require.Equal(t, tag, testRepo.firstTagName)
 }
 
-func TestFailureDescribeTag(t *testing.T) {
+func TestFailureDescribeTags(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	_, err := testRepo.sut.DescribeTag("wrong")
+	_, err := testRepo.sut.Describe(
+		git.NewDescribeOptions().
+			WithRevision("wrong").
+			WithAbbrev(0).
+			WithTags(),
+	)
 	require.NotNil(t, err)
 }
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -195,4 +196,23 @@ func URLPrefixForBucket(bucket string) string {
 		urlPrefix = ProductionBucketURL
 	}
 	return urlPrefix
+}
+
+// GetTag returns the tag from the current working directory
+func GetTag() (string, error) {
+	repo, err := git.OpenRepo(".")
+	if err != nil {
+		return "", errors.Wrap(err, "opening current repository")
+	}
+	describeOutput, err := repo.Describe(
+		git.NewDescribeOptions().
+			WithAlways().
+			WithDirty().
+			WithTags(),
+	)
+	if err != nil {
+		return "", err
+	}
+	t := time.Now().Format("20060102")
+	return fmt.Sprintf("v%s-%s", t, describeOutput), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind api-change

#### What this PR does / why we need it:
`git.DescribeTag` and `git.GetTag` had overlapping functionality so we now
introduce a new method `git.Describe()`. This method takes
`git.DescribeOptions` to ensure enough flexibility to be used by future
API consumers as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed `git.DescribeTag` and `git.GetTag` in favor of the new method `git.Describe()`.
  This method takes the new type `git.DescribeOptions` to ensure enough flexibility for the future.
```
