### PR TITLE
Fix invalid previous tag on krel changelog for beta releases > 0

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -323,8 +323,8 @@ func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 	for _, t := range allTags {
 		tag := t.GetName()
 
-		// Alpha releases are only available on the master branch
-		if strings.Contains(tag, "alpha") {
+		// alpha and beta releases are only available on the master branch
+		if strings.Contains(tag, "beta") || strings.Contains(tag, "alpha") {
 			releases.addIfNotExisting(git.Master, tag)
 			continue
 		}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -125,9 +125,9 @@ func TestLatestGitHubTagsPerBranchSuccessMultipleForSameBranch(t *testing.T) {
 
 	// Then
 	require.Nil(t, err)
-	require.Len(t, res, 5)
-	require.Equal(t, tag2, res[git.Master])
-	require.Equal(t, tag1, res["release-1.18"])
+	require.Len(t, res, 4)
+	require.Equal(t, tag1, res[git.Master])
+	require.Empty(t, res["release-1.18"])
 	require.Empty(t, res["release-1.17"])
 	require.Equal(t, tag5, res["release-1.16"])
 	require.Equal(t, tag3, res["release-1.15"])


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
The changelog for v1.19.0-beta.1 is diffing against the wrong version
(the latest alpha, but it should be v1.19.0-beta.0):
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md/#changelog-since-v1190-alpha3

This is a regression introduced with our latest branch cut changes and
should be fixed with this commit.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/cc @Verolop @cpanato @justaugustus 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed invalid previous tag selection on `krel changelog` for beta releases > 0
```
