### PR TITLE
gh2gcs: Add go-based CLI for uploading GH releases to GCS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ filegroup(
         "//lib:all-srcs",
         "//pkg/command:all-srcs",
         "//pkg/gcp:all-srcs",
+        "//pkg/gh2gcs:all-srcs",
         "//pkg/git:all-srcs",
         "//pkg/github:all-srcs",
         "//pkg/http:all-srcs",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
         ":package-srcs",
         "//cmd/blocking-testgrid-tests:all-srcs",
         "//cmd/gcbuilder:all-srcs",
+        "//cmd/gh2gcs:all-srcs",
         "//cmd/krel:all-srcs",
         "//cmd/kubepkg:all-srcs",
         "//cmd/patch-announce:all-srcs",

--- a/cmd/gh2gcs/BUILD.bazel
+++ b/cmd/gh2gcs/BUILD.bazel
@@ -8,12 +8,6 @@ go_library(
     deps = ["//cmd/gh2gcs/cmd:go_default_library"],
 )
 
-go_binary(
-    name = "kubepkg",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -28,5 +22,11 @@ filegroup(
         "//cmd/gh2gcs/cmd:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "gh2gcs",
+    embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/gh2gcs/BUILD.bazel
+++ b/cmd/gh2gcs/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/release/cmd/gh2gcs",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd/gh2gcs/cmd:go_default_library"],
+)
+
+go_binary(
+    name = "kubepkg",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/gh2gcs/cmd:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/gh2gcs/cmd/BUILD.bazel
+++ b/cmd/gh2gcs/cmd/BUILD.bazel
@@ -6,9 +6,11 @@ go_library(
     importpath = "k8s.io/release/cmd/gh2gcs/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/gcp:go_default_library",
         "//pkg/gh2gcs:go_default_library",
         "//pkg/github:go_default_library",
         "//pkg/log:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],

--- a/cmd/gh2gcs/cmd/BUILD.bazel
+++ b/cmd/gh2gcs/cmd/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["root.go"],
+    importpath = "k8s.io/release/cmd/gh2gcs/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/github:go_default_library",
+        "//pkg/log:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -145,12 +145,15 @@ func run(opts *options) error {
 	// TODO: Support downloading releases via yaml config
 	uploadConfig := &gh2gcs.Config{}
 	releaseConfig := &gh2gcs.ReleaseConfig{
-		Org:        opts.org,
-		Repo:       opts.repo,
-		Tags:       []string{},
-		GCSBucket:  opts.bucket,
-		ReleaseDir: opts.releaseDir,
+		Org:            opts.org,
+		Repo:           opts.repo,
+		Tags:           []string{},
+		GCSBucket:      opts.bucket,
+		ReleaseDir:     opts.releaseDir,
+		GCSCopyOptions: gh2gcs.DefaultGCSCopyOptions,
 	}
+
+	// TODO: Expose certain GCSCopyOptions for user configuration
 
 	if len(opts.tags) > 0 {
 		releaseConfig.Tags = opts.tags

--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/github"
+	"k8s.io/release/pkg/log"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:               "gh2gcs --org kubernetes --repo release [--tag v0.0.0]",
+	Short:             "gh2gcs uploads GitHub releases to Google Cloud Storage",
+	Example:           "gh2gcs --org kubernetes --repo release --tag v0.0.0",
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	PersistentPreRunE: initLogging,
+	RunE: func(*cobra.Command, []string) error {
+		return run(opts)
+	},
+}
+
+type options struct {
+	org         string
+	repo        string
+	tag         string
+	gcsEndpoint string
+	outputDir   string
+	logLevel    string
+}
+
+var opts = &options{}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(
+		&opts.org,
+		"org",
+		// TODO: Remove test value
+		"containernetworking",
+		"org",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.repo,
+		"repo",
+		// TODO: Remove test value
+		"plugins",
+		"repo",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.tag,
+		"tag",
+		// TODO: Remove test value
+		"",
+		"tag",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.gcsEndpoint,
+		"gcs-endpoint",
+		// TODO: Remove test value
+		"k8s-staging-release-test/augustus/cni",
+		"org",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.outputDir,
+		"output-dir",
+		"",
+		"org",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.logLevel,
+		"log-level",
+		"info",
+		"the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'",
+	)
+}
+
+func initLogging(*cobra.Command, []string) error {
+	return log.SetupGlobalLogger(opts.logLevel)
+}
+
+func run(opts *options) error {
+	if opts.outputDir == "" {
+		tmpDir, err := ioutil.TempDir("", "gh2gcs")
+		if err != nil {
+			return err
+		}
+
+		opts.outputDir = tmpDir
+	}
+
+	// Create a real GitHub API client
+	gh := github.New()
+
+	// TODO: Support downloading releases via yaml config
+	// TODO: Support single release or multi-release scenarios
+	if err := gh.DownloadReleaseAssets(opts.org, opts.repo, opts.tag, opts.outputDir); err != nil {
+		return err
+	}
+
+	// TODO: Add GCS upload logic
+
+	return nil
+}
+
+// Validate verifies if all set options are valid
+func (o *options) Validate() error {
+	// TODO: Add validation logic for options
+	return nil
+}

--- a/cmd/gh2gcs/main.go
+++ b/cmd/gh2gcs/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/release/cmd/gh2gcs/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -20,6 +20,7 @@ set -o pipefail
 
 RELEASE_TOOLS=(
   blocking-testgrid-tests
+  gh2gcs
   kubepkg
   krel
 )

--- a/pkg/gcp/BUILD.bazel
+++ b/pkg/gcp/BUILD.bazel
@@ -24,6 +24,7 @@ filegroup(
         ":package-srcs",
         "//pkg/gcp/auth:all-srcs",
         "//pkg/gcp/build:all-srcs",
+        "//pkg/gcp/gcs:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/gcp/gcs/BUILD.bazel
+++ b/pkg/gcp/gcs/BUILD.bazel
@@ -2,12 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["gh2gcs.go"],
-    importpath = "k8s.io/release/pkg/gh2gcs",
+    srcs = ["gcs.go"],
+    importpath = "k8s.io/release/pkg/gcp/gcs",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/gcp/gcs:go_default_library",
-        "//pkg/github:go_default_library",
+        "//pkg/command:go_default_library",
+        "//pkg/gcp:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcs
 
 import (
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -30,37 +31,69 @@ var (
 	gcsPrefix      = "gs://"
 	concurrentFlag = "-m"
 	recursiveFlag  = "-r"
+	noClobberFlag  = "-n"
 )
 
+type Options struct {
+	// gsutil options
+	Concurrent bool
+	Recursive  bool
+	NoClobber  bool
+
+	// local options
+	// AllowMissing allows a copy operation to be skipped if the source or
+	// destination does not exist. This is useful for scenarios where copy
+	// operations happen in a loop/channel, so a single "failure" does not block
+	// the entire operation.
+	AllowMissing bool
+}
+
 // CopyToGCS copies a local directory to the specified GCS path
-func CopyToGCS(src, gcsPath string, recursive, concurrent bool) error {
+func CopyToGCS(src, gcsPath string, opts *Options) error {
+	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
 	gcsPath = normalizeGCSPath(gcsPath)
 
-	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
-	return bucketCopy(src, gcsPath, recursive, concurrent)
+	_, err := os.Stat(src)
+	if err != nil {
+		logrus.Info("unable to get local source directory info")
+
+		if opts.AllowMissing {
+			logrus.Infof("Source directory (%s) does not exist. Skipping GCS upload.", src)
+			return nil
+		}
+
+		return errors.New("source directory does not exist")
+	}
+
+	return bucketCopy(src, gcsPath, opts)
 }
 
 // CopyToLocal copies a GCS path to the specified local directory
-func CopyToLocal(gcsPath, dst string, recursive, concurrent bool) error {
+func CopyToLocal(gcsPath, dst string, opts *Options) error {
+	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
 	gcsPath = normalizeGCSPath(gcsPath)
 
-	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
-	return bucketCopy(gcsPath, dst, recursive, concurrent)
+	return bucketCopy(gcsPath, dst, opts)
 }
 
-func bucketCopy(src, dst string, recursive, concurrent bool) error {
+func bucketCopy(src, dst string, opts *Options) error {
 	args := []string{}
 
-	if concurrent {
-		logrus.Info("Setting GCS copy to run concurrently")
+	if opts.Concurrent {
+		logrus.Debug("Setting GCS copy to run concurrently")
 		args = append(args, concurrentFlag)
 	}
 
 	args = append(args, "cp")
-	if recursive {
-		logrus.Info("Setting GCS copy to run recursively")
+	if opts.Recursive {
+		logrus.Debug("Setting GCS copy to run recursively")
 		args = append(args, recursiveFlag)
 	}
+	if opts.NoClobber {
+		logrus.Debug("Setting GCS copy to not clobber existing files")
+		args = append(args, noClobberFlag)
+	}
+
 	args = append(args, src, dst)
 
 	cpErr := command.Execute(gcp.GSUtilExecutable, args...)

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -32,6 +32,7 @@ var (
 	recursiveFlag  = "-r"
 )
 
+// CopyToGCS copies a local directory to the specified GCS path
 func CopyToGCS(src, gcsPath string, recursive, concurrent bool) error {
 	gcsPath = normalizeGCSPath(gcsPath)
 
@@ -39,6 +40,7 @@ func CopyToGCS(src, gcsPath string, recursive, concurrent bool) error {
 	return bucketCopy(src, gcsPath, recursive, concurrent)
 }
 
+// CopyToLocal copies a GCS path to the specified local directory
 func CopyToLocal(gcsPath, dst string, recursive, concurrent bool) error {
 	gcsPath = normalizeGCSPath(gcsPath)
 

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/command"
+	"k8s.io/release/pkg/gcp"
+)
+
+var (
+	gcsPrefix      = "gs://"
+	concurrentFlag = "-m"
+	recursiveFlag  = "-r"
+)
+
+func CopyToGCS(src, gcsPath string, recursive, concurrent bool) error {
+	gcsPath = normalizeGCSPath(gcsPath)
+
+	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
+	return bucketCopy(src, gcsPath, recursive, concurrent)
+}
+
+func CopyToLocal(gcsPath, dst string, recursive, concurrent bool) error {
+	gcsPath = normalizeGCSPath(gcsPath)
+
+	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
+	return bucketCopy(gcsPath, dst, recursive, concurrent)
+}
+
+func bucketCopy(src, dst string, recursive, concurrent bool) error {
+	args := []string{}
+
+	if concurrent {
+		logrus.Info("Setting GCS copy to run concurrently")
+		args = append(args, concurrentFlag)
+	}
+
+	args = append(args, "cp")
+	if recursive {
+		logrus.Info("Setting GCS copy to run recursively")
+		args = append(args, recursiveFlag)
+	}
+	args = append(args, src, dst)
+
+	cpErr := command.Execute(gcp.GSUtilExecutable, args...)
+	if cpErr != nil {
+		return errors.Wrap(cpErr, "gcs copy")
+	}
+
+	return nil
+}
+
+func normalizeGCSPath(gcsPath string) string {
+	gcsPath = strings.TrimPrefix(gcsPath, gcsPrefix)
+	gcsPath = gcsPrefix + gcsPath
+
+	return gcsPath
+}

--- a/pkg/gh2gcs/BUILD.bazel
+++ b/pkg/gh2gcs/BUILD.bazel
@@ -2,15 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["root.go"],
-    importpath = "k8s.io/release/cmd/gh2gcs/cmd",
+    srcs = ["gh2gcs.go"],
+    importpath = "k8s.io/release/pkg/gh2gcs",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/gh2gcs:go_default_library",
         "//pkg/github:go_default_library",
-        "//pkg/log:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_github_spf13_cobra//:go_default_library",
     ],
 )
 

--- a/pkg/gh2gcs/BUILD.bazel
+++ b/pkg/gh2gcs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/gcp/gcs:go_default_library",
         "//pkg/github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -23,10 +23,14 @@ import (
 	"k8s.io/release/pkg/github"
 )
 
+// Config contains a slice of `ReleaseConfig` to be used when unmarshalling a
+// yaml config containing multiple repository configs.
 type Config struct {
 	ReleaseConfigs []ReleaseConfig
 }
 
+// ReleaseConfig contains source (GitHub) and destination (GCS) information
+// to perform a copy/upload operation using gh2gcs.
 type ReleaseConfig struct {
 	Org        string
 	Repo       string
@@ -35,6 +39,8 @@ type ReleaseConfig struct {
 	ReleaseDir string
 }
 
+// DownloadReleases downloads release assets to a local directory
+// Assets to download are derived from the tags specified in `ReleaseConfig`.
 func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
 	tags := releaseCfg.Tags
 	if err := ghClient.DownloadReleaseAssets(releaseCfg.Org, releaseCfg.Repo, tags, outputDir); err != nil {
@@ -44,6 +50,8 @@ func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, output
 	return nil
 }
 
+// Upload copies a set of release assets from local directory to GCS
+// Assets to upload are derived from the tags specified in `ReleaseConfig`.
 func Upload(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
 	uploadBase := filepath.Join(outputDir, releaseCfg.Org, releaseCfg.Repo)
 	gcsPath := filepath.Join(releaseCfg.GCSBucket, releaseCfg.ReleaseDir)

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -18,6 +18,9 @@ package gh2gcs
 
 import (
 	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/github"
@@ -43,6 +46,14 @@ type ReleaseConfig struct {
 // Assets to download are derived from the tags specified in `ReleaseConfig`.
 func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
 	tags := releaseCfg.Tags
+	tagsString := strings.Join(tags, ", ")
+
+	logrus.Infof(
+		"Downloading assets for the following %s/%s release tags: %s",
+		releaseCfg.Org,
+		releaseCfg.Repo,
+		tagsString,
+	)
 	if err := ghClient.DownloadReleaseAssets(releaseCfg.Org, releaseCfg.Repo, tags, outputDir); err != nil {
 		return err
 	}

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -35,11 +35,19 @@ type Config struct {
 // ReleaseConfig contains source (GitHub) and destination (GCS) information
 // to perform a copy/upload operation using gh2gcs.
 type ReleaseConfig struct {
-	Org        string
-	Repo       string
-	Tags       []string
-	GCSBucket  string
-	ReleaseDir string
+	Org            string
+	Repo           string
+	Tags           []string
+	GCSBucket      string
+	ReleaseDir     string
+	GCSCopyOptions *gcs.Options
+}
+
+var DefaultGCSCopyOptions = &gcs.Options{
+	Concurrent:   true,
+	Recursive:    true,
+	NoClobber:    true,
+	AllowMissing: true,
 }
 
 // DownloadReleases downloads release assets to a local directory
@@ -70,7 +78,7 @@ func Upload(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string
 	tags := releaseCfg.Tags
 	for _, tag := range tags {
 		srcDir := filepath.Join(uploadBase, tag)
-		if err := gcs.CopyToGCS(srcDir, gcsPath, true, true); err != nil {
+		if err := gcs.CopyToGCS(srcDir, gcsPath, releaseCfg.GCSCopyOptions); err != nil {
 			return err
 		}
 	}

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gh2gcs
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/github"
+)
+
+type Config struct {
+	ReleaseConfigs []ReleaseConfig
+}
+
+type ReleaseConfig struct {
+	Org        string
+	Name       string
+	Tags       []string
+	GCSBucket  string
+	ReleaseDir string
+}
+
+func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
+	tags := releaseCfg.Tags
+	if err := ghClient.DownloadReleaseAssets(releaseCfg.Org, releaseCfg.Name, tags, outputDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO: Add GCS upload logic
+func UploadToGCS(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
+	logrus.Info("Uploading to GCS...")
+	return nil
+}

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -35,12 +35,13 @@ type Config struct {
 // ReleaseConfig contains source (GitHub) and destination (GCS) information
 // to perform a copy/upload operation using gh2gcs.
 type ReleaseConfig struct {
-	Org            string
-	Repo           string
-	Tags           []string
-	GCSBucket      string
-	ReleaseDir     string
-	GCSCopyOptions *gcs.Options
+	Org                string
+	Repo               string
+	Tags               []string
+	IncludePrereleases bool
+	GCSBucket          string
+	ReleaseDir         string
+	GCSCopyOptions     *gcs.Options
 }
 
 var DefaultGCSCopyOptions = &gcs.Options{

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -422,6 +422,12 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 		releaseTag := release.GetTagName()
 		logrus.Infof("Download assets for %s/%s@%s", owner, repo, releaseTag)
 
+		assets := release.Assets
+		if len(assets) == 0 {
+			logrus.Infof("Skipping download for %s/%s@%s as no release assets were found", owner, repo, releaseTag)
+			continue
+		}
+
 		releaseDir := filepath.Join(outputDir, owner, repo, releaseTag)
 		if err := os.MkdirAll(releaseDir, os.FileMode(0o777)); err != nil {
 			return errors.Wrap(err, "creating output directory for release assets")
@@ -429,7 +435,6 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 
 		logrus.Infof("Writing assets to %s", releaseDir)
 
-		assets := release.Assets
 		for _, asset := range assets {
 			if asset.GetID() == 0 {
 				return errors.New("asset ID should never be zero")

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -289,14 +289,14 @@ func TestCreatePullRequest(t *testing.T) {
 	require.Equal(t, fakeID, pr.GetID())
 }
 
-func TestGetRespository(t *testing.T) {
+func TestGetRepository(t *testing.T) {
 	// Given
 	sut, client := newSUT()
 	fakeRepositoryID := int64(54596517) // k/release
 	kubernetesUserID := int64(13629408)
 	kubernetesLogin := "kubernetes"
 	repoName := "release"
-	client.GetRespositoryReturns(&gogithub.Repository{
+	client.GetRepositoryReturns(&gogithub.Repository{
 		ID:   &fakeRepositoryID,
 		Name: &repoName,
 		Owner: &gogithub.User{
@@ -329,7 +329,7 @@ func TestRepoIsForkOf(t *testing.T) {
 
 	trueVal := true
 
-	client.GetRespositoryReturns(&gogithub.Repository{
+	client.GetRepositoryReturns(&gogithub.Repository{
 		Name: &repoName,
 		Fork: &trueVal,
 		Owner: &gogithub.User{
@@ -364,7 +364,7 @@ func TestRepoIsNotForkOf(t *testing.T) {
 
 	trueVal := true
 
-	client.GetRespositoryReturns(&gogithub.Repository{
+	client.GetRepositoryReturns(&gogithub.Repository{
 		Name: &repoName,
 		Fork: &trueVal,
 		Owner: &gogithub.User{

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -19,6 +19,7 @@ package githubfakes
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	githuba "github.com/google/go-github/v29/github"
@@ -26,6 +27,43 @@ import (
 )
 
 type FakeClient struct {
+	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)
+	createPullRequestMutex       sync.RWMutex
+	createPullRequestArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
+		arg6 string
+		arg7 string
+	}
+	createPullRequestReturns struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}
+	createPullRequestReturnsOnCall map[int]struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}
+	DownloadReleaseAssetStub        func(context.Context, string, string, int64) (io.ReadCloser, string, error)
+	downloadReleaseAssetMutex       sync.RWMutex
+	downloadReleaseAssetArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}
+	downloadReleaseAssetReturns struct {
+		result1 io.ReadCloser
+		result2 string
+		result3 error
+	}
+	downloadReleaseAssetReturnsOnCall map[int]struct {
+		result1 io.ReadCloser
+		result2 string
+		result3 error
+	}
 	GetCommitStub        func(context.Context, string, string, string) (*githuba.Commit, *githuba.Response, error)
 	getCommitMutex       sync.RWMutex
 	getCommitArgsForCall []struct {
@@ -62,6 +100,24 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	GetReleaseByTagStub        func(context.Context, string, string, string) (*githuba.RepositoryRelease, *githuba.Response, error)
+	getReleaseByTagMutex       sync.RWMutex
+	getReleaseByTagArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	getReleaseByTagReturns struct {
+		result1 *githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}
+	getReleaseByTagReturnsOnCall map[int]struct {
+		result1 *githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}
 	GetRepoCommitStub        func(context.Context, string, string, string) (*githuba.RepositoryCommit, *githuba.Response, error)
 	getRepoCommitMutex       sync.RWMutex
 	getRepoCommitArgsForCall []struct {
@@ -80,8 +136,8 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
-	getRepositoryMutex       sync.RWMutex
 	GetRepositoryStub        func(context.Context, string, string) (*githuba.Repository, *githuba.Response, error)
+	getRepositoryMutex       sync.RWMutex
 	getRepositoryArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
@@ -97,8 +153,8 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
-	listBranchesMutex       sync.RWMutex
 	ListBranchesStub        func(context.Context, string, string, *githuba.BranchListOptions) ([]*githuba.Branch, *githuba.Response, error)
+	listBranchesMutex       sync.RWMutex
 	listBranchesArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
@@ -188,9 +244,14 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
-	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)
-	createPullRequestMutex       sync.RWMutex
-	createPullRequestArgsForCall []struct {
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string, arg7 string) (*githuba.PullRequest, error) {
+	fake.createPullRequestMutex.Lock()
+	ret, specificReturn := fake.createPullRequestReturnsOnCall[len(fake.createPullRequestArgsForCall)]
+	fake.createPullRequestArgsForCall = append(fake.createPullRequestArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
@@ -198,18 +259,131 @@ type FakeClient struct {
 		arg5 string
 		arg6 string
 		arg7 string
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.createPullRequestMutex.Unlock()
+	if fake.CreatePullRequestStub != nil {
+		return fake.CreatePullRequestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
-	createPullRequestReturns struct {
-		result1 *githuba.PullRequest
-		result2 error
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
-	createPullRequestReturnsOnCall map[int]struct {
-		result1 *githuba.PullRequest
-		result2 error
-	}
+	fakeReturns := fake.createPullRequestReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
 
-	invocations      map[string][][]interface{}
-	invocationsMutex sync.RWMutex
+func (fake *FakeClient) CreatePullRequestCallCount() int {
+	fake.createPullRequestMutex.RLock()
+	defer fake.createPullRequestMutex.RUnlock()
+	return len(fake.createPullRequestArgsForCall)
+}
+
+func (fake *FakeClient) CreatePullRequestCalls(stub func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)) {
+	fake.createPullRequestMutex.Lock()
+	defer fake.createPullRequestMutex.Unlock()
+	fake.CreatePullRequestStub = stub
+}
+
+func (fake *FakeClient) CreatePullRequestArgsForCall(i int) (context.Context, string, string, string, string, string, string) {
+	fake.createPullRequestMutex.RLock()
+	defer fake.createPullRequestMutex.RUnlock()
+	argsForCall := fake.createPullRequestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+}
+
+func (fake *FakeClient) CreatePullRequestReturns(result1 *githuba.PullRequest, result2 error) {
+	fake.createPullRequestMutex.Lock()
+	defer fake.createPullRequestMutex.Unlock()
+	fake.CreatePullRequestStub = nil
+	fake.createPullRequestReturns = struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) CreatePullRequestReturnsOnCall(i int, result1 *githuba.PullRequest, result2 error) {
+	fake.createPullRequestMutex.Lock()
+	defer fake.createPullRequestMutex.Unlock()
+	fake.CreatePullRequestStub = nil
+	if fake.createPullRequestReturnsOnCall == nil {
+		fake.createPullRequestReturnsOnCall = make(map[int]struct {
+			result1 *githuba.PullRequest
+			result2 error
+		})
+	}
+	fake.createPullRequestReturnsOnCall[i] = struct {
+		result1 *githuba.PullRequest
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) DownloadReleaseAsset(arg1 context.Context, arg2 string, arg3 string, arg4 int64) (io.ReadCloser, string, error) {
+	fake.downloadReleaseAssetMutex.Lock()
+	ret, specificReturn := fake.downloadReleaseAssetReturnsOnCall[len(fake.downloadReleaseAssetArgsForCall)]
+	fake.downloadReleaseAssetArgsForCall = append(fake.downloadReleaseAssetArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("DownloadReleaseAsset", []interface{}{arg1, arg2, arg3, arg4})
+	fake.downloadReleaseAssetMutex.Unlock()
+	if fake.DownloadReleaseAssetStub != nil {
+		return fake.DownloadReleaseAssetStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.downloadReleaseAssetReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) DownloadReleaseAssetCallCount() int {
+	fake.downloadReleaseAssetMutex.RLock()
+	defer fake.downloadReleaseAssetMutex.RUnlock()
+	return len(fake.downloadReleaseAssetArgsForCall)
+}
+
+func (fake *FakeClient) DownloadReleaseAssetCalls(stub func(context.Context, string, string, int64) (io.ReadCloser, string, error)) {
+	fake.downloadReleaseAssetMutex.Lock()
+	defer fake.downloadReleaseAssetMutex.Unlock()
+	fake.DownloadReleaseAssetStub = stub
+}
+
+func (fake *FakeClient) DownloadReleaseAssetArgsForCall(i int) (context.Context, string, string, int64) {
+	fake.downloadReleaseAssetMutex.RLock()
+	defer fake.downloadReleaseAssetMutex.RUnlock()
+	argsForCall := fake.downloadReleaseAssetArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) DownloadReleaseAssetReturns(result1 io.ReadCloser, result2 string, result3 error) {
+	fake.downloadReleaseAssetMutex.Lock()
+	defer fake.downloadReleaseAssetMutex.Unlock()
+	fake.DownloadReleaseAssetStub = nil
+	fake.downloadReleaseAssetReturns = struct {
+		result1 io.ReadCloser
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) DownloadReleaseAssetReturnsOnCall(i int, result1 io.ReadCloser, result2 string, result3 error) {
+	fake.downloadReleaseAssetMutex.Lock()
+	defer fake.downloadReleaseAssetMutex.Unlock()
+	fake.DownloadReleaseAssetStub = nil
+	if fake.downloadReleaseAssetReturnsOnCall == nil {
+		fake.downloadReleaseAssetReturnsOnCall = make(map[int]struct {
+			result1 io.ReadCloser
+			result2 string
+			result3 error
+		})
+	}
+	fake.downloadReleaseAssetReturnsOnCall[i] = struct {
+		result1 io.ReadCloser
+		result2 string
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeClient) GetCommit(arg1 context.Context, arg2 string, arg3 string, arg4 string) (*githuba.Commit, *githuba.Response, error) {
@@ -350,6 +524,75 @@ func (fake *FakeClient) GetPullRequestReturnsOnCall(i int, result1 *githuba.Pull
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) GetReleaseByTag(arg1 context.Context, arg2 string, arg3 string, arg4 string) (*githuba.RepositoryRelease, *githuba.Response, error) {
+	fake.getReleaseByTagMutex.Lock()
+	ret, specificReturn := fake.getReleaseByTagReturnsOnCall[len(fake.getReleaseByTagArgsForCall)]
+	fake.getReleaseByTagArgsForCall = append(fake.getReleaseByTagArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("GetReleaseByTag", []interface{}{arg1, arg2, arg3, arg4})
+	fake.getReleaseByTagMutex.Unlock()
+	if fake.GetReleaseByTagStub != nil {
+		return fake.GetReleaseByTagStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getReleaseByTagReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) GetReleaseByTagCallCount() int {
+	fake.getReleaseByTagMutex.RLock()
+	defer fake.getReleaseByTagMutex.RUnlock()
+	return len(fake.getReleaseByTagArgsForCall)
+}
+
+func (fake *FakeClient) GetReleaseByTagCalls(stub func(context.Context, string, string, string) (*githuba.RepositoryRelease, *githuba.Response, error)) {
+	fake.getReleaseByTagMutex.Lock()
+	defer fake.getReleaseByTagMutex.Unlock()
+	fake.GetReleaseByTagStub = stub
+}
+
+func (fake *FakeClient) GetReleaseByTagArgsForCall(i int) (context.Context, string, string, string) {
+	fake.getReleaseByTagMutex.RLock()
+	defer fake.getReleaseByTagMutex.RUnlock()
+	argsForCall := fake.getReleaseByTagArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) GetReleaseByTagReturns(result1 *githuba.RepositoryRelease, result2 *githuba.Response, result3 error) {
+	fake.getReleaseByTagMutex.Lock()
+	defer fake.getReleaseByTagMutex.Unlock()
+	fake.GetReleaseByTagStub = nil
+	fake.getReleaseByTagReturns = struct {
+		result1 *githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetReleaseByTagReturnsOnCall(i int, result1 *githuba.RepositoryRelease, result2 *githuba.Response, result3 error) {
+	fake.getReleaseByTagMutex.Lock()
+	defer fake.getReleaseByTagMutex.Unlock()
+	fake.GetReleaseByTagStub = nil
+	if fake.getReleaseByTagReturnsOnCall == nil {
+		fake.getReleaseByTagReturnsOnCall = make(map[int]struct {
+			result1 *githuba.RepositoryRelease
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.getReleaseByTagReturnsOnCall[i] = struct {
+		result1 *githuba.RepositoryRelease
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) GetRepoCommit(arg1 context.Context, arg2 string, arg3 string, arg4 string) (*githuba.RepositoryCommit, *githuba.Response, error) {
 	fake.getRepoCommitMutex.Lock()
 	ret, specificReturn := fake.getRepoCommitReturnsOnCall[len(fake.getRepoCommitArgsForCall)]
@@ -414,6 +657,143 @@ func (fake *FakeClient) GetRepoCommitReturnsOnCall(i int, result1 *githuba.Repos
 	}
 	fake.getRepoCommitReturnsOnCall[i] = struct {
 		result1 *githuba.RepositoryCommit
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetRepository(arg1 context.Context, arg2 string, arg3 string) (*githuba.Repository, *githuba.Response, error) {
+	fake.getRepositoryMutex.Lock()
+	ret, specificReturn := fake.getRepositoryReturnsOnCall[len(fake.getRepositoryArgsForCall)]
+	fake.getRepositoryArgsForCall = append(fake.getRepositoryArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetRepository", []interface{}{arg1, arg2, arg3})
+	fake.getRepositoryMutex.Unlock()
+	if fake.GetRepositoryStub != nil {
+		return fake.GetRepositoryStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getRepositoryReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) GetRepositoryCallCount() int {
+	fake.getRepositoryMutex.RLock()
+	defer fake.getRepositoryMutex.RUnlock()
+	return len(fake.getRepositoryArgsForCall)
+}
+
+func (fake *FakeClient) GetRepositoryCalls(stub func(context.Context, string, string) (*githuba.Repository, *githuba.Response, error)) {
+	fake.getRepositoryMutex.Lock()
+	defer fake.getRepositoryMutex.Unlock()
+	fake.GetRepositoryStub = stub
+}
+
+func (fake *FakeClient) GetRepositoryArgsForCall(i int) (context.Context, string, string) {
+	fake.getRepositoryMutex.RLock()
+	defer fake.getRepositoryMutex.RUnlock()
+	argsForCall := fake.getRepositoryArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) GetRepositoryReturns(result1 *githuba.Repository, result2 *githuba.Response, result3 error) {
+	fake.getRepositoryMutex.Lock()
+	defer fake.getRepositoryMutex.Unlock()
+	fake.GetRepositoryStub = nil
+	fake.getRepositoryReturns = struct {
+		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetRepositoryReturnsOnCall(i int, result1 *githuba.Repository, result2 *githuba.Response, result3 error) {
+	fake.getRepositoryMutex.Lock()
+	defer fake.getRepositoryMutex.Unlock()
+	fake.GetRepositoryStub = nil
+	if fake.getRepositoryReturnsOnCall == nil {
+		fake.getRepositoryReturnsOnCall = make(map[int]struct {
+			result1 *githuba.Repository
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.getRepositoryReturnsOnCall[i] = struct {
+		result1 *githuba.Repository
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListBranches(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.BranchListOptions) ([]*githuba.Branch, *githuba.Response, error) {
+	fake.listBranchesMutex.Lock()
+	ret, specificReturn := fake.listBranchesReturnsOnCall[len(fake.listBranchesArgsForCall)]
+	fake.listBranchesArgsForCall = append(fake.listBranchesArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.BranchListOptions
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ListBranches", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listBranchesMutex.Unlock()
+	if fake.ListBranchesStub != nil {
+		return fake.ListBranchesStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.listBranchesReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListBranchesCallCount() int {
+	fake.listBranchesMutex.RLock()
+	defer fake.listBranchesMutex.RUnlock()
+	return len(fake.listBranchesArgsForCall)
+}
+
+func (fake *FakeClient) ListBranchesCalls(stub func(context.Context, string, string, *githuba.BranchListOptions) ([]*githuba.Branch, *githuba.Response, error)) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = stub
+}
+
+func (fake *FakeClient) ListBranchesArgsForCall(i int) (context.Context, string, string, *githuba.BranchListOptions) {
+	fake.listBranchesMutex.RLock()
+	defer fake.listBranchesMutex.RUnlock()
+	argsForCall := fake.listBranchesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) ListBranchesReturns(result1 []*githuba.Branch, result2 *githuba.Response, result3 error) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = nil
+	fake.listBranchesReturns = struct {
+		result1 []*githuba.Branch
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListBranchesReturnsOnCall(i int, result1 []*githuba.Branch, result2 *githuba.Response, result3 error) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = nil
+	if fake.listBranchesReturnsOnCall == nil {
+		fake.listBranchesReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.Branch
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.listBranchesReturnsOnCall[i] = struct {
+		result1 []*githuba.Branch
 		result2 *githuba.Response
 		result3 error
 	}{result1, result2, result3}
@@ -699,12 +1079,22 @@ func (fake *FakeClient) ListTagsReturnsOnCall(i int, result1 []*githuba.Reposito
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createPullRequestMutex.RLock()
+	defer fake.createPullRequestMutex.RUnlock()
+	fake.downloadReleaseAssetMutex.RLock()
+	defer fake.downloadReleaseAssetMutex.RUnlock()
 	fake.getCommitMutex.RLock()
 	defer fake.getCommitMutex.RUnlock()
 	fake.getPullRequestMutex.RLock()
 	defer fake.getPullRequestMutex.RUnlock()
+	fake.getReleaseByTagMutex.RLock()
+	defer fake.getReleaseByTagMutex.RUnlock()
 	fake.getRepoCommitMutex.RLock()
 	defer fake.getRepoCommitMutex.RUnlock()
+	fake.getRepositoryMutex.RLock()
+	defer fake.getRepositoryMutex.RUnlock()
+	fake.listBranchesMutex.RLock()
+	defer fake.listBranchesMutex.RUnlock()
 	fake.listCommitsMutex.RLock()
 	defer fake.listCommitsMutex.RUnlock()
 	fake.listPullRequestsWithCommitMutex.RLock()
@@ -730,109 +1120,6 @@ func (fake *FakeClient) recordInvocation(key string, args []interface{}) {
 		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
-}
-
-func (fake *FakeClient) CreatePullRequest(
-	arg1 context.Context, arg2, arg3, arg4, arg5, arg6, arg7 string,
-) (*githuba.PullRequest, error) {
-	fake.createPullRequestMutex.Lock()
-	ret, specificReturn := fake.createPullRequestReturnsOnCall[len(fake.createPullRequestArgsForCall)]
-	fake.createPullRequestArgsForCall = append(fake.createPullRequestArgsForCall, struct {
-		arg1 context.Context
-		arg2 string
-		arg3 string
-		arg4 string
-		arg5 string
-		arg6 string
-		arg7 string
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.createPullRequestMutex.Unlock()
-	if fake.CreatePullRequestStub != nil {
-		return fake.CreatePullRequestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.createPullRequestReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) CreatePullRequestReturns(result1 *githuba.PullRequest, result2 error) {
-	fake.createPullRequestMutex.Lock()
-	defer fake.createPullRequestMutex.Unlock()
-	fake.CreatePullRequestStub = nil
-	fake.createPullRequestReturns = struct {
-		result1 *githuba.PullRequest
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetRepository(
-	arg1 context.Context, arg2, arg3 string,
-) (*githuba.Repository, *githuba.Response, error) {
-	fake.getRepositoryMutex.Lock()
-	ret, specificReturn := fake.getRepositoryReturnsOnCall[len(fake.createPullRequestArgsForCall)]
-	fake.getRepositoryArgsForCall = append(fake.getRepositoryArgsForCall, struct {
-		arg1 context.Context
-		arg2 string
-		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("GetRepository", []interface{}{arg1, arg2, arg3})
-	fake.getRepositoryMutex.Unlock()
-	if fake.GetRepositoryStub != nil {
-		return fake.GetRepositoryStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.getRepositoryReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeClient) GetRespositoryReturns(result1 *githuba.Repository, result2 *githuba.Response, result3 error) {
-	fake.getRepositoryMutex.Lock()
-	defer fake.getRepositoryMutex.Unlock()
-	fake.GetRepositoryStub = nil
-	fake.getRepositoryReturns = struct {
-		result1 *githuba.Repository
-		result2 *githuba.Response
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeClient) ListBranches(
-	arg1 context.Context, arg2, arg3 string, arg4 *githuba.BranchListOptions,
-) ([]*githuba.Branch, *githuba.Response, error) {
-	fake.listBranchesMutex.Lock()
-	ret, specificReturn := fake.listBranchesReturnsOnCall[len(fake.createPullRequestArgsForCall)]
-	fake.listBranchesArgsForCall = append(fake.listBranchesArgsForCall, struct {
-		arg1 context.Context
-		arg2 string
-		arg3 string
-		arg4 *githuba.BranchListOptions
-	}{arg1, arg2, arg3, arg4})
-	fake.recordInvocation("ListBranches", []interface{}{arg1, arg2, arg3, arg4})
-	fake.listBranchesMutex.Unlock()
-	if fake.ListBranchesStub != nil {
-		return fake.ListBranchesStub(arg1, arg2, arg3, arg4)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.listBranchesReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeClient) ListBranchesReturns(result1 []*githuba.Branch, result2 *githuba.Response, result3 error) {
-	fake.listBranchesMutex.Lock()
-	defer fake.listBranchesMutex.Unlock()
-	fake.ListBranchesStub = nil
-	fake.listBranchesReturns = struct {
-		result1 []*githuba.Branch
-		result2 *githuba.Response
-		result3 error
-	}{result1, result2, result3}
 }
 
 var _ github.Client = new(FakeClient)

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -134,6 +135,20 @@ func (c *githubNotesRecordClient) ListReleases(
 		return nil, nil, err
 	}
 	return releases, resp, nil
+}
+
+// TODO: Complete logic
+func (c *githubNotesRecordClient) GetReleaseByTag(
+	ctx context.Context, owner, repo, tag string,
+) (*github.RepositoryRelease, *github.Response, error) {
+	return nil, nil, nil
+}
+
+// TODO: Complete logic
+func (c *githubNotesRecordClient) DownloadReleaseAsset(
+	context.Context, string, string, int64,
+) (io.ReadCloser, string, error) {
+	return nil, "", nil
 }
 
 func (c *githubNotesRecordClient) ListTags(

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"sync"
@@ -118,6 +119,20 @@ func (c *githubNotesReplayClient) ListReleases(
 		return nil, nil, err
 	}
 	return result, record.response(), nil
+}
+
+// TODO: Complete logic
+func (c *githubNotesReplayClient) GetReleaseByTag(
+	ctx context.Context, owner, repo, tag string,
+) (*github.RepositoryRelease, *github.Response, error) {
+	return nil, nil, nil
+}
+
+// TODO: Complete logic
+func (c *githubNotesReplayClient) DownloadReleaseAsset(
+	context.Context, string, string, int64,
+) (io.ReadCloser, string, error) {
+	return nil, "", nil
 }
 
 func (c *githubNotesReplayClient) ListTags(


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig network node

#### What this PR does / why we need it:

gh2gcs is go-based CLI tool to download GitHub releases and then upload them to a GCS bucket.

This is roughly adapted from the [upload script](https://github.com/kubernetes/kubernetes/pull/91370#issuecomment-632939543) I wrote for the CNI plugins@v0.8.6 k/k PR.

The intention here is to provide a simple tool that can be used by Release Managers or other project maintainers to ensure their release assets are kept up-to-date in a Kubernetes GCS release bucket.

Eventually, it will support a yaml-based config that allows multiple repos to uploaded in one run.

Inspired by the following issues: https://github.com/kubernetes/sig-release/issues/245, https://github.com/kubernetes/release/issues/739

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
gh2gcs: Add go-based CLI for uploading GH releases to GCS
```
