### PR TITLE
Fix release-notes TOC to contain dependency report

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -296,14 +296,6 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 		}
 
 		const nl = "\n"
-		if releaseNotesOpts.tableOfContents {
-			toc, err := notes.GenerateTOC(markdown)
-			if err != nil {
-				return errors.Wrap(err, "generating table of contents")
-			}
-			markdown = toc + nl + markdown
-		}
-
 		if releaseNotesOpts.dependencies {
 			url := git.GetRepoURL(opts.GithubOrg, opts.GithubRepo, false)
 			deps, err := notes.NewDependencies().ChangesForURL(
@@ -313,6 +305,14 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 				return errors.Wrap(err, "generating dependency report")
 			}
 			markdown += strings.Repeat(nl, 2) + deps
+		}
+
+		if releaseNotesOpts.tableOfContents {
+			toc, err := notes.GenerateTOC(markdown)
+			if err != nil {
+				return errors.Wrap(err, "generating table of contents")
+			}
+			markdown = toc + nl + markdown
 		}
 
 		if _, err := output.WriteString(markdown); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The generated TOC did not contain the optional dependency report, which is now fixed.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed `release-notes` table of contents to also contain dependency report if available
```
