### PR TITLE
push-build: Support uploading multiple version markers

### DIFF
--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
   - "${_BUCKET}"
   - "${_REGISTRY}"
   - "${_ALLOW_DUP}"
-  - "${_EXTRA_PUBLISH_FILE}"
+  - "${_EXTRA_VERSION_MARKERS}"
   - "${_HYPERKUBE}"
 
 options:
@@ -62,5 +62,5 @@ substitutions:
   _BUCKET: ''
   _REGISTRY: ''
   _ALLOW_DUP: ''
-  _EXTRA_PUBLISH_FILE: ''
+  _EXTRA_VERSION_MARKERS: ''
   _HYPERKUBE: ''

--- a/gcb/build/variants.yaml
+++ b/gcb/build/variants.yaml
@@ -5,7 +5,7 @@ variants:
     BUCKET: '--bucket=k8s-staging-releng'
     REGISTRY: '--docker-registry=gcr.io/k8s-staging-releng'
     ALLOW_DUP: '--allow-dup'
-    EXTRA_PUBLISH_FILE: '--extra-publish-file=k8s-master'
+    EXTRA_VERSION_MARKERS: '--extra-version-markers=k8s-master'
     HYPERKUBE: '--hyperkube'
   build-ci-fast:
     CI: '--ci'
@@ -18,5 +18,5 @@ variants:
     BUCKET: '--bucket=kubernetes-release-dev'
     REGISTRY: '--docker-registry=gcr.io/kubernetes-ci-images'
     ALLOW_DUP: '--allow-dup'
