### PR TITLE
cmd/kubepkg: Better way to override local directory for artifacts

### DIFF
--- a/cmd/kubepkg/templates/latest/deb/kubeadm/debian/rules
+++ b/cmd/kubepkg/templates/latest/deb/kubeadm/debian/rules
@@ -2,15 +2,15 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
-KUBE_USE_LOCAL_ARTIFACTS?=
+KUBE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
-ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
-	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .GoArch }}/kubeadm usr/bin/kubeadm
+ifneq ($(KUBE_LOCAL_ARTIFACTS),)
+	cp $(KUBE_LOCAL_ARTIFACTS)/bin/linux/{{ .GoArch }}/kubeadm usr/bin/kubeadm
 else
 	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubeadm \

--- a/cmd/kubepkg/templates/latest/deb/kubectl/debian/rules
+++ b/cmd/kubepkg/templates/latest/deb/kubectl/debian/rules
@@ -2,15 +2,15 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
-KUBE_USE_LOCAL_ARTIFACTS?=
+KUBE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
-ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
-	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .GoArch }}/kubectl usr/bin/kubectl
+ifneq ($(KUBE_LOCAL_ARTIFACTS),)
+	cp $(KUBE_LOCAL_ARTIFACTS)/bin/linux/{{ .GoArch }}/kubectl usr/bin/kubectl
 else
 	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubectl \

--- a/cmd/kubepkg/templates/latest/deb/kubelet/debian/rules
+++ b/cmd/kubepkg/templates/latest/deb/kubelet/debian/rules
@@ -2,15 +2,15 @@
 # -*- makefile -*-
 
 #export DH_VERBOSE=1
-KUBE_USE_LOCAL_ARTIFACTS?=
+KUBE_LOCAL_ARTIFACTS?=
 
 build:
 	echo noop
 
 binary:
 	mkdir -p usr/bin
-ifeq ($(KUBE_USE_LOCAL_ARTIFACTS),y)
-	cp $(shell go env GOPATH)/src/k8s.io/kubernetes/_output/dockerized/bin/linux/{{ .GoArch }}/kubelet usr/bin/kubelet
+ifneq ($(KUBE_LOCAL_ARTIFACTS),)
+	cp $(KUBE_LOCAL_ARTIFACTS)/bin/linux/{{ .GoArch }}/kubelet usr/bin/kubelet
 else
 	curl --fail -sSL --retry 5 \
 		-o usr/bin/kubelet \


### PR DESCRIPTION
The current override is not pleasant to use, let's keep it simple with
a single env var `KUBE_LOCAL_ARTIFACTS` which is the directory to where
the binaries can be found. No need to muck around with `go env` or use
the hard coded path off k8s.io/kubernetes that is specific to one of the
two build systems in kubernetes.

This way it does not matter how the binaries were built, just that they
are available in a well-known tree structure. We use the same tree
structure in the url for the downloads from gcs as well as a bonus.

Also, *NO* one is using this today, so we should not break existing things.

- https://grep.app/search?q=KUBE_USE_LOCAL_ARTIFACTS
- https://cs.k8s.io/?q=KUBE_USE_LOCAL_ARTIFACTS&i=nope&files=&repos=

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
