### PR TITLE
Refactor kubepkg options into own package

### DIFF
--- a/cmd/kubepkg/cmd/debs.go
+++ b/cmd/kubepkg/cmd/debs.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/kubepkg"
+	"k8s.io/release/pkg/kubepkg/options"
 )
 
 // debsCmd represents the base command when called without any subcommands
@@ -30,10 +30,11 @@ var debsCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PreRunE: func(*cobra.Command, []string) error {
-		return rootOpts.validate()
+		return opts.Validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		return run(rootOpts, kubepkg.BuildDeb)
+		opts = opts.WithBuildType(options.BuildDeb)
+		return run(opts)
 	},
 }
 

--- a/cmd/kubepkg/cmd/rpms.go
+++ b/cmd/kubepkg/cmd/rpms.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/kubepkg"
+	"k8s.io/release/pkg/kubepkg/options"
 )
 
 // rpmsCmd represents the base command when called without any subcommands
@@ -30,10 +30,11 @@ var rpmsCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PreRunE: func(*cobra.Command, []string) error {
-		return rootOpts.validate()
+		return opts.Validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		return run(rootOpts, kubepkg.BuildRpm)
+		opts = opts.WithBuildType(options.BuildRpm)
+		return run(opts)
 	},
 }
 

--- a/pkg/kubepkg/BUILD.bazel
+++ b/pkg/kubepkg/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/command:go_default_library",
         "//pkg/github:go_default_library",
+        "//pkg/kubepkg/options:go_default_library",
         "//pkg/release:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_blang_semver//:go_default_library",
@@ -28,7 +29,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/kubepkg/options:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )
@@ -39,6 +43,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/github/githubfakes:go_default_library",
+        "//pkg/kubepkg/options:go_default_library",
         "//pkg/release/releasefakes:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/release/pkg/github/githubfakes"
