### PR TITLE
changelog: remove changelog files from other releases when we cut the first official release

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -524,8 +524,8 @@ func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
 			return errors.Wrapf(err, "checking out release branch %s", branch)
 		}
 
-		// Remove all other changelog files if we’re on the first RC
-		if len(tag.Pre) > 1 && tag.Pre[0].String() == "rc" && tag.Pre[1].String() == "1" {
+		// Remove all other changelog files if we’re on the the first official release
+		if tag.Patch == 0 && len(tag.Pre) == 0 {
 			pattern := filepath.Join(repoChangelogDir, "CHANGELOG-*.md")
 			logrus.Infof("Removing unnecessary %s files", pattern)
 			if err := repo.Rm(true, pattern); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
Before we clean the changelogs files when cutting the `rc.1` but if we have patch releases during this time and also branch FF tasks the release branch will fail.

So, after some discussions, we thought that is safe to remove the files when we cut the official release.


#### Which issue(s) this PR fixes:
 - Fixes https://github.com/kubernetes/sig-release/issues/1154

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
changelog: remove changelog files from other releases when we cut the first official release
```

/assign @saschagrunert @tpepper @justaugustus 
cc @kubernetes/release-managers 