### PR TITLE
kube-cross: Build v1.14.5-1 and v1.13.13-1 images

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -20,10 +20,10 @@ IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)
 CONFIG?=go1.14
-KUBE_CROSS_VERSION?=v1.14.4-1
+KUBE_CROSS_VERSION?=v1.14.5-1
 
 # Build args
-GO_VERSION?=1.14.4
+GO_VERSION?=1.14.5
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.9
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   go1.14:
     CONFIG: 'go1.14'
-    GO_VERSION: '1.14.4'
-    KUBE_CROSS_VERSION: 'v1.14.4-2'
+    GO_VERSION: '1.14.5'
+    KUBE_CROSS_VERSION: 'v1.14.5-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
   go1.13:
     CONFIG: 'go1.13'
-    GO_VERSION: '1.13.12'
-    KUBE_CROSS_VERSION: 'v1.13.12-2'
+    GO_VERSION: '1.13.13'
+    KUBE_CROSS_VERSION: 'v1.13.13-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency
/priority critical-urgent

#### What this PR does / why we need it:

go1.14.5 and go1.13.13 (security releases) have been announced: https://groups.google.com/d/topic/golang-announce/XZNfaiwgt2w/discussion
ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1594746089427800

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @hasheddan @cpanato @dims @BenTheElder 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/hold until https://github.com/kubernetes/release/pull/1404 merges

#### Does this PR introduce a user-facing change?

```release-note
kube-cross: Build v1.14.5-1 and v1.13.13-1 images
```
