### PR TITLE
revert Anago hacks

### DIFF
--- a/anago
+++ b/anago
@@ -598,8 +598,7 @@ prepare_tree () {
   # Tagging
   commit_string="Kubernetes $label_common release ${RELEASE_VERSION[$label]}"
   logecho -n "Tagging $commit_string on $branch: "
-  logecho "Revert this bug workaround:  temporarily do not git tag"
-  #logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
+  logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
 }
 
 ##############################################################################
@@ -1251,15 +1250,14 @@ set_release_values () {
                                 $PARENT_BRANCH \
    || return 1
 
-  logecho "Revert this bug workaround: temporarily skipping check for existing tag"
   # Check that this tag doesn't exist. Staged builds may be old
-  #if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
-  #      $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
-  #   logecho
-  #   logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
-  #   logecho "An old --buildversion was specified on the command-line."
-  #   return 1
-  #fi
+  if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
+        $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
+     logecho
+     logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
+     logecho "An old --buildversion was specified on the command-line."
+     return 1
+  fi
 
 }
 

--- a/anago
+++ b/anago
@@ -1470,8 +1470,7 @@ elif ! ((FLAGS_prebuild)); then
   if ((FLAGS_stage)); then
     common::stepindex "stage_source_tree"
   else
-    logecho "Revert this bug workaround:  temporarily not calling push_git_objects"
-    #common::stepindex "push_git_objects"
+    common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"
   if ! ((FLAGS_stage)); then


### PR DESCRIPTION
This reverts the two temporary hacks used to resolve the partial build/release of 1.18.4 after a GitHub push failed.  These hacks must not be present during any subsequent build and need reverted immediately after 1.18.4 is successfully cut.

/kind bug
/kind cleanup
/priority critical-urgent

```release-note
NONE
```
