### PR TITLE
k8s-cloud-builder: Build on kube-cross:v1.14.6-1 and v1.13.14-1

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,9 +1,9 @@
 variants:
   cross1.14:
     CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.5-1'
+    KUBE_CROSS_VERSION: 'v1.14.6-1'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.13:
     CONFIG: 'cross1.13'
-    KUBE_CROSS_VERSION: 'v1.13.13-1'
+    KUBE_CROSS_VERSION: 'v1.13.14-1'
     SKOPEO_VERSION: 'v0.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Updates k8s-cloud-builder to pick up the new `kube-cross:v1.14.6-1` and `kube-cross:v1.13.14-1` images (ref: https://github.com/kubernetes/release/pull/1415, https://github.com/kubernetes/k8s.io/pull/1037)

/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build on kube-cross:v1.14.6-1 and v1.13.14-1
```
