### PR TITLE
Remove deprecated FormatSpecMarkdown from notes options

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -347,7 +347,7 @@ func generateReleaseNotes(opts *changelogOptions, branch, startRev, endRev strin
 
 	markdown, err := doc.RenderMarkdownTemplate(
 		opts.bucket, opts.tars,
-		options.FormatSpecDefaultGoTemplateInline+releaseNotesTemplate,
+		options.FormatSpecGoTemplateInline+releaseNotesTemplate,
 	)
 	if err != nil {
 		return "", errors.Wrapf(

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -87,7 +87,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | release-tars            | RELEASE_TARS    |                     | No       | Directory of tars to sha512 sum for display                                                                                       |
 | **OUTPUT OPTIONS**      |
 | output                  | OUTPUT          |                     | No       | The path where the release notes will be written                                                                                  |
-| format                  | FORMAT          | go-template:default | Yes      | The format for notes output (options: json, go-template:path/to/template.file)                                                    |
+| format                  | FORMAT          | go-template:default | Yes      | The format for notes output (options: json, go-template:inline:<template-string> go-template:path/to/template.file)               |
 | release-version         | RELEASE_VERSION |                     | No       | The release version to tag the notes with                                                                                         |
 | **LOG OPTIONS**         |
 | debug                   | DEBUG           | false               | No       | Enable debug logging (options: true, false)                                                                                       |

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -152,9 +152,9 @@ func init() {
 		fmt.Sprintf("The format for notes output (options: %s)",
 			strings.Join([]string{
 				options.FormatSpecNone,
-				options.FormatSpecMarkdown, //nolint:golint,deprecated // This option internally corresponds to options.FormatSpecGoTemplateDefault
 				options.FormatSpecJSON,
 				options.FormatSpecDefaultGoTemplate,
+				options.FormatSpecGoTemplateInline,
 			}, ", "),
 		),
 	)
@@ -292,7 +292,7 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 		if err := enc.Encode(releaseNotes); err != nil {
 			return errors.Wrapf(err, "encoding JSON output")
 		}
-	case strings.HasPrefix(format, "go-template:"):
+	case strings.HasPrefix(format, options.GoTemplatePrefix):
 		doc, err := document.CreateDocument(releaseNotes, history)
 		if err != nil {
 			return errors.Wrapf(err, "creating release note document")

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -302,10 +302,10 @@ func (d *Document) template(templateSpec string) (string, error) {
 		return defaultReleaseNotesTemplate, nil
 	}
 
-	if !strings.HasPrefix(templateSpec, "go-template:") {
+	if !strings.HasPrefix(templateSpec, options.GoTemplatePrefix) {
 		return "", errors.Errorf("bad template format: expected format %q, got %q", "go-template:path/to/file.txt", templateSpec)
 	}
-	templatePathOrOnline := strings.TrimPrefix(templateSpec, "go-template:")
+	templatePathOrOnline := strings.TrimPrefix(templateSpec, options.GoTemplatePrefix)
 
 	if strings.HasPrefix(templatePathOrOnline, "inline:") {
 		return strings.TrimPrefix(templatePathOrOnline, "inline:"), nil

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -121,13 +121,11 @@ const (
 )
 
 const (
-	FormatSpecNone                    = ""
-	FormatSpecJSON                    = "json"
-	FormatSpecDefaultGoTemplate       = "go-template:default"
-	FormatSpecDefaultGoTemplateInline = "go-template:inline:"
-
-	// Deprecated: This option is internally translated to `FormatSpecDefaultGoTemplate`
-	FormatSpecMarkdown = "markdown"
+	FormatSpecNone              = ""
+	FormatSpecJSON              = "json"
+	FormatSpecDefaultGoTemplate = GoTemplatePrefix + "default"
+	FormatSpecGoTemplateInline  = GoTemplatePrefix + "inline:"
+	GoTemplatePrefix            = "go-template:"
 )
 
 // New creates a new Options instance with the default values
@@ -221,8 +219,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	}
 
 	// Set the format
-	// TODO: Remove "markdown" after some time as it is deprecated in PR#1008
-	if o.Format == FormatSpecMarkdown || o.Format == FormatSpecNone {
+	if o.Format == FormatSpecNone {
 		o.Format = FormatSpecDefaultGoTemplate
 	}
 

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -384,7 +384,7 @@ func TestValidateAndFinishSuccessDefaultTemplate(t *testing.T) {
 	defer options.testRepo.cleanup(t)
 
 	// Given
-	options.Format = FormatSpecMarkdown
+	options.Format = FormatSpecNone
 
 	// When
 	require.Nil(t, options.ValidateAndFinish())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
We now cleanup the rendering options and remove the deprecated
`FormatSpecMarkdown`. The `release-notes` (non krel) tool has been
adapted as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `--format go-template:inline:<template-string> options to `release-notes` tool
- Removed deprecated `FormatSpecMarkdown` from `options` package
```
