### PR TITLE
lib/release: Use regex to prevent ACL changes on K8s Infra GCS buckets

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -982,7 +982,7 @@ release::gcs::publish () {
     "$publish_file_dst" || return 1
 
   if ((FLAGS_nomock)) && ! ((FLAGS_private_bucket)); then
-    # New Kubernetes infra buckets, like k8s-staging-releng, have a
+    # New Kubernetes infra buckets, like k8s-staging-kubernetes, have a
     # bucket-only ACL policy set, which means attempting to set the ACL on an
     # object will fail. We should skip this ACL change in those instances, as
     # new buckets already default to being publicly readable.
@@ -990,7 +990,7 @@ release::gcs::publish () {
     # Ref:
     # - https://cloud.google.com/storage/docs/bucket-policy-only
     # - https://github.com/kubernetes/release/issues/904
-    if [[ "$bucket" != "k8s-staging-releng" ]]; then
+    if ! [[ "$bucket" =~ ^k8s- ]]; then
       logecho -n "Making uploaded version file public: "
       logrun -s $GSUTIL acl ch -R -g all:R $publish_file_dst || return 1
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We've changed the GCS buckets used in anago a few times now, so adding a
regex check here (`^k8s-`) is more appropriate to future-proof this code
path against bucket name changes.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato

#### Does this PR introduce a user-facing change?

```release-note
lib/release: Use regex to prevent ACL changes on K8s Infra GCS buckets
```