-    EXTRA_PUBLISH_FILE: '--extra-publish-file=k8s-master'
+    EXTRA_VERSION_MARKERS: '--extra-version-markers=k8s-master'
     HYPERKUBE: '--hyperkube'

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -803,7 +803,7 @@ release::gcs::publish_version () {
   local version=$2
   local build_output=$3
   local bucket=$4
-  local extra_publish_file=$5
+  local extra_version_markers=$5
   local release_dir="gs://$bucket/$build_type/$version"
   local version_major
   local version_minor
@@ -829,8 +829,11 @@ release::gcs::publish_version () {
   publish_files=($type
                  $type-$version_major
                  $type-$version_major.$version_minor
-                 $extra_publish_file
                 )
+
+  for marker in "${extra_version_markers[@]}"; do
+    publish_files+=("$marker")
+  done
 
   logecho
   logecho "Publish official pointer text files to $bucket..."

--- a/push-build.sh
+++ b/push-build.sh
@@ -174,6 +174,10 @@ GCS_DEST=${FLAGS_release_type:-$GCS_DEST}
 GCS_DEST+="$FLAGS_gcs_suffix"
 GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:${FLAGS_extra_publish_file:-}}"
 
+PREVIOUS_IFS=$IFS
+IFS=',' read -ra GCS_EXTRA_VERSION_MARKERS <<< "$GCS_EXTRA_VERSION_MARKERS_STRING"
+IFS=$PREVIOUS_IFS
+
 if ((FLAGS_nomock)); then
   logecho
   logecho "$PROG is running a *REAL* push!!"
@@ -245,7 +249,7 @@ if ! ((FLAGS_noupdatelatest)); then
   attempt=0
   while ((attempt<max_attempts)); do
     release::gcs::publish_version $GCS_DEST $LATEST $KUBE_ROOT/_output \
-                                  $RELEASE_BUCKET $GCS_EXTRA_VERSION_MARKERS_STRING && break
+                                  $RELEASE_BUCKET $GCS_EXTRA_VERSION_MARKERS && break
     ((attempt++))
   done
   ((attempt>=max_attempts)) && common::exit 1 "Exiting..."

--- a/push-build.sh
+++ b/push-build.sh
@@ -41,29 +41,37 @@ PROG=${0##*/}
 #+     interface in kubernetes proper.
 #+
 #+ OPTIONS
-#+     [--nomock]                - Enables a real push (--ci only)
-#+     [--federation]            - Enable FEDERATION push
-#+     [--ci]                    - Used when called from Jenkins (for ci runs)
-#+     [--extra-publish-file=]   - Used when need to upload additional version
-#+                                 file to GCS. The path is relative and is
-#+                                 append to a GCS path. (--ci only)
-#+     [--bucket=]               - Specify an alternate bucket for pushes
-#+     [--release-type=]         - Override auto-detected release type
-#+                                 (normally devel or ci)
-#+     [--release-kind=]         - Kind of release to push to GCS. Supported
-#+                                 values are kubernetes(default) or federation.
-#+     [--gcs-suffix=]           - Specify a suffix to append to the upload
-#+                                 destination on GCS.
-#+     [--docker-registry=]      - If set, push docker images to specified
-#+                                 registry/project
-#+     [--version-suffix=]       - Append suffix to version name if set.
-#+     [--noupdatelatest]        - Do not update the latest file
-#+     [--private-bucket]        - Do not mark published bits on GCS as
-#+                                 publicly readable.
-#+     [--allow-dup]             - Do not exit error if the build already
-#+                                 exists on the gcs path.
-#+     [--help | -man]           - display man page for this script
-#+     [--usage | -?]            - display in-line usage
+#+     [--nomock]                  - Enables a real push (--ci only)
+#+     [--federation]              - Enable FEDERATION push
+#+     [--ci]                      - Used when called from Jenkins (for ci
+#+                                   runs)
+#+     [--extra-publish-file=]     - [DEPRECATED - use --extra-version-markers
+#+                                   instead] Used when need to upload
+#+                                   additional version file to GCS. The path
+#+                                   is relative and is append to a GCS path.
+#+                                   (--ci only)
+#+     [--extra-version-markers=]  - Used when need to upload additional
+#+                                   version markers to GCS. The path is
+#+                                   relative and is append to a GCS path.
+#+                                   (--ci only)
+#+     [--bucket=]                 - Specify an alternate bucket for pushes
+#+     [--release-type=]           - Override auto-detected release type
+#+                                   (normally devel or ci)
+#+     [--release-kind=]           - Kind of release to push to GCS. Supported
+#+                                   values are kubernetes(default) or
+#+                                   federation.
+#+     [--gcs-suffix=]             - Specify a suffix to append to the upload
+#+                                   destination on GCS.
+#+     [--docker-registry=]        - If set, push docker images to specified
+#+                                   registry/project
+#+     [--version-suffix=]         - Append suffix to version name if set.
+#+     [--noupdatelatest]          - Do not update the latest file
+#+     [--private-bucket]          - Do not mark published bits on GCS as
+#+                                   publicly readable.
+#+     [--allow-dup]               - Do not exit error if the build already
+#+                                   exists on the gcs path.
+#+     [--help | -man]             - display man page for this script
+#+     [--usage | -?]              - display in-line usage
 #+
 #+ EXAMPLES
 #+     $PROG                     - Do a developer push
@@ -164,7 +172,7 @@ GCS_DEST="devel"
 ((FLAGS_ci)) && GCS_DEST="ci"
 GCS_DEST=${FLAGS_release_type:-$GCS_DEST}
 GCS_DEST+="$FLAGS_gcs_suffix"
-GCS_EXTRA_PUBLISH_FILE=${FLAGS_extra_publish_file:-}
+GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:${FLAGS_extra_publish_file:-}}"
 
 if ((FLAGS_nomock)); then
   logecho
@@ -237,7 +245,7 @@ if ! ((FLAGS_noupdatelatest)); then
   attempt=0
   while ((attempt<max_attempts)); do
     release::gcs::publish_version $GCS_DEST $LATEST $KUBE_ROOT/_output \
-                                  $RELEASE_BUCKET $GCS_EXTRA_PUBLISH_FILE && break
+                                  $RELEASE_BUCKET $GCS_EXTRA_VERSION_MARKERS_STRING && break
     ((attempt++))
   done
   ((attempt>=max_attempts)) && common::exit 1 "Exiting..."


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig testing

#### What this PR does / why we need it:

- Prefer `--extra-version-markers` over `--extra-publish-file`
  In build jobs that use --extra-publish-file, I've only ever seen the
  flag used to mean an additional version marker to upload.

  Here we make the flag explicit in its usage (by renaming it to
  --extra-version-markers), while supporting fallback usage of
  --extra-publish-file.
- Support uploading multiple version markers

Inspired by the kubepkg test failures (https://github.com/kubernetes/kubernetes/issues/88408) and one of the eventual fixes (https://github.com/kubernetes/release/pull/1383), I started thinking about version markers again (https://github.com/kubernetes/sig-release/issues/850, https://github.com/kubernetes/sig-release/issues/759).

This is a next step to remove our dependence on the "named", shifting [version markers](https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md):
- `k8s-master`
- `k8s-beta`
- `k8s-stable1`
- `k8s-stable2`
- `k8s-stable3`

By allowing multiple version markers to be specified via `--extra-version-markers` or `--extra-publish-file` in build jobs, we can start to move CI jobs away from the named markers and instead use, for example:
- `latest-cross`
- `latest-1.19-cross`
- `latest-1.18-cross`
- `latest-1.17-cross`
- `latest-1.16-cross`

/assign @hasheddan @saschagrunert @cpanato @tpepper 
cc: @kubernetes/release-engineering @BenTheElder @spiffxp 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/hold until I'm back at a computer, in case merging this has adverse effects on CI build jobs 

#### Does this PR introduce a user-facing change?

```release-note
push-build: Support uploading multiple version markers
```
