### PR TITLE
k8s-cloud-builder: Build cross1.14 variant on kube-cross:v1.14.4-2

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.14:
     CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.4-1'
+    KUBE_CROSS_VERSION: 'v1.14.4-2'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.13:
     CONFIG: 'cross1.13'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/88638 has merged, so we need to roll a new k8s-cloud-builder image.
/priority critical-urgent

Updates k8s-cloud-builder to pick up the new `kube-cross:v1.14.4-2` image (ref: https://github.com/kubernetes/release/pull/1372, https://github.com/kubernetes/k8s.io/pull/974)

/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build cross1.14 variant on kube-cross:v1.14.4-2
```
