### PR TITLE
kubepkg: Use the cross build version marker (ci/k8s-master) for packages

### DIFF
--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -445,7 +445,7 @@ func (c *Client) GetKubernetesVersion(packageDef *PackageDefinition) (string, er
 	case ChannelTesting:
 		return c.impl.GetKubeVersion(release.VersionTypeStablePreRelease)
 	case ChannelNightly:
-		return c.impl.GetKubeVersion(release.VersionTypeCILatest)
+		return c.impl.GetKubeVersion(release.VersionTypeCILatestCross)
 	}
 
 	return c.impl.GetKubeVersion(release.VersionTypeStable)
@@ -577,7 +577,7 @@ func (c *Client) GetCIBuildsDownloadLinkBase(packageDef *PackageDefinition) (str
 	ciVersion := packageDef.KubernetesVersion
 	if ciVersion == "" {
 		var err error
-		ciVersion, err = c.impl.GetKubeVersion(release.VersionTypeCILatest)
+		ciVersion, err = c.impl.GetKubeVersion(release.VersionTypeCILatestCross)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -60,6 +60,10 @@ const (
 	// for example `v1.19.0-alpha.0.721+f8ff8f44206ff4`
 	VersionTypeCILatest VersionType = "ci/latest"
 
+	// VersionTypeCILatestCross references the latest CI cross build Kubernetes
+	// version, for example `v1.19.0-alpha.0.721+f8ff8f44206ff4`
+	VersionTypeCILatestCross VersionType = "ci/k8s-master"
+
 	// baseURL is the base URL for every release version retrieval
 	baseURL = "https://dl.k8s.io/"
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind bug failing-test

#### What this PR does / why we need it:

Hopefully the last piece of fixing https://github.com/kubernetes/kubernetes/issues/88408.

Recent CI runs for the kubepkg job are failing as follows:

```console
dpkg-buildpackage: info: source package kubelet
dpkg-buildpackage: info: source version 1.19.0-beta.2.511-aadaa5d6a917fc-0
dpkg-buildpackage: info: source distribution nightly
dpkg-buildpackage: info: source changed by Kubernetes Authors <kubernetes-dev@googlegroups.com>
dpkg-buildpackage: info: host architecture armhf
dh clean --with systemd
   dh_clean
echo noop
noop
mkdir -p usr/bin
curl --fail -sSL --retry 5 \
	-o usr/bin/kubelet \
	"https://dl.k8s.io/ci/v1.19.0-beta.2.511+aadaa5d6a917fc/bin/linux/arm/kubelet"
dpkg-architecture: warning: specified GNU system type arm-linux-gnueabihf does not match CC system type x86_64-linux-gnu, try setting a correct CC environment variable
 dpkg-source --before-build .
 fakeroot debian/rules clean
 debian/rules build
 fakeroot debian/rules binary
curl: (22) The requested URL returned error: 404 
make: *** [debian/rules:12: binary] Error 22
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
FATA running debian package build: command /usr/bin/dpkg-buildpackage --unsigned-source --unsigned-changes --build=binary --host-arch armhf did not succeed: dpkg-architecture: warning: specified GNU system type arm-linux-gnueabihf does not match CC system type x86_64-linux-gnu, try setting a correct CC environment variable
 dpkg-source --before-build .
 fakeroot debian/rules clean
 debian/rules build
 fakeroot debian/rules binary
curl: (22) The requested URL returned error: 404 
make: *** [debian/rules:12: binary] Error 22
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2 
```

To translate, kubepkg gets a 404 from https://dl.k8s.io/ci/v1.19.0-beta.2.511+aadaa5d6a917fc/bin/linux/arm/kubelet.
Note the arch here (`arm`).

kubepkg was previously using the ci/latest [version marker](https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md), which points to a `linux/amd64`-only Kubernetes build (`ci-kubernetes-build-fast`).

This PR adds the `ci/k8s-master` version marker, which points to a cross build instead (`ci-kubernetes-build`).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @hasheddan @cpanato @tpepper 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/88408

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kubepkg: Use the cross build version marker (ci/k8s-master) for packages
```
