### PR TITLE
Move Notes and Kind type into notes package

### DIFF
--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -36,7 +36,7 @@ import (
 
 // Document represents the underlying structure of a release notes document.
 type Document struct {
-	NotesWithActionRequired Notes          `json:"action_required"`
+	NotesWithActionRequired notes.Notes    `json:"action_required"`
 	Notes                   NoteCollection `json:"notes"`
 	Downloads               *FileMetadata  `json:"downloads"`
 	CurrentRevision         string         `json:"release_tag"`
@@ -135,16 +135,16 @@ type File struct {
 
 // NoteCategory contains notes of the same `Kind` (i.e category).
 type NoteCategory struct {
-	Kind        Kind
-	NoteEntries *Notes
+	Kind        notes.Kind
+	NoteEntries *notes.Notes
 }
 
 // NoteCollection is a collection of note categories.
 type NoteCollection []NoteCategory
 
 // Sort sorts the collection by priority order.
-func (n *NoteCollection) Sort(kindPriority []Kind) {
-	indexOf := func(kind Kind) int {
+func (n *NoteCollection) Sort(kindPriority []notes.Kind) {
+	indexOf := func(kind notes.Kind) int {
 		for i, prioKind := range kindPriority {
 			if kind == prioKind {
 				return i
@@ -159,46 +159,25 @@ func (n *NoteCollection) Sort(kindPriority []Kind) {
 	})
 }
 
-// TODO: These should probably go into the notes package.
-type Kind string
-type NotesByKind map[Kind]Notes
-type Notes []string
-
-// TODO: These should probably go into the notes package.
-const (
-	KindAPIChange     Kind = "api-change"
-	KindBug           Kind = "bug"
-	KindCleanup       Kind = "cleanup"
-	KindDeprecation   Kind = "deprecation"
-	KindDesign        Kind = "design"
-	KindDocumentation Kind = "documentation"
-	KindFailingTest   Kind = "failing-test"
-	KindFeature       Kind = "feature"
-	KindFlake         Kind = "flake"
-	KindRegression    Kind = "regression"
-	KindOther         Kind = "Other (Cleanup or Flake)"
-	KindUncategorized Kind = "Uncategorized"
-)
-
-var kindPriority = []Kind{
-	KindDeprecation,
-	KindAPIChange,
-	KindFeature,
-	KindDesign,
-	KindDocumentation,
-	KindFailingTest,
-	KindBug,
-	KindRegression,
-	KindCleanup,
-	KindFlake,
-	KindOther,
-	KindUncategorized,
+var kindPriority = []notes.Kind{
+	notes.KindDeprecation,
+	notes.KindAPIChange,
+	notes.KindFeature,
+	notes.KindDesign,
+	notes.KindDocumentation,
+	notes.KindFailingTest,
+	notes.KindBug,
+	notes.KindRegression,
+	notes.KindCleanup,
+	notes.KindFlake,
+	notes.KindOther,
+	notes.KindUncategorized,
 }
 
-var kindMap = map[Kind]Kind{
-	KindRegression: KindBug,
-	KindCleanup:    KindOther,
-	KindFlake:      KindOther,
+var kindMap = map[notes.Kind]notes.Kind{
+	notes.KindRegression: notes.KindBug,
+	notes.KindCleanup:    notes.KindOther,
+	notes.KindFlake:      notes.KindOther,
 }
 
 // GatherReleaseNotesDocument creates a new gatherer and collects the release
@@ -226,7 +205,7 @@ func New(
 	previousRev, currentRev string,
 ) (*Document, error) {
 	doc := &Document{
-		NotesWithActionRequired: Notes{},
+		NotesWithActionRequired: notes.Notes{},
 		Notes:                   NoteCollection{},
 		CurrentRevision:         currentRev,
 		PreviousRevision:        previousRev,
@@ -239,7 +218,7 @@ func New(
 		return stripRE.ReplaceAllLiteralString(s, "")
 	}
 
-	kindCategory := make(map[Kind]NoteCategory)
+	kindCategory := make(map[notes.Kind]NoteCategory)
 	for _, pr := range history {
 		note := releaseNotes[pr]
 
@@ -249,28 +228,28 @@ func New(
 			if existing, ok := kindCategory[kind]; ok {
 				*existing.NoteEntries = append(*existing.NoteEntries, processNote(note.Markdown))
 			} else {
-				kindCategory[kind] = NoteCategory{Kind: kind, NoteEntries: &Notes{processNote(note.Markdown)}}
+				kindCategory[kind] = NoteCategory{Kind: kind, NoteEntries: &notes.Notes{processNote(note.Markdown)}}
 			}
 		} else if note.ActionRequired {
 			doc.NotesWithActionRequired = append(doc.NotesWithActionRequired, processNote(note.Markdown))
 		} else {
 			for _, kind := range note.Kinds {
-				mappedKind := mapKind(Kind(kind))
+				mappedKind := mapKind(notes.Kind(kind))
 
 				if existing, ok := kindCategory[mappedKind]; ok {
 					*existing.NoteEntries = append(*existing.NoteEntries, processNote(note.Markdown))
 				} else {
-					kindCategory[mappedKind] = NoteCategory{Kind: mappedKind, NoteEntries: &Notes{processNote(note.Markdown)}}
+					kindCategory[mappedKind] = NoteCategory{Kind: mappedKind, NoteEntries: &notes.Notes{processNote(note.Markdown)}}
 				}
 			}
 
 			if len(note.Kinds) == 0 {
 				// the note has not been categorized so far
-				kind := KindUncategorized
+				kind := notes.KindUncategorized
 				if existing, ok := kindCategory[kind]; ok {
 					*existing.NoteEntries = append(*existing.NoteEntries, processNote(note.Markdown))
 				} else {
-					kindCategory[kind] = NoteCategory{Kind: kind, NoteEntries: &Notes{processNote(note.Markdown)}}
+					kindCategory[kind] = NoteCategory{Kind: kind, NoteEntries: &notes.Notes{processNote(note.Markdown)}}
 				}
 			}
 		}
@@ -400,10 +379,10 @@ func CreateDownloadsTable(w io.Writer, bucket, tars, prevTag, newTag string) err
 	return nil
 }
 
-func highestPriorityKind(kinds []string) Kind {
+func highestPriorityKind(kinds []string) notes.Kind {
 	for _, prioKind := range kindPriority {
 		for _, k := range kinds {
-			kind := Kind(k)
+			kind := notes.Kind(k)
 			if kind == prioKind {
 				return kind
 			}
@@ -411,25 +390,25 @@ func highestPriorityKind(kinds []string) Kind {
 	}
 
 	// Kind not in priority slice, returning the first one
-	return Kind(kinds[0])
+	return notes.Kind(kinds[0])
 }
 
-func mapKind(kind Kind) Kind {
+func mapKind(kind notes.Kind) notes.Kind {
 	if newKind, ok := kindMap[kind]; ok {
 		return newKind
 	}
 	return kind
 }
 
-func prettyKind(kind Kind) string {
-	if kind == KindAPIChange {
+func prettyKind(kind notes.Kind) string {
+	if kind == notes.KindAPIChange {
 		return "API Change"
-	} else if kind == KindFailingTest {
+	} else if kind == notes.KindFailingTest {
 		return "Failing Test"
-	} else if kind == KindBug {
+	} else if kind == notes.KindBug {
 		return "Bug or Regression"
-	} else if kind == KindOther {
-		return string(KindOther)
+	} else if kind == notes.KindOther {
+		return string(notes.KindOther)
 	}
 	return strings.Title(string(kind))
 }

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -275,11 +275,11 @@ func TestNew(t *testing.T) {
 				notes.ReleaseNotesHistory{0},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindUncategorized,
-						NoteEntries: &Notes{"No one gave me a kind"},
+						Kind:        notes.KindUncategorized,
+						NoteEntries: &notes.Notes{"No one gave me a kind"},
 					},
 				},
 			},
@@ -288,18 +288,18 @@ func TestNew(t *testing.T) {
 			"notes of same kind are lexicographically sorted.",
 			args{
 				notes.ReleaseNotes{
-					0: makeReleaseNote(KindDeprecation, "C"),
-					1: makeReleaseNote(KindDeprecation, "B"),
-					2: makeReleaseNote(KindDeprecation, "A"),
+					0: makeReleaseNote(notes.KindDeprecation, "C"),
+					1: makeReleaseNote(notes.KindDeprecation, "B"),
+					2: makeReleaseNote(notes.KindDeprecation, "A"),
 				},
 				notes.ReleaseNotesHistory{0, 1, 2},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindDeprecation,
-						NoteEntries: &Notes{"A", "B", "C"},
+						Kind:        notes.KindDeprecation,
+						NoteEntries: &notes.Notes{"A", "B", "C"},
 					},
 				},
 			},
@@ -308,26 +308,26 @@ func TestNew(t *testing.T) {
 			"notes are sorted by kind priority",
 			args{
 				notes.ReleaseNotes{
-					0: makeReleaseNote(KindFeature, "C"),
-					1: makeReleaseNote(KindAPIChange, "B"),
-					2: makeReleaseNote(KindDeprecation, "A"),
+					0: makeReleaseNote(notes.KindFeature, "C"),
+					1: makeReleaseNote(notes.KindAPIChange, "B"),
+					2: makeReleaseNote(notes.KindDeprecation, "A"),
 				},
 				notes.ReleaseNotesHistory{0, 1, 2},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindDeprecation,
-						NoteEntries: &Notes{"A"},
+						Kind:        notes.KindDeprecation,
+						NoteEntries: &notes.Notes{"A"},
 					},
 					NoteCategory{
-						Kind:        KindAPIChange,
-						NoteEntries: &Notes{"B"},
+						Kind:        notes.KindAPIChange,
+						NoteEntries: &notes.Notes{"B"},
 					},
 					NoteCategory{
-						Kind:        KindFeature,
-						NoteEntries: &Notes{"C"},
+						Kind:        notes.KindFeature,
+						NoteEntries: &notes.Notes{"C"},
 					},
 				},
 			},
@@ -336,20 +336,20 @@ func TestNew(t *testing.T) {
 			"strip unwanted prefixes",
 			args{
 				notes.ReleaseNotes{
-					0: makeReleaseNote(KindBug, "- single dash"),
-					1: makeReleaseNote(KindBug, "-- double dash"),
-					2: makeReleaseNote(KindBug, "* single star"),
-					3: makeReleaseNote(KindBug, "** double star"),
-					4: makeReleaseNote(KindBug, "- --someflag"),
+					0: makeReleaseNote(notes.KindBug, "- single dash"),
+					1: makeReleaseNote(notes.KindBug, "-- double dash"),
+					2: makeReleaseNote(notes.KindBug, "* single star"),
+					3: makeReleaseNote(notes.KindBug, "** double star"),
+					4: makeReleaseNote(notes.KindBug, "- --someflag"),
 				},
 				notes.ReleaseNotesHistory{0, 1, 2, 3, 4},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind: KindBug,
-						NoteEntries: &Notes{
+						Kind: notes.KindBug,
+						NoteEntries: &notes.Notes{
 							"--someflag",
 							"double dash",
 							"double star",
@@ -366,18 +366,18 @@ func TestNew(t *testing.T) {
 				notes.ReleaseNotes{
 					0: &notes.ReleaseNote{
 						Markdown:       "A duplicate note gets the highest priority kind found",
-						Kinds:          []string{string(KindAPIChange), string(KindDeprecation)},
+						Kinds:          []string{string(notes.KindAPIChange), string(notes.KindDeprecation)},
 						DuplicateKind:  true,
 						ActionRequired: false,
 					}},
 				notes.ReleaseNotesHistory{0},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindDeprecation,
-						NoteEntries: &Notes{"A duplicate note gets the highest priority kind found"},
+						Kind:        notes.KindDeprecation,
+						NoteEntries: &notes.Notes{"A duplicate note gets the highest priority kind found"},
 					},
 				},
 			},
@@ -388,18 +388,18 @@ func TestNew(t *testing.T) {
 				notes.ReleaseNotes{
 					0: &notes.ReleaseNote{
 						Markdown:       "This note should not appear as a regular note.",
-						Kinds:          []string{string(KindDeprecation)},
+						Kinds:          []string{string(notes.KindDeprecation)},
 						DuplicateKind:  true,
 						ActionRequired: false,
 					}},
 				notes.ReleaseNotesHistory{0},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindDeprecation,
-						NoteEntries: &Notes{"This note should not appear as a regular note."},
+						Kind:        notes.KindDeprecation,
+						NoteEntries: &notes.Notes{"This note should not appear as a regular note."},
 					},
 				},
 			},
@@ -408,17 +408,17 @@ func TestNew(t *testing.T) {
 			"notes mapping to a single kind",
 			args{
 				notes.ReleaseNotes{
-					0: makeReleaseNote(KindCleanup, "PR#1"),
-					1: makeReleaseNote(KindFlake, "PR#2"),
+					0: makeReleaseNote(notes.KindCleanup, "PR#1"),
+					1: makeReleaseNote(notes.KindFlake, "PR#2"),
 				},
 				notes.ReleaseNotesHistory{0, 1},
 			},
 			&Document{
-				NotesWithActionRequired: Notes{},
+				NotesWithActionRequired: notes.Notes{},
 				Notes: NoteCollection{
 					NoteCategory{
-						Kind:        KindOther,
-						NoteEntries: &Notes{"PR#1", "PR#2"},
+						Kind:        notes.KindOther,
+						NoteEntries: &notes.Notes{"PR#1", "PR#2"},
 					},
 				},
 			},
@@ -467,23 +467,23 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Given
 			testNotes := notes.ReleaseNotes{
-				0:  makeReleaseNote(KindDeprecation, "Deprecation #1."),
-				1:  makeReleaseNote(KindBug, "Bugfix."),
-				2:  makeReleaseNote(KindCleanup, "Clean up."),
-				3:  makeReleaseNote(KindDesign, "Design change."),
-				4:  makeReleaseNote(KindDocumentation, "Update docs."),
-				5:  makeReleaseNote(KindFailingTest, "Fix a failing test."),
-				6:  makeReleaseNote(KindFeature, "A feature."),
-				7:  makeReleaseNote(KindFlake, "Fix a flakey test."),
+				0:  makeReleaseNote(notes.KindDeprecation, "Deprecation #1."),
+				1:  makeReleaseNote(notes.KindBug, "Bugfix."),
+				2:  makeReleaseNote(notes.KindCleanup, "Clean up."),
+				3:  makeReleaseNote(notes.KindDesign, "Design change."),
+				4:  makeReleaseNote(notes.KindDocumentation, "Update docs."),
+				5:  makeReleaseNote(notes.KindFailingTest, "Fix a failing test."),
+				6:  makeReleaseNote(notes.KindFeature, "A feature."),
+				7:  makeReleaseNote(notes.KindFlake, "Fix a flakey test."),
 				8:  makeReleaseNote("", "Uncategorized note."),
-				9:  makeReleaseNote(KindBug, "- This note was prepended with a dash (-) initially."),
-				10: makeReleaseNote(KindBug, "* This note was prepended with a star (*) initially."),
+				9:  makeReleaseNote(notes.KindBug, "- This note was prepended with a dash (-) initially."),
+				10: makeReleaseNote(notes.KindBug, "* This note was prepended with a star (*) initially."),
 			}
-			duplicate := makeReleaseNote(KindDeprecation, "This note is duplicated across SIGs.")
-			duplicate.Kinds = append(duplicate.Kinds, string(KindBug))
+			duplicate := makeReleaseNote(notes.KindDeprecation, "This note is duplicated across SIGs.")
+			duplicate.Kinds = append(duplicate.Kinds, string(notes.KindBug))
 			duplicate.DuplicateKind = true
 
-			actionNeeded := makeReleaseNote(KindAPIChange, "Action required note.")
+			actionNeeded := makeReleaseNote(notes.KindAPIChange, "Action required note.")
 			actionNeeded.ActionRequired = true
 			testNotes[11] = duplicate
 			testNotes[12] = actionNeeded
@@ -524,7 +524,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 	}
 }
 
-func makeReleaseNote(kind Kind, markdown string) *notes.ReleaseNote {
+func makeReleaseNote(kind notes.Kind, markdown string) *notes.ReleaseNote {
 	n := &notes.ReleaseNote{Markdown: markdown}
 	if kind != "" {
 		n.Kinds = []string{string(kind)}

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -50,6 +50,24 @@ const (
 	maxParallelRequests = 10
 )
 
+type Notes []string
+type Kind string
+
+const (
+	KindAPIChange     Kind = "api-change"
+	KindBug           Kind = "bug"
+	KindCleanup       Kind = "cleanup"
+	KindDeprecation   Kind = "deprecation"
+	KindDesign        Kind = "design"
+	KindDocumentation Kind = "documentation"
+	KindFailingTest   Kind = "failing-test"
+	KindFeature       Kind = "feature"
+	KindFlake         Kind = "flake"
+	KindRegression    Kind = "regression"
+	KindOther         Kind = "Other (Cleanup or Flake)"
+	KindUncategorized Kind = "Uncategorized"
+)
+
 // ReleaseNote is the type that represents the total sum of all the information
 // we've gathered about a single release note.
 type ReleaseNote struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Refactor both types into the `notes` package to have a more streamlined
logic around the `document` and `notes` package.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
