### PR TITLE
Fix default --dependencies flag value in documentation

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -89,7 +89,7 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | output                  | OUTPUT          |                     | No       | The path where the release notes will be written                                                                                  |
 | format                  | FORMAT          | go-template:default | Yes      | The format for notes output (options: json, go-template:inline:<template-string> go-template:path/to/template.file)               |
 | release-version         | RELEASE_VERSION |                     | No       | The release version to tag the notes with                                                                                         |
-| dependencies            |                 | false               | No       | Add dependency report                                                                                                             |
+| dependencies            |                 | true                | No       | Add dependency report                                                                                                             |
 | **LOG OPTIONS**         |
 | debug                   | DEBUG           | false               | No       | Enable debug logging (options: true, false)                                                                                       |
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
The README.md states that the default value is `false`, but that's not
the actual case.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Refers to https://github.com/kubernetes/release/pull/1292#discussion_r427655597

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Change [release-notes/README.md](/cmd/release-notes/README.md) to correctly state that the default value of `--dependencies` is `true`
```
