### PR TITLE
push-build: Support pushing cross builds to a /cross subdirectory

### DIFF
--- a/anago
+++ b/anago
@@ -1382,7 +1382,7 @@ push_all_artifacts () {
   if [[ -z "$STAGED_LOCATION" ]]; then
     # Locally Stage the release artifacts in build directory (gcs-stage)
     common::runstep release::gcs::locally_stage_release_artifacts \
-     $BUCKET_TYPE $version $BUILD_OUTPUT-$version || return 1
+     $version $BUILD_OUTPUT-$version || return 1
   fi
 
   # The full release stage case

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -644,17 +644,15 @@ release::gcs::push_release_artifacts() {
 
 ###############################################################################
 # Locally stage the release artifacts to staging directory
-# @param build_type - One of 'release' or 'ci'
 # @param version - The version
 # @param build_output - build output directory
 # @optparam release_kind - defaults to kubernetes
 # @return 1 on failure
 release::gcs::locally_stage_release_artifacts() {
-  local build_type=$1
-  local version=$2
-  local build_output=$3
+  local version=$1
+  local build_output=$2
   # --release-kind used by push-build.sh
-  local release_kind=${4:-"kubernetes"}
+  local release_kind=${3:-"kubernetes"}
   local platform
   local release_stage=$build_output/release-stage
   local release_tars=$build_output/release-tars

--- a/push-build.sh
+++ b/push-build.sh
@@ -218,7 +218,7 @@ while ((attempt<max_attempts)); do
     release::gcs::bazel_push_build $GCS_DEST $LATEST $KUBE_ROOT/_output \
                                    $RELEASE_BUCKET && break
   else
-    release::gcs::locally_stage_release_artifacts $GCS_DEST $LATEST \
+    release::gcs::locally_stage_release_artifacts $LATEST \
                                                   $KUBE_ROOT/_output \
                                                   $FLAGS_release_kind
     release::gcs::push_release_artifacts \

--- a/push-build.sh
+++ b/push-build.sh
@@ -45,6 +45,7 @@ PROG=${0##*/}
 #+     [--federation]              - Enable FEDERATION push
 #+     [--ci]                      - Used when called from Jenkins (for ci
 #+                                   runs)
+#+     [--cross]                   - Specifies a cross build
 #+     [--extra-publish-file=]     - [DEPRECATED - use --extra-version-markers
 #+                                   instead] Used when need to upload
 #+                                   additional version file to GCS. The path
@@ -221,9 +222,16 @@ while ((attempt<max_attempts)); do
     release::gcs::locally_stage_release_artifacts $LATEST \
                                                   $KUBE_ROOT/_output \
                                                   $FLAGS_release_kind
+
+    if ((FLAGS_cross)); then
+      BUILD_DEST="$GCS_DEST/cross"
+    else
+      BUILD_DEST="$GCS_DEST"
+    fi
+
     release::gcs::push_release_artifacts \
      $KUBE_ROOT/_output/gcs-stage/$LATEST \
-     gs://$RELEASE_BUCKET/$GCS_DEST/$LATEST && break
+     gs://$RELEASE_BUCKET/$BUILD_DEST/$LATEST && break
   fi
   ((attempt++))
 done


### PR DESCRIPTION
#### What type of PR is this?

/kind feature cleanup
/priority critical-urgent

#### What this PR does / why we need it:

- push-build: Support pushing cross builds to a /cross subdirectory
- lib/release: Remove unused build_type from local staging function

Follow-up to https://github.com/kubernetes/release/pull/1385.

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering @BenTheElder @spiffxp 
ref: https://github.com/kubernetes/sig-release/issues/850, https://github.com/kubernetes/sig-release/issues/759

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

I'll come back with more details shortly; just getting the PR up in the meantime.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
push-build: Support pushing cross builds to a /cross subdirectory
```
