### PR TITLE
cmd/schedule-builder: Add CLI tool for release schedule generation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
         "//cmd/krel:all-srcs",
         "//cmd/kubepkg:all-srcs",
         "//cmd/release-notes:all-srcs",
+        "//cmd/schedule-builder:all-srcs",
         "//lib:all-srcs",
         "//pkg/announce:all-srcs",
         "//pkg/command:all-srcs",

--- a/cmd/schedule-builder/BUILD.bazel
+++ b/cmd/schedule-builder/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/release/cmd/schedule-builder",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd/schedule-builder/cmd:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/schedule-builder/cmd:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "schedule-builder",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/schedule-builder/README.md
+++ b/cmd/schedule-builder/README.md
@@ -1,0 +1,91 @@
+# Schedule Builder
+
+This simple tool has the objective to parse the yaml file located in [SIG-Release](https://github.com/kubernetes/sig-release/blob/master/releases/), which shows the scheduled and past patch releases of the current Kubernetes Release cycle in machine readable format.
+
+## Install
+
+The simplest way to install the `schedule-builder` CLI is via `go get`:
+
+```
+$ go get k8s.io/release/cmd/schedule-builder
+```
+
+This will install `schedule-builder` to `$(go env GOPATH)/bin/schedule-builder`.
+
+Also if you have the `kubernetes/release` cloned you can run the `make release-tools` to build all the tools.
+
+## Usage
+
+To run this tool you can just do, assuming you have cloned both `SIG-Release` and `Release` repositories, like
+
+```
+.
++-- kubernetes
+|   +-- sig-release
+|   +-- release
+```
+
+```bash
+$ schedule-builder --schedule-path ../sig-release/releases/schedule.yaml
+```
+
+The output will be something similiar to this
+
+```
+### Timeline
+
+### 1.18
+
+Next patch release is **1.18.4**
+
+End of Life for **1.18** is **TBD**
+
+| PATCH RELEASE | CHERRY PICK DEADLINE  | TARGET DATE |
+|---------------|-----------------------|-------------|
+| 1.18.4        | 2020-06-12            | 2020-06-17  |
+| 1.18.3        | 2020-05-15            | 2020-05-20  |
+| 1.18.2        | 2020-04-13            | 2020-04-16  |
+| 1.18.1        | 2020-04-06            | 2020-04-08  |
+
+### 1.17
+
+Next patch release is **1.17.7**
+
+End of Life for **1.17** is **TBD**
+
+| PATCH RELEASE |                                 CHERRY PICK DEADLINE                                  | TARGET DATE |
+|---------------|---------------------------------------------------------------------------------------|-------------|
+| 1.17.7        | 2020-06-12                                                                            | 2020-06-17  |
+| 1.17.6        | 2020-05-15                                                                            | 2020-05-20  |
+| 1.17.5        | 2020-04-13                                                                            | 2020-04-16  |
+| 1.17.4        | 2020-03-09                                                                            | 2020-03-12  |
+| 1.17.3        | 2020-02-07                                                                            | 2020-02-11  |
+| 1.17.2        | No-op release https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion | 2020-01-21  |
+| 1.17.1        | 2020-01-10                                                                            | 2020-01-14  |
+
+### 1.16
+
+Next patch release is **1.16.11**
+
+End of Life for **1.16** is **TBD**
+
+| PATCH RELEASE |                                 CHERRY PICK DEADLINE                                  | TARGET DATE |
+|---------------|---------------------------------------------------------------------------------------|-------------|
+| 1.16.11       | 2020-06-12                                                                            | 2020-06-17  |
+| 1.16.10       | 2020-05-15                                                                            | 2020-05-20  |
+| 1.16.9        | 2020-04-13                                                                            | 2020-04-16  |
+| 1.16.8        | 2020-03-09                                                                            | 2020-03-12  |
+| 1.16.7        | 2020-02-07                                                                            | 2020-02-11  |
+| 1.16.6        | No-op release https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion | 2020-01-21  |
+| 1.16.5        | 2020-01-10                                                                            | 2020-01-14  |
+| 1.16.4        | 2019-12-06                                                                            | 2019-12-11  |
+| 1.16.3        | 2019-11-08                                                                            | 2019-11-13  |
+| 1.16.2        | 2019-10-11                                                                            | 2019-10-15  |
+| 1.16.1        | 2019-09-27                                                                            | 2019-10-02  |
+```
+
+Also can save the schedule in a file, to do that, you can set the `--output-file` flag together with the filename.
+
+```
+$ schedule-builder --schedule-path ../sig-release/releases/schedule.yaml --output-file my-schedule.md
+```

--- a/cmd/schedule-builder/cmd/BUILD.bazel
+++ b/cmd/schedule-builder/cmd/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["root.go"],
+    importpath = "k8s.io/release/cmd/schedule-builder/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/log:go_default_library",
+        "@com_github_olekukonko_tablewriter//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/log"
+	"sigs.k8s.io/yaml"
+)
+
+// PatchSchedule main struct to hold the schedules
+type PatchSchedule struct {
+	Schedules []Schedule `yaml:"schedules"`
+}
+
+// PreviousPatches struct to define the old pacth schedules
+type PreviousPatches struct {
+	Release            string `yaml:"release"`
+	CherryPickDeadline string `yaml:"cherryPickDeadline"`
+	TargetDate         string `yaml:"targetDate"`
+}
+
+// Schedule struct to define the release schedule for a specific version
+type Schedule struct {
+	Release            string            `yaml:"release"`
+	Next               string            `yaml:"next"`
+	CherryPickDeadline string            `yaml:"cherryPickDeadline"`
+	TargetDate         string            `yaml:"targetDate"`
+	EndOfLifeDate      string            `yaml:"endOfLifeDate"`
+	PreviousPatches    []PreviousPatches `yaml:"previousPatches"`
+}
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:               "schedule-builder --config-path path/to/schedule.yaml [--output-file <filename.md>]",
+	Short:             "schedule-builder generate a humam readable format of the Kubernetes release schedule",
+	Example:           "schedule-builder --config-path /home/user/kubernetes/sig-release/releases/schedule.yaml",
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	PersistentPreRunE: initLogging,
+	RunE: func(*cobra.Command, []string) error {
+		return run(opts)
+	},
+}
+
+type options struct {
+	configPath string
+	outputFile string
+	logLevel   string
+}
+
+var opts = &options{}
+
+const (
+	configPathFlag = "config-path"
+	outputFileFlag = "output-file"
+)
+
+var requiredFlags = []string{
+	configPathFlag,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(
+		&opts.configPath,
+		configPathFlag,
+		"",
+		"path where can find the schedule.yaml file",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.outputFile,
+		outputFileFlag,
+		"",
+		"name of the file that save the schedule to. If not set it will just output to the stdout.",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&opts.logLevel,
+		"log-level",
+		"info",
+		"the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'",
+	)
+
+	for _, flag := range requiredFlags {
+		if err := rootCmd.MarkPersistentFlagRequired(flag); err != nil {
+			logrus.Fatal(err)
+		}
+	}
+}
+
+func initLogging(*cobra.Command, []string) error {
+	return log.SetupGlobalLogger(opts.logLevel)
+}
+
+func run(opts *options) error {
+	if err := opts.SetAndValidate(); err != nil {
+		return errors.Wrap(err, "validating schedule-path options")
+	}
+
+	logrus.Infof("Reading the schedule file %s...", opts.configPath)
+	data, err := ioutil.ReadFile(opts.configPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to read the file")
+	}
+
+	var patchSchedule PatchSchedule
+
+	logrus.Info("Parsing the schedule...")
+	err = yaml.UnmarshalStrict(data, &patchSchedule)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode the file")
+	}
+
+	logrus.Info("Generating the markdown output...")
+
+	output := []string{}
+	output = append(output, "### Timeline\n")
+	for _, releaseSchedule := range patchSchedule.Schedules {
+		output = append(output, fmt.Sprintf("### %s\n", releaseSchedule.Release),
+			fmt.Sprintf("Next patch release is **%s**\n", releaseSchedule.Next),
+			fmt.Sprintf("End of Life for **%s** is **%s**\n", releaseSchedule.Release, releaseSchedule.EndOfLifeDate))
+
+		tableString := &strings.Builder{}
+		table := tablewriter.NewWriter(tableString)
+		table.SetAutoWrapText(false)
+		table.SetHeader([]string{"Patch Release", "Cherry Pick Deadline", "Target Date"})
+		table.Append([]string{strings.TrimSpace(releaseSchedule.Next), strings.TrimSpace(releaseSchedule.CherryPickDeadline), strings.TrimSpace(releaseSchedule.TargetDate)})
+
+		for _, previous := range releaseSchedule.PreviousPatches {
+			table.Append([]string{strings.TrimSpace(previous.Release), strings.TrimSpace(previous.CherryPickDeadline), strings.TrimSpace(previous.TargetDate)})
+		}
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		table.SetCenterSeparator("|")
+		table.Render()
+
+		output = append(output, tableString.String())
+	}
+
+	scheduleOut := strings.Join(output, "\n")
+
+	logrus.Info("Schedule parsed")
+	println(scheduleOut)
+
+	if opts.outputFile != "" {
+		logrus.Infof("Saving schedule to a file %s.", opts.outputFile)
+		err := ioutil.WriteFile(opts.outputFile, []byte(scheduleOut), 0644)
+		if err != nil {
+			return errors.Wrap(err, "failed to save schedule to the file")
+		}
+		logrus.Info("File saved")
+	}
+
+	return nil
+}
+
+// SetAndValidate sets some default options and verifies if options are valid
+func (o *options) SetAndValidate() error {
+	logrus.Info("Validating schedule-path options...")
+
+	if o.configPath == "" {
+		return errors.Errorf("need to set the config-path")
+	}
+
+	return nil
+}

--- a/cmd/schedule-builder/main.go
+++ b/cmd/schedule-builder/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/release/cmd/schedule-builder/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -23,6 +23,7 @@ RELEASE_TOOLS=(
   gh2gcs
   kubepkg
   krel
+  schedule-builder
 )
 
 setup_env() {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add the parser tool to generate the markdown schedule based on the machine-readable format that is proposed in this PR https://github.com/kubernetes/sig-release/pull/1096


#### Which issue(s) this PR fixes:
 - Fixes https://github.com/kubernetes/sig-release/issues/718

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
adds schedule parser to generate markdown text based on the machine-readable format
```

/cc @justaugustus @tpepper @kubernetes/release-managers  
