### PR TITLE
gh2gcs: add yaml config option

### DIFF
--- a/cmd/gh2gcs/cmd/BUILD.bazel
+++ b/cmd/gh2gcs/cmd/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )
 

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,15 @@ require (
 	github.com/sendgrid/sendgrid-go v3.6.0+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/yuin/goldmark v1.1.32
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	google.golang.org/api v0.21.0
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.18.3
+	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -36,16 +36,16 @@ var (
 
 type Options struct {
 	// gsutil options
-	Concurrent bool
-	Recursive  bool
-	NoClobber  bool
+	Concurrent *bool
+	Recursive  *bool
+	NoClobber  *bool
 
 	// local options
 	// AllowMissing allows a copy operation to be skipped if the source or
 	// destination does not exist. This is useful for scenarios where copy
 	// operations happen in a loop/channel, so a single "failure" does not block
 	// the entire operation.
-	AllowMissing bool
+	AllowMissing *bool
 }
 
 // CopyToGCS copies a local directory to the specified GCS path
@@ -57,7 +57,7 @@ func CopyToGCS(src, gcsPath string, opts *Options) error {
 	if err != nil {
 		logrus.Info("unable to get local source directory info")
 
-		if opts.AllowMissing {
+		if *opts.AllowMissing {
 			logrus.Infof("Source directory (%s) does not exist. Skipping GCS upload.", src)
 			return nil
 		}
@@ -79,17 +79,17 @@ func CopyToLocal(gcsPath, dst string, opts *Options) error {
 func bucketCopy(src, dst string, opts *Options) error {
 	args := []string{}
 
-	if opts.Concurrent {
+	if *opts.Concurrent {
 		logrus.Debug("Setting GCS copy to run concurrently")
 		args = append(args, concurrentFlag)
 	}
 
 	args = append(args, "cp")
-	if opts.Recursive {
+	if *opts.Recursive {
 		logrus.Debug("Setting GCS copy to run recursively")
 		args = append(args, recursiveFlag)
 	}
-	if opts.NoClobber {
+	if *opts.NoClobber {
 		logrus.Debug("Setting GCS copy to not clobber existing files")
 		args = append(args, noClobberFlag)
 	}

--- a/pkg/gh2gcs/BUILD.bazel
+++ b/pkg/gh2gcs/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/gcp/gcs:go_default_library",
         "//pkg/github:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -24,31 +24,33 @@ import (
 
 	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/github"
+	"k8s.io/utils/pointer"
 )
 
 // Config contains a slice of `ReleaseConfig` to be used when unmarshalling a
 // yaml config containing multiple repository configs.
 type Config struct {
-	ReleaseConfigs []ReleaseConfig
+	ReleaseConfigs []ReleaseConfig `yaml:"releaseConfigs"`
 }
 
 // ReleaseConfig contains source (GitHub) and destination (GCS) information
 // to perform a copy/upload operation using gh2gcs.
 type ReleaseConfig struct {
-	Org                string
-	Repo               string
-	Tags               []string
-	IncludePrereleases bool
-	GCSBucket          string
-	ReleaseDir         string
-	GCSCopyOptions     *gcs.Options
+	Org                string       `yaml:"org"`
+	Repo               string       `yaml:"repo"`
+	Tags               []string     `yaml:"tags"`
+	IncludePrereleases bool         `yaml:"includePrereleases"`
+	GCSBucket          string       `yaml:"gcsBucket"`
+	ReleaseDir         string       `yaml:"releaseDir"`
+	GCSCopyOptions     *gcs.Options `yaml:"gcsCopyOptions"`
 }
 
+// DefaultGCSCopyOptions have the default options for the GCS copy action
 var DefaultGCSCopyOptions = &gcs.Options{
-	Concurrent:   true,
-	Recursive:    true,
-	NoClobber:    true,
-	AllowMissing: true,
+	Concurrent:   pointer.BoolPtr(true),
+	Recursive:    pointer.BoolPtr(true),
+	NoClobber:    pointer.BoolPtr(true),
+	AllowMissing: pointer.BoolPtr(true),
 }
 
 // DownloadReleases downloads release assets to a local directory
@@ -85,4 +87,30 @@ func Upload(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string
 	}
 
 	return nil
+}
+
+// CheckGCSCopyOptions checks if the user set any config or we need to set the default config
+func CheckGCSCopyOptions(copyOptions *gcs.Options) *gcs.Options {
+	// set the GCS Copy options to default values
+	if copyOptions == nil {
+		return DefaultGCSCopyOptions
+	}
+
+	if copyOptions.AllowMissing == nil {
+		copyOptions.AllowMissing = pointer.BoolPtr(true)
+	}
+
+	if copyOptions.Concurrent == nil {
+		copyOptions.Concurrent = pointer.BoolPtr(true)
+	}
+
+	if copyOptions.NoClobber == nil {
+		copyOptions.NoClobber = pointer.BoolPtr(true)
+	}
+
+	if copyOptions.Recursive == nil {
+		copyOptions.Recursive = pointer.BoolPtr(true)
+	}
+
+	return copyOptions
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduce to the user of `gh2gcs` an option to define the download/upload releases artifacts using a YAML configuration file, which can have multiple configurations like:

```yaml
releaseConfigs:
  - org: kubernetes
    repo: kubernetes
    tags:
    - v1.18.0
    - v1.17.0
    - v1.16.0
    - v1.16.1
    - v1.16.2
    includePrereleases: false
    gcsBucket: test
    releaseDir: release
    gcsCopyOptions:
      concurrent: true
      recursive: false
      noclobber: false
      allowmissing: false
  - org: kubernetes
    repo: release
    tags:
    - v0.3.4
    includePrereleases: false
    gcsBucket: test2
    releaseDir: release
```

#### Which issue(s) this PR fixes:

Fixes partially https://github.com/kubernetes/release/issues/1320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gh2gcs: add yaml config option
```

/cc @justaugustus @saschagrunert 