### PR TITLE
Verify non dirty or mismatched k/release checkouts

### DIFF
--- a/pkg/git/BUILD.bazel
+++ b/pkg/git/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "@com_github_go_git_go_git_v5//:go_default_library",
         "@com_github_go_git_go_git_v5//config:go_default_library",
         "@com_github_go_git_go_git_v5//plumbing/object:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -842,3 +842,26 @@ func TestBranchFailure(t *testing.T) {
 	require.NotNil(t, err)
 	require.Empty(t, res)
 }
+
+func TestIsDirtySuccess(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	dirty, err := testRepo.sut.IsDirty()
+	require.Nil(t, err)
+	require.False(t, dirty)
+}
+
+func TestIsDirtyFailure(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	require.Nil(t, ioutil.WriteFile(
+		filepath.Join(testRepo.sut.Dir(), "any-file"),
+		[]byte("test"), os.FileMode(0755)),
+	)
+
+	dirty, err := testRepo.sut.IsDirty()
+	require.Nil(t, err)
+	require.True(t, dirty)
+}

--- a/pkg/git/gitfakes/fake_worktree.go
+++ b/pkg/git/gitfakes/fake_worktree.go
@@ -64,6 +64,18 @@ type FakeWorktree struct {
 		result1 plumbing.Hash
 		result2 error
 	}
+	StatusStub        func() (gita.Status, error)
+	statusMutex       sync.RWMutex
+	statusArgsForCall []struct {
+	}
+	statusReturns struct {
+		result1 gita.Status
+		result2 error
+	}
+	statusReturnsOnCall map[int]struct {
+		result1 gita.Status
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -255,6 +267,61 @@ func (fake *FakeWorktree) CommitReturnsOnCall(i int, result1 plumbing.Hash, resu
 	}{result1, result2}
 }
 
