### PR TITLE
k8s-cloud-builder: Build cross1.14 variant on kube-cross:v1.14.3-1

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.14:
     CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.2-4'
+    KUBE_CROSS_VERSION: 'v1.14.3-1'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.13:
     CONFIG: 'cross1.13'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

go1.14.3 is out: https://golang.org/doc/devel/release.html#go1.14

Updates k8s-cloud-builder to pick up the new `kube-cross:v1.14.3-1` image (ref: https://github.com/kubernetes/release/pull/1294, https://github.com/kubernetes/k8s.io/pull/877)

cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build cross1.14 variant on kube-cross:v1.14.3-1
```
