### PR TITLE
Make hack/verify-shellcheck.sh work with podman

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -23,8 +23,8 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-# upstream shellcheck latest stable image as of January 10th, 2019
-SHELLCHECK_IMAGE="koalaman/shellcheck-alpine:v0.6.0@sha256:7d4d712a2686da99d37580b4e2f45eb658b74e4b01caf67c1099adc294b96b52"
+# upstream shellcheck latest stable image as of June 16th, 2020
+SHELLCHECK_IMAGE="koalaman/shellcheck-alpine:v0.7.1"
 
 # Find all shell scripts excluding:
 # - Anything git-ignored - No need to lint untracked files.
@@ -51,8 +51,10 @@ SHELLCHECK_OPTIONS=(
   "--color=auto"
 )
 
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+
 # actually shellcheck
-docker run \
-  --rm -v "${REPO_ROOT}:${REPO_ROOT}" -w "${REPO_ROOT}" \
+"${CONTAINER_RUNTIME}" run \
+  --rm -it -v "${REPO_ROOT}:${REPO_ROOT}" -w "${REPO_ROOT}" \
   "${SHELLCHECK_IMAGE}" \
   shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}"


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We still use docker as default for shell-checking but now we can run it
on top of podman as well:

```bash
> CONTAINER_RUNTIME=podman ./hack/verify-shellcheck.sh
```
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
I think we should somehow either fix or exclude the failing shellcheck lints to be able to let them run in the CI.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Make `hack/verify-shellcheck.sh` work with docker-compatible container runtimes, for example
  by setting `CONTAINER_RUNTIME=podman hack/verify-shellcheck.sh`  
```
