### PR TITLE
OWNERS: Add Release Manager Associates as release-engineering-reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,10 @@
 
 approvers:
   - sig-release-leads
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - sig/release
   - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,18 +5,23 @@ aliases:
     - calebamiles
     - justaugustus
     - tpepper
-  release-engineering:
+  release-engineering-approvers:
     - calebamiles # subproject owner
-    - dougm # Patch Release Team
-    - feiskyer # Patch Release Team
-    - hoegaarden # Patch Release Team
-    - idealhack # Patch Release Team
-    - justaugustus # subproject owner / Patch Release Team
-    - tpepper # subproject owner / Patch Release Team
-  branch-managers:
-    - cpanato
-    - hasheddan
-    - saschagrunert
+    - dougm # Release Manager
+    - feiskyer # Release Manager
+    - hoegaarden # Release Manager
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - tpepper # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - cpanato # Release Manager
+    - hasheddan # Release Manager
+    - jimangel # Release Manager Associate
+    - markyjackson-taulia # Release Manager Associate
+    - saschagrunert # Release Manager
+    - sethmccombs # Release Manager Associate
+    - verolop # Release Manager Associate
+    - xmudrii # Release Manager Associate
   build-admins:
     - aleksandra-malinowska
     - listx

--- a/cmd/kubepkg/OWNERS
+++ b/cmd/kubepkg/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
   - build-admins
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - area/release-eng

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
   - build-admins
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - area/release-eng

--- a/packages/deb/OWNERS
+++ b/packages/deb/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
   - build-admins
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - area/release-eng

--- a/packages/rpm/OWNERS
+++ b/packages/rpm/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
   - build-admins
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - area/release-eng


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add Release Manager Associates as `release-engineering-reviewers`
(Part of Release Manager team consolidation in https://github.com/kubernetes/sig-release/pull/1106.)

/assign @tpepper 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
