### PR TITLE
Improve algorithm to determine previous tag and branch in relnotes

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -699,12 +699,15 @@ func (r *Repo) PreviousTag(tag, branch string) (string, error) {
 		return "", err
 	}
 
-	idx := 0
+	idx := -1
 	for i, t := range tags {
 		if t == tag {
 			idx = i
 			break
 		}
+	}
+	if idx == -1 {
+		return "", errors.New("could not find specified tag in branch")
 	}
 	if len(tags) < idx+1 {
 		return "", errors.New("unable to find previous tag")


### PR DESCRIPTION
#### What type of PR is this?
> /kind cleanup

#### What this PR does / why we need it:

When generating the release notes for a specific tag in JSON, krel would calculate the previous the wrong and/or read from the wrong branch (an example can be seen in [this PR for v1.18.1](https://github.com/kubernetes-sigs/release-notes/pull/153) )

This change improves the way krel determines the tag range and the branch it uses. This is now done by checking if the release branch exists in the repository and by reading the tag list from the branch.

It also fixes a small bug in the git pkg where `git.PreviousTag()` would return an incorrect tag when passing a non existing tag.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:

Currently, this change will only be triggered when automatically generating a pull request to update the release notes website.

#### Does this PR introduce a user-facing change?

```release-note
- Improve the algorithm used to determine the startTag and branch when generating the JSON version of the release notes for a specific tag
- Fix a small bug in the git pkg where `git.PreviousTag()` would return an incorrect tag when passing a non existing tag
```
