### PR TITLE
kube-cross: overwrite user and group for etcd source

### DIFF
--- a/images/build/cross/Dockerfile
+++ b/images/build/cross/Dockerfile
@@ -89,6 +89,7 @@ ARG ETCD_VERSION
 RUN mkdir -p /usr/local/src/etcd \
   && cd /usr/local/src/etcd \
   && curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | tar -xz \
+  && chown -R $(id -u):$(id -g) /usr/local/src/etcd \
   && ln -s ../src/etcd/etcd-${ETCD_VERSION}-linux-amd64/etcd /usr/local/bin/
 
 # Cleanup a bit

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,12 +2,12 @@ variants:
   go1.14:
     CONFIG: 'go1.14'
     GO_VERSION: '1.14.5'
-    KUBE_CROSS_VERSION: 'v1.14.5-1'
+    KUBE_CROSS_VERSION: 'v1.14.5-2'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
   go1.13:
     CONFIG: 'go1.13'
     GO_VERSION: '1.13.13'
-    KUBE_CROSS_VERSION: 'v1.13.13-1'
+    KUBE_CROSS_VERSION: 'v1.13.13-2'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We now use the current users U/GID for the downloaded etcd sources to
allow rootless execution in docker/podman.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

ref: https://github.com/kubernetes/release/issues/1403

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed rootless docker/podman execution for `kube-cross` container image
```
