### PR TITLE
Fix setting start-rev in krel changelog

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -314,6 +314,7 @@ func generateReleaseNotes(opts *changelogOptions, branch, startRev, endRev strin
 
 	notesOptions := options.New()
 	notesOptions.Branch = branch
+	notesOptions.StartRev = startRev
 	notesOptions.EndSHA = endRev
 	notesOptions.RepoPath = rootOpts.repoPath
 	notesOptions.ReleaseBucket = opts.bucket
@@ -324,7 +325,7 @@ func generateReleaseNotes(opts *changelogOptions, branch, startRev, endRev strin
 	notesOptions.Pull = false
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "validating notes options")
 	}
 
 	gatherer, err := notes.NewGatherer(context.Background(), notesOptions)

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -195,7 +195,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 		if o.StartRev != "" && o.StartSHA == "" {
 			sha, err := repo.RevParse(o.StartRev)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "resolving %s", o.StartRev)
 			}
 			logrus.Infof("using found start SHA: %s", sha)
 			o.StartSHA = sha
@@ -203,7 +203,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 		if o.EndRev != "" && o.EndSHA == "" {
 			sha, err := repo.RevParse(o.EndRev)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "resolving %s", o.EndRev)
 			}
 			logrus.Infof("using found end SHA: %s", sha)
 			o.EndSHA = sha


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
It's not possible to omit the start revision in krel changelog so we have to add them to the notes options.

#### Which issue(s) this PR fixes:

Fixes #1276

#### Special notes for your reviewer:
Unfortunately those kind of issues are not easy to test without a real repository within an integration-like environment. Our current tests shadow such bugs because they use the fake-recorded GitHub API.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed `krel changelog` start revision retrieval issue (#1276)
```
