### PR TITLE
Add CreatePullRequest() to github pkg and clients

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -193,14 +193,9 @@ func (g *githubClient) ListTags(
 	}
 }
 
-// CreatePullRequest Creates a new pull request in owner/repo:baseBranch to merge changes from headBranchName
-// which is a string containing a branch in the same repository or a user:branch pair
 func (g *githubClient) CreatePullRequest(
 	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
 ) (*github.PullRequest, error) {
-
-	// headBranchName := fmt.Sprintf("%s:%s", owner, sourceBranch)
-
 	newPullRequest := &github.NewPullRequest{
 		Title:               &title,
 		Head:                &headBranchName,
@@ -214,8 +209,7 @@ func (g *githubClient) CreatePullRequest(
 		return pr, err
 	}
 
-	// sugar.Infof("PR created: %s\n", pr.GetHTMLURL())
-	logrus.Infof("Succesfully created PR #%d", pr.GetNumber())
+	logrus.Infof("Successfully created PR #%d", pr.GetNumber())
 	return pr, nil
 }
 
@@ -322,4 +316,18 @@ func (g *GitHub) Releases(owner, repo string, includePrereleases bool) ([]*githu
 	}
 
 	return releases, nil
+}
+
+// CreatePullRequest Creates a new pull request in owner/repo:baseBranch to merge changes from headBranchName
+// which is a string containing a branch in the same repository or a user:branch pair
+func (g *GitHub) CreatePullRequest(
+	owner, repo, baseBranchName, headBranchName, title, body string,
+) (*github.PullRequest, error) {
+	// Use the client to create a new PR
+	pr, err := g.Client().CreatePullRequest(context.Background(), owner, repo, baseBranchName, headBranchName, title, body)
+	if err != nil {
+		return pr, err
+	}
+
+	return pr, nil
 }

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -272,3 +272,18 @@ func TestReleasesFailed(t *testing.T) {
 	require.NotNil(t, err)
 	require.Nil(t, res, nil)
 }
+
+func TestCreatePullRequest(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	fakeID := int64(1234)
+	client.CreatePullRequestReturns(&gogithub.PullRequest{ID: &fakeID}, nil)
+
+	// When
+	pr, err := sut.CreatePullRequest("kubernetes-fake-org", "kubernetes-fake-repo", "master", "user:head-branch", "PR Title", "PR Body")
+
+	// Then
+	require.Nil(t, err)
+	require.NotNil(t, pr, nil)
+	require.Equal(t, fakeID, pr.GetID())
+}

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -723,4 +723,14 @@ func (fake *FakeClient) CreatePullRequest(
 	return fakeReturns.result1, fakeReturns.result2
 }
 
+func (fake *FakeClient) CreatePullRequestReturns(result1 *githuba.PullRequest, result2 error) {
+	fake.createPullRequestMutex.Lock()
+	defer fake.createPullRequestMutex.Unlock()
+	fake.CreatePullRequestStub = nil
+	fake.createPullRequestReturns = struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}{result1, result2}
+}
+
 var _ github.Client = new(FakeClient)

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -153,6 +153,26 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)
+	createPullRequestMutex       sync.RWMutex
+	createPullRequestArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
+		arg6 string
+		arg7 string
+	}
+	createPullRequestReturns struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}
+	createPullRequestReturnsOnCall map[int]struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}
+
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -675,6 +695,32 @@ func (fake *FakeClient) recordInvocation(key string, args []interface{}) {
 		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
+}
+
+func (fake *FakeClient) CreatePullRequest(
+	arg1 context.Context, arg2, arg3, arg4, arg5, arg6, arg7 string,
+) (*githuba.PullRequest, error) {
+	fake.createPullRequestMutex.Lock()
+	ret, specificReturn := fake.createPullRequestReturnsOnCall[len(fake.createPullRequestArgsForCall)]
+	fake.createPullRequestArgsForCall = append(fake.createPullRequestArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
+		arg6 string
+		arg7 string
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.createPullRequestMutex.Unlock()
+	if fake.CreatePullRequestStub != nil {
+		return fake.CreatePullRequestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.createPullRequestReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 var _ github.Client = new(FakeClient)

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -147,6 +147,13 @@ func (c *githubNotesRecordClient) ListTags(
 	return tags, resp, nil
 }
 
+func (c *githubNotesRecordClient) CreatePullRequest(
+	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
+) (*github.PullRequest, error) {
+
+	return &github.PullRequest{}, nil
+}
+
 // recordAPICall records a single GitHub API call into a JSON file by ensuring
 // naming conventions
 func (c *githubNotesRecordClient) recordAPICall(

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -150,7 +150,6 @@ func (c *githubNotesRecordClient) ListTags(
 func (c *githubNotesRecordClient) CreatePullRequest(
 	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
 ) (*github.PullRequest, error) {
-
 	return &github.PullRequest{}, nil
 }
 

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -135,6 +135,13 @@ func (c *githubNotesReplayClient) ListTags(
 	return result, record.response(), nil
 }
 
+func (c *githubNotesReplayClient) CreatePullRequest(
+	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
+) (*github.PullRequest, error) {
+
+	return &github.PullRequest{}, nil
+}
+
 func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error) {
 	c.replayMutex.Lock()
 	defer c.replayMutex.Unlock()

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -138,7 +138,6 @@ func (c *githubNotesReplayClient) ListTags(
 func (c *githubNotesReplayClient) CreatePullRequest(
 	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
 ) (*github.PullRequest, error) {
-
 	return &github.PullRequest{}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR enables creating Pull Requests in a GItHub repository from the github pkg. It adds a `CreatePullRequest()` func and its corresponding implementation in `github.Client`. It also adds noop functions in the replay and record packages to keep them compatible with the Client interface. Finally it adds some basic testing.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
I've split the PR in two commits:
1. The first one adds the implementation of the `CreatePullRequest()` func to the interface and the clients (the real one, fake, replay and record).
2. The second commit adds another `CreatePullRequest()` function to the github package and it's corresponding tests in `TestCreatePullRequest()`.

#### Does this PR introduce a user-facing change?
```release-note
Add `CreatePullRequest()` to the github package
```
