### PR TITLE
Fix error handling in buildconfig run

### DIFF
--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -144,9 +144,8 @@ func ConstructBuilds(buildType BuildType, packages, channels []string, kubeVersi
 	for _, pkg := range packages {
 		// TODO: Get package directory for any version once package definitions are broken out
 		packageTemplateDir := filepath.Join(templateDir, string(buildType), pkg)
-		_, err := os.Stat(packageTemplateDir)
-		if err != nil {
-			return nil, err
+		if _, err := os.Stat(packageTemplateDir); err != nil {
+			return nil, errors.Wrap(err, "finding package template dir")
 		}
 
 		b := &Build{
@@ -306,8 +305,7 @@ func (bc *buildConfig) run() error {
 	specDir := filepath.Join(bc.workspace, string(bc.Channel), bc.Package)
 	specDirWithArch := filepath.Join(specDir, bc.GoArch)
 
-	err = os.MkdirAll(specDirWithArch, workspaceInfo.Mode())
-	if err != nil {
+	if err := os.MkdirAll(specDirWithArch, workspaceInfo.Mode()); err != nil {
 		return err
 	}
 
@@ -316,8 +314,7 @@ func (bc *buildConfig) run() error {
 		defer os.RemoveAll(specDirWithArch)
 	}
 
-	_, err = buildSpecs(bc, specDirWithArch)
-	if err != nil {
+	if _, err := buildSpecs(bc, specDirWithArch); err != nil {
 		return err
 	}
 
@@ -350,7 +347,7 @@ func (bc *buildConfig) run() error {
 
 		dstPath := filepath.Join(dstParts...)
 		if mkdirErr := os.MkdirAll(dstPath, os.FileMode(0777)); mkdirErr != nil {
-			return err
+			return mkdirErr
 		}
 
 		mvErr := command.New("mv", filepath.Join(specDir, fileName), dstPath).RunSuccess()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This fixes the return of a wrong error in kubepkg.go and refactors the
error handling paths to be a bit more streamlined.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
