### PR TITLE
Finish repo state check in gcbmgr

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -892,12 +892,25 @@ func (r *Repo) PushToRemote(remote, remoteBranch string) error {
 // LsRemote can be used to run `git ls-remote` with the provided args on the
 // repository
 func (r *Repo) LsRemote(args ...string) (string, error) {
-	cmdArgs := append([]string{"ls-remote"}, args...)
+	return r.runGitCmd("ls-remote", args...)
+}
+
+// Branch can be used to run `git branch` with the provided args on the
+// repository
+func (r *Repo) Branch(args ...string) (string, error) {
+	return r.runGitCmd("branch", args...)
+}
+
+// runGitCmd runs the provided command in the repository root and appends the
+// args. The command will run silently and return the captured output or an
+// error in case of any failure.
+func (r *Repo) runGitCmd(cmd string, args ...string) (string, error) {
+	cmdArgs := append([]string{cmd}, args...)
 	res, err := command.NewWithWorkDir(
 		r.Dir(), gitExecutable, cmdArgs...,
-	).RunSuccessOutput()
+	).RunSilentSuccessOutput()
 	if err != nil {
-		return "", errors.Wrap(err, "running git ls-remote")
+		return "", errors.Wrapf(err, "running git %s", cmd)
 	}
 	return res.OutputTrimNL(), nil
 }

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -815,3 +815,21 @@ func TestLSRemoteFailure(t *testing.T) {
 	require.NotNil(t, err)
 	require.Empty(t, res)
 }
+
+func TestBranchSuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	res, err := testRepo.sut.Branch()
+	require.Nil(t, err)
+	require.Contains(t, res, testRepo.branchName)
+}
+
+func TestBranchFailure(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	res, err := testRepo.sut.Branch("--invalid")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}

