### PR TITLE
Release Notes: Check if branch exists before creating a PR

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -78,6 +78,10 @@ type Client interface {
 		context.Context, string, string, *github.ListOptions,
 	) ([]*github.RepositoryTag, *github.Response, error)
 
+	ListBranches(
+		context.Context, string, string, *github.BranchListOptions,
+	) ([]*github.Branch, *github.Response, error)
+
 	CreatePullRequest(
 		context.Context, string, string, string, string, string, string,
 	) (*github.PullRequest, error)
@@ -195,6 +199,17 @@ func (g *githubClient) ListTags(
 			return tags, resp, err
 		}
 	}
+}
+
+func (g *githubClient) ListBranches(
+	ctx context.Context, owner, repo string, opt *github.BranchListOptions,
+) ([]*github.Branch, *github.Response, error) {
+	branches, response, err := g.Repositories.ListBranches(ctx, owner, repo, opt)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "fetching brnaches from repo")
+	}
+
+	return branches, response, nil
 }
 
 func (g *githubClient) CreatePullRequest(
@@ -357,6 +372,18 @@ func (g *GitHub) GetRepository(
 	}
 
 	return repository, nil
+}
+
+// ListBranches gets a repository using the current client
+func (g *GitHub) ListBranches(
+	owner, repo string,
+) ([]*github.Branch, error) {
+	branches, _, err := g.Client().ListBranches(context.Background(), owner, repo, &github.BranchListOptions{})
+	if err != nil {
+		return branches, errors.Wrap(err, "getting branches from client")
+	}
+
+	return branches, nil
 }
 
 // RepoIsForkOf Function that checks if a repository is a fork of another

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -386,3 +386,34 @@ func TestRepoIsNotForkOf(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, result, false)
 }
+
+func TestListBranches(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+
+	branch0 := "master"
+	branch1 := "myfork"
+	branch2 := "feature-branch"
+
+	branches := []*gogithub.Branch{
+		{
+			Name: &branch0,
+		},
+		{
+			Name: &branch1,
+		},
+		{
+			Name: &branch2,
+		},
+	}
+
+	client.ListBranchesReturns(branches, &gogithub.Response{NextPage: 0}, nil)
+
+	// When
+	result, err := sut.ListBranches("kubernetes", "kubernotia")
+
+	// Then
+	require.Nil(t, err)
+	require.Len(t, result, 3)
+	require.Equal(t, result[1].GetName(), branch1)
+}

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -97,6 +97,24 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	listBranchesMutex       sync.RWMutex
+	ListBranchesStub        func(context.Context, string, string, *githuba.BranchListOptions) ([]*githuba.Branch, *githuba.Response, error)
+	listBranchesArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.BranchListOptions
+	}
+	listBranchesReturns struct {
+		result1 []*githuba.Branch
+		result2 *githuba.Response
+		result3 error
+	}
+	listBranchesReturnsOnCall map[int]struct {
+		result1 []*githuba.Branch
+		result2 *githuba.Response
+		result3 error
+	}
 	ListCommitsStub        func(context.Context, string, string, *githuba.CommitsListOptions) ([]*githuba.RepositoryCommit, *githuba.Response, error)
 	listCommitsMutex       sync.RWMutex
 	listCommitsArgsForCall []struct {
@@ -778,6 +796,40 @@ func (fake *FakeClient) GetRespositoryReturns(result1 *githuba.Repository, resul
 	fake.GetRepositoryStub = nil
 	fake.getRepositoryReturns = struct {
 		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListBranches(
+	arg1 context.Context, arg2, arg3 string, arg4 *githuba.BranchListOptions,
+) ([]*githuba.Branch, *githuba.Response, error) {
+	fake.listBranchesMutex.Lock()
+	ret, specificReturn := fake.listBranchesReturnsOnCall[len(fake.createPullRequestArgsForCall)]
+	fake.listBranchesArgsForCall = append(fake.listBranchesArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.BranchListOptions
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ListBranches", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listBranchesMutex.Unlock()
+	if fake.ListBranchesStub != nil {
+		return fake.ListBranchesStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.listBranchesReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListBranchesReturns(result1 []*githuba.Branch, result2 *githuba.Response, result3 error) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = nil
+	fake.listBranchesReturns = struct {
+		result1 []*githuba.Branch
 		result2 *githuba.Response
 		result3 error
 	}{result1, result2, result3}

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -41,6 +41,7 @@ const (
 	gitHubAPIListReleases               gitHubAPI = "ListReleases"
 	gitHubAPIListTags                   gitHubAPI = "ListTags"
 	gitHubAPIGetRepository              gitHubAPI = "GetRepository"
+	gitHubAPIListBranches               gitHubAPI = "ListBranches"
 )
 
 type apiRecord struct {
@@ -167,6 +168,21 @@ func (c *githubNotesRecordClient) GetRepository(
 	}
 
 	return repository, resp, nil
+}
+
+func (c *githubNotesRecordClient) ListBranches(
+	ctx context.Context, owner, repo string, opts *github.BranchListOptions,
+) ([]*github.Branch, *github.Response, error) {
+	branches, resp, err := c.client.ListBranches(ctx, owner, repo, opts)
+	if err != nil {
+		return branches, resp, err
+	}
+
+	if err := c.recordAPICall(gitHubAPIListBranches, branches, resp); err != nil {
+		return nil, nil, err
+	}
+
+	return branches, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -156,6 +156,21 @@ func (c *githubNotesReplayClient) GetRepository(
 	return repository, record.response(), nil
 }
 
+func (c *githubNotesReplayClient) ListBranches(
+	ctx context.Context, owner, repo string, opts *github.BranchListOptions,
+) ([]*github.Branch, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPIListBranches)
+	if err != nil {
+		return nil, nil, err
+	}
+	branches := make([]*github.Branch, 0)
+	record := apiRecord{Result: branches}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return branches, record.response(), nil
+}
+
 func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error) {
 	c.replayMutex.Lock()
 	defer c.replayMutex.Unlock()


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds a new function `ListBranches()` to the github package and clients which lists the branches that exist in a repository. It also adds it to the fake and record clients and adds some rudimentary testing.

Finally, the new function is used to verify that branches where the release notes will be pushed do not exist before attempting to create a pull request with a new revision of the draft or a patch for the website. Previously this could lead the process to fail.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- Add `github.ListBranches()` to the package and clients to list the branches of a GitHub repository .
- When creating pull requests, verify that branches do not exist before pushing new revisions of the release notes draft or patches to the website.  
```
