### PR TITLE
Env var for saving spec files to help with local/testing scenarios

### DIFF
--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -183,22 +183,26 @@ func ConstructBuilds(buildType BuildType, packages, channels []string, kubeVersi
 func WalkBuilds(builds []Build, architectures []string, specOnly bool) error {
 	logrus.Infof("Walking builds...")
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "kubepkg")
-	if err != nil {
-		return err
+	var err error
+	workingDir := os.Getenv("KUBEPKG_WORKING_DIR")
+	if workingDir == "" {
+		workingDir, err = ioutil.TempDir(os.TempDir(), "kubepkg")
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, arch := range architectures {
 		for _, build := range builds {
 			for _, packageDef := range build.Definitions {
-				if err := buildPackage(build, packageDef, arch, tmpDir, specOnly); err != nil {
+				if err := buildPackage(build, packageDef, arch, workingDir, specOnly); err != nil {
 					return err
 				}
 			}
 		}
 	}
 	if specOnly {
-		logrus.Infof("Package specs have been saved in %v", tmpDir)
+		logrus.Infof("Package specs have been saved in %v", workingDir)
 	}
 	logrus.Infof("Successfully walked builds")
 	return nil


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
With this PR, it's easy to inject a directory to save the spec files instead of a random temp directory using for example:
```
KUBEPKG_WORKING_DIR=~/testing ../../kubepkg debs --arch amd64 --channels nightly --spec-only
``` 

This will enable us to test/build debs from locally built libraries in conjunction with the `KUBE_USE_LOCAL_ARTIFACTS` flag for some CI scenarios (example we could use this as in cluster-api scenarios to build local debs on demand say from a PR)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
