### PR TITLE
Add `Commands` structure to command package

### DIFF
--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -308,3 +308,20 @@ func TestSuccessLogWriterStdErrAndStdOutOnlyStdOut(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, res.Output(), string(content))
 }
+
+func TestCommandsSuccess(t *testing.T) {
+	res, err := New("echo", "1").Verbose().
+		Add("echo", "2").Add("echo", "3").Run()
+	require.Nil(t, err)
+	require.True(t, res.Success())
+	require.Zero(t, res.ExitCode())
+	require.Contains(t, res.Output(), "1")
+	require.Contains(t, res.Output(), "2")
+	require.Contains(t, res.Output(), "3")
+}
+
+func TestCommandsFailure(t *testing.T) {
+	res, err := New("echo", "1").Add("wrong").Add("echo", "3").Run()
+	require.NotNil(t, err)
+	require.Nil(t, res)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The `Commands` structure allows concatenation of commands by preserving
their working directory and verbosity mode. This reduces the noise when
running multiple commands sequentially.

Demo:
```go
New("echo", "1").Verbose().Add("echo", "2").Add("echo", "3").Run()
```
will result int:
```
+ /usr/bin/echo 1
1
+ /usr/bin/echo 2
2
+ /usr/bin/echo 3
3
```


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `Commands` structure which can be used to run multiple commands sequentially by preserving
  the working directory and verbosity mode. The structure can be used by calling the
  `Add(cmd string, args string...)` method of `Command` or `Commands`.
  Calling `Run()` on `Commands` will run each command in sequence by aborting if the first command fails.
```
