### PR TITLE
[VDF] Partial revert of k8s.gcr.io cutover

### DIFF
--- a/anago
+++ b/anago
@@ -259,11 +259,12 @@ copy_logs_to_workdir () {
 }
 
 ###############################################################################
-# Ensures we have write access to a specified registry
-# @param registry - A registry to check the ACLs for
+# Ensures all registries that will be used during both mock and --nomock
+# runs allow write access so we don't fall over later
+# @param registries - A space separated list of registries
 #
 ensure_registry_acls () {
-  local registry="$1"
+  local registries=($1)
   local emptyfile="$TMPDIR/empty-file.$$"
   local gs_path
   local r
@@ -275,30 +276,27 @@ ensure_registry_acls () {
 
   # Short of creating a hardcoded map of project-id to registry, translating
   # _ to - seems to be a simple rule to keep this, well, simple.
-  r=${registry//_/-}
+  for r in ${registries[*]//_/-}; do
+    # In this context, "google-containers" is still used
+    if [[ "$r" == "$GCRIO_PATH_PROD" ]]; then
+      artifact_namespace="google-containers"
+    else
+      artifact_namespace="${r/gcr.io\//}"
+    fi
 
-  # When we are no-mock mode we need to perform an image promotion, so it's
-  # unnecessary to check for write access to the production container registry.
-  if ((FLAGS_nomock)); then
-    logecho -n "Skipping container registry ACL check on $GCRIO_PATH_PROD in no-mock mode: "
-    logecho $OK
-    return 0
-  else
-    artifact_namespace="${r/gcr.io\//}"
-  fi
+    gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
+    logecho -n "Checking write access to registry $r: "
+    if logrun $GSUTIL -q cp $emptyfile $gs_path && \
+       logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
+      logecho $OK
+    else
+      logecho $FAILED
+      ((retcode++))
+    fi
 
-  gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
-  logecho -n "Checking write access to registry $r: "
-  if logrun $GSUTIL -q cp $emptyfile $gs_path && \
-      logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
-    logecho $OK
-  else
-    logecho $FAILED
-    ((retcode++))
-  fi
-
-  # Always reset back to $USER
-  ((FLAGS_gcb)) || logrun $GCLOUD config set account $GCP_USER
+    # Always reset back to $USER
+    ((FLAGS_gcb)) || logrun $GCLOUD config set account $GCP_USER
+  done
 
   logrun rm -f $emptyfile
 
@@ -380,7 +378,7 @@ check_prerequisites () {
 
   # Verify write access to all container registries that might be used
   # to ensure both mock and --nomock runs will work.
-  ensure_registry_acls "$GCRIO_PATH" || return 1
+  ensure_registry_acls "${ALL_CONTAINER_REGISTRIES[*]}" || return 1
 
   logecho -n "Checking cloud project state: "
   GCLOUD_PROJECT=$($GCLOUD config get-value project 2>/dev/null)
@@ -1446,13 +1444,8 @@ push_all_artifacts () {
        gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
 
-    # When we are no-mock mode we need to perform an image promotion, so
-    # instead of pushing to the production container registry, we validate
-    # that the manifest is populated on the remote registry.
-    if ! ((FLAGS_nomock)); then
-      common::runstep release::docker::release \
+    common::runstep release::docker::release \
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
-    fi
 
     common::runstep release::docker::validate_remote_manifests \
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -34,7 +34,7 @@ readonly GCRIO_PATH_PROD="k8s.gcr.io"
 # TODO(vdf): Remove all GCRIO_PATH_PROD_PUSH logic once the k8s.gcr.io vanity
 #            domain flip (VDF) is successful
 readonly GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
-readonly GCRIO_PATH_TEST="gcr.io/k8s-staging-kubernetes"
+readonly GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
 
 readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
 readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"
@@ -1362,6 +1362,9 @@ release::send_announcement () {
 # READ_RELEASE_BUCKETS - array of readable buckets for multiple sourcing of
 #                        mock staged builds
 # GCRIO_PATH - GCR path based on mock or --nomock
+# ALL_CONTAINER_REGISTRIES - when running mock (via GCB) this array also
+#                            contains k8s.gcr.io so we can check access in mock
+#                            mode before an actual release occurs
 release::set_globals () {
   logecho -n "Setting global variables: "
 
@@ -1388,6 +1391,7 @@ release::set_globals () {
   fi
 
   GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
+  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"
@@ -1419,6 +1423,8 @@ release::set_globals () {
 
   WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
   READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET")
+
+  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   # TODO:
   # These KUBE_ globals extend beyond the scope of the new release refactored


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This partially reverts commits:
- 29b8e1da5c4bc08d1bbfc64b61e68e59bbe4f70b
- 4343e86a4fb406523445eed3173334633d6ef801
- dcaf5c063cd8929834fe3916d2fb5408b7954149

From @listx on [k-dev](https://groups.google.com/d/msg/kubernetes-dev/MkXnkTSJ_vs/TW-aZFHmAwAJ):
> We found a hard-coded internal reference that we had missed which
caused some large fraction of traffic from certain regions to be sent to
the wrong place. Because it is Friday afternoon, we will halt the
rollout, do a fast rollback, and try again early next week. Sorry!

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 
/priority critical-urgent

#### Special notes for your reviewer:

I've kept the manifest validation logic in here from https://github.com/kubernetes/release/pull/1199 and only reverted the project/bucket changes.

#### Does this PR introduce a user-facing change?

```release-note
[VDF] Partial revert of k8s.gcr.io cutover
```
