### PR TITLE
Improve release-notes --format help output

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -151,10 +151,10 @@ func init() {
 		util.EnvDefault("FORMAT", options.FormatSpecDefaultGoTemplate),
 		fmt.Sprintf("The format for notes output (options: %s)",
 			strings.Join([]string{
-				options.FormatSpecNone,
 				options.FormatSpecJSON,
 				options.FormatSpecDefaultGoTemplate,
-				options.FormatSpecGoTemplateInline,
+				options.FormatSpecGoTemplateInline + "<template>",
+				options.GoTemplatePrefix + "<file.template>",
 			}, ", "),
 		),
 	)


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
The help output for the format was a bit misleading:

```
--format string     The format for notes output (options: , json,
                    go-template:default, go-template:inline:)
                    (default "go-template:default")
```

This is now improved by giving examples and removing the "empty format":

```
--format string     The format for notes output (options: json,
                    go-template:default, go-template:inline:<template>,
                    go-template:<file.template>)
                    (default "go-template:default")
```
#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Improved the help output for `release-notes --format` option 
```
