### PR TITLE
Use k8s-artifacts-cri-tools GCS bucket as source for CRI tools

### DIFF
--- a/debian/bionic/cri-tools/debian/rules
+++ b/debian/bionic/cri-tools/debian/rules
@@ -9,7 +9,7 @@ build:
 binary:
 	mkdir -p ./bin
 	curl -sSL --fail --retry 5 \
-		"https://github.com/kubernetes-sigs/cri-tools/releases/download/v$(CRI_TOOLS_VERSION)/crictl-v$(CRI_TOOLS_VERSION)-linux-{{ .Arch }}.tar.gz" \
+		"https://storage.googleapis.com/k8s-artifacts-cri-tools/release/v$(CRI_TOOLS_VERSION)/crictl-v$(CRI_TOOLS_VERSION)-linux-{{ .Arch }}.tar.gz" \
 		| tar -C ./bin -xz
 	dh_testroot
 	dh_auto_install

--- a/rpm/kubelet.spec
+++ b/rpm/kubelet.spec
@@ -28,7 +28,7 @@ Source3: https://dl.k8s.io/v%{KUBE_VERSION}/bin/linux/%{ARCH}/kubeadm
 Source4: 10-kubeadm.conf
 Source5: https://dl.k8s.io/network-plugins/cni-plugins-%{ARCH}-v%{CNI_VERSION}.tgz
 Source6: kubelet.env
-Source7: https://github.com/kubernetes-sigs/cri-tools/releases/download/v%{CRI_TOOLS_VERSION}/crictl-v%{CRI_TOOLS_VERSION}-linux-%{ARCH}.tar.gz
+Source7: https://storage.googleapis.com/k8s-artifacts-cri-tools/release/v%{CRI_TOOLS_VERSION}/crictl-v%{CRI_TOOLS_VERSION}-linux-%{ARCH}.tar.gz
 
 BuildRequires: systemd
 BuildRequires: curl
@@ -157,6 +157,10 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Fri May 29 2020 Stephen Augustus <saugustus@vmware.com> - 1.18.4
+- Source cri-tools from https://storage.googleapis.com/k8s-artifacts-cri-tools/release
+  instead of https://github.com/kubernetes-sigs/cri-tools
+
 * Thu Jun 24 2019 Stephen Augustus <saugustus@vmware.com> - 1.15.1
 - Bump minimum versions of all kubernetes dependencies
 - Remove conditional logic for unsupported versions of Kubernetes


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now have a community-owned GCS bucket for CRI tools, so let's utilize it here.

/assign @saschagrunert @cpanato 
ref: https://github.com/kubernetes-sigs/cri-tools/issues/616

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Use k8s-artifacts-cri-tools GCS bucket as source for CRI tools
```
