### PR TITLE
kube-cross: Build v1.14.6-1

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -20,10 +20,10 @@ IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)
 CONFIG?=go1.14
-KUBE_CROSS_VERSION?=v1.14.5-1
+KUBE_CROSS_VERSION?=v1.14.6-1
 
 # Build args
-GO_VERSION?=1.14.5
+GO_VERSION?=1.14.6
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.9
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   go1.14:
     CONFIG: 'go1.14'
-    GO_VERSION: '1.14.5'
-    KUBE_CROSS_VERSION: 'v1.14.5-2'
+    GO_VERSION: '1.14.6'
+    KUBE_CROSS_VERSION: 'v1.14.6-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
   go1.13:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area dependency
/priority critical-urgent

#### What this PR does / why we need it:
go1.14.6 announced and needed for the ppc64le platform, announce: https://groups.google.com/g/golang-announce/c/9KNZ5g9tv4o/m/n_CqeNoUBwAJ

/assign @tpepper @saschagrunert @hasheddan @cpanato @dims @BenTheElder
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kube-cross: Build v1.14.6-1
```
