### PR TITLE
krel: clarify announce subcommand help

### DIFF
--- a/cmd/krel/cmd/announce.go
+++ b/cmd/krel/cmd/announce.go
@@ -43,11 +43,12 @@ var announceCmd = &cobra.Command{
 	Short: "Announce Kubernetes releases",
 	Long: fmt.Sprintf(`krel announce
 
-krel announce can be used to announce already built Kubernetes releases to the
-%q and %q Google Group.
+krel announce can be used to mail an announcement of an already
+built Kubernetes release to the %q and %q Google Groups.
 
-If --nomock=true (the default), then the mail will be sent only to a test
-Google Group %q.
+By default the mail will be sent only to a test Google Group %q,
+ie: the announcement run will only be a mock run.  To do an
+official announcement, use the --nomock flag.
 
 It is necessary to export the $%s environment variable. An API key can be created by
 registering a sendgrid.com account and adding the key here:


### PR DESCRIPTION
The mock versus nomock distinction reads slightly unclear in the
announce.go help text, because of the presence of both positive and
negative modifiers ("no" and "true").  The --nomock flag actually
defaults to false in root.go, meaning it is false when not present
on the command line and specifying --nomock on the command line
sets the flag to true.  One could optionally say --nomock=false or
--nomock=true, but that's a less likely usage and shouldn't need
documented.

Signed-off-by: Tim Pepper <tpepper@vmware.com>


/kind cleanup
/kind documentation
```release-note
NONE
```
