### PR TITLE
push-build: Prevent cross build and amd64 version marker collisions

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -824,10 +824,19 @@ release::gcs::publish_version () {
     version_minor=${BASH_REMATCH[2]}
   fi
 
-  publish_files=($type
-                 $type-$version_major
-                 $type-$version_major.$version_minor
-                )
+  if ((FLAGS_cross)); then
+    publish_files=(
+      "$type-cross"
+      "$type-$version_major-cross"
+      "$type-$version_major.$version_minor-cross"
+    )
+  else
+    publish_files=(
+      "$type"
+      "$type-$version_major"
+      "$type-$version_major.$version_minor"
+    )
+  fi
 
   for marker in "${extra_version_markers[@]}"; do
     publish_files+=("$marker")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

(Follow-up to https://github.com/kubernetes/release/pull/1386 and https://github.com/kubernetes/release/pull/1385.)
(Needed for https://github.com/kubernetes/test-infra/pull/18158.)

Now that the --cross flag exists for push-build.sh, we add logic to
suffix "-cross" to version markers during a cross build.

This will produce the following markers when publishing a cross build:
- `latest-cross`
- `latest-x-cross`
- `latest-x.y-cross`

As opposed to:
- `latest`
- `latest-x`
- `latest-x.y`

thus preventing collisions between the two build variants.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering @BenTheElder @spiffxp 
ref: https://github.com/kubernetes/sig-release/issues/850, https://github.com/kubernetes/sig-release/issues/759

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
push-build: Prevent cross build and amd64 version marker collisions
```
