### PR TITLE
push-build: look for version in bazel-bin

### DIFF
--- a/push-build.sh
+++ b/push-build.sh
@@ -121,11 +121,18 @@ RELEASE_BUCKET=${FLAGS_bucket:-"kubernetes-release-dev"}
 # This will canonicalize the path
 KUBE_ROOT=$(pwd -P)
 
+# TODO: this should really just read the version from the release tarball always
 USE_BAZEL=false
 if release::was_built_with_bazel $KUBE_ROOT $FLAGS_release_kind; then
   USE_BAZEL=true
-  bazel build //:version
-  LATEST=$(cat $KUBE_ROOT/bazel-genfiles/version)
+  # The check for version in bazel-genfiles can be removed once everyone is off
+  # of versions before 0.25.0.
+  # https://github.com/bazelbuild/bazel/issues/8651
+  if [[ -r  "$KUBE_ROOT/bazel-genfiles/version" ]]; then
+    LATEST=$(cat $KUBE_ROOT/bazel-genfiles/version)
+  else
+    LATEST=$(cat $KUBE_ROOT/bazel-bin/version)
+  fi
 else
   LATEST=$(tar -O -xzf $KUBE_ROOT/_output/release-tars/$FLAGS_release_kind.tar.gz $FLAGS_release_kind/version)
 fi


### PR DESCRIPTION
#### What this PR does / why we need it:

**Partial cherry pick of https://github.com/kubernetes/release/pull/1211**
bazel-bin and bazel-genfiles have pointed to the same location since
0.25. -genfiles is deprecated.

Issue: bazelbuild/bazel#8651

#### Which issue(s) this PR fixes:

We're seeing `pull-release-cluster-up` job failures on the `build-admins` branch, specifically in these two PRs: https://github.com/kubernetes/release/pull/1250, https://github.com/kubernetes/release/pull/1309

cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/release/pull/1250#issuecomment-627652333

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
