### PR TITLE
Add a patch-to-latest discover mode

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -82,7 +82,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | repo-path               | REPO_PATH       | /tmp/k8s-repo       | No       | Path to a local Kubernetes repository, used only for tag discovery                                                                |
 | start-rev               | START_REV       |                     | No       | The git revision to start at. Can be used as alternative to start-sha                                                             |
 | env-rev                 | END_REV         |                     | No       | The git revision to end at. Can be used as alternative to end-sha                                                                 |
-| discover                | DISCOVER        | none                | No       | The revision discovery mode for automatic revision retrieval (options: none, mergebase-to-latest, patch-to-patch, minor-to-minor) |
+| discover                | DISCOVER        | none                | No       | The revision discovery mode for automatic revision retrieval (options: none, mergebase-to-latest, patch-to-patch, patch-to-latest, minor-to-minor) |
 | release-bucket          | RELEASE_BUCKET  | kubernetes-release  | No       | Specify gs bucket to point to in generated notes (default "kubernetes-release")                                                   |
 | release-tars            | RELEASE_TARS    |                     | No       | Directory of tars to sha512 sum for display                                                                                       |
 | **OUTPUT OPTIONS**      |

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -116,6 +116,7 @@ const (
 	RevisionDiscoveryModeNONE              = "none"
 	RevisionDiscoveryModeMergeBaseToLatest = "mergebase-to-latest"
 	RevisionDiscoveryModePatchToPatch      = "patch-to-patch"
+	RevisionDiscoveryModePatchToLatest     = "patch-to-latest"
 	RevisionDiscoveryModeMinorToMinor      = "minor-to-minor"
 )
 
@@ -238,6 +239,8 @@ func (o *Options) resolveDiscoverMode() error {
 		result, err = repo.LatestReleaseBranchMergeBaseToLatest()
 	} else if o.DiscoverMode == RevisionDiscoveryModePatchToPatch {
 		result, err = repo.LatestPatchToPatch(o.Branch)
+	} else if o.DiscoverMode == RevisionDiscoveryModePatchToLatest {
+		result, err = repo.LatestPatchToLatest(o.Branch)
 	} else if o.DiscoverMode == RevisionDiscoveryModeMinorToMinor {
 		result, err = repo.LatestNonPatchFinalToMinor()
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds a patch-to-latest discover mode, that generates the release notes from the latest patch release to the top of the release branch.

We use this tool to generate release notes for kubernetes-csi repos. Our release model is to generate the release notes before tagging the release, so the existing "patch-to-patch" doesn't work for us. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds "patch-to-latest" discover mode.
```