+	"k8s.io/release/pkg/kubepkg/options"
 	"k8s.io/release/pkg/release/releasefakes"
 )
 
 func newSUT() *Client {
-	sut := New()
+	opts := options.New()
+	sut := New(opts)
 
 	githubMock := &githubfakes.FakeClient{}
 	sut.github.SetClient(githubMock)
@@ -402,68 +404,4 @@ func TestGetCNIDownloadLinkSuccess(t *testing.T) {
 func TestGetCNIDownloadLinkFailure(t *testing.T) {
 	_, err := getCNIDownloadLink(nil, "amd64")
 	require.NotNil(t, err)
-}
-
-func TestIsSupportedSuccess(t *testing.T) {
-	testcases := []struct {
-		name     string
-		input    []string
-		check    []string
-		expected bool
-	}{
-		{
-			name: "single input",
-			input: []string{
-				"kubelet",
-			},
-			check:    SupportedPackages,
-			expected: true,
-		},
-		{
-			name: "multiple inputs",
-			input: []string{
-				"release",
-				"testing",
-			},
-			check:    SupportedChannels,
-			expected: true,
-		},
-		{
-			name:     "no inputs",
-			input:    []string{},
-			check:    SupportedArchitectures,
-			expected: true,
-		},
-	}
-
-	for _, tc := range testcases {
-		actual := IsSupported(tc.input, tc.check)
-
-		require.Equal(t, tc.expected, actual)
-	}
-}
-
-func TestIsSupportedFailure(t *testing.T) {
-	testcases := []struct {
-		name     string
-		input    []string
-		check    []string
-		expected bool
-	}{
-		{
-			name: "some supported, some unsupported",
-			input: []string{
-				"fakearch",
-				"amd64",
-			},
-			check:    SupportedArchitectures,
-			expected: true,
-		},
-	}
-
-	for _, tc := range testcases {
-		actual := IsSupported(tc.input, tc.check)
-
-		require.NotEqual(t, tc.expected, actual)
-	}
 }

--- a/pkg/kubepkg/options/BUILD.bazel
+++ b/pkg/kubepkg/options/BUILD.bazel
@@ -1,22 +1,22 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "debs.go",
-        "root.go",
-        "rpms.go",
-    ],
-    importpath = "k8s.io/release/cmd/kubepkg/cmd",
+    srcs = ["options.go"],
+    importpath = "k8s.io/release/pkg/kubepkg/options",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/kubepkg:go_default_library",
-        "//pkg/kubepkg/options:go_default_library",
-        "//pkg/log:go_default_library",
+        "//pkg/util:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_github_spf13_cobra//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["options_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//require:go_default_library"],
 )
 
 filegroup(

--- a/pkg/kubepkg/options/options.go
+++ b/pkg/kubepkg/options/options.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"path/filepath"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/util"
+)
+
+type Options struct {
+	buildType BuildType
+
+	revision        string
+	kubeVersion     string
+	cniVersion      string
+	criToolsVersion string
+
+	packages      []string
+	channels      []string
+	architectures []string
+
+	releaseDownloadLinkBase string
+
+	templateDir string
+	specOnly    bool
+}
+
+type BuildType string
+
+const (
+	BuildDeb BuildType = "deb"
+	BuildRpm BuildType = "rpm"
+	BuildAll BuildType = "all"
+
+	DefaultReleaseDownloadLinkBase = "https://dl.k8s.io"
+
+	defaultRevision = "0"
+	templateRootDir = "templates"
+)
+
+var (
+	supportedPackages = []string{
+		"kubelet", "kubectl", "kubeadm", "kubernetes-cni", "cri-tools",
+	}
+	supportedChannels = []string{
+		"release", "testing", "nightly",
+	}
+	supportedArchitectures = []string{
+		"amd64", "arm", "arm64", "ppc64le", "s390x",
+	}
+	latestTemplateDir = filepath.Join(templateRootDir, "latest")
+)
+
+func New() *Options {
+	return &Options{
+		revision:                defaultRevision,
+		packages:                supportedPackages,
+		channels:                supportedChannels,
+		architectures:           supportedArchitectures,
+		releaseDownloadLinkBase: DefaultReleaseDownloadLinkBase,
+		templateDir:             latestTemplateDir,
+	}
+}
+
+func (o *Options) WithBuildType(buildType BuildType) *Options {
+	o.buildType = buildType
+	return o
+}
+
+func (o *Options) WithRevision(revision string) *Options {
+	o.revision = revision
+	return o
+}
+
+func (o *Options) WithKubeVersion(kubeVersion string) *Options {
+	o.kubeVersion = kubeVersion
+	return o
+}
+
+func (o *Options) WithCNIVersion(cniVersion string) *Options {
+	o.cniVersion = cniVersion
+	return o
+}
+
+func (o *Options) WithCRIToolsVersion(criToolsVersion string) *Options {
+	o.criToolsVersion = criToolsVersion
+	return o
+}
+
+func (o *Options) WithPackages(packages ...string) *Options {
+	o.packages = packages
+	return o
+}
+
+func (o *Options) WithChannels(channels ...string) *Options {
+	o.channels = channels
+	return o
+}
+
+func (o *Options) WithArchitectures(architectures ...string) *Options {
+	o.architectures = architectures
+	return o
+}
+
+func (o *Options) WithReleaseDownloadLinkBase(releaseDownloadLinkBase string) *Options {
+	o.releaseDownloadLinkBase = releaseDownloadLinkBase
+	return o
+}
+
+func (o *Options) WithTemplateDir(templateDir string) *Options {
+	o.templateDir = templateDir
+	return o
+}
+
+func (o *Options) WithSpecOnly(specOnly bool) *Options {
+	o.specOnly = specOnly
+	return o
+}
+
+func (o *Options) BuildType() BuildType {
+	return o.buildType
+}
+
+func (o *Options) Revision() string {
+	return o.revision
+}
+
+func (o *Options) KubeVersion() string {
+	return o.kubeVersion
+}
+
+func (o *Options) CNIVersion() string {
+	return o.cniVersion
+}
+
+func (o *Options) CRIToolsVersion() string {
+	return o.criToolsVersion
+}
+
+func (o *Options) Packages() []string {
+	return o.packages
+}
+
+func (o *Options) Channels() []string {
+	return o.channels
+}
+
+func (o *Options) Architectures() []string {
+	return o.architectures
+}
+
+func (o *Options) ReleaseDownloadLinkBase() string {
+	return o.releaseDownloadLinkBase
+}
+
+func (o *Options) TemplateDir() string {
+	return o.templateDir
+}
+
+func (o *Options) SpecOnly() bool {
+	return o.specOnly
+}
+
+// Validate verifies if all set options are valid
+func (o *Options) Validate() error {
+	if ok := isSupported(o.packages, supportedPackages); !ok {
+		return errors.New("package selections are not supported")
+	}
+	if ok := isSupported(o.channels, supportedChannels); !ok {
+		return errors.New("channel selections are not supported")
+	}
+	if ok := isSupported(o.architectures, supportedArchitectures); !ok {
+		return errors.New("architectures selections are not supported")
+	}
+
+	// Replace the "+" with a "-" to make it semver-compliant
+	o.kubeVersion = util.TrimTagPrefix(o.kubeVersion)
+
+	return nil
+}
+
+// TODO: kubepkg is failing validations when multiple options are selected
+//       It seems like StringArrayVar is treating the multiple comma-separated
+//       values as a single value.
+//
+// Example:
+// $ time kubepkg debs --arch amd64,arm
+// <snip>
+// INFO[0000] Adding 'amd64,arm' (type: string) to not supported
+// INFO[0000] The following options are not supported: [amd64,arm]
+// FATA[0000] architectures selections are not supported
+func isSupported(input, expected []string) bool {
+	notSupported := []string{}
+
+	supported := false
+	for _, i := range input {
+		supported = false
+		for _, j := range expected {
+			if i == j {
+				supported = true
+				break
+			}
+		}
+
+		if !supported {
+			logrus.Infof(
+				"Adding %q (type: %v) to not supported", i, reflect.TypeOf(i),
+			)
+			notSupported = append(notSupported, i)
+		}
+	}
+
+	if len(notSupported) > 0 {
+		logrus.Infof(
+			"The following options are not supported: %v", notSupported,
+		)
+		return false
+	}
+
+	return true
+}

