### PR TITLE
Cut -rc.1 for the first release candidate on a new branch

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -415,7 +415,7 @@ release::set_release_version () {
     RELEASE_VERSION[alpha]="v${release_branch[major]}"
     RELEASE_VERSION[alpha]+=".$((${release_branch[minor]}+1)).0-alpha.0"
     RELEASE_VERSION[rc]="v${release_branch[major]}.${release_branch[minor]}"
-    RELEASE_VERSION[rc]+=".0-rc.0"
+    RELEASE_VERSION[rc]+=".0-rc.1"
     RELEASE_VERSION_PRIME=${RELEASE_VERSION[rc]}
   elif [[ $branch =~ release- ]]; then
     # Build out the RELEASE_VERSION dict


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Instead of cutting rc.0 we should intend to cut rc.1 for the first
release candidate if the parent branch is `master`.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed the first release candidate on a new branch to be `rc.1` instead of `rc.0`
```
