### PR TITLE
kubepkg: Use k8s-artifacts-cri-tools GCS bucket as source for CRI tools

### DIFF
--- a/cmd/kubepkg/templates/latest/deb/cri-tools/debian/rules
+++ b/cmd/kubepkg/templates/latest/deb/cri-tools/debian/rules
@@ -7,7 +7,7 @@ build:
 binary:
 	mkdir -p ./bin
 	curl -sSL --fail --retry 5 \
-		"https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ .Version }}/crictl-v{{ .Version }}-linux-{{ .GoArch }}.tar.gz" \
+		"https://storage.googleapis.com/k8s-artifacts-cri-tools/release/v{{ .Version }}/crictl-v{{ .Version }}-linux-{{ .GoArch }}.tar.gz" \
 		| tar -C ./bin -xz
 	dh_testroot
 	dh_auto_install

--- a/cmd/kubepkg/templates/latest/rpm/cri-tools/cri-tools.spec
+++ b/cmd/kubepkg/templates/latest/rpm/cri-tools/cri-tools.spec
@@ -5,7 +5,7 @@ Summary: Command-line utility for interacting with a container runtime.
 
 License: ASL 2.0
 URL: https://kubernetes.io
-Source0: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ .Version }}/crictl-v{{ .Version }}-linux-{{ .GoArch }}.tar.gz
+Source0: https://storage.googleapis.com/k8s-artifacts-cri-tools/release/v{{ .Version }}/crictl-v{{ .Version }}-linux-{{ .GoArch }}.tar.gz
 
 BuildRequires: systemd
 BuildRequires: curl


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now have a community-owned GCS bucket for CRI tools, so let's utilize it here.

/assign @saschagrunert @cpanato 
ref: https://github.com/kubernetes-sigs/cri-tools/issues/616

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubepkg: Use k8s-artifacts-cri-tools GCS bucket as source for CRI tools
```