+func (fake *FakeWorktree) Status() (gita.Status, error) {
+	fake.statusMutex.Lock()
+	ret, specificReturn := fake.statusReturnsOnCall[len(fake.statusArgsForCall)]
+	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Status", []interface{}{})
+	fake.statusMutex.Unlock()
+	if fake.StatusStub != nil {
+		return fake.StatusStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.statusReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeWorktree) StatusCallCount() int {
+	fake.statusMutex.RLock()
+	defer fake.statusMutex.RUnlock()
+	return len(fake.statusArgsForCall)
+}
+
+func (fake *FakeWorktree) StatusCalls(stub func() (gita.Status, error)) {
+	fake.statusMutex.Lock()
+	defer fake.statusMutex.Unlock()
+	fake.StatusStub = stub
+}
+
+func (fake *FakeWorktree) StatusReturns(result1 gita.Status, result2 error) {
+	fake.statusMutex.Lock()
+	defer fake.statusMutex.Unlock()
+	fake.StatusStub = nil
+	fake.statusReturns = struct {
+		result1 gita.Status
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeWorktree) StatusReturnsOnCall(i int, result1 gita.Status, result2 error) {
+	fake.statusMutex.Lock()
+	defer fake.statusMutex.Unlock()
+	fake.StatusStub = nil
+	if fake.statusReturnsOnCall == nil {
+		fake.statusReturnsOnCall = make(map[int]struct {
+			result1 gita.Status
+			result2 error
+		})
+	}
+	fake.statusReturnsOnCall[i] = struct {
+		result1 gita.Status
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeWorktree) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -264,6 +331,8 @@ func (fake *FakeWorktree) Invocations() map[string][][]interface{} {
 	defer fake.checkoutMutex.RUnlock()
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
+	fake.statusMutex.RLock()
+	defer fake.statusMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/release/releasefakes/fake_repository.go
+++ b/pkg/release/releasefakes/fake_repository.go
@@ -25,19 +25,6 @@ import (
 )
 
 type FakeRepository struct {
-	BranchStub        func(...string) (string, error)
-	branchMutex       sync.RWMutex
-	branchArgsForCall []struct {
-		arg1 []string
-	}
-	branchReturns struct {
-		result1 string
-		result2 error
-	}
-	branchReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
-	}
 	CurrentBranchStub        func() (string, error)
 	currentBranchMutex       sync.RWMutex
 	currentBranchArgsForCall []struct {
@@ -61,6 +48,30 @@ type FakeRepository struct {
 	}
 	describeReturnsOnCall map[int]struct {
 		result1 string
+		result2 error
+	}
+	HeadStub        func() (string, error)
+	headMutex       sync.RWMutex
+	headArgsForCall []struct {
+	}
+	headReturns struct {
+		result1 string
+		result2 error
+	}
+	headReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
+	IsDirtyStub        func() (bool, error)
+	isDirtyMutex       sync.RWMutex
+	isDirtyArgsForCall []struct {
+	}
+	isDirtyReturns struct {
+		result1 bool
+		result2 error
+	}
+	isDirtyReturnsOnCall map[int]struct {
+		result1 bool
 		result2 error
 	}
 	LsRemoteStub        func(...string) (string, error)
@@ -90,69 +101,6 @@ type FakeRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeRepository) Branch(arg1 ...string) (string, error) {
-	fake.branchMutex.Lock()
-	ret, specificReturn := fake.branchReturnsOnCall[len(fake.branchArgsForCall)]
-	fake.branchArgsForCall = append(fake.branchArgsForCall, struct {
-		arg1 []string
-	}{arg1})
-	fake.recordInvocation("Branch", []interface{}{arg1})
-	fake.branchMutex.Unlock()
-	if fake.BranchStub != nil {
-		return fake.BranchStub(arg1...)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.branchReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeRepository) BranchCallCount() int {
-	fake.branchMutex.RLock()
-	defer fake.branchMutex.RUnlock()
-	return len(fake.branchArgsForCall)
-}
-
-func (fake *FakeRepository) BranchCalls(stub func(...string) (string, error)) {
-	fake.branchMutex.Lock()
-	defer fake.branchMutex.Unlock()
-	fake.BranchStub = stub
-}
-
-func (fake *FakeRepository) BranchArgsForCall(i int) []string {
-	fake.branchMutex.RLock()
-	defer fake.branchMutex.RUnlock()
-	argsForCall := fake.branchArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeRepository) BranchReturns(result1 string, result2 error) {
-	fake.branchMutex.Lock()
-	defer fake.branchMutex.Unlock()
-	fake.BranchStub = nil
-	fake.branchReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeRepository) BranchReturnsOnCall(i int, result1 string, result2 error) {
-	fake.branchMutex.Lock()
-	defer fake.branchMutex.Unlock()
-	fake.BranchStub = nil
-	if fake.branchReturnsOnCall == nil {
-		fake.branchReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
-		})
-	}
-	fake.branchReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeRepository) CurrentBranch() (string, error) {
@@ -269,6 +217,116 @@ func (fake *FakeRepository) DescribeReturnsOnCall(i int, result1 string, result2
 	}
 	fake.describeReturnsOnCall[i] = struct {
 		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) Head() (string, error) {
+	fake.headMutex.Lock()
+	ret, specificReturn := fake.headReturnsOnCall[len(fake.headArgsForCall)]
+	fake.headArgsForCall = append(fake.headArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Head", []interface{}{})
+	fake.headMutex.Unlock()
+	if fake.HeadStub != nil {
+		return fake.HeadStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.headReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) HeadCallCount() int {
+	fake.headMutex.RLock()
+	defer fake.headMutex.RUnlock()
+	return len(fake.headArgsForCall)
+}
+
+func (fake *FakeRepository) HeadCalls(stub func() (string, error)) {
+	fake.headMutex.Lock()
+	defer fake.headMutex.Unlock()
+	fake.HeadStub = stub
+}
+
+func (fake *FakeRepository) HeadReturns(result1 string, result2 error) {
+	fake.headMutex.Lock()
+	defer fake.headMutex.Unlock()
+	fake.HeadStub = nil
+	fake.headReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) HeadReturnsOnCall(i int, result1 string, result2 error) {
+	fake.headMutex.Lock()
+	defer fake.headMutex.Unlock()
+	fake.HeadStub = nil
+	if fake.headReturnsOnCall == nil {
+		fake.headReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.headReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) IsDirty() (bool, error) {
+	fake.isDirtyMutex.Lock()
+	ret, specificReturn := fake.isDirtyReturnsOnCall[len(fake.isDirtyArgsForCall)]
+	fake.isDirtyArgsForCall = append(fake.isDirtyArgsForCall, struct {
+	}{})
+	fake.recordInvocation("IsDirty", []interface{}{})
+	fake.isDirtyMutex.Unlock()
+	if fake.IsDirtyStub != nil {
+		return fake.IsDirtyStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.isDirtyReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) IsDirtyCallCount() int {
+	fake.isDirtyMutex.RLock()
+	defer fake.isDirtyMutex.RUnlock()
+	return len(fake.isDirtyArgsForCall)
+}
+
+func (fake *FakeRepository) IsDirtyCalls(stub func() (bool, error)) {
+	fake.isDirtyMutex.Lock()
+	defer fake.isDirtyMutex.Unlock()
+	fake.IsDirtyStub = stub
+}
+
+func (fake *FakeRepository) IsDirtyReturns(result1 bool, result2 error) {
+	fake.isDirtyMutex.Lock()
+	defer fake.isDirtyMutex.Unlock()
+	fake.IsDirtyStub = nil
+	fake.isDirtyReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) IsDirtyReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isDirtyMutex.Lock()
+	defer fake.isDirtyMutex.Unlock()
+	fake.IsDirtyStub = nil
+	if fake.isDirtyReturnsOnCall == nil {
+		fake.isDirtyReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isDirtyReturnsOnCall[i] = struct {
+		result1 bool
 		result2 error
 	}{result1, result2}
 }
@@ -394,12 +452,14 @@ func (fake *FakeRepository) RemotesReturnsOnCall(i int, result1 []*git.Remote, r
 func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.branchMutex.RLock()
-	defer fake.branchMutex.RUnlock()
 	fake.currentBranchMutex.RLock()
 	defer fake.currentBranchMutex.RUnlock()
 	fake.describeMutex.RLock()
 	defer fake.describeMutex.RUnlock()
+	fake.headMutex.RLock()
+	defer fake.headMutex.RUnlock()
+	fake.isDirtyMutex.RLock()
+	defer fake.isDirtyMutex.RUnlock()
 	fake.lsRemoteMutex.RLock()
 	defer fake.lsRemoteMutex.RUnlock()
 	fake.remotesMutex.RLock()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now verify that the worktree is neither dirty nor diverged from the
    latest remote commit. This introduces a new API function
    `git.IsDirty()` as well as updates all surrounding tests.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/release/issues/1278

#### Special notes for your reviewer:
Requires https://github.com/kubernetes/release/pull/1283
/hold
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `git.IsDirty()` method to verify the state of a local repository
- `krel gcbmgr` now verifies that the local copy of k/release is neither dirty nor diverged with the latest remote commit
```
