### PR TITLE
Quarterly OWNERS updates

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,6 +15,7 @@ aliases:
     - tpepper # subproject owner / Patch Release Team
   branch-managers:
     - cpanato
+    - hasheddan
     - saschagrunert
   build-admins:
     - aleksandra-malinowska

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,6 @@ aliases:
     - justaugustus
     - tpepper
   release-engineering:
-    - aleksandra-malinowska # Patch Release Team
     - calebamiles # subproject owner
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -49,4 +49,5 @@ aliases:
     - saschagrunert
   release-notes-reviewers:
     - jeefy
+    - puerco
     - saschagrunert

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,11 +46,7 @@ aliases:
     - saschagrunert
   release-notes-approvers:
     - jeefy
-    - marpaia
-    - onyiny-ang
     - saschagrunert
   release-notes-reviewers:
     - jeefy
-    - marpaia
-    - onyiny-ang
     - saschagrunert


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

- Remove @aleksandra-malinowska from Patch Release Team (ref: https://github.com/kubernetes/sig-release/issues/987)
- Promote @hasheddan to Branch Manager (ref: https://github.com/kubernetes/sig-release/issues/1041)
- Prune inactive release notes reviewers/approvers
- Add @puerco to release-notes-reviewers

/assign @tpepper 
cc: @kubernetes/release-engineering @kubernetes/sig-release-admins 
/hold