### PR TITLE
Infer default sender for krel announce

### DIFF
--- a/pkg/mail/BUILD.bazel
+++ b/pkg/mail/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/release/pkg/mail",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sendgrid_rest//:go_default_library",
         "@com_github_sendgrid_sendgrid_go//:go_default_library",
         "@com_github_sendgrid_sendgrid_go//helpers/mail:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
If the `--email` and `--name` flags are not set for `krel announce`,
then we now infer the default mail and name directly from the API.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Automatically infer the `krel announce` default sender address and name from sendgrid if the flags (`--email,-e` and `--name,-n`) are not set
```
