### PR TITLE
Add ls-remote to git package

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -888,3 +888,16 @@ func (r *Repo) PushToRemote(remote, remoteBranch string) error {
 
 	return command.NewWithWorkDir(r.Dir(), gitExecutable, args...).RunSuccess()
 }
+
+// LsRemote can be used to run `git ls-remote` with the provided args on the
+// repository
+func (r *Repo) LsRemote(args ...string) (string, error) {
+	cmdArgs := append([]string{"ls-remote"}, args...)
+	res, err := command.NewWithWorkDir(
+		r.Dir(), gitExecutable, cmdArgs...,
+	).RunSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "running git ls-remote")
+	}
+	return res.OutputTrimNL(), nil
+}

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -795,3 +795,23 @@ func TestPushToRemoteFailureBranchNotExisting(t *testing.T) {
 	err := testRepo.sut.PushToRemote(git.DefaultRemote, "some-branch")
 	require.NotNil(t, err)
 }
+
+func TestLSRemoteSuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	res, err := testRepo.sut.LsRemote()
+	require.Nil(t, err)
+	require.Contains(t, res, testRepo.firstCommit)
+	require.Contains(t, res, testRepo.secondBranchCommit)
+	require.Contains(t, res, testRepo.thirdBranchCommit)
+}
+
+func TestLSRemoteFailure(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	res, err := testRepo.sut.LsRemote("invalid")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The new API method `git.LsRemote()` allows users to run git ls-remote on
the repository by providing additional args.

This is finally needed for the completion of the `CheckState()` method
inside the pkg/repository package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add `LsRemote()` method to `git` package repository
```
