### PR TITLE
gh2gcs: clean temporary folder if output-dir is not set

### DIFF
--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -77,6 +78,11 @@ var (
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
+	}
+
+	if !rootCmd.Flags().Changed(outputDirFlag) {
+		logrus.Infof("Cleaning temporary directory %s", opts.outputDir)
+		os.RemoveAll(opts.outputDir)
 	}
 }
 
@@ -204,7 +210,6 @@ func run(opts *options) error {
 func (o *options) SetAndValidate() error {
 	logrus.Info("Validating gh2gcs options...")
 
-	// TODO: Temp dir should cleanup after itself
 	if o.outputDir == "" {
 		tmpDir, err := ioutil.TempDir("", "gh2gcs")
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

clean the temporary folder when the flag `output-dir` is not set 

#### Which issue(s) this PR fixes:

Fixes partially https://github.com/kubernetes/release/issues/1320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gh2gcs: clean temporary folder if output-dir is not set
```

/cc @justaugustus 