### PR TITLE
kube-cross: Build v1.14.4-2 and v1.13.12-2 images

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -25,7 +25,7 @@ KUBE_CROSS_VERSION?=v1.14.4-1
 # Build args
 GO_VERSION?=1.14.4
 PROTOBUF_VERSION?=3.0.2
-ETCD_VERSION?=v3.4.7
+ETCD_VERSION?=v3.4.9
 
 # TODO: Support multi-arch kube-cross images
 #       ref:

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,12 +2,12 @@ variants:
   go1.14:
     CONFIG: 'go1.14'
     GO_VERSION: '1.14.4'
-    KUBE_CROSS_VERSION: 'v1.14.4-1'
+    KUBE_CROSS_VERSION: 'v1.14.4-2'
     PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.7'
+    ETCD_VERSION: 'v3.4.9'
   go1.13:
     CONFIG: 'go1.13'
     GO_VERSION: '1.13.12'
-    KUBE_CROSS_VERSION: 'v1.13.12-1'
+    KUBE_CROSS_VERSION: 'v1.13.12-2'
     PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.7'
+    ETCD_VERSION: 'v3.4.9'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Uses etcd v3.4.9
ref: https://github.com/kubernetes/kubernetes/issues/91266

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

Not strictly required for, but affects https://github.com/kubernetes/release/issues/1216 and https://github.com/kubernetes/release/issues/1257.
cc: @Verolop @markyjackson-taulia 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kube-cross: Build v1.14.4-2 and v1.13.12-2 images
```
