### PR TITLE
Fix import group order in kubepkg.go

### DIFF
--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -26,10 +26,10 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	gogithub "github.com/google/go-github/v29/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	gogithub "github.com/google/go-github/v29/github"
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/kubepkg/options"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
A tiny follow up to fix the import path grouping in kubepkg.go.
#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes/release/pull/1290#discussion_r426748545
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
