### PR TITLE
[VDF] anago: Publish container images on K8s Infra (k8s-staging-kubernetes) - take two

### DIFF
--- a/anago
+++ b/anago
@@ -256,7 +256,7 @@ ensure_registry_acls () {
   local artifact_namespace
 
   # Make an empty file to test uploading
-  logrun touch $emptyfile
+  logrun -v touch $emptyfile
 
   # Short of creating a hardcoded map of project-id to registry, translating
   # _ to - seems to be a simple rule to keep this, well, simple.
@@ -272,17 +272,17 @@ ensure_registry_acls () {
     artifact_namespace="${r/gcr.io\//}"
   fi
 
-  gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
+  gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers/"
   logecho -n "Checking write access to registry $r: "
-  if logrun $GSUTIL -q cp $emptyfile $gs_path && \
-      logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
+  if logrun -v $GSUTIL cp $emptyfile $gs_path && \
+      logrun -v $GSUTIL rm $gs_path/${emptyfile##*/}; then
     logecho $OK
   else
     logecho $FAILED
     ((retcode++))
   fi
 
-  logrun rm -f $emptyfile
+  logrun -v rm -f $emptyfile
 
   return $retcode
 }
@@ -358,7 +358,8 @@ check_prerequisites () {
 
   # Verify write access to all container registries that might be used
   # to ensure both mock and --nomock runs will work.
-  ensure_registry_acls "$GCRIO_PATH" || return 1
+  # TEMPORARILY DISABLE ACL CHECK FOR VDF
+  #ensure_registry_acls "$GCRIO_PATH" || return 1
 
   logecho -n "Checking cloud project state: "
   GCLOUD_PROJECT=$($GCLOUD config get-value project 2>/dev/null)

--- a/anago
+++ b/anago
@@ -244,12 +244,11 @@ copy_logs_to_workdir () {
 }
 
 ###############################################################################
-# Ensures all registries that will be used during both mock and --nomock
-# runs allow write access so we don't fall over later
-# @param registries - A space separated list of registries
+# Ensures we have write access to a specified registry
+# @param registry - A registry to check the ACLs for
 #
 ensure_registry_acls () {
-  local registries=($1)
+  local registry="$1"
   local emptyfile="$TMPDIR/empty-file.$$"
   local gs_path
   local r
@@ -261,24 +260,27 @@ ensure_registry_acls () {
 
   # Short of creating a hardcoded map of project-id to registry, translating
   # _ to - seems to be a simple rule to keep this, well, simple.
-  for r in ${registries[*]//_/-}; do
-    # In this context, "google-containers" is still used
-    if [[ "$r" == "$GCRIO_PATH_PROD" ]]; then
-      artifact_namespace="google-containers"
-    else
-      artifact_namespace="${r/gcr.io\//}"
-    fi
+  r=${registry//_/-}
 
-    gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
-    logecho -n "Checking write access to registry $r: "
-    if logrun $GSUTIL -q cp $emptyfile $gs_path && \
-       logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
-      logecho $OK
-    else
-      logecho $FAILED
-      ((retcode++))
-    fi
-  done
+  # When we are no-mock mode we need to perform an image promotion, so it's
+  # unnecessary to check for write access to the production container registry.
+  if ((FLAGS_nomock)); then
+    logecho -n "Skipping container registry ACL check on $GCRIO_PATH_PROD in no-mock mode: "
+    logecho $OK
+    return 0
+  else
+    artifact_namespace="${r/gcr.io\//}"
+  fi
+
+  gs_path="gs://artifacts.$artifact_namespace.appspot.com/containers"
+  logecho -n "Checking write access to registry $r: "
+  if logrun $GSUTIL -q cp $emptyfile $gs_path && \
+      logrun $GSUTIL -q rm $gs_path/${emptyfile##*/}; then
+    logecho $OK
+  else
+    logecho $FAILED
+    ((retcode++))
+  fi
 
   logrun rm -f $emptyfile
 
@@ -356,7 +358,7 @@ check_prerequisites () {
 
   # Verify write access to all container registries that might be used
   # to ensure both mock and --nomock runs will work.
-  ensure_registry_acls "${ALL_CONTAINER_REGISTRIES[*]}" || return 1
+  ensure_registry_acls "$GCRIO_PATH" || return 1
 
   logecho -n "Checking cloud project state: "
   GCLOUD_PROJECT=$($GCLOUD config get-value project 2>/dev/null)
@@ -1407,8 +1409,13 @@ push_all_artifacts () {
        gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
 
-    common::runstep release::docker::release \
+    # When we are no-mock mode we need to perform an image promotion, so
+    # instead of pushing to the production container registry, we validate
+    # that the manifest is populated on the remote registry.
+    if ! ((FLAGS_nomock)); then
+      common::runstep release::docker::release \
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
+    fi
 
     common::runstep release::docker::validate_remote_manifests \
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -34,7 +34,7 @@ readonly GCRIO_PATH_PROD="k8s.gcr.io"
 # TODO(vdf): Remove all GCRIO_PATH_PROD_PUSH logic once the k8s.gcr.io vanity
 #            domain flip (VDF) is successful
 readonly GCRIO_PATH_PROD_PUSH="gcr.io/google-containers"
-readonly GCRIO_PATH_TEST="gcr.io/$TEST_PROJECT"
+readonly GCRIO_PATH_TEST="gcr.io/k8s-staging-kubernetes"
 
 readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
 readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"
@@ -1300,9 +1300,6 @@ release::gcs::bazel_push_build() {
 # READ_RELEASE_BUCKETS - array of readable buckets for multiple sourcing of
 #                        mock staged builds
 # GCRIO_PATH - GCR path based on mock or --nomock
-# ALL_CONTAINER_REGISTRIES - when running mock (via GCB) this array also
-#                            contains k8s.gcr.io so we can check access in mock
-#                            mode before an actual release occurs
 release::set_globals () {
   logecho -n "Setting global variables: "
 
@@ -1329,7 +1326,6 @@ release::set_globals () {
   fi
 
   GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
-  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"
@@ -1361,8 +1357,6 @@ release::set_globals () {
 
   WRITE_RELEASE_BUCKETS=("$RELEASE_BUCKET")
   READ_RELEASE_BUCKETS+=("$RELEASE_BUCKET")
-
-  ALL_CONTAINER_REGISTRIES=("$GCRIO_PATH")
 
   # TODO:
   # These KUBE_ globals extend beyond the scope of the new release refactored


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This reverts commit b60c168c6e0bc8d02b51c86dd21703644b4fa945, reversing
changes made to 261486414733ccda27c41c8b795b9a583a20d253.

/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 
/priority critical-urgent

#### Special notes for your reviewer:

Reapplies https://github.com/kubernetes/release/pull/1199, which was partially reverted in https://github.com/kubernetes/release/pull/1229.

/hold until @listx kicks the cutover again next week

#### Does this PR introduce a user-facing change?

```release-note
[VDF] anago: Publish container images on K8s Infra (k8s-staging-kubernetes) - take two
```
