### PR TITLE
anago: Fix '--build-version' flag in anago tooltip for 'krel gcbmgr'

### DIFF
--- a/anago
+++ b/anago
@@ -1779,7 +1779,7 @@ if ((FLAGS_stage)); then
   logecho "To release this staged build, run:"
   logecho
   logecho -n "$ krel gcbmgr --release ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
-             "--buildversion=$JENKINS_BUILD_VERSION"
+             "--build-version=$JENKINS_BUILD_VERSION"
   logecho
   logecho
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:
In `krel gcbmgr` the flag for build version is now `--build-version`
(note the hyphenation compared to the shell-based 'gcbmgr's `--buildversion`.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