--- a/pkg/kubepkg/options/options_test.go
+++ b/pkg/kubepkg/options/options_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptions(t *testing.T) {
+	str := "test-string"
+	slice := []string{str, str, str}
+
+	sut := New()
+
+	require.Equal(t, BuildDeb, sut.WithBuildType(BuildDeb).BuildType())
+	require.Equal(t, str, sut.WithRevision(str).Revision())
+	require.Equal(t, str, sut.WithKubeVersion(str).KubeVersion())
+	require.Equal(t, str, sut.WithCNIVersion(str).CNIVersion())
+	require.Equal(t, str, sut.WithCRIToolsVersion(str).CRIToolsVersion())
+	require.Equal(t, slice, sut.WithPackages(slice...).Packages())
+	require.Equal(t, slice, sut.WithChannels(slice...).Channels())
+	require.Equal(t, slice, sut.WithArchitectures(slice...).Architectures())
+	require.Equal(t, str, sut.WithReleaseDownloadLinkBase(str).ReleaseDownloadLinkBase())
+	require.Equal(t, str, sut.WithTemplateDir(str).TemplateDir())
+	require.Equal(t, true, sut.WithSpecOnly(true).SpecOnly())
+}
+
+func TestValidateSuccess(t *testing.T) {
+	require.Nil(t, New().Validate())
+}
+
+func TestValidateFailureWrongPackage(t *testing.T) {
+	require.NotNil(t, New().WithPackages("wrong").Validate())
+}
+
+func TestValidateFailureWrongChannel(t *testing.T) {
+	require.NotNil(t, New().WithChannels("wrong").Validate())
+}
+
+func TestValidateFailureWrongArchitecture(t *testing.T) {
+	require.NotNil(t, New().WithArchitectures("wrong").Validate())
+}
+
+func TestIsSupportedSuccess(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []string
+		check    []string
+		expected bool
+	}{
+		{
+			name: "single input",
+			input: []string{
+				"kubelet",
+			},
+			check:    supportedPackages,
+			expected: true,
+		},
+		{
+			name: "multiple inputs",
+			input: []string{
+				"release",
+				"testing",
+			},
+			check:    supportedChannels,
+			expected: true,
+		},
+		{
+			name:     "no inputs",
+			input:    []string{},
+			check:    supportedArchitectures,
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		actual := isSupported(tc.input, tc.check)
+
+		require.Equal(t, tc.expected, actual)
+	}
+}
+
+func TestIsSupportedFailure(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []string
+		check    []string
+		expected bool
+	}{
+		{
+			name: "some supported, some unsupported",
+			input: []string{
+				"fakearch",
+				"amd64",
+			},
+			check:    supportedArchitectures,
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		actual := isSupported(tc.input, tc.check)
+
+		require.NotEqual(t, tc.expected, actual)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind cleanup

#### What this PR does / why we need it:
This allows API restructuing and a clean builder pattern on the new
`options` package. Tests have been added to the new package as well,
which bumps its test coverage to 100%.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Follow-up of https://github.com/kubernetes/release/pull/1282

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added dedicated `options` package for configuring `kubepkg`
```
