### PR TITLE
Set commands globally to verbose if log level >= Debug

### DIFF
--- a/pkg/command/BUILD.bazel
+++ b/pkg/command/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["command.go"],
+    srcs = [
+        "command.go",
+        "global.go",
+    ],
     importpath = "k8s.io/release/pkg/command",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,7 +16,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["command_test.go"],
+    srcs = [
+        "command_test.go",
+        "global_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//require:go_default_library"],
 )

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -103,6 +103,12 @@ func (c *Command) Verbose() *Command {
 	return c
 }
 
+// isVerbose returns true if the command is in verbose mode, either set locally
+// or global
+func (c *Command) isVerbose() bool {
+	return GetGlobalVerbose() || c.verbose
+}
+
 // Add a command with the same working directory as well as verbosity mode.
 // Returns a new Commands instance.
 func (c *Command) Add(cmd string, args ...string) Commands {
@@ -254,7 +260,7 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 			}()
 		}
 
-		if c.verbose {
+		if c.isVerbose() {
 			fmt.Fprintf(stdOutWriter, "+ %s\n", c.String())
 		}
 

--- a/pkg/command/global.go
+++ b/pkg/command/global.go
@@ -14,27 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package command
 
 import (
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-
-	"k8s.io/release/pkg/command"
+	"sync/atomic"
 )
 
-func SetupGlobalLogger(level string) error {
-	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
-	lvl, err := logrus.ParseLevel(level)
-	if err != nil {
-		return errors.Wrapf(err, "setting log level to %s", level)
+// atomicInt is the global variable for storing the globally set verbosity
+// level. It should never be used directly to avoid data races.
+var atomicInt int32
+
+// SetGlobalVerbose sets the global command verbosity to the specified value
+func SetGlobalVerbose(to bool) {
+	var i int32 = 0
+	if to {
+		i = 1
 	}
-	logrus.SetLevel(lvl)
-	if lvl >= logrus.DebugLevel {
-		logrus.Debug("Setting commands globally into verbose mode")
-		command.SetGlobalVerbose(true)
-	}
-	logrus.AddHook(NewFilenameHook())
-	logrus.Debugf("Using log level %q", lvl)
-	return nil
+	atomic.StoreInt32(&atomicInt, i)
+}
+
+// GetGlobalVerbose returns the globally set command verbosity
+func GetGlobalVerbose() bool {
+	return atomic.LoadInt32(&atomicInt) != 0
 }

--- a/pkg/command/global_test.go
+++ b/pkg/command/global_test.go
@@ -14,27 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package command
 
 import (
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	"testing"
 
-	"k8s.io/release/pkg/command"
+	"github.com/stretchr/testify/require"
 )
 
-func SetupGlobalLogger(level string) error {
-	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
-	lvl, err := logrus.ParseLevel(level)
-	if err != nil {
-		return errors.Wrapf(err, "setting log level to %s", level)
-	}
-	logrus.SetLevel(lvl)
-	if lvl >= logrus.DebugLevel {
-		logrus.Debug("Setting commands globally into verbose mode")
-		command.SetGlobalVerbose(true)
-	}
-	logrus.AddHook(NewFilenameHook())
-	logrus.Debugf("Using log level %q", lvl)
-	return nil
+func TestSetGlobalVerboseSuccess(t *testing.T) {
+	require.False(t, GetGlobalVerbose())
+	SetGlobalVerbose(true)
+	require.True(t, GetGlobalVerbose())
 }

--- a/pkg/log/BUILD.bazel
+++ b/pkg/log/BUILD.bazel
@@ -8,7 +8,11 @@ go_library(
     ],
     importpath = "k8s.io/release/pkg/log",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "//pkg/command:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now use an atomic bool abstraction to be able to set commands into
verbose mode globally. This allows us to make commands automatically
verbose if the log level is higher than `Debug`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `command.SetGlobalVerbose(bool)` and `command.GetGlobalVerbose() bool` functions to
  globally set the commands verbosity mode
- Changed commands to be automatically verbose when the specified `log-level=[debug,trace]`
```
