### PR TITLE
krel release-notes refactor & cleanup

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -519,10 +519,30 @@ func (g *GitHub) RepoIsForkOf(
 
 	// Check if the parent repo matches the owner/repo string
 	if repository.GetParent().GetFullName() == fmt.Sprintf("%s/%s", parentOwner, parentRepo) {
-		logrus.Infof("%s/%s is a fork of %s/%s", forkOwner, forkRepo, parentOwner, parentRepo)
+		logrus.Debugf("%s/%s is a fork of %s/%s", forkOwner, forkRepo, parentOwner, parentRepo)
 		return true, nil
 	}
 
 	logrus.Infof("%s/%s is not a fork of %s/%s", forkOwner, forkRepo, parentOwner, parentRepo)
+	return false, nil
+}
+
+// BranchExists checks if a branch exists in a given repo
+func (g *GitHub) BranchExists(
+	owner, repo, branchname string,
+) (isBranch bool, err error) {
+	branches, err := g.ListBranches(owner, repo)
+	if err != nil {
+		return false, errors.Wrap(err, "while listing repository branches")
+	}
+
+	for _, branch := range branches {
+		if branch.GetName() == branchname {
+			logrus.Debugf("Branch %s already exists in %s/%s", branchname, owner, repo)
+			return true, nil
+		}
+	}
+
+	logrus.Debugf("Repository %s/%s does not have a branch named %s", owner, repo, branchname)
 	return false, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This is is the final cleanup of the `krel release-notes` to clean up several months worth of changes we made to add the capability to create the pull requests to krel. It is a general refactor of `release-notes.go` removing duplicate code and simplifying things where possible.

According to what we discussed, this PR also simplifies the command line interface and limits the scope of krel to only create the pull requests for the notes of a given release. The rest of the tools and options will still be available in the general purpose `release-notes` tool.

The command line interface is now simpler. The GitHub organization of the user is now just `--org` and help messages are now more concise. Invoking `krel release-notes` without any options will now display the usage information instead of surprising the user running with some defaults.

To be able to re-generate the JSON notes of a given tag (and avoid bugs like #838 ), `addReferenceToAssetsFile()` is now idempotent.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

`github.BranchExists()` tests are coming, I want to wait for #1344 to merge before making more changes to the github pkg

Docs will be updated once this merges to reflect changes to the command line interface

#### Does this PR introduce a user-facing change?

```release-note
* Function `BranchExists()` has been ported to the github package.
* The `addReferenceToAssetsFile()` function idempotent to enable re-generation of json files
* The GitHub organization flag to create PRs is now simply `--org` 
* The `--website-org` and `--draft-org` have been removed
* Fork checking is now done in an independent block which can be called independently
* `--create-draft-pr` and `--create-website-pr` can now be run at the same time
* Running krel release-notes without any option now shows usage info and exits
```