--- a/pkg/release/releasefakes/fake_repository.go
+++ b/pkg/release/releasefakes/fake_repository.go
@@ -25,6 +25,19 @@ import (
 )
 
 type FakeRepository struct {
+	BranchStub        func(...string) (string, error)
+	branchMutex       sync.RWMutex
+	branchArgsForCall []struct {
+		arg1 []string
+	}
+	branchReturns struct {
+		result1 string
+		result2 error
+	}
+	branchReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	CurrentBranchStub        func() (string, error)
 	currentBranchMutex       sync.RWMutex
 	currentBranchArgsForCall []struct {
@@ -50,6 +63,19 @@ type FakeRepository struct {
 		result1 string
 		result2 error
 	}
+	LsRemoteStub        func(...string) (string, error)
+	lsRemoteMutex       sync.RWMutex
+	lsRemoteArgsForCall []struct {
+		arg1 []string
+	}
+	lsRemoteReturns struct {
+		result1 string
+		result2 error
+	}
+	lsRemoteReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	RemotesStub        func() ([]*git.Remote, error)
 	remotesMutex       sync.RWMutex
 	remotesArgsForCall []struct {
@@ -64,6 +90,69 @@ type FakeRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeRepository) Branch(arg1 ...string) (string, error) {
+	fake.branchMutex.Lock()
+	ret, specificReturn := fake.branchReturnsOnCall[len(fake.branchArgsForCall)]
+	fake.branchArgsForCall = append(fake.branchArgsForCall, struct {
+		arg1 []string
+	}{arg1})
+	fake.recordInvocation("Branch", []interface{}{arg1})
+	fake.branchMutex.Unlock()
+	if fake.BranchStub != nil {
+		return fake.BranchStub(arg1...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.branchReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) BranchCallCount() int {
+	fake.branchMutex.RLock()
+	defer fake.branchMutex.RUnlock()
+	return len(fake.branchArgsForCall)
+}
+
+func (fake *FakeRepository) BranchCalls(stub func(...string) (string, error)) {
+	fake.branchMutex.Lock()
+	defer fake.branchMutex.Unlock()
+	fake.BranchStub = stub
+}
+
+func (fake *FakeRepository) BranchArgsForCall(i int) []string {
+	fake.branchMutex.RLock()
+	defer fake.branchMutex.RUnlock()
+	argsForCall := fake.branchArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRepository) BranchReturns(result1 string, result2 error) {
+	fake.branchMutex.Lock()
+	defer fake.branchMutex.Unlock()
+	fake.BranchStub = nil
+	fake.branchReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) BranchReturnsOnCall(i int, result1 string, result2 error) {
+	fake.branchMutex.Lock()
+	defer fake.branchMutex.Unlock()
+	fake.BranchStub = nil
+	if fake.branchReturnsOnCall == nil {
+		fake.branchReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.branchReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRepository) CurrentBranch() (string, error) {
@@ -184,6 +273,69 @@ func (fake *FakeRepository) DescribeReturnsOnCall(i int, result1 string, result2
 	}{result1, result2}
 }
 
+func (fake *FakeRepository) LsRemote(arg1 ...string) (string, error) {
+	fake.lsRemoteMutex.Lock()
+	ret, specificReturn := fake.lsRemoteReturnsOnCall[len(fake.lsRemoteArgsForCall)]
+	fake.lsRemoteArgsForCall = append(fake.lsRemoteArgsForCall, struct {
+		arg1 []string
+	}{arg1})
+	fake.recordInvocation("LsRemote", []interface{}{arg1})
+	fake.lsRemoteMutex.Unlock()
+	if fake.LsRemoteStub != nil {
+		return fake.LsRemoteStub(arg1...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.lsRemoteReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) LsRemoteCallCount() int {
+	fake.lsRemoteMutex.RLock()
+	defer fake.lsRemoteMutex.RUnlock()
+	return len(fake.lsRemoteArgsForCall)
+}
+
+func (fake *FakeRepository) LsRemoteCalls(stub func(...string) (string, error)) {
+	fake.lsRemoteMutex.Lock()
+	defer fake.lsRemoteMutex.Unlock()
+	fake.LsRemoteStub = stub
+}
+
+func (fake *FakeRepository) LsRemoteArgsForCall(i int) []string {
+	fake.lsRemoteMutex.RLock()
+	defer fake.lsRemoteMutex.RUnlock()
+	argsForCall := fake.lsRemoteArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRepository) LsRemoteReturns(result1 string, result2 error) {
+	fake.lsRemoteMutex.Lock()
+	defer fake.lsRemoteMutex.Unlock()
+	fake.LsRemoteStub = nil
+	fake.lsRemoteReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) LsRemoteReturnsOnCall(i int, result1 string, result2 error) {
+	fake.lsRemoteMutex.Lock()
+	defer fake.lsRemoteMutex.Unlock()
+	fake.LsRemoteStub = nil
+	if fake.lsRemoteReturnsOnCall == nil {
+		fake.lsRemoteReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.lsRemoteReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeRepository) Remotes() ([]*git.Remote, error) {
 	fake.remotesMutex.Lock()
 	ret, specificReturn := fake.remotesReturnsOnCall[len(fake.remotesArgsForCall)]
@@ -242,10 +394,14 @@ func (fake *FakeRepository) RemotesReturnsOnCall(i int, result1 []*git.Remote, r
 func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.branchMutex.RLock()
+	defer fake.branchMutex.RUnlock()
 	fake.currentBranchMutex.RLock()
 	defer fake.currentBranchMutex.RUnlock()
 	fake.describeMutex.RLock()
 	defer fake.describeMutex.RUnlock()
+	fake.lsRemoteMutex.RLock()
+	defer fake.lsRemoteMutex.RUnlock()
 	fake.remotesMutex.RLock()
 	defer fake.remotesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The `CheckState` method of the `repository` package now verifies that
the latest remote commit is available in the local repository.

For that a new `git` API repository method `Branch()` has been added as
well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Follow-up of https://github.com/kubernetes/release/pull/1252

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- `krel gcbmgr` now validates that the latest remote commit of the release repository
  is available in the local repository checkout. To ensure that a new `git` API
  method `Branch()` has been added as well.
```
