### PR TITLE
Add `document.GatherReleaseNotesDocument` and `notes.GatherReleaseNotes` API

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -327,23 +326,12 @@ func generateReleaseNotes(opts *changelogOptions, branch, startRev, endRev strin
 		return "", err
 	}
 
-	gatherer, err := notes.NewGatherer(context.Background(), notesOptions)
+	doc, err := document.GatherReleaseNotesDocument(
+		notesOptions, startRev, opts.tag,
+	)
 	if err != nil {
-		return "", errors.Wrapf(err, "retrieving notes gatherer")
+		return "", err
 	}
-
-	releaseNotes, history, err := gatherer.ListReleaseNotes()
-	if err != nil {
-		return "", errors.Wrapf(err, "listing release notes")
-	}
-
-	// Create the markdown
-	doc, err := document.CreateDocument(releaseNotes, history)
-	if err != nil {
-		return "", errors.Wrapf(err, "creating release note document")
-	}
-	doc.PreviousRevision = startRev
-	doc.CurrentRevision = opts.tag
 
 	markdown, err := doc.RenderMarkdownTemplate(
 		opts.bucket, opts.tars,

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -592,16 +591,14 @@ func releaseNotesJSON(tag string) (string, error) {
 	logrus.Infof("Using end tag %v", tag)
 
 	// Fetch the notes
-	gatherer, err := notes.NewGatherer(context.Background(), notesOptions)
+	releaseNotes, history, err := notes.GatherReleaseNotes(notesOptions)
 	if err != nil {
-		return "", errors.Wrapf(err, "retrieving notes gatherer")
-	}
-	releaseNotes, history, err := gatherer.ListReleaseNotes()
-	if err != nil {
-		return "", errors.Wrapf(err, "listing release notes")
+		return "", errors.Wrapf(err, "gathering release notes")
 	}
 
-	doc, err := document.CreateDocument(releaseNotes, history)
+	doc, err := document.New(
+		releaseNotes, history, notesOptions.StartRev, notesOptions.EndRev,
+	)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating release note document")
 	}
@@ -636,16 +633,14 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	logrus.Infof("Using end tag %v", releaseNotesOpts.tag)
 
 	// Fetch the notes
-	gatherer, err := notes.NewGatherer(context.Background(), notesOptions)
+	releaseNotes, history, err := notes.GatherReleaseNotes(notesOptions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "retrieving notes gatherer")
-	}
-	releaseNotes, history, err := gatherer.ListReleaseNotes()
-	if err != nil {
-		return nil, errors.Wrapf(err, "listing release notes")
+		return nil, errors.Wrapf(err, "gathering release notes")
 	}
 
-	doc, err := document.CreateDocument(releaseNotes, history)
+	doc, err := document.New(
+		releaseNotes, history, notesOptions.StartRev, notesOptions.EndRev,
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating release note document")
 	}

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -223,21 +222,6 @@ func init() {
 	)
 }
 
-func GetReleaseNotes() (notes.ReleaseNotes, notes.ReleaseNotesHistory, error) {
-	logrus.Info("fetching all commits. This might take a while...")
-
-	gatherer, err := notes.NewGatherer(context.Background(), opts)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "retrieving notes gatherer")
-	}
-	releaseNotes, history, err := gatherer.ListReleaseNotes()
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "listing release notes")
-	}
-
-	return releaseNotes, history, nil
-}
-
 func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNotesHistory) (err error) {
 	logrus.Info("got the commits, performing rendering")
 
@@ -293,15 +277,10 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 			return errors.Wrapf(err, "encoding JSON output")
 		}
 	case strings.HasPrefix(format, options.GoTemplatePrefix):
-		doc, err := document.CreateDocument(releaseNotes, history)
+		doc, err := document.New(releaseNotes, history, opts.StartRev, opts.EndRev)
 		if err != nil {
 			return errors.Wrapf(err, "creating release note document")
 		}
