### PR TITLE
packages/deb: Use go modules instead of vendor in build Dockerfile

### DIFF
--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -26,8 +26,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD . /src
-ADD vendor /go/src
 
 WORKDIR /src
+
+RUN go mod download
 
 ENTRYPOINT ["go", "run", "/src/build.go"]

--- a/packages/deb/go.mod
+++ b/packages/deb/go.mod
@@ -1,0 +1,5 @@
+module k8s.io/release/packages/deb
+
+go 1.14
+
+require github.com/blang/semver v3.5.1+incompatible

--- a/packages/deb/go.sum
+++ b/packages/deb/go.sum
@@ -1,0 +1,2 @@
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/packages/deb/jenkins.sh
+++ b/packages/deb/jenkins.sh
@@ -24,7 +24,7 @@ declare -r IMG_NAME="debian-builder:${BUILD_TAG}"
 declare -r DEB_RELEASE_BUCKET="gs://kubernetes-release-dev/debian"
 
 docker build -t "${IMG_NAME}" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-docker run --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}" $@
+docker run -it --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}" $@
 
 gsutil -m cp -nrc bin "${DEB_RELEASE_BUCKET}/${BUILD_TAG}"
 printf "%s" "${BUILD_TAG}" | gsutil cp - "${DEB_RELEASE_BUCKET}/latest"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

As part of forward-porting the build admin scripts in https://github.com/kubernetes/release/pull/1342, I removed `vendor/` from that directory, which was actually required for the Dockerfile.

This removes the requirement and uses go modules instead.

Currently blocking the deb builds for today's patch releases, so:
/priority critical-urgent
ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1592413106485800?thread_ts=1592385667.452000&cid=CJH2GBF7Y

/assign @listx @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
packages/deb: Use go modules instead of vendor in build Dockerfile
```
