### PR TITLE
Remove unnecessary double check in releaselib.sh

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -163,16 +163,12 @@ release::set_build_version () {
     $(common::run_gobin blocking-testgrid-tests "$branch")
   )
 
-  if [[ -z ${all_jobs[*]} ]]; then
-    logecho "$FAILED: Curl to testgrid/config/config.yaml"
-  fi
-
-  local main_job="${all_jobs[0]}"
-
   if [[ -z "${all_jobs[*]}" ]]; then
     logecho "No sig-$branch-blocking list found in the testgrid config.yaml!"
     return 1
   fi
+
+  local main_job="${all_jobs[0]}"
 
   # Loop through the remainder, excluding anything specified by --exclude_suites
   for ((i=1;i<${#all_jobs[*]};i++)); do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We check if the all jobs array is set twice, so we now do it just once
and return in case of that error.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