-
-		// TODO: Not sure these options are guaranteed to be set but we need
-		// them in rendering. Perhaps these should be set in CreateDocument()?
-		doc.PreviousRevision = opts.StartRev
-		doc.CurrentRevision = opts.EndRev
 
 		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, opts.Format)
 		if err != nil {
@@ -332,9 +311,9 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 }
 
 func run(*cobra.Command, []string) error {
-	releaseNotes, history, err := GetReleaseNotes()
+	releaseNotes, history, err := notes.GatherReleaseNotes(opts)
 	if err != nil {
-		return errors.Wrapf(err, "retrieving release notes")
+		return errors.Wrapf(err, "gathering release notes")
 	}
 
 	return WriteReleaseNotes(releaseNotes, history)

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -201,12 +201,35 @@ var kindMap = map[Kind]Kind{
 	KindFlake:      KindOther,
 }
 
-// CreateDocument assembles an organized document from an unorganized set of
-// release notes
-func CreateDocument(releaseNotes notes.ReleaseNotes, history notes.ReleaseNotesHistory) (*Document, error) {
+// GatherReleaseNotesDocument creates a new gatherer and collects the release
+// notes into a fresh document
+func GatherReleaseNotesDocument(
+	opts *options.Options, previousRev, currentRev string,
+) (*Document, error) {
+	releaseNotes, history, err := notes.GatherReleaseNotes(opts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "gathering release notes")
+	}
+
+	doc, err := New(releaseNotes, history, previousRev, currentRev)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating release note document")
+	}
+
+	return doc, nil
+}
+
+// New assembles an organized document from an unorganized set of release notes
+func New(
+	releaseNotes notes.ReleaseNotes,
+	history notes.ReleaseNotesHistory,
+	previousRev, currentRev string,
+) (*Document, error) {
 	doc := &Document{
 		NotesWithActionRequired: Notes{},
 		Notes:                   NoteCollection{},
+		CurrentRevision:         currentRev,
+		PreviousRevision:        previousRev,
 	}
 
 	stripRE := regexp.MustCompile(`^([-\*]+\s+)`)

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -256,7 +256,7 @@ func setupTestDir(t *testing.T, dir string) {
 	}
 }
 
-func TestCreateDocument(t *testing.T) {
+func TestNew(t *testing.T) {
 	type args struct {
 		releaseNotes notes.ReleaseNotes
 		history      notes.ReleaseNotesHistory
@@ -426,7 +426,7 @@ func TestCreateDocument(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateDocument(tt.args.releaseNotes, tt.args.history)
+			got, err := New(tt.args.releaseNotes, tt.args.history, "", "")
 			require.NoError(t, err)
 			require.Equal(t, got, tt.want, "Unexpected return.")
 		})
@@ -488,10 +488,8 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 			testNotes[11] = duplicate
 			testNotes[12] = actionNeeded
 
-			doc, err := CreateDocument(testNotes, makeReleaseNoteHistory(testNotes))
+			doc, err := New(testNotes, makeReleaseNoteHistory(testNotes), "v1.16.0", "v1.16.1")
 			require.NoError(t, err, "Creating test document.")
-			doc.PreviousRevision = "v1.16.0"
-			doc.CurrentRevision = "v1.16.1"
 
 			templateSpec := tt.templateSpec
 			var dir string

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -166,6 +166,24 @@ func NewGathererWithClient(ctx context.Context, c github.Client) *Gatherer {
 	}
 }
 
+// GatherReleaseNotes creates a new gatherer and collects the release notes
+// afterwards
+func GatherReleaseNotes(opts *options.Options) (ReleaseNotes, ReleaseNotesHistory, error) {
+	logrus.Info("Gathering release notes")
+	gatherer, err := NewGatherer(context.Background(), opts)
+
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "retrieving notes gatherer")
+	}
+
+	releaseNotes, history, err := gatherer.ListReleaseNotes()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "listing release notes")
+	}
+
+	return releaseNotes, history, nil
+}
+
 // ListReleaseNotes produces a list of fully contextualized release notes
 // starting from a given commit SHA and ending at starting a given commit SHA.
 func (g *Gatherer) ListReleaseNotes() (ReleaseNotes, ReleaseNotesHistory, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
This simplifies the usage of the pkg/notes and pkg/document packages by
introducting the two new API functions. The `CreateDocument` functions
is now simply called `New` and takes the start and end rev as additional
parameters.

All tests and API consumers have been adapted as well.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `document.GatherReleaseNotesDocument` and `notes.GatherReleaseNotes` API
- Changed `document.CreateDocument` to `document.New` which now needs a start and end tag for later rendering as well
```
