### PR TITLE
gcbmgr: default list job variable to 5 if a negative number was set

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -376,7 +376,11 @@ var BuildListJobs = build.ListJobs
 
 // listJobs lists recent GCB jobs run in the specified project
 func listJobs(project string, lastJobs int64) error {
-	logrus.Infof("Listing last %d GCB jobs:", lastJobs)
+	if lastJobs < 0 {
+		logrus.Infof("--list-jobs was set to a negative number, defaulting to 5")
+		lastJobs = 5
+	}
 
+	logrus.Infof("Listing last %d GCB jobs:", lastJobs)
 	return BuildListJobs(project, lastJobs)
 }


### PR DESCRIPTION
#### What type of PR is this?
 /kind cleanup

#### What this PR does / why we need it:
Default to 5 last jobs if a negative number was set 

follow up of https://github.com/kubernetes/release/pull/1194#discussion_r395951127
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcbmgr: default to 5 last jobs when a negative number is set
```
