### PR TITLE
Remove --build-at-head flag from anago and releaselib

### DIFF
--- a/anago
+++ b/anago
@@ -30,7 +30,6 @@ PROG=${0##*/}
 #+            [--basedir=<alt base work dir>]
 #+            [--security_layer=/path/to/pointer/to/script]
 #+            [--exclude-suites="<suite> ..."]
-#+            [--build-at-head]
 #+            [--prebuild] [--buildonly]
 #+            [--mailto=<email1>,<email2>]
 #+            [--tmpdir=</alt/tmp>]
@@ -75,9 +74,6 @@ PROG=${0##*/}
 #+     Simply specify the <branch> you want to release from and follow the
 #+     prompts.  <branch> is one of master, release-1.2, etc. and the release
 #+     is based on the <branch> value and the [--type] flag:
-#+
-#+     WARNING: --build-at-head bypasses any test analysis and builds directly
-#+     at the HEAD Of the named branch.  Mostly for testing.
 #+
 #+     Branch     RC  Official    Type
 #+     ------     --  --------    ----
@@ -126,7 +122,6 @@ PROG=${0##*/}
 #+                                 Default: $HOME/.kubernetes-releaserc
 #+     [--exclude-suites=]       - Space separated list of CI suites regex to
 #+                                 exclude from go/nogo criteria
-#+     [--build-at-head]         - Force a build at HEAD of named branch
 #+     [--mailto=]               - Comma-separated list of addresses to send
 #+                                 announcement email to. Overrides default list.
 #+     [--github-release-draft]  - Force a github release draft for mock runs.
@@ -155,11 +150,6 @@ PROG=${0##*/}
 #+                               - Do a mock official release from release-1.1
 #+     $PROG --nomock --type=official release-1.1
 #+                               - Do an official release from release-1.1
-#+     $PROG release-1.8 --stage --build-at-head
-#+                               - Stage a HEAD build locally and on GCS
-#+     $PROG release-1.8 --nomock --build-at-head
-#+                               - Release the staged build
-#+                                 (assuming HEAD hasn't changed)
 #+
 #+ FILES
 #+     build/release.sh

--- a/find_green_build
+++ b/find_green_build
@@ -24,7 +24,7 @@ PROG=${0##*/}
 #+ SYNOPSIS
 #+     $PROG  [--official] [<release branch>]
 #+            [--github-token=<token>] [--exclude-suites="<suite> ..."]
-#+            [--build-at-head] [--allow-stale-build] [--limit=N]
+#+            [--allow-stale-build] [--limit=N]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
 #+
@@ -46,7 +46,6 @@ PROG=${0##*/}
 #+     [--allow-stale-build] - Keep going even if the build is behind HEAD.
 #+                             This should only be used to display CI status.
 #+                             Branch cuts can't actually use stale builds.
-#+     [--build-at-head]     - (From anago) Just quickly return the HEAD build.
 #+     [--limit=]            - Limit the primary check to a count of N
 #+                             (Default: 100)
 #+     [--help | -man]       - display man page for this script

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -181,14 +181,10 @@ release::set_build_version () {
   # finer granularity at the Jenkin's job level to determine if a build is ok.
   release::get_job_cache -d $job_path/$main_job &
 
-  # If we're forcing a --build-at-head, we only need to capture the $main_job
-  # details.
-  if ! ((FLAGS_build_at_head)); then
-    # Update secondary caches limited by main cache last build number
-      for other_job in ${secondary_jobs[@]}; do
+  # Update secondary caches limited by main cache last build number
+  for other_job in ${secondary_jobs[@]}; do
     release::get_job_cache $job_path/$other_job &
-    done
-  fi
+  done
 
   # Wait for background fetches.
   wait
@@ -230,20 +226,6 @@ release::set_build_version () {
                         jq -r '.[0] | .commit .author .date')
       build_sha1_date=$(date +"%R %m/%d" -d "$build_sha1_date")
 
-      # See anago for --build-at-head
-      # This method requires a call to release::get_job_cache() to initially
-      # set $build_version, however it is less fragile than ls-remote and
-      # sorting
-      if ((FLAGS_build_at_head)); then
-        build_version=${build_version/$build_sha1/$branch_head}
-        # Force job_count so we don't fail
-        job_count=1
-        logecho
-        logecho "Forced --build-at-head specified." \
-                "Setting build_version=$build_version"
-        logecho
-        break
-      fi
     elif [[ $good_job =~ JOB\[([0-9]+)\]=(${VER_REGEX[release]}) ]]; then
       logecho
       logecho "$ATTENTION: Newly tagged versions exclude git hash." \


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
The is not actively used any more and removing it will reduce the
technical depth as well as making the transformation to golang easier.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed `--build-at-head` flag from anago
```
