### PR TITLE
k8s-cloud-builder: Build images on kube-cross v1.14.2-4 and v1.13.9-5

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,9 +1,9 @@
 variants:
   cross1.14:
     CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.2-1'
+    KUBE_CROSS_VERSION: 'v1.14.2-4'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.13:
     CONFIG: 'cross1.13'
-    KUBE_CROSS_VERSION: 'v1.13.9-2'
+    KUBE_CROSS_VERSION: 'v1.13.9-5'
     SKOPEO_VERSION: 'v0.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**Unblocks Kubernetes releases**

Now that kube-cross v1.14.2-4 and v1.13.9-5 have been promoted in https://github.com/kubernetes/k8s.io/pull/860 (ref: https://github.com/kubernetes/release/pull/1279), we should rebuild the k8s-cloud-builder images to get their versioning back in sync with the `kube-cross` version.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/priority critical-urgent
/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build images on kube-cross v1.14.2-4 and v1.13.9-5
```
