### PR TITLE
dependencies/testgrid: update to use release v0.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.44.3
-	github.com/GoogleCloudPlatform/testgrid v0.0.7
+	github.com/GoogleCloudPlatform/testgrid v0.0.10
 	github.com/bazelbuild/rules_go v0.22.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golangci/golangci-lint v1.23.3

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/testgrid v0.0.7 h1:tKM75ScxinVqDkguwG5AnsQZn9XCNpxAdEey1OfJgiE=
-github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
+github.com/GoogleCloudPlatform/testgrid v0.0.10 h1:UBYR7CmCLwOoWJMHXVlDMurCTzZLKww/WslxsbAvFX4=
+github.com/GoogleCloudPlatform/testgrid v0.0.10/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1 h1:VlW4R6jmBIv3/u1JNlawEvJMM4J+dPORPaZasQee8Us=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=

--- a/repos.bzl
+++ b/repos.bzl
@@ -921,8 +921,8 @@ def go_repositories():
         build_file_generation = "off",
         build_file_proto_mode = "package",
         importpath = "github.com/GoogleCloudPlatform/testgrid",
-        sum = "h1:tKM75ScxinVqDkguwG5AnsQZn9XCNpxAdEey1OfJgiE=",
-        version = "v0.0.7",
+        sum = "h1:UBYR7CmCLwOoWJMHXVlDMurCTzZLKww/WslxsbAvFX4=",
+        version = "v0.0.10",
     )
     go_repository(
         name = "com_google_cloud_go_datastore",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update `testgrid` dependency to [v0.0.10](https://github.com/GoogleCloudPlatform/testgrid/tree/v0.0.10) which is the latest available and has the [following changes](https://github.com/GoogleCloudPlatform/testgrid/releases/tag/v0.0.10):

- Make resultstore search project specific

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
dependencies/testgrid: update to use release v0.0.10
```
