### PR TITLE
kube-cross: Build v1.13.14-1 and v1.15.0-beta.1-canary-1 images

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -39,6 +39,7 @@ all: build push
 build:
 	docker build \
 		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
+		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION) \
 		-t $(PROD_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION) \
 		--build-arg=GO_VERSION=$(GO_VERSION) \
@@ -48,6 +49,7 @@ build:
 
 push:
 	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)-$(CONFIG)
+	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):latest-$(CONFIG)
 	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION)
 	docker manifest create --amend $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
 		$(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION)

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -1,7 +1,9 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 1200s
+
 options:
   substitution_option: ALLOW_LOOSE
+
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200713-e9b3d9d'
     entrypoint: make
@@ -16,6 +18,7 @@ steps:
     - ETCD_VERSION=$_ETCD_VERSION
     args:
     - all
+
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
@@ -26,6 +29,16 @@ substitutions:
   _KUBE_CROSS_VERSION: 'v0.0.0-0'
   _PROTOBUF_VERSION: '0.0.0'
   _ETCD_VERSION: 'v0.0.0'
+
+tags:
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_CONFIG}
+- ${_GO_VERSION}
+- ${_KUBE_CROSS_VERSION}
+- ${_PROTOBUF_VERSION}
+- ${_ETCD_VERSION}
+
 images:
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_KUBE_CROSS_VERSION'
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_GIT_TAG-$_CONFIG'

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -29,3 +29,4 @@ substitutions:
 images:
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_KUBE_CROSS_VERSION'
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_GIT_TAG-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:latest-$_CONFIG'

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20191019-6567e5c'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200713-e9b3d9d'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,10 @@
 variants:
+  canary:
+    CONFIG: 'canary'
+    GO_VERSION: '1.15beta1'
+    KUBE_CROSS_VERSION: 'v1.15.0-beta.1-canary-1'
+    PROTOBUF_VERSION: '3.0.2'
+    ETCD_VERSION: 'v3.4.9'
   go1.14:
     CONFIG: 'go1.14'
     GO_VERSION: '1.14.6'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -7,7 +7,7 @@ variants:
     ETCD_VERSION: 'v3.4.9'
   go1.13:
     CONFIG: 'go1.13'
-    GO_VERSION: '1.13.13'
-    KUBE_CROSS_VERSION: 'v1.13.13-2'
+    GO_VERSION: '1.13.14'
+    KUBE_CROSS_VERSION: 'v1.13.14-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency
/priority important-soon

#### What this PR does / why we need it:

- kube-cross: Update GCB image to gcb-docker-gcloud:v20200713-e9b3d9d
- kube-cross: Build v1.13.14-1 image
- kube-cross: Add canary variant to test Golang pre-releases
- kube-cross: Add tags to GCB jobs 

Continuation of https://github.com/kubernetes/release/issues/1410.
ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1594948018000900

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @hasheddan @cpanato @dims @BenTheElder 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/hold for testing

#### Does this PR introduce a user-facing change?

```release-note
kube-cross: Build v1.13.14-1 and v1.15.0-beta.1-canary-1 images
```
