### PR TITLE
Add releng-ci-go container image for CI

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -33,5 +33,6 @@ bit more on that [in the cloud-build docs][gcb_images].
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | [k8s-cloud-builder](./k8s-cloud-builder/) | The "main" image, [`anago`](../anago) runs with on cloud-build (submitted via [`krel gcbmgr`](../docs/krel)) |
 | [releng-ci-bazel](./releng-ci-bazel)      | The bazel image used for CI testing                                                                  |
+| [releng-ci-go](./releng-ci-go)            | The golang image used for CI testing                                                                 |
 
 [gcb_images]: https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts#storing_images_in

--- a/images/releng-ci-go/Dockerfile
+++ b/images/releng-ci-go/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN apt-get update && \
+    apt-get install -y \
+        bsdmainutils \
+        build-essential \
+        google-cloud-sdk \
+        jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Some tests require a working git executable, so we configure a pseudo-user
+RUN git config --global user.name releng-ci-user && \
+    git config --global user.email nobody@k8s.io

--- a/images/releng-ci-go/cloudbuild.yaml
+++ b/images/releng-ci-go/cloudbuild.yaml
@@ -1,0 +1,25 @@
+---
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/releng-ci-go:$_GIT_TAG
+      - --tag=gcr.io/$PROJECT_ID/releng-ci-go:latest
+      - .
+  - name: gcr.io/gcp-runtimes/container-structure-test
+    args:
+      - test
+      - --image=gcr.io/$PROJECT_ID/releng-ci-go:latest
+      - --config=test.yaml
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+images:
+  - 'gcr.io/$PROJECT_ID/releng-ci-go:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/releng-ci-go:latest'

--- a/images/releng-ci-go/test.yaml
+++ b/images/releng-ci-go/test.yaml
@@ -1,0 +1,32 @@
+---
+# https://github.com/GoogleContainerTools/container-structure-test
+schemaVersion: '2.0.0'
+
+commandTests:
+  - name: commands are available
+    command: /test.sh
+    args:
+      - gcc
+    setup:
+      -
+        - bash
+        - -c
+        - |
+          cat <<'EOF' >/test.sh
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          exitCode=0
+          for cmd in "$@"
+          do
+            if command -v "$cmd" >/dev/null 2>&1; then
+              echo -n .
+            else
+              exitCode=1
+              echo >&2 "${cmd} NOT available."
+            fi
+          done
+          exit $exitCode
+          EOF
+
+          chmod +x /test.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The `releng-ci-go` container images should be used in substitution for
the bazel toolchain after migrating the test cases.
#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes/release/issues/1150

#### Special notes for your reviewer:
Let's discuss if we wanna go this path, but we have issues updating the golang dependencies as well as repo-infra (see https://github.com/kubernetes/release/pull/1255)
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `releng-ci-go` container image for bazel-less CI tests
```
