### PR TITLE
Do not conflict kubernetes-cni package for RPMs

### DIFF
--- a/cmd/kubepkg/templates/latest/rpm/kubelet/kubelet.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubelet/kubelet.spec
@@ -17,7 +17,6 @@ Requires: ethtool
 Requires: iproute
 Requires: ebtables
 Requires: conntrack
-Obsoletes: kubernetes-cni
 Conflicts: kubernetes-cni
 
 %description
@@ -67,6 +66,10 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Thu Jun 18 2020 Sascha Grunert <sgrunert@suse.com.com> - 1.18.4
+- Do not Obsolete with kubernetes-cni package to unbreak previous
+  releases
+
 * Fri May 22 2020 Stephen Augustus <saugustus@vmware.com> - 1.18.4
 - Bundle CNI plugins (v0.8.6) in kubelet package
 

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -39,7 +39,6 @@ Requires: ethtool
 Requires: iproute
 Requires: ebtables
 Requires: conntrack
-Obsoletes: kubernetes-cni
 Conflicts: kubernetes-cni
 
 
@@ -145,6 +144,10 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Thu Jun 18 2020 Sascha Grunert <sgrunert@suse.com.com> - 1.18.4
+- Do not Obsolete with kubernetes-cni package to unbreak previous
+  releases
+
 * Fri May 29 2020 Stephen Augustus <saugustus@vmware.com> - 1.18.4
 - Source cri-tools from https://storage.googleapis.com/k8s-artifacts-cri-tools/release
   instead of https://github.com/kubernetes-sigs/cri-tools


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
This should unbreak previous releases for debs and rpms which still rely
on the kubernetes-cni package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/kubernetes/issues/92242

#### Special notes for your reviewer:

Hold on, I might be completely wrong with that change. I'm not exactly sure about the implications so please review with care.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed `kubernetes-cni` obsoletion/replacement to unbreak previous deb/rpm packages
```
