### PR TITLE
Add command.Verbose() method

### DIFF
--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -61,6 +61,14 @@ func TestFailurePipeWrongArgument(t *testing.T) {
 	require.NotEmpty(t, res.Error())
 }
 
+func TestSuccessVerbose(t *testing.T) {
+	res, err := New("echo", "hi").Verbose().Run()
+	require.Nil(t, err)
+	require.Contains(t, res.stdOut, "echo hi")
+	require.True(t, res.Success())
+	require.Zero(t, res.ExitCode())
+}
+
 func TestSuccessWithWorkingDir(t *testing.T) {
 	res, err := NewWithWorkDir("/", "ls", "-1").Run()
 	require.Nil(t, err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The new `command.Verbose()` method enables verbose output for commands,
like:

```
+ /usr/bin/echo hi
hi
```

This is especially handy when writing multiple commands in sequence.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `command.Verbose()` method which enables verbose output (printing the command before execution) for the command invocation
```
