### PR TITLE
HACK: temporarily skip git push

### DIFF
--- a/anago
+++ b/anago
@@ -1470,7 +1470,8 @@ elif ! ((FLAGS_prebuild)); then
   if ((FLAGS_stage)); then
     common::stepindex "stage_source_tree"
   else
-    common::stepindex "push_git_objects"
+    logecho "Revert this bug workaround:  temporarily not calling push_git_objects"
+    #common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"
   if ! ((FLAGS_stage)); then


### PR DESCRIPTION
We need a more meaningful error handling than this, but this is a hack
to try to proceed with the 1.18.4 build which hit an error in pushing to
GitHub yet expected content appears to correctly be in upstream git.

This commit needs reverted ASAP.

Signed-off-by: Tim Pepper <tpepper@vmware.com>