### PR TITLE
Make `MatchesExcludeFilter` and `MatchesIncludeFilter` public

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -199,31 +199,6 @@ func (g *Gatherer) ListReleaseNotes() (ReleaseNotes, ReleaseNotesHistory, error)
 			continue
 		}
 
-		// exclusionFilters is a list of regular expressions that match notes text that
-		// are deemed to have no content and should NOT be added to release notes.
-		exclusionFilters := []string{
-			"^(?i)(none|n/a)$", // 'none' or 'n/a' case insensitive
-		}
-		excluded := false
-		for _, filter := range exclusionFilters {
-			match, err := regexp.MatchString(filter, strings.ToUpper(strings.TrimSpace(note.Text)))
-			if err != nil {
-				return nil, nil, err
-			}
-			if match {
-				excluded = true
-				logrus.
-					WithField("sha", result.commit.GetSHA()).
-					WithField("func", "ListReleaseNotes").
-					WithField("filter", filter).
-					Debug("Excluding notes that are deemed to have no content based on filter, and should NOT be added to release notes.")
-				break
-			}
-		}
-		if excluded {
-			continue
-		}
-
 		if _, ok := dedupeCache[note.Text]; !ok {
 			notes[note.PrNumber] = note
 			history = append(history, note.PrNumber)
@@ -485,10 +460,6 @@ var noteExclusionFilters = []*regexp.Regexp{
 	// the 'none','n/a','na' can also optionally be wrapped in quotes ' or "
 	regexp.MustCompile("(?i)```(release-note[s]?\\s*)?('|\")?(none|n/a|na)?('|\")?\\s*```"),
 
-	// This filter is too aggressive within the PR body and picks up matches unrelated to release notes
-	// 'none' or 'n/a' case insensitive wrapped optionally with whitespace
-	// regexp.MustCompile("(?i)\\s*(none|n/a)\\s*"),
-
 	// simple '/release-note-none' tag
 	regexp.MustCompile("/release-note-none"),
 }
@@ -500,20 +471,23 @@ var noteInclusionFilters = []*regexp.Regexp{
 	regexp.MustCompile("Does this PR introduce a user-facing change?"),
 }
 
-func matchesFilter(msg string, filters []*regexp.Regexp) *regexp.Regexp {
-	for _, filter := range filters {
-		if filter.MatchString(msg) {
-			return filter
-		}
-	}
-	return nil
-}
-
-func matchesExcludeFilter(msg string) *regexp.Regexp {
+// MatchesExcludeFilter returns true if the string matches an excluded release note
+func MatchesExcludeFilter(msg string) bool {
 	return matchesFilter(msg, noteExclusionFilters)
 }
-func matchesIncludeFilter(msg string) *regexp.Regexp {
+
+// MatchesIncludeFilter returns true if the string matches an included release note
+func MatchesIncludeFilter(msg string) bool {
 	return matchesFilter(msg, noteInclusionFilters)
+}
+
+func matchesFilter(msg string, filters []*regexp.Regexp) bool {
+	for _, filter := range filters {
+		if filter.MatchString(msg) {
+			return true
+		}
+	}
+	return false
 }
 
 // gatherNotes list commits that have release notes starting from a given
@@ -598,23 +572,20 @@ func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, e
 			WithField("pr body", pr.GetBody()).
 			Debugf("Obtaining PR associated with commit sha %q", commit.GetSHA())
 
-		if re := matchesExcludeFilter(prBody); re != nil {
-			logrus.
-				WithField("func", "listCommitsWithNotes").
-				WithField("filter", re.String()).
-				Debug("Excluding notes for PR based on the exclusion filter.")
-			// try next PR
+		if MatchesExcludeFilter(prBody) {
+			logrus.Debugf(
+				"Excluding note for PR #%d based on the exclusion filter",
+				pr.GetNumber(),
+			)
 			continue
 		}
 
-		if re := matchesIncludeFilter(prBody); re != nil {
+		if MatchesIncludeFilter(prBody) {
 			res := &Result{commit: commit, pullRequest: pr}
-			logrus.
-				WithField("func", "listCommitsWithNotes").
-				WithField("filter", re.String()).
-				Debug("Including notes for PR based on the inclusion filter.")
-
-			// TODO is this really intentional?
+			logrus.Debugf(
+				"Including notes for PR #%d based on the inclusion filter",
+				pr.GetNumber(),
+			)
 			// Do not test further PRs for this commmit as soon as one PR matched
 			return res, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now make the  `MatchesExcludeFilter` and `MatchesIncludeFilter`
functions public within the notes package, because this way API
consumers can reuse this project for string matching on release notes.

We also cleanup another additional exclusion, which should not be needed
any more.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `MatchesExcludeFilter` and `MatchesIncludeFilter` public functions to `notes` package
```
