### PR TITLE
kube-cross: bump to go1.13.12

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -7,7 +7,7 @@ variants:
     ETCD_VERSION: 'v3.4.7'
   go1.13:
     CONFIG: 'go1.13'
-    GO_VERSION: '1.13.9'
-    KUBE_CROSS_VERSION: 'v1.13.9-5'
+    GO_VERSION: '1.13.12'
+    KUBE_CROSS_VERSION: 'v1.13.12-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.7'


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area dependency

**What this PR does / why we need it:**

go1.13.12 has been released. Here we update kube-cross appropriately.

build-image approvers:
/assign @BenTheElder @liggitt @cblecker @dims @listx
cc: @kubernetes/release-engineering

ref: kubernetes/kubernetes#1134

Does this PR introduce a user-facing change?
```release-note
kube-cross: Update to go1.13.12
```