### PR TITLE
Fix kubepkg options parsing

### DIFF
--- a/cmd/kubepkg/cmd/debs.go
+++ b/cmd/kubepkg/cmd/debs.go
@@ -33,8 +33,7 @@ var debsCmd = &cobra.Command{
 		return opts.Validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		opts = opts.WithBuildType(options.BuildDeb)
-		return run(opts)
+		return run(options.BuildDeb)
 	},
 }
 

--- a/cmd/kubepkg/cmd/rpms.go
+++ b/cmd/kubepkg/cmd/rpms.go
@@ -33,8 +33,7 @@ var rpmsCmd = &cobra.Command{
 		return opts.Validate()
 	},
 	RunE: func(*cobra.Command, []string) error {
-		opts = opts.WithBuildType(options.BuildRpm)
-		return run(opts)
+		return run(options.BuildRpm)
 	},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
The custom options where not working at all before because of the
parsing in `init()`. This as been fixed by making the flag vars global
and the ad-hoc creation of `options.Options`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/release/issues/1331

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed not working `kubepkg` flag parsing
```
