### PR TITLE
kube-cross: Build v1.14.2-3 and v1.13.9-4 images

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -20,13 +20,13 @@ IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)
 CONFIG?=go1.14
-KUBE_CROSS_VERSION?=v1.14.2-2
+KUBE_CROSS_VERSION?=v1.14.2-3
 
 # Build args
 GO_VERSION?=1.14.2
-PROTOBUF_VERSION?=3.0.2
-ETCD_VERSION?=v3.2.24
-SKOPEO_VERSION?=v0.1.41
+PROTOBUF_VERSION?=3.11.4
+ETCD_VERSION?=v3.4.7
+SKOPEO_VERSION?=v0.2.0
 
 # TODO: Support multi-arch kube-cross images
 #       ref:

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -22,12 +22,12 @@ substitutions:
   # can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _CONFIG: 'go1.14'
-  _GO_VERSION: '1.14.2'
-  _KUBE_CROSS_VERSION: 'v1.14.2-2'
-  _PROTOBUF_VERSION: '3.0.2'
-  _ETCD_VERSION: 'v3.2.24'
-  _SKOPEO_VERSION: 'v0.1.41'
+  _CONFIG: 'go0.0'
+  _GO_VERSION: '0.0.0'
+  _KUBE_CROSS_VERSION: 'v0.0.0-0'
+  _PROTOBUF_VERSION: '0.0.0'
+  _ETCD_VERSION: 'v0.0.0'
+  _SKOPEO_VERSION: 'v0.0.0'
 images:
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_KUBE_CROSS_VERSION'
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_GIT_TAG-$_CONFIG'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,17 +2,19 @@ variants:
   go1.14:
     CONFIG: 'go1.14'
     GO_VERSION: '1.14.2'
-    KUBE_CROSS_VERSION: 'v1.14.2-2'
-    PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.2.24'
-    SKOPEO_VERSION: 'v0.1.41'
+    KUBE_CROSS_VERSION: 'v1.14.2-3'
+    PROTOBUF_VERSION: '3.11.4'
+    ETCD_VERSION: 'v3.4.7'
+    SKOPEO_VERSION: 'v0.2.0'
   go1.13:
     CONFIG: 'go1.13'
     GO_VERSION: '1.13.9'
-    KUBE_CROSS_VERSION: 'v1.13.9-3'
-    PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.2.24'
-    SKOPEO_VERSION: 'v0.1.41'
+    KUBE_CROSS_VERSION: 'v1.13.9-4'
+    PROTOBUF_VERSION: '3.11.4'
+    ETCD_VERSION: 'v3.4.7'
+    SKOPEO_VERSION: 'v0.2.0'
+  # DO NOT UPDATE CONFIGS BELOW THIS COMMENT
+  # The following Go versions are out of support
   go1.12:
     CONFIG: 'go1.12'
     GO_VERSION: '1.12.17'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- kube-cross: Build v1.14.2-3 and v1.13.9-4 images

  Dependency updates:
  - PROTOBUF_VERSION to 3.11.4
  - ETCD_VERSION to v3.4.7
  - SKOPEO_VERSION to v0.2.0

- kube-cross: Zero out substitution values in GCB config
    
  Here we explicitly provide fake values for each of the variables in the
  kube-cross GCB config to prevent accidental builds that circumvent the
  Makefile or variants.yaml configs.

#### Special notes for your reviewer:

/hold for testing
- go1.14: https://console.cloud.google.com/cloud-build/builds/4156a2a9-24f8-471d-99ef-bc13a4effc33?project=k8s-staging-build-image
- go1.13: https://console.cloud.google.com/cloud-build/builds/b81c54b9-8d8a-42e9-ae44-699602013bfb?project=k8s-staging-build-image
- go1.12: https://console.cloud.google.com/cloud-build/builds/3d3d449b-dca3-48f9-98bd-e9da136f5659?project=k8s-staging-build-image

#### Does this PR introduce a user-facing change?

```release-note
kube-cross: Build v1.14.2-3 and v1.13.9-4 images

Dependency updates:
- PROTOBUF_VERSION to 3.11.4
- ETCD_VERSION to v3.4.7
- SKOPEO_VERSION to v0.2.0
```
