### PR TITLE
Add dependency report option to release-notes tool

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -89,6 +89,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | output                  | OUTPUT          |                     | No       | The path where the release notes will be written                                                                                  |
 | format                  | FORMAT          | go-template:default | Yes      | The format for notes output (options: json, go-template:inline:<template-string> go-template:path/to/template.file)               |
 | release-version         | RELEASE_VERSION |                     | No       | The release version to tag the notes with                                                                                         |
+| dependencies            |                 | false               | No       | Add dependency report                                                                                                             |
 | **LOG OPTIONS**         |
 | debug                   | DEBUG           | false               | No       | Enable debug logging (options: true, false)                                                                                       |
 

--- a/pkg/notes/dependencies.go
+++ b/pkg/notes/dependencies.go
@@ -53,9 +53,15 @@ func (d *Dependencies) SetMoDiff(moDiff MoDiff) {
 // Changes collects the dependency change report as markdown between
 // both provided revisions. The function errors if anything went wrong.
 func (d *Dependencies) Changes(from, to string) (string, error) {
+	return d.ChangesForURL(git.GetDefaultKubernetesRepoURL(), from, to)
+}
+
+// Changes collects the dependency change report as markdown between
+// both provided revisions for the specified repository URL. The function
+// errors if anything went wrong.
+func (d *Dependencies) ChangesForURL(url, from, to string) (string, error) {
 	config := modiff.NewConfig(
-		strings.TrimPrefix(git.GetDefaultKubernetesRepoURL(), "https://"),
-		from, to, true, 2,
+		strings.TrimPrefix(url, "https://"), from, to, true, 2,
 	)
 
 	res, err := d.moDiff.Run(config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
The relese-notes tool now support the `--dependencies` flag as well.
We also have to take the repository into consideration now.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `--dependencies` flag to `release-notes` tool to add a dependency report
```
