### PR TITLE
pkg/gcp: Swap GCloudExecutable and TarExecutable const values

### DIFF
--- a/anago
+++ b/anago
@@ -1781,7 +1781,7 @@ if ((FLAGS_stage)); then
   logecho
   logecho "To release this staged build, run:"
   logecho
-  logecho -n "$ krel gcbmgr --release ${EXTRA_FLAGS[*]} $RELEASE_BRANCH" \
+  logecho -n "$ krel gcbmgr --release ${EXTRA_FLAGS[*]} --branch $RELEASE_BRANCH" \
              "--build-version=$JENKINS_BUILD_VERSION"
   logecho
   logecho

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	GCloudExecutable = "tar"
+	GCloudExecutable = "gcloud"
 	GSUtilExecutable = "gsutil"
-	TarExecutable    = "gcloud"
+	TarExecutable    = "tar"
 )
 
 // PreCheck checks if all requirements are fulfilled to run this package and


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

**Releases are broken without this fix**

- pkg/gcp: Swap `GCloudExecutable` and `TarExecutable` const values
- anago: Add `--branch` to krel gcbmgr command tip

```
$ krel gcbmgr --stage
INFO Verifying repository state                   
INFO Found matching branch "master"               
INFO Found matching organization "kubernetes" and repository "release" in remote: origin (https://github.com/kubernetes/release) 
INFO Verifying remote HEAD commit                 
INFO Got remote commit: 569a07bc48cf52e25ba4b1f33772b0e1a5999b27 
INFO Verifying that remote commit is available locally 
INFO Repository is up-to-date                     
INFO Running gcbmgr with the following options: &{Stage:true Release:false Stream:false Branch:master ReleaseType:prerelease BuildVersion: GcpUser: LastJobs:5 Repo:0xc0004018f0 Version:0xc000401900} 
INFO Build options: {  cloudbuild.yaml   kubernetes-release-test false false false   } 
FATA command /bin/tar auth list --filter=status:ACTIVE --format=value(account) --verbosity=debug did not succeed: tar: You may not specify more than one '-Acdtrux', '--delete' or  '--test-label' option
Try 'tar --help' or 'tar --usage' for more information. 
```

/assign @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering 
/priority critical-urgent
ref: https://github.com/kubernetes/release/pull/1251

#### Does this PR introduce a user-facing change?

```release-note
- pkg/gcp: Swap GCloudExecutable and TarExecutable const values
- anago: Add '--branch' to krel gcbmgr command tip
```
