### PR TITLE
Use internal log package for kubepkg

### DIFF
--- a/cmd/kubepkg/cmd/BUILD.bazel
+++ b/cmd/kubepkg/cmd/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kubepkg:go_default_library",
+        "//pkg/log:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/cmd/kubepkg/cmd/root.go
+++ b/cmd/kubepkg/cmd/root.go
@@ -22,13 +22,14 @@ import (
 	"github.com/spf13/cobra"
 
 	kpkg "k8s.io/release/pkg/kubepkg"
+	"k8s.io/release/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "kubepkg",
-	Short:   "kubepkg",
-	PreRunE: initLogging,
+	Use:               "kubepkg",
+	Short:             "kubepkg",
+	PersistentPreRunE: initLogging,
 }
 
 type rootOptions struct {
@@ -135,14 +136,7 @@ func initConfig() {
 }
 
 func initLogging(*cobra.Command, []string) error {
-	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
-	lvl, err := logrus.ParseLevel(rootOpts.logLevel)
-	if err != nil {
-		return err
-	}
-	logrus.SetLevel(lvl)
-	logrus.Debugf("Using log level %q", lvl)
-	return nil
+	return log.SetupGlobalLogger(rootOpts.logLevel)
 }
 
 func validateOptions(ro *rootOptions) error {

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -63,7 +63,7 @@ const (
 
 var (
 	minimumCRIToolsVersion = minimumKubernetesVersion
-	LatestTemplateDir      = fmt.Sprintf("%s/%s", templateRootDir, "latest")
+	LatestTemplateDir      = filepath.Join(templateRootDir, "latest")
 
 	buildArchMap = map[string]map[BuildType]string{
 		"amd64": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
#### What this PR does / why we need it:
We can switch to our own internal log package to get the same
enhancements for kubepkg like we have for krel and gcbmgr.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add file location to debug log output of kubepkg
```
