### PR TITLE
kubepkg: Use StringSliceVar for flags

### DIFF
--- a/cmd/kubepkg/README.md
+++ b/cmd/kubepkg/README.md
@@ -9,8 +9,7 @@
   - [Example: Building nightly kubeadm debs for amd64 architecture](#example-building-nightly-kubeadm-debs-for-amd64-architecture)
   - [Example: Building deb specs for all packages, all channels, and all architectures](#example-building-deb-specs-for-all-packages-all-channels-and-all-architectures)
 - [Known Issues](#known-issues)
-  - [Building rpms is not currently supported](#building-rpms-is-not-currently-supported)
-  - [Supplying multiple options as a comma-separated string will fail](#supplying-multiple-options-as-a-comma-separated-string-will-fail)
+  - [Building rpms is not _currently_ supported](#building-rpms-is-not-currently-supported)
 
 ## Installation
 
@@ -31,14 +30,14 @@ Available Commands:
   rpms        rpms creates RPMs for Kubernetes components
 
 Flags:
-      --arch stringArray                    architectures to build for (default [amd64,arm,arm64,ppc64le,s390x])
-      --channels stringArray                channels to build for (default [release,testing,nightly])
+      --arch strings                        architectures to build for (default [amd64,arm,arm64,ppc64le,s390x])
+      --channels strings                    channels to build for (default [release,testing,nightly])
       --cni-version string                  CNI version to build
       --cri-tools-version string            CRI tools version to build
   -h, --help                                help for kubepkg
       --kube-version string                 Kubernetes version to build
       --log-level string                    the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace' (default "info")
-      --packages stringArray                packages to build (default [kubelet,kubectl,kubeadm,kubernetes-cni,cri-tools])
+      --packages strings                    packages to build (default [kubelet,kubectl,kubeadm,kubernetes-cni,cri-tools])
       --release-download-link-base string   release download link base (default "https://dl.k8s.io")
       --revision string                     deb package revision. (default "0")
       --spec-only                           only create specs instead of building packages
@@ -64,14 +63,3 @@ kubepkg debs --spec-only
 We haven't written the logic for building rpms yet.
 
 Right now, you can build rpm specs using the `--spec-only` flag and then use a tool of your choice to build the rpms using the specs produced.
-
-### Supplying multiple options as a comma-separated string will fail
-
-Example:
-
-```shell
-kubepkg debs --packages kubeadm,kubelet
-```
-
-This is a bug between the `IsSupported` validation function and the format of the string array provided.
-User-supplied comma-separated options appear get interpreted as a string (`"foo,bar"`) instead of a slice (`[]string{"foo","bar"}`).

--- a/cmd/kubepkg/cmd/root.go
+++ b/cmd/kubepkg/cmd/root.go
@@ -48,7 +48,7 @@ func Execute() {
 
 func init() {
 	packages := []string{}
-	rootCmd.PersistentFlags().StringArrayVar(
+	rootCmd.PersistentFlags().StringSliceVar(
 		&packages,
 		"packages",
 		opts.Packages(),
@@ -56,7 +56,7 @@ func init() {
 	)
 
 	channels := []string{}
-	rootCmd.PersistentFlags().StringArrayVar(
+	rootCmd.PersistentFlags().StringSliceVar(
 		&channels,
 		"channels",
 		opts.Channels(),
@@ -64,7 +64,7 @@ func init() {
 	)
 
 	architectures := []string{}
-	rootCmd.PersistentFlags().StringArrayVar(
+	rootCmd.PersistentFlags().StringSliceVar(
 		&architectures,
 		"arch",
 		opts.Architectures(),

--- a/pkg/kubepkg/options/options.go
+++ b/pkg/kubepkg/options/options.go
@@ -198,16 +198,6 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-// TODO: kubepkg is failing validations when multiple options are selected
-//       It seems like StringArrayVar is treating the multiple comma-separated
-//       values as a single value.
-//
-// Example:
-// $ time kubepkg debs --arch amd64,arm
-// <snip>
-// INFO[0000] Adding 'amd64,arm' (type: string) to not supported
-// INFO[0000] The following options are not supported: [amd64,arm]
-// FATA[0000] architectures selections are not supported
 func isSupported(input, expected []string) bool {
 	notSupported := []string{}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes ability to process multiple arches, channels, and packages.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubepkg: Allow processing multiple arches, channels, and packages via flag
```
