### PR TITLE
Make kubepkg tests independent from the internet

### DIFF
--- a/cmd/kubepkg/cmd/debs.go
+++ b/cmd/kubepkg/cmd/debs.go
@@ -19,14 +19,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	kpkg "k8s.io/release/pkg/kubepkg"
+	"k8s.io/release/pkg/kubepkg"
 )
-
-type debsOptions struct {
-}
-
-// TODO: Determine if we need debsOpts
-var debsOpts = &debsOptions{} // nolint: deadcode,varcheck,unused
 
 // debsCmd represents the base command when called without any subcommands
 var debsCmd = &cobra.Command{
@@ -39,18 +33,10 @@ var debsCmd = &cobra.Command{
 		return rootOpts.validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		return runDebs(rootOpts)
+		return run(rootOpts, kubepkg.BuildDeb)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(debsCmd)
-}
-
-func runDebs(ro *rootOptions) error {
-	builds, err := kpkg.ConstructBuilds("deb", ro.packages, ro.channels, ro.kubeVersion, ro.revision, ro.cniVersion, ro.criToolsVersion, ro.templateDir)
-	if err != nil {
-		return err
-	}
-	return kpkg.WalkBuilds(builds, ro.architectures, ro.specOnly)
 }

--- a/cmd/kubepkg/cmd/root.go
+++ b/cmd/kubepkg/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"k8s.io/release/pkg/kubepkg"
 	kpkg "k8s.io/release/pkg/kubepkg"
 	"k8s.io/release/pkg/log"
 	"k8s.io/release/pkg/util"
@@ -155,4 +156,16 @@ func (r *rootOptions) validate() error {
 	r.kubeVersion = util.TrimTagPrefix(r.kubeVersion)
 
 	return nil
+}
+
+func run(ro *rootOptions, buildType kubepkg.BuildType) error {
+	client := kubepkg.New()
+	builds, err := client.ConstructBuilds(
+		buildType, ro.packages, ro.channels, ro.kubeVersion, ro.revision,
+		ro.cniVersion, ro.criToolsVersion, ro.templateDir,
+	)
+	if err != nil {
+		return errors.Wrap(err, "running kubepkg")
+	}
+	return client.WalkBuilds(builds, ro.architectures, ro.specOnly)
 }

--- a/cmd/kubepkg/cmd/rpms.go
+++ b/cmd/kubepkg/cmd/rpms.go
@@ -19,14 +19,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	kpkg "k8s.io/release/pkg/kubepkg"
+	"k8s.io/release/pkg/kubepkg"
 )
