### PR TITLE
Release notes mappings libraries and in krel release-notes

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -107,6 +107,7 @@ type releaseNotesOptions struct {
 	createWebsitePR bool
 	dependencies    bool
 	websiteRepo     string
+	mapProviders    []string
 }
 
 type releaseNotesResult struct {
@@ -165,6 +166,14 @@ func init() {
 		"dependencies",
 		true,
 		"add dependency report",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringSliceVarP(
+		&releaseNotesOpts.mapProviders,
+		"maps-from",
+		"m",
+		[]string{},
+		"specify a location to recursively look for release notes *.y[a]ml file mappings",
 	)
 
 	rootCmd.AddCommand(releaseNotesCmd)
@@ -668,6 +677,7 @@ func releaseNotesJSON(tag string) (string, error) {
 	notesOptions.EndRev = tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.ReleaseVersion = util.TrimTagPrefix(tag)
+	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return "", err
@@ -707,6 +717,7 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	notesOptions.EndRev = releaseNotesOpts.tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.ReleaseVersion = util.TrimTagPrefix(releaseNotesOpts.tag)
+	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -240,6 +240,14 @@ func init() {
 		true,
 		"Add dependency report",
 	)
+
+	cmd.PersistentFlags().StringSliceVarP(
+		&opts.MapProviderStrings,
+		"maps-from",
+		"m",
+		[]string{},
+		"specify a location to recursively look for release notes *.y[a]ml file mappings",
+	)
 }
 
 func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {

--- a/docs/release-notes-maps.md
+++ b/docs/release-notes-maps.md
@@ -1,0 +1,128 @@
+# Release Notes Map Files
+
+The release notes libraries and command libraries now support incorporating
+data from sources outside of the data gathered from pull requests and the
+GitHub API through the use of _map files_.
+
+A release note map file is a YAML construct intended to add and/or modify
+the information in a release note gathered from GitHub. The motivations for
+developing the maps are to give the release notes team more flexibility 
+to edit the notes during the release cycle and to be able to add more
+data and domain-specific context to the release notes.
+
+## Reading Map Files with `release-notes` or `krel` 
+
+To read the map files, a new `--maps-from` flag has been added
+to the `release-notes` command and the `krel release-notes` subcommand.
+This new flag takes as value a location from which to read YAML files:
+
+```console
+release-notes --maps-from=/path/to/yaml/files/
+
+# Future map locations would be prefixed with a URL-like schema.
+# An example, to read from a GCP bucket (not yet implemented):
+
+krel release-notes --maps-from=gs://bucket-name/path/
+```
+
+The logic to read from each location is handled by a MapProvider (see below).
+
+## Release Notes Map Format
+
+A release notes map has two parts, each one optional. The first one
+allows us to override the data fields defined in the associated 
+Pull Request. The second part provides a mechanism for adding more data
+to a release note to provide more context or additional
+information to a release note.
+
+### Overriding Fields: the `release-note` section
+
+The first part of the YAML in a map file overrides the data defined in the release note pull request. Each of the fields corresponds to a PR data field. A map file
+can contain any of them. An example:
+
+```yaml
+---
+pr: 123
+commit: 1a89038915fe77d73bf7c9cfa8f2ce123a464c82
+release-note:  
+  text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+  author: kubernetes-ci-robot
+  areas:
+    - release-eng
+  kinds:
+    - feature
+  sigs:
+    - release
+  feature: true
+  action_required: false
+  release_version: v1.19.0
+  documentation:
+    - description: Release Notes Improvements
+      url: https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/1733-release-notes
+      type: kep
+```
+Any of the fields defined in a map file fully overrides its PR counterpart. 
+
+### Adding data: The `datafields` section
+
+The second section in a release notes map is the `datafields` struct. 
+A data field is a free form YAML structure defined under a key in the YAML
+file. The idea of a datafield is to be able to have a central and extensible
+way to add content and improve the context of a note.
+
+The interpretation and rendering of each data field are specific to their
+domain. While our libraries will read the data fields under a new key, 
+rendering and use need to be implemented manually.
+
+The initial implementation of a data field was written to add CVE
+vulnerability data to a release note (see issue [#1354](https://github.com/kubernetes/release/issues/1354)). An example of the CVE information in a map file:
+
+```yaml
+datafields:
+  cve:
+    id: CVE-2019-1010260
+    title: "CVE-2020-8555: Half-Blind SSRF in kube-controller-manager"
+    published: 2020-05-28
+    score: 5.2
+    rating: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N
+    linkedPRs:
+    - 89794
+    - 89796
+    - 89837
+    - 89838
+    - 89839
+    description:
+        There exists a Server Side Request Forgery (SSRF) vulnerability in kube-controller-manager that allows certain authorized users to leak up to 500 bytes of arbitrary information from unprotected endpoints within the master's host network (such as link-local or loopback services).
+        An attacker with permissions to create a pod with certain built-in Volume types (GlusterFS, Quobyte, StorageOS, ScaleIO) or permissions to create a StorageClass can cause kube-controller-manager to make GET requests or POST requests without an attacker controlled request body from the master's host network.
+```
+
+## Finding Maps: The `MapProvider` Interface
+
+Release notes maps are simple YAML files. In order to find and read them, the 
+release notes libraries have implemented a MapProvider interface. The job of
+a MapProvider is to initialize itself from a location string and implement 
+a single hook function `GetMapsForPR(int)`. The release notes libraries will
+request maps by PR number from each provider defined. It will request the
+maps after gathering the data from GitHub and just before rendering.
+
+In theory, any number of map providers can be attached to the release notes
+process by invoking the `--maps-from` flag:
+
+```console
+release-notes --maps-from=/path/to/mapfiles/ 
+```
+
+The motivation of having a MapProvider interface is to be able to _read_
+maps from different sources. Currently, we have a single provider `DirectoryMapProvider` which takes a directory name as a location and reads
+the YAML files found in it.
+
+Additional ideas in flight for new MapProviders include a `GitHubMapProvider`
+and `GoogleCloudStorageProvider` which would add the ability to read from
+a (possibly private) GitHub repo and a Google Cloud Storage bucket.
+
+To add a new provider, create a new URL-like init string to be associated 
+with the provider by its schema (for example "gs://"). Then hack the 
+`notes.NewProviderFromInitString` function to recognize it. Finally,
+add your file reading logic and implement the `GetMapsForPR()` hook to
+return the data when called.
+

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	gcsPrefix      = "gs://"
+	// GcsPrefix url prefix for google cloud storage buckets
+	GcsPrefix      = "gs://"
 	concurrentFlag = "-m"
 	recursiveFlag  = "-r"
 	noClobberFlag  = "-n"
@@ -105,8 +106,8 @@ func bucketCopy(src, dst string, opts *Options) error {
 }
 
 func normalizeGCSPath(gcsPath string) string {
-	gcsPath = strings.TrimPrefix(gcsPath, gcsPrefix)
-	gcsPath = gcsPrefix + gcsPath
+	gcsPath = strings.TrimPrefix(gcsPath, GcsPrefix)
+	gcsPath = GcsPrefix + gcsPath
 
 	return gcsPath
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -39,6 +39,8 @@ import (
 const (
 	// TokenEnvKey is the default GitHub token environemt variable key
 	TokenEnvKey = "GITHUB_TOKEN"
+	// GitHubURL Prefix for github URLs
+	GitHubURL = "https://github.com/"
 )
 
 // GitHub is a wrapper around GitHub related functionality

--- a/pkg/notes/BUILD.bazel
+++ b/pkg/notes/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dependencies.go",
         "notes.go",
+        "notes_map.go",
         "toc.go",
     ],
     importpath = "k8s.io/release/pkg/notes",
@@ -18,6 +19,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_saschagrunert_go_modiff//pkg/modiff:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )
 

--- a/pkg/notes/document/BUILD.bazel
+++ b/pkg/notes/document/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/notes/options:go_default_library",
         "//pkg/release:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/pkg/notes/maps/testdata/cve-2020-8555.yaml
+++ b/pkg/notes/maps/testdata/cve-2020-8555.yaml
@@ -1,0 +1,21 @@
+---
+pr: 89796 
+releasenote:
+  author: kubernetes/product-security-committee
+  text: Implement changes to mitigate CVE-2020-8555
+datafields:
+  cve:
+    id: CVE-2019-1010260
+    title: "CVE-2020-8555: Half-Blind SSRF in kube-controller-manager"
+    published: 2020-05-28
+    score: 5.2
+    rating: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N
+    linkedPRs:
+    - 89794
+    - 89796
+    - 89837
+    - 89838
+    - 89839
+    description:
+        There exists a Server Side Request Forgery (SSRF) vulnerability in kube-controller-manager that allows certain authorized users to leak up to 500 bytes of arbitrary information from unprotected endpoints within the master's host network (such as link-local or loopback services).
+        An attacker with permissions to create a pod with certain built-in Volume types (GlusterFS, Quobyte, StorageOS, ScaleIO) or permissions to create a StorageClass can cause kube-controller-manager to make GET requests or POST requests without an attacker controlled request body from the master's host network.

--- a/pkg/notes/maps/testdata/fullmap.yaml
+++ b/pkg/notes/maps/testdata/fullmap.yaml
@@ -1,0 +1,50 @@
+---
+pr: 123
+commit: 1a89038915fe77d73bf7c9cfa8f2ce123a464c82
+release-note:  
+  text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+  author: kubernetes-ci-robot
+  areas:
+    - testarea
+  kinds:
+    - documentation
+  sigs:
+    - api-machinery
+  feature: true
+  action_required: false
+  release_version: v1.18.4
+  documentation:
+    - description: Test documentation
+      url: https://wkdkjdjkdkfj
+      type: kep
+datafields:
+  cve:
+    id: CVE-2019-1010260
+    description: Really bad SSRF in KCM
+    published: 2020-10-05
+    score: 5.2
+    linkedPRs:
+    - 9876
+    - 9875
+---
+pr: 123
+release-note:
+  author: kubernetes-ci-robot
+---
+pr: 123
+datafields:
+  classifier-score:
+    # Hypothetical ML score
+    qa-score: 0.35635 # ← would need to fix this one
+    suggested-kinds:
+      - kind/bug
+---
+# Demo of linked PRs, joined for whatever use
+pr: 123
+datafields:
+  linkedPRs:
+    - 123
+    - 234
+    - 345
+
+

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -53,6 +53,17 @@ const (
 type Notes []string
 type Kind string
 
+// CVEData Information of a linked CVE vulnerability
+type CVEData struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Published   string  `json:"published"`
+	Score       float32 `json:"score"`
+	Rating      string  `json:"rating"`
+	LinkedPRs   []int   `json:"linkedPRs"`
+	Description string  `json:"description"`
+}
+
 const (
 	KindAPIChange     Kind = "api-change"
 	KindBug           Kind = "bug"
@@ -121,6 +132,9 @@ type ReleaseNote struct {
 	// Tags each note with a release version if specified
 	// If not specified, omitted
 	ReleaseVersion string `json:"release_version,omitempty"`
+
+	// DataFields a key indexed map of data fields
+	DataFields map[string]ReleaseNotesDataField `json:"data_fields,omitempty"`
 }
 
 type Documentation struct {
@@ -191,9 +205,10 @@ type Result struct {
 }
 
 type Gatherer struct {
-	client  github.Client
-	context context.Context
-	options *options.Options
+	client       github.Client
+	context      context.Context
+	options      *options.Options
+	MapProviders []*MapProvider
 }
 
 // NewGatherer creates a new notes gatherer
@@ -239,6 +254,16 @@ func GatherReleaseNotes(opts *options.Options) (*ReleaseNotes, error) {
 // ListReleaseNotes produces a list of fully contextualized release notes
 // starting from a given commit SHA and ending at starting a given commit SHA.
 func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
+	// Load map providers
+	mapProviders := []MapProvider{}
+	for _, initString := range g.options.MapProviderStrings {
+		provider, err := NewProviderFromInitString(initString)
+		if err != nil {
+			return nil, errors.Wrap(err, "while getting release notes map providers")
+		}
+		mapProviders = append(mapProviders, provider)
+	}
+
 	commits, err := g.listCommits(g.options.Branch, g.options.StartSHA, g.options.EndSHA)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing commits")
@@ -268,6 +293,19 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 			continue
 		}
 
+		// Query our map providers for additional data for the release note
+		for _, provider := range mapProviders {
+			noteMaps, err := provider.GetMapsForPR(result.pullRequest.GetNumber())
+			if err != nil {
+				return nil, errors.Wrap(err, "Error while looking up note map")
+			}
+
+			for _, noteMap := range noteMaps {
+				if err := note.ApplyMap(noteMap); err != nil {
+					return nil, errors.Wrapf(err, "applying notemap for PR #%d", result.pullRequest.GetNumber())
+				}
+			}
+		}
 		if _, ok := dedupeCache[note.Text]; !ok {
 			notes.Set(note.PrNumber, note)
 			dedupeCache[note.Text] = struct{}{}
@@ -381,6 +419,7 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*Releas
 	if err != nil {
 		return nil, err
 	}
+
 	documentation := DocumentationFromString(prBody)
 
 	author := pr.GetUser().GetLogin()
@@ -402,6 +441,7 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*Releas
 		isDuplicateKind = true
 	}
 
+	// TODO: Spin this to sep function
 	indented := strings.ReplaceAll(text, "\n", "\n  ")
 	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
 		indented, pr.GetNumber(), prURL, author, authorURL)
@@ -931,4 +971,69 @@ func prettifySIGList(sigs []string) string {
 	}
 
 	return sigList
+}
+
+// ApplyMap Modifies the content of the release using information from
+//  a ReleaseNotesMap
+func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap) error {
+	logrus.Infof("Applying map to note from PR %d", rn.PrNumber)
+	reRenderMarkdown := false
+	if noteMap.ReleaseNote.Author != nil {
+		rn.Author = *noteMap.ReleaseNote.Author
+		rn.AuthorURL = "https://github.com/" + *noteMap.ReleaseNote.Author
+		reRenderMarkdown = true
+	}
+
+	if noteMap.ReleaseNote.Text != nil {
+		rn.Text = *noteMap.ReleaseNote.Text
+		reRenderMarkdown = true
+	}
+
+	if noteMap.ReleaseNote.Documentation != nil {
+		rn.Documentation = *noteMap.ReleaseNote.Documentation
+	}
+
+	if noteMap.ReleaseNote.Areas != nil {
+		rn.Areas = *noteMap.ReleaseNote.Areas
+	}
+
+	if noteMap.ReleaseNote.Kinds != nil {
+		rn.Kinds = *noteMap.ReleaseNote.Kinds
+	}
+
+	if noteMap.ReleaseNote.SIGs != nil {
+		rn.SIGs = *noteMap.ReleaseNote.SIGs
+	}
+
+	if noteMap.ReleaseNote.Feature != nil {
+		rn.Feature = *noteMap.ReleaseNote.Feature
+	}
+
+	if noteMap.ReleaseNote.ActionRequired != nil {
+		rn.ActionRequired = *noteMap.ReleaseNote.ActionRequired
+	}
+
+	if noteMap.ReleaseNote.ReleaseVersion != nil {
+		rn.ReleaseVersion = *noteMap.ReleaseNote.ReleaseVersion
+	}
+
+	// If there are datafields, add them
+	if len(noteMap.DataFields) > 0 {
+		rn.DataFields = make(map[string]ReleaseNotesDataField)
+	}
+	for key, df := range noteMap.DataFields {
+		rn.DataFields[key] = df
+	}
+
+	// If parts of the markup where modified, change them
+	// TODO: Spin this to sep function
+	if reRenderMarkdown {
+		indented := strings.ReplaceAll(rn.Text, "\n", "\n  ")
+		markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
+			indented, rn.PrNumber, rn.PrURL, rn.Author, rn.AuthorURL)
+		// Uppercase the first character of the markdown to make it look uniform
+		rn.Markdown = strings.ToUpper(string(markdown[0])) + markdown[1:]
+		logrus.Warn(rn.Markdown)
+	}
+	return nil
 }

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notes
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+// MapProvider interface that obtains release notes maps from a source
+type MapProvider interface {
+	GetMapsForPR(int) (map[int]*ReleaseNotesMap, error)
+}
+
+// NewProviderFromInitString creates a new map provider from an initialization string
+func NewProviderFromInitString(initString string) (MapProvider, error) {
+	// If init string starts with gs:// return a CloudStorageProvider
+	if initString[0:5] == "gs://" {
+		// Currently for illustration purposes
+		return nil, errors.New("CloudStorageProvider is not yet implemented")
+	}
+
+	// Otherwise, build a DirectoryMapProvider using the
+	// whole init string as the path
+	fileStat, err := os.Stat(initString)
+	if os.IsNotExist(err) {
+		return nil, errors.New("release notes map path does not exist")
+	}
+	if !fileStat.IsDir() {
+		return nil, errors.New("release notes map path is not a directory")
+	}
+
+	return &DirectoryMapProvider{Path: initString}, nil
+}
+
+// ParseReleaseNotesMap Parses a Release Notes Map
+func ParseReleaseNotesMap(mapPath string) (*[]ReleaseNotesMap, error) {
+	notemaps := []ReleaseNotesMap{}
+	yamlReader, err := os.Open(mapPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening maps")
+	}
+
+	decoder := yaml.NewDecoder(yamlReader)
+	noteMap := ReleaseNotesMap{}
+
+	for {
+		if err := decoder.Decode(&noteMap); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, errors.Wrap(err, "decoding note map")
+		}
+		notemaps = append(notemaps, noteMap)
+	}
+
+	return &notemaps, nil
+}
+
+// ReleaseNotesMap Represents
+type ReleaseNotesMap struct {
+	// Pull request where the note was published
+	PR int `json:"pr"`
+	// SHA of the notes commit
+	Commit      string `json:"commit"`
+	ReleaseNote struct {
+		// Text is the actual content of the release note
+		Text *string `json:"text,omitempty"`
+
+		// Docs is additional documentation for the release note
+		Documentation *[]*Documentation `json:"documentation,omitempty"`
+
+		// Author is the GitHub username of the commit author
+		Author *string `json:"author,omitempty"`
+
+		// Areas is a list of the labels beginning with area/
+		Areas *[]string `json:"areas,omitempty"`
+
+		// Kinds is a list of the labels beginning with kind/
+		Kinds *[]string `json:"kinds,omitempty"`
+
+		// SIGs is a list of the labels beginning with sig/
+		SIGs *[]string `json:"sigs,omitempty"`
+
+		// Indicates whether or not a note will appear as a new feature
+		Feature *bool `json:"feature,omitempty"`
+
+		// ActionRequired indicates whether or not the release-note-action-required
+		// label was set on the PR
+		ActionRequired *bool `json:"action_required,omitempty"`
+
+		// Tags each note with a release version if specified
+		// If not specified, omitted
+		ReleaseVersion *string `json:"release_version,omitempty"`
+	} `json:"releasenote"`
+
+	DataFields map[string]ReleaseNotesDataField `json:"datafields"`
+}
+
+// ReleaseNotesDataField extra data added to a release note
+type ReleaseNotesDataField interface{}
+
+// DirectoryMapProvider is a provider that gets maps from a directory
+type DirectoryMapProvider struct {
+	Path string
+	Maps map[int]map[int]*ReleaseNotesMap
+}
+
+// readMaps Open the dir and read dir notes
+func (mp *DirectoryMapProvider) readMaps() error {
+	var fileList []string
+	mp.Maps = map[int]map[int]*ReleaseNotesMap{}
+
+	err := filepath.Walk(mp.Path, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
+			fileList = append(fileList, path)
+		}
+		return nil
+	})
+
+	counter := 0
+	for _, fileName := range fileList {
+		notemaps, err := ParseReleaseNotesMap(fileName)
+		if err != nil {
+			return errors.Wrapf(err, "while parsing note map in %s", fileName)
+		}
+		for _, notemap := range *notemaps {
+			if _, ok := mp.Maps[notemap.PR]; !ok {
+				mp.Maps[notemap.PR] = map[int]*ReleaseNotesMap{}
+			}
+			mp.Maps[notemap.PR][len(mp.Maps[notemap.PR])] = &notemap
+			counter++
+		}
+	}
+	logrus.Infof("Successfully parsed %d release notes maps for %d PRs from %s", counter, len(mp.Maps), mp.Path)
+	return err
+}
+
+// GetMapsForPR get the release notes maps for a specific PR number
+func (mp *DirectoryMapProvider) GetMapsForPR(pr int) (notesMap map[int]*ReleaseNotesMap, err error) {
+	if mp.Maps == nil {
+		err := mp.readMaps()
+		if err != nil {
+			return nil, errors.Wrap(err, "while reading release notes maps")
+		}
+	}
+	if notesMap, ok := mp.Maps[pr]; ok {
+		return notesMap, nil
+	}
+	return nil, nil
+}

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -114,6 +114,9 @@ type Options struct {
 
 	githubToken string
 	gitCloneFn  func(string, string, string, bool) (*git.Repo, error)
+
+	// MapProviders list of release notes map providers to query during generations
+	MapProviderStrings []string
 }
 
 type RevisionDiscoveryMode string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is the first effort to add the capability to process mapping files to the release notes package.

The release notes mapping files (format is detailed below) will allow expanding the information in release notes in two ways:

- __Modifying original data:__ The map can supersede release note data defined in the original pull request by  overriding certain fields in a file which will eventually end up in the release notes document.

- __Adding new fields of information:__ A map file can define new data structures which can be associated with the release note to add more information to the release note. Current plans include adding security information and a quality score. 

Mapping files can come from a variety of sources. This PR adds a new interface `MapProvider` whose job is to obtain and parse map files. MapProviders can be written to collect release notes files from a variety of sources: reading from a directory (a proof of concept is included), a bucket, a private GitHub repo, an encrypted archive, etc. 

The krel release-notes subcommand has been modified with a new `--maps-from` flag to enable MapProviders when generating release notes. For example, to invoke it with a `DirectoryMapProvider` we would use the following flags

```console
krel release-notes --create-website-pr --tag v1.19.beta.2 \
   --maps-from=/notes-maps/
# With an hypothetical provider for a bucket
krel release-notes --create-website-pr --tag v1.19.beta.2 \
   --maps-from=gs://k8s-release-notes-bucket
```

When MapProviders are active, the notes gatherer will query the provider for mappings for a specific note when generating it. Using a new method ApplyMap() the gatherer will modify the release note with data from the map.

The proposed map file format has two parts: one that overrides the original release note data and one that adds data fields, which are free-form data structures keyed in associative array fashion by a keyword. An example:

```yaml
---
pr:  123
commit: 1a89038915fe77d73bf7c9cfa8f2ce123a464c82
release-note:  
  text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
  author: kubernetes-ci-robot
  areas:
    - testarea
  kinds:
    - documentation
  sigs:
    - api-machinery
  feature: true
  action_required: false
  release_version: v1.18.4
  documentation:
    - description: Test documentation
      url: https://wkdkjdjkdkfj
      type: kep
datafields:
  # Score is a simple float
  score: 5.2
  # CVE data is a full blown struct
  cve:
    id: CVE-2019-1010260
    description: Really bad SSRF in KCM
    published: 2020-10-05
    issues:
    - 9876
    - 9875

```

#### Which issue(s) this PR fixes:
Related to
 - #1354
 -  kubernetes/enhancements#1833 

#### Special notes for your reviewer:
This PR is a proof of concept, should run but is still untested. 

I've provided a few sample maps in pkg/notes/maps/testdata/ to illustrate the format and its capabilities.

 A simple implementation of a `MapProvider` is included in this PR: `DirectoryMapProvider`. This MapProvider is the simplest provider possible: it reads a directory, looking for yaml files and tries to open them as release notes maps.

#### Does this PR introduce a user-facing change?
```release-note
* New capability in release notes pkg to read map files which can modify release notes data and add new, arbitrary fields.
* Function `ApplyMap()` was added to `ReleasNote`  type to enable it to get a map and modify itself
* New interface `MapProvider` which gets release notes map files
* New flag in `krel release-notes` to enable map providers: `--maps-from` 
```
