### PR TITLE
Add record/replay functionality to github.GetReleaseByTag

### DIFF
--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -43,6 +43,7 @@ const (
 	gitHubAPIListTags                   gitHubAPI = "ListTags"
 	gitHubAPIGetRepository              gitHubAPI = "GetRepository"
 	gitHubAPIListBranches               gitHubAPI = "ListBranches"
+	gitHubAPIGetReleaseByTag            gitHubAPI = "GetReleaseByTag"
 )
 
 type apiRecord struct {
@@ -137,11 +138,17 @@ func (c *githubNotesRecordClient) ListReleases(
 	return releases, resp, nil
 }
 
-// TODO: Complete logic
 func (c *githubNotesRecordClient) GetReleaseByTag(
 	ctx context.Context, owner, repo, tag string,
 ) (*github.RepositoryRelease, *github.Response, error) {
-	return nil, nil, nil
+	release, resp, err := c.client.GetReleaseByTag(ctx, owner, repo, tag)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIGetReleaseByTag, release, resp); err != nil {
+		return nil, nil, err
+	}
+	return release, resp, nil
 }
 
 // TODO: Complete logic

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -121,11 +121,19 @@ func (c *githubNotesReplayClient) ListReleases(
 	return result, record.response(), nil
 }
 
-// TODO: Complete logic
 func (c *githubNotesReplayClient) GetReleaseByTag(
 	ctx context.Context, owner, repo, tag string,
 ) (*github.RepositoryRelease, *github.Response, error) {
-	return nil, nil, nil
+	data, err := c.readRecordedData(gitHubAPIGetReleaseByTag)
+	if err != nil {
+		return nil, nil, err
+	}
+	result := &github.RepositoryRelease{}
+	record := apiRecord{Result: result}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return result, record.response(), nil
 }
 
 // TODO: Complete logic


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The implementation was missing which now has been added and the
corresponding `TODO` is now resolved.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add record/replay functionality to `github.GetReleaseByTag`
```
