### PR TITLE
Validate --type flag on anago

### DIFF
--- a/anago
+++ b/anago
@@ -40,7 +40,7 @@ PROG=${0##*/}
 #+ DESCRIPTION
 #+     $PROG produces Kubernetes releases.
 #+
-#+     Driven by the named source <branch> and an optional [--type] flag, $PROG
+#+     Driven by the named source <branch> and an [--type] flag, $PROG
 #+     determines what needs to be released and calculates the version.
 #+
 #+     [--buildversion=] will override the automatic check for a build version
@@ -191,6 +191,10 @@ common::validate_command_line "$ORIG_CMDLINE" || common::exit 1 "Exiting..."
 
 # Validate command-line
 common::argc_validate 1 || common::exit 1 "Exiting..."
+
+if [[ ! $FLAGS_type =~ ^(alpha|beta|rc|official)$ ]]; then
+    common::exit 1 "--type must be either 'alpha', 'beta', 'rc' or 'official'"
+fi
 
 # Set positional args
 RELEASE_BRANCH=${POSITIONAL_ARGV[0]}
@@ -828,8 +832,8 @@ copy_staged_from_gcs () {
 # * alpha is alone, pushes tags only
 # * beta is alone, pushes tags only
 # * rc is alone, pushes branch and tags
-# * official pushes both official and beta items - branch and tags
-# * New branch tags a new alpha or beta on master and pushes
+# * official pushes both official and RC items - branch and tags
+# * New branch tags a new alpha on master, new RC on new branch and pushes
 #   new branch and tags on both
 PROGSTEP[push_git_objects]="PUSH GIT OBJECTS"
 push_git_objects () {

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -418,7 +418,7 @@ release::set_release_version () {
     RELEASE_VERSION[beta]+=".0-beta.0"
     RELEASE_VERSION_PRIME=${RELEASE_VERSION[beta]}
   elif [[ "$parent_branch" =~ release- ]]; then
-    # When we do branched branches we end up with two rcs so deal with it
+    # When we do branched branches we end up with two RCs so deal with it
     # by creating a couple of rc indexes.
     # rc0 is the branch-point-minor + 1 + rc.1 because
     # branch-point-minor +1 +rc.0 already exists. This tag lands on the new


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now validate the --type flag to be either `alpha`, `beta`, `rc` or `official`.

This commit also contains some small documentation cleanups from a
previous change.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Follow-up of https://github.com/kubernetes/release/pull/1286

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added flag validation for `anago --type`, which must be either `alpha`, `beta`, `rc` or `official`.
```