-
-type rpmsOptions struct {
-}
-
-// TODO: Determine if we need rpmsOpts
-var rpmsOpts = &rpmsOptions{} // nolint: deadcode,varcheck,unused
 
 // rpmsCmd represents the base command when called without any subcommands
 var rpmsCmd = &cobra.Command{
@@ -39,18 +33,10 @@ var rpmsCmd = &cobra.Command{
 		return rootOpts.validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		return runRpms(rootOpts)
+		return run(rootOpts, kubepkg.BuildRpm)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(rpmsCmd)
-}
-
-func runRpms(ro *rootOptions) error {
-	builds, err := kpkg.ConstructBuilds("rpm", ro.packages, ro.channels, ro.kubeVersion, ro.revision, ro.cniVersion, ro.criToolsVersion, ro.templateDir)
-	if err != nil {
-		return err
-	}
-	return kpkg.WalkBuilds(builds, ro.architectures, ro.specOnly)
 }

--- a/pkg/kubepkg/BUILD.bazel
+++ b/pkg/kubepkg/BUILD.bazel
@@ -37,5 +37,9 @@ go_test(
     name = "go_default_test",
     srcs = ["kubepkg_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//require:go_default_library"],
+    deps = [
+        "//pkg/github/githubfakes:go_default_library",
+        "//pkg/release/releasefakes:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -20,7 +20,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/github/githubfakes"
+	"k8s.io/release/pkg/release/releasefakes"
 )
+
+func newSUT() *Client {
+	sut := New()
+
+	githubMock := &githubfakes.FakeClient{}
+	sut.github.SetClient(githubMock)
+
+	versionMock := &releasefakes.FakeVersionClient{}
+	sut.version.SetClient(versionMock)
+
+	return sut
+}
 
 func TestGetPackageVersionSuccess(t *testing.T) {
 	testcases := []struct {
@@ -59,8 +74,9 @@ func TestGetPackageVersionSuccess(t *testing.T) {
 		},
 	}
 
+	sut := newSUT()
 	for _, tc := range testcases {
-		actual, err := getPackageVersion(
+		actual, err := sut.getPackageVersion(
 			&PackageDefinition{
 				Name:              tc.packageName,
 				Version:           tc.version,
@@ -68,16 +84,14 @@ func TestGetPackageVersionSuccess(t *testing.T) {
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetPackageVersionFailure(t *testing.T) {
-	_, err := getPackageVersion(nil)
+	sut := newSUT()
+	_, err := sut.getPackageVersion(nil)
 	require.NotNil(t, err)
 }
 
@@ -99,24 +113,23 @@ func TestGetKubernetesVersionSuccess(t *testing.T) {
 		},
 	}
 
+	sut := newSUT()
 	for _, tc := range testcases {
-		actual, err := getKubernetesVersion(
+		actual, err := sut.getKubernetesVersion(
 			&PackageDefinition{
 				Version:           tc.version,
 				KubernetesVersion: tc.kubeVersion,
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetKubernetesVersionFailure(t *testing.T) {
-	_, err := getKubernetesVersion(nil)
+	sut := newSUT()
+	_, err := sut.getKubernetesVersion(nil)
 	require.NotNil(t, err)
 }
 
@@ -154,10 +167,7 @@ func TestGetCNIVersionSuccess(t *testing.T) {
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
@@ -186,24 +196,23 @@ func TestGetCRIToolsVersionSuccess(t *testing.T) {
 		},
 	}
 
+	sut := newSUT()
 	for _, tc := range testcases {
-		actual, err := getCRIToolsVersion(
+		actual, err := sut.getCRIToolsVersion(
 			&PackageDefinition{
 				Version:           tc.version,
 				KubernetesVersion: tc.kubeVersion,
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCRIToolsVersionFailure(t *testing.T) {
-	_, err := getCRIToolsVersion(nil)
+	sut := newSUT()
+	_, err := sut.getCRIToolsVersion(nil)
 	require.NotNil(t, err)
 }
 
@@ -227,24 +236,23 @@ func TestGetDownloadLinkBaseSuccess(t *testing.T) {
 		},
 	}
 
+	sut := newSUT()
 	for _, tc := range testcases {
-		actual, err := getDownloadLinkBase(
+		actual, err := sut.getDownloadLinkBase(
 			&PackageDefinition{
 				KubernetesVersion: tc.kubeVersion,
 				Channel:           tc.channel,
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetDownloadLinkBaseFailure(t *testing.T) {
-	_, err := getDownloadLinkBase(nil)
+	sut := newSUT()
+	_, err := sut.getDownloadLinkBase(nil)
 	require.NotNil(t, err)
 }
 
@@ -261,23 +269,22 @@ func TestGetCIBuildsDownloadLinkBaseSuccess(t *testing.T) {
 		},
 	}
 
+	sut := newSUT()
 	for _, tc := range testcases {
-		actual, err := getCIBuildsDownloadLinkBase(
+		actual, err := sut.getCIBuildsDownloadLinkBase(
 			&PackageDefinition{
 				KubernetesVersion: tc.kubeVersion,
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
 
 func TestGetCIBuildsDownloadLinkBaseFailure(t *testing.T) {
-	_, err := getCIBuildsDownloadLinkBase(nil)
+	sut := newSUT()
+	_, err := sut.getCIBuildsDownloadLinkBase(nil)
 	require.NotNil(t, err)
 }
 
@@ -306,10 +313,7 @@ func TestGetDefaultReleaseDownloadLinkBaseSuccess(t *testing.T) {
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
@@ -351,10 +355,7 @@ func TestGetDependenciesSuccess(t *testing.T) {
 			},
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }
@@ -393,10 +394,7 @@ func TestGetCNIDownloadLinkSuccess(t *testing.T) {
 			tc.arch,
 		)
 
-		if err != nil {
-			t.Fatalf("did not expect an error: %v", err)
-		}
-
+		require.Nil(t, err)
 		require.Equal(t, tc.expected, actual)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change
/kind failing-test

#### What this PR does / why we need it:
We now use the already existing mock clients to avoid internet access
during the test execution. This now allows further test enhancements to
increase the overall test coverage of the kubepkg package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/release/issues/1000

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `kubepkg.Client` struct type to allow better encapsulation (has to be created via `kubepkg.New()`)
```
