### PR TITLE
anago: set verbose to git push

### DIFF
--- a/anago
+++ b/anago
@@ -829,16 +829,16 @@ push_git_objects () {
   logecho "Pushing$dryrun_flag tags"
   for release_type in "${ORDERED_RELEASE_KEYS[@]}"; do
     logecho -n "Pushing ${RELEASE_VERSION[$release_type]} tag: "
-    logrun -s git push$dryrun_flag origin ${RELEASE_VERSION[$release_type]} || return 1
+    logrun -v -s git push -v $dryrun_flag origin ${RELEASE_VERSION[$release_type]} || return 1
   done
 
   if [[ "$RELEASE_BRANCH" =~ release- ]]; then
     logecho -n "Pushing$dryrun_flag $RELEASE_BRANCH branch: "
-    logrun -v -s git push$dryrun_flag origin $RELEASE_BRANCH || return 1
+    logrun -v -s git push -v $dryrun_flag origin $RELEASE_BRANCH || return 1
     # Additionally push the parent branch if a branch of branch
     if [[ "$PARENT_BRANCH" =~ release- ]]; then
       logecho -n "Pushing$dryrun_flag $PARENT_BRANCH branch: "
-      logrun -v -s git push$dryrun_flag origin $PARENT_BRANCH || return 1
+      logrun -v -s git push -v $dryrun_flag origin $PARENT_BRANCH || return 1
     fi
   fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Set verbose logs when git push objects 


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
anago: set verbose to git push
```
