### PR TITLE
Add GetRepository() to github pkg and RepoIsForkOf() to verify inheritance

### DIFF
--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -80,6 +80,23 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	getRepositoryMutex       sync.RWMutex
+	GetRepositoryStub        func(context.Context, string, string) (*githuba.Repository, *githuba.Response, error)
+	getRepositoryArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}
+	getRepositoryReturns struct {
+		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}
+	getRepositoryReturnsOnCall map[int]struct {
+		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}
 	ListCommitsStub        func(context.Context, string, string, *githuba.CommitsListOptions) ([]*githuba.RepositoryCommit, *githuba.Response, error)
 	listCommitsMutex       sync.RWMutex
 	listCommitsArgsForCall []struct {
@@ -731,6 +748,39 @@ func (fake *FakeClient) CreatePullRequestReturns(result1 *githuba.PullRequest, r
 		result1 *githuba.PullRequest
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClient) GetRepository(
+	arg1 context.Context, arg2, arg3 string,
+) (*githuba.Repository, *githuba.Response, error) {
+	fake.getRepositoryMutex.Lock()
+	ret, specificReturn := fake.getRepositoryReturnsOnCall[len(fake.createPullRequestArgsForCall)]
+	fake.getRepositoryArgsForCall = append(fake.getRepositoryArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetRepository", []interface{}{arg1, arg2, arg3})
+	fake.getRepositoryMutex.Unlock()
+	if fake.GetRepositoryStub != nil {
+		return fake.GetRepositoryStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getRepositoryReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) GetRespositoryReturns(result1 *githuba.Repository, result2 *githuba.Response, result3 error) {
+	fake.getRepositoryMutex.Lock()
+	defer fake.getRepositoryMutex.Unlock()
+	fake.GetRepositoryStub = nil
+	fake.getRepositoryReturns = struct {
+		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
 }
 
 var _ github.Client = new(FakeClient)

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -40,6 +40,7 @@ const (
 	gitHubAPIListPullRequestsWithCommit gitHubAPI = "ListPullRequestsWithCommit"
 	gitHubAPIListReleases               gitHubAPI = "ListReleases"
 	gitHubAPIListTags                   gitHubAPI = "ListTags"
+	gitHubAPIGetRepository              gitHubAPI = "GetRepository"
 )
 
 type apiRecord struct {
@@ -151,6 +152,21 @@ func (c *githubNotesRecordClient) CreatePullRequest(
 	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
 ) (*github.PullRequest, error) {
 	return &github.PullRequest{}, nil
+}
+
+func (c *githubNotesRecordClient) GetRepository(
+	ctx context.Context, owner, repo string,
+) (*github.Repository, *github.Response, error) {
+	repository, resp, err := c.client.GetRepository(ctx, owner, repo)
+	if err != nil {
+		return repository, resp, err
+	}
+
+	if err := c.recordAPICall(gitHubAPIGetRepository, repository, resp); err != nil {
+		return nil, nil, err
+	}
+
+	return repository, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -141,6 +141,21 @@ func (c *githubNotesReplayClient) CreatePullRequest(
 	return &github.PullRequest{}, nil
 }
 
+func (c *githubNotesReplayClient) GetRepository(
+	ctx context.Context, owner, repo string,
+) (*github.Repository, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPIGetRepository)
+	if err != nil {
+		return nil, nil, err
+	}
+	repository := &github.Repository{}
+	record := apiRecord{Result: repository}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return repository, record.response(), nil
+}
+
 func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error) {
 	c.replayMutex.Lock()
 	defer c.replayMutex.Unlock()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR Adds the following features to the github package:

* It adds a new function `GetRepository()` to the github package that returns a `github.Repository` from the GitHub API
* It adds implementations of this function to the real client, `githubNotesRecordClient`, `githubNotesReplayClient` and to the fake client.
* It implements a new function in the github package called `RepoIsForkOf()` which verifies that one repo is a fork of another using the github API. 
* Adds tests to `github_test.go` for said functions

#### Which issue(s) this PR fixes:

Relates to #834 

#### Special notes for your reviewer:

I've tried to emulate the record/replay functionality by following the patterns found in the code. But I'm not familiar with that feature, please let me know if they are implemented right.

#### Does this PR introduce a user-facing change?
```release-note
* Add `RepoIsForkOf()` to check repository inheritance.
* Add `GetRepository()` functions in all clients to get repository data from the GitHub API.
```
