### PR TITLE
push-build: Support pushing fast builds to a /fast subdirectory

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -824,11 +824,11 @@ release::gcs::publish_version () {
     version_minor=${BASH_REMATCH[2]}
   fi
 
-  if ((FLAGS_cross)); then
+  if ((FLAGS_fast)); then
     publish_files=(
-      "$type-cross"
-      "$type-$version_major-cross"
-      "$type-$version_major.$version_minor-cross"
+      "$type-fast"
+      "$type-$version_major-fast"
+      "$type-$version_major.$version_minor-fast"
     )
   else
     publish_files=(

--- a/push-build.sh
+++ b/push-build.sh
@@ -45,7 +45,7 @@ PROG=${0##*/}
 #+     [--federation]              - Enable FEDERATION push
 #+     [--ci]                      - Used when called from Jenkins (for ci
 #+                                   runs)
-#+     [--cross]                   - Specifies a cross build
+#+     [--fast]                    - Specifies a fast build (linux amd64 only)
 #+     [--extra-publish-file=]     - [DEPRECATED - use --extra-version-markers
 #+                                   instead] Used when need to upload
 #+                                   additional version file to GCS. The path
@@ -223,8 +223,8 @@ while ((attempt<max_attempts)); do
                                                   $KUBE_ROOT/_output \
                                                   $FLAGS_release_kind
 
-    if ((FLAGS_cross)); then
-      BUILD_DEST="$GCS_DEST/cross"
+    if ((FLAGS_fast)); then
+      BUILD_DEST="$GCS_DEST/fast"
     else
       BUILD_DEST="$GCS_DEST"
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

(Follow-up to https://github.com/kubernetes/release/pull/1387, https://github.com/kubernetes/release/pull/1386, and https://github.com/kubernetes/release/pull/1385.)

(This inverts the logic of a previous commit --> 1e56e602677cabc57d41e24e603c1a6bfe6c64e1)

After reviewing the Kubernetes build scenarios and currently configured
jobs, it becomes clear that a "fast" build (linux/amd64-only) is a
special case.

Fast builds only happen on the master branch, which means master version
markers are the only ones experiencing collisions.

That said, cross builds are the default build type across release
branches and we should instead special-case fast builds, giving them
their own subdirectory and version markers to leverage.

The following markers should be built when an accompanying k/test-infra
PR is merged:
- `latest-fast`
- `latest-1-fast`
- `latest-1.19-fast`

With fast builds being published to the following location:
gs://kubernetes-release-dev/ci/fast/

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering @BenTheElder @spiffxp 
ref: https://github.com/kubernetes/sig-release/issues/850, https://github.com/kubernetes/sig-release/issues/759

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
push-build: Support pushing fast builds to a /fast subdirectory
```
