### PR TITLE
images: Use docker buildx for kube-cross images and consolidate go-based image Makefiles

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -65,7 +65,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "k8s.gcr.io/kube-cross"
-    version: v1.15.1-1
+    version: v1.15.1-2
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
@@ -74,7 +74,7 @@ dependencies:
     version: go1.15
     refPaths:
     - path: images/build/cross/Makefile
-      match: CONFIG\?=go\d+.\d+
+      match: CONFIG \?= go\d+.\d+
     - path: images/build/cross/variants.yaml
       match: go\d+.\d+
 

--- a/images/Makefile.common-image
+++ b/images/Makefile.common-image
@@ -56,8 +56,8 @@ push: container
 
 .PHONY: manifest
 manifest: push
-	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(PLATFORMS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
-	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(IMAGE)-$(subst linux/,,$(firstword $(PLATFORMS))):$(IMAGE_VERSION)
+	@for platform in $(PLATFORMS); do docker manifest annotate --arch "$${platform##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${platform##*/}:${IMAGE_VERSION}; done
 	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
 
 # enable buildx

--- a/images/Makefile.common-image
+++ b/images/Makefile.common-image
@@ -1,0 +1,66 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set default shell
+SHELL=/bin/bash -o pipefail
+
+IMAGE = $(REGISTRY)/$(IMGNAME)
+
+TAG ?= $(shell git describe --tags --always --dirty)
+
+# TODO: Uncomment once all images using this Makefile can be built on all
+#       supported Kubernetes server platforms.
+#PLATFORMS ?= linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
+
+# Ensure support for 'docker buildx' and 'docker manifest' commands
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# build with buildx
+# https://github.com/docker/buildx/issues/59
+.PHONY: container
+container: init-docker-buildx
+	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
+	@for platform in $(PLATFORMS); do \
+		echo "Starting build for $${platform} platform"; \
+		docker buildx build \
+			--load \
+			--progress plain \
+			--platform $${platform} \
+			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
+			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
+			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
+			$(BUILD_ARGS) \
+			.; \
+	done
+
+.PHONY: push
+push: container
+	echo "Pushing $(IMGNAME) tags"
+	@for platform in $(PLATFORMS); do \
+		echo "Pushing tags for $${platform} platform"; \
+		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
+		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
+		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
+	done
+
+.PHONY: manifest
+manifest: push
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(PLATFORMS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
+	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
+	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
+
+# enable buildx
+.PHONY: init-docker-buildx
+init-docker-buildx:
+	./../../../hack/init-buildx.sh

--- a/images/build/Makefile.build-image
+++ b/images/build/Makefile.build-image
@@ -1,0 +1,18 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set default shell
+SHELL=/bin/bash -o pipefail
+
+REGISTRY ?= gcr.io/k8s-staging-build-image

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY:	build push
+# set default shell
+SHELL=/bin/bash -o pipefail
 
-STAGING_REGISTRY?=gcr.io/k8s-staging-build-image
-PROD_REGISTRY?=k8s.gcr.io/build-image
-IMAGE=kube-cross
+REGISTRY ?= gcr.io/k8s-staging-build-image
+IMGNAME = kube-cross
+IMAGE = $(REGISTRY)/$(IMGNAME)
 
-TAG?=$(shell git describe --tags --always --dirty)
-CONFIG?=go1.15
-KUBE_CROSS_VERSION?=v1.15.1-1
+TAG ?= $(shell git describe --tags --always --dirty)
+IMAGE_VERSION ?= v1.15.1-2
+CONFIG ?= go1.15
 
 # Build args
 GO_VERSION?=1.15.1
@@ -32,28 +33,43 @@ ETCD_VERSION?=v3.4.13
 #       - https://github.com/kubernetes/release/pull/1140/commits/e96924f58d9ce2bb73045fbba13f259b4345c0d9#r395056830
 #       - https://github.com/kubernetes/kubernetes/issues/78964
 #       - https://github.com/kubernetes/kubernetes/issues/75114
-ARCH=amd64
+PLATFORMS ?= linux/amd64 #linux/arm linux/arm64 linux/ppc64le linux/s390x
 
-all: build push
+# build with buildx
+.PHONY: container
+container: init-docker-buildx
+	echo "Building kube-cross for the following platforms: $(PLATFORMS)"
+	# https://github.com/docker/buildx/issues/59
+	$(foreach PLATFORM,$(PLATFORMS), \
+		echo "Starting build for $(PLATFORM) platform"; \
+		docker buildx build \
+			--load \
+			--progress plain \
+			--platform $(PLATFORM) \
+			--tag $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION) \
+			--tag $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG) \
+			--tag $(IMAGE)-$(PLATFORM):latest-$(CONFIG) \
+			--build-arg=GO_VERSION=$(GO_VERSION) \
+			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
+			--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
+			.;)
 
-build:
-	docker build \
-		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
-		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):latest-$(CONFIG) \
-		-t $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION) \
-		-t $(PROD_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION) \
-		--build-arg=GO_VERSION=$(GO_VERSION) \
-		--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
-		--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
-		.
+.PHONY: push
+push: container
+	$(foreach PLATFORM,$(PLATFORMS), \
+		docker push $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION);)
+	$(foreach PLATFORM,$(PLATFORMS), \
+		docker push $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG);)
+	$(foreach PLATFORM,$(PLATFORMS), \
+		docker push $(IMAGE)-$(PLATFORM):latest-$(CONFIG);)
 
-push:
-	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)-$(CONFIG)
-	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):latest-$(CONFIG)
-	docker push $(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION)
-	docker manifest create --amend $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
-		$(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION)
-	docker manifest annotate $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
-		$(STAGING_REGISTRY)/$(IMAGE)-$(ARCH):$(KUBE_CROSS_VERSION) \
-		--arch $(ARCH)
-	docker manifest push -p $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION)
+.PHONY: manifest
+manifest: push
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(PLATFORMS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
+	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
+	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
+
+# enable buildx
+.PHONY: init-docker-buildx
+init-docker-buildx:
+	./../../../hack/init-buildx.sh

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -36,32 +36,34 @@ ETCD_VERSION?=v3.4.13
 PLATFORMS ?= linux/amd64 #linux/arm linux/arm64 linux/ppc64le linux/s390x
 
 # build with buildx
+# https://github.com/docker/buildx/issues/59
 .PHONY: container
 container: init-docker-buildx
-	echo "Building kube-cross for the following platforms: $(PLATFORMS)"
-	# https://github.com/docker/buildx/issues/59
-	$(foreach PLATFORM,$(PLATFORMS), \
-		echo "Starting build for $(PLATFORM) platform"; \
+	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
+	@for platform in $(PLATFORMS); do \
+		echo "Starting build for $${platform} platform"; \
 		docker buildx build \
 			--load \
 			--progress plain \
-			--platform $(PLATFORM) \
-			--tag $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION) \
-			--tag $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG) \
-			--tag $(IMAGE)-$(PLATFORM):latest-$(CONFIG) \
+			--platform $${platform} \
+			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
+			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
+			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
 			--build-arg=GO_VERSION=$(GO_VERSION) \
 			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
 			--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
-			.;)
+			.; \
+	done
 
 .PHONY: push
 push: container
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION);)
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG);)
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):latest-$(CONFIG);)
+	echo "Pushing $(IMGNAME) tags"
+	@for platform in $(PLATFORMS); do \
+		echo "Pushing tags for $${platform} platform"; \
+		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
+		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
+		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
+	done
 
 .PHONY: manifest
 manifest: push

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set default shell
-SHELL=/bin/bash -o pipefail
+# include the common image-building Makefiles
+include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
-REGISTRY ?= gcr.io/k8s-staging-build-image
 IMGNAME = kube-cross
-IMAGE = $(REGISTRY)/$(IMGNAME)
-
-TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= v1.15.1-2
 CONFIG ?= go1.15
 
@@ -35,43 +31,6 @@ ETCD_VERSION?=v3.4.13
 #       - https://github.com/kubernetes/kubernetes/issues/75114
 PLATFORMS ?= linux/amd64 #linux/arm linux/arm64 linux/ppc64le linux/s390x
 
-# build with buildx
-# https://github.com/docker/buildx/issues/59
-.PHONY: container
-container: init-docker-buildx
-	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
-	@for platform in $(PLATFORMS); do \
-		echo "Starting build for $${platform} platform"; \
-		docker buildx build \
-			--load \
-			--progress plain \
-			--platform $${platform} \
-			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
-			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
-			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
-			--build-arg=GO_VERSION=$(GO_VERSION) \
-			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
-			--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
-			.; \
-	done
-
-.PHONY: push
-push: container
-	echo "Pushing $(IMGNAME) tags"
-	@for platform in $(PLATFORMS); do \
-		echo "Pushing tags for $${platform} platform"; \
-		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
-		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
-		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
-	done
-
-.PHONY: manifest
-manifest: push
-	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(PLATFORMS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
-	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
-	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
-
-# enable buildx
-.PHONY: init-docker-buildx
-init-docker-buildx:
-	./../../../hack/init-buildx.sh
+BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
+             --build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
+             --build-arg=ETCD_VERSION=$(ETCD_VERSION)

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -6,18 +6,24 @@ options:
 
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
-    entrypoint: bash
+    entrypoint: 'bash'
+    dir: ./images/build/cross
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
     - TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
     - CONFIG=$_CONFIG
     - GO_VERSION=$_GO_VERSION
-    - KUBE_CROSS_VERSION=$_KUBE_CROSS_VERSION
+    - IMAGE_VERSION=$_IMAGE_VERSION
     - PROTOBUF_VERSION=$_PROTOBUF_VERSION
     - ETCD_VERSION=$_ETCD_VERSION
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # set the home to /root explicitly to if using docker buildx
+    - HOME=/root
     args:
-    - all
+    - -c
+    - |
+      gcloud auth configure-docker \
+      && make manifest
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
@@ -26,7 +32,7 @@ substitutions:
   _PULL_BASE_REF: 'dev'
   _CONFIG: 'go0.0'
   _GO_VERSION: '0.0.0'
-  _KUBE_CROSS_VERSION: 'v0.0.0-0'
+  _IMAGE_VERSION: 'v0.0.0-0'
   _PROTOBUF_VERSION: '0.0.0'
   _ETCD_VERSION: 'v0.0.0'
 
@@ -35,11 +41,11 @@ tags:
 - ${_PULL_BASE_REF}
 - ${_CONFIG}
 - ${_GO_VERSION}
-- ${_KUBE_CROSS_VERSION}
+- ${_IMAGE_VERSION}
 - ${_PROTOBUF_VERSION}
 - ${_ETCD_VERSION}
 
 images:
-  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_KUBE_CROSS_VERSION'
+  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_IMAGE_VERSION'
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_GIT_TAG-$_CONFIG'
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:latest-$_CONFIG'

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -5,8 +5,8 @@ options:
   substitution_option: ALLOW_LOOSE
 
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200713-e9b3d9d'
-    entrypoint: make
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+    entrypoint: bash
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - TAG=$_GIT_TAG

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,12 +2,12 @@ variants:
   canary:
     CONFIG: 'canary'
     GO_VERSION: '1.15.1'
-    KUBE_CROSS_VERSION: 'v1.15.1-canary-1'
+    IMAGE_VERSION: 'v1.15.1-canary-2'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
     GO_VERSION: '1.15.1'
-    KUBE_CROSS_VERSION: 'v1.15.1-1'
+    IMAGE_VERSION: 'v1.15.1-2'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
     entrypoint: make
     dir: ./images/build/debian-base
     env:

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
     entrypoint: make
     dir: ./images/build/debian-hyperkube-base
     env:

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
     entrypoint: make
     dir: ./images/build/debian-iptables
     env:

--- a/images/build/go-runner/Dockerfile
+++ b/images/build/go-runner/Dockerfile
@@ -36,18 +36,17 @@ COPY ./go.* ./
 # ref: https://golang.org/doc/go1.15#go-command
 ENV GOPROXY="https://proxy.golang.org|direct"
 
-RUN go env
-
-# Cache the go build
-RUN go build .
-
 # Build
 ARG package=.
 ARG ARCH
 
-# Do not force rebuild of up-to-date packages (do not use -a)
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -ldflags '-s -w -buildid= -extldflags "-static"' \
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=${ARCH}
+
+RUN go env
+
+RUN go build -ldflags '-s -w -buildid= -extldflags "-static"' \
     -o go-runner ${package}
 
 # Production image

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set default shell
-SHELL=/bin/bash -o pipefail
+# include the common image-building Makefiles
+include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
-REGISTRY ?= gcr.io/k8s-staging-build-image
 IMGNAME = go-runner
-IMAGE = $(REGISTRY)/$(IMGNAME)
-
-TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= buster-v2.0.1
 CONFIG ?= buster
 
@@ -46,42 +42,5 @@ build:
 clean:
 	rm go-runner
 
-# build with buildx
-# https://github.com/docker/buildx/issues/59
-.PHONY: container
-container: init-docker-buildx
-	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
-	@for platform in $(PLATFORMS); do \
-		echo "Starting build for $${platform} platform"; \
-		docker buildx build \
-			--load \
-			--progress plain \
-			--platform $${platform} \
-			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
-			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
-			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
-			--build-arg=GO_VERSION=$(GO_VERSION) \
-			--build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-			.; \
-		done
-
-.PHONY: push
-push: container
-	echo "Pushing $(IMGNAME) tags"
-	@for platform in $(PLATFORMS); do \
-		echo "Pushing tags for $${platform} platform"; \
-		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
-		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
-		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
-	done
-
-.PHONY: manifest
-manifest: push
-	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(PLATFORMS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
-	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
-	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
-
-# enable buildx
-.PHONY: init-docker-buildx
-init-docker-buildx:
-	./../../../hack/init-buildx.sh
+BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
+             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE)

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -46,30 +46,34 @@ build:
 clean:
 	rm go-runner
 
+# build with buildx
+# https://github.com/docker/buildx/issues/59
 .PHONY: container
 container: init-docker-buildx
-	echo "Building go-runner for the following platforms: $(PLATFORMS)"
-	# https://github.com/docker/buildx/issues/59
-	$(foreach PLATFORM,$(PLATFORMS), \
-		echo "Starting build for $(PLATFORM) platform"; \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build \
-		--load \
-		--progress plain \
-		--platform $(PLATFORM) \
-		--tag $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION) \
-		--tag $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG) \
-		--tag $(IMAGE)-$(PLATFORM):latest-$(CONFIG) \
-		--build-arg=GO_VERSION=$(GO_VERSION) \
-		--build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) .;)
+	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
+	@for platform in $(PLATFORMS); do \
+		echo "Starting build for $${platform} platform"; \
+		docker buildx build \
+			--load \
+			--progress plain \
+			--platform $${platform} \
+			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
+			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
+			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
+			--build-arg=GO_VERSION=$(GO_VERSION) \
+			--build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
+			.; \
+		done
 
 .PHONY: push
 push: container
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):$(IMAGE_VERSION);)
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):$(TAG)-$(CONFIG);)
-	$(foreach PLATFORM,$(PLATFORMS), \
-		docker push $(IMAGE)-$(PLATFORM):latest-$(CONFIG);)
+	echo "Pushing $(IMGNAME) tags"
+	@for platform in $(PLATFORMS); do \
+		echo "Pushing tags for $${platform} platform"; \
+		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
+		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
+		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
+	done
 
 .PHONY: manifest
 manifest: push

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -46,6 +46,6 @@ tags:
 - ${_DISTROLESS_IMAGE}
 
 images:
-  - 'gcr.io/$PROJECT_ID/go-runner-linux/amd64:$_IMAGE_VERSION'
-  - 'gcr.io/$PROJECT_ID/go-runner-linux/amd64:$_GIT_TAG-$_CONFIG'
-  - 'gcr.io/$PROJECT_ID/go-runner-linux/amd64:latest-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/go-runner-amd64:$_IMAGE_VERSION'
+  - 'gcr.io/$PROJECT_ID/go-runner-amd64:$_GIT_TAG-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/go-runner-amd64:latest-$_CONFIG'

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -8,7 +8,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
     entrypoint: 'bash'
     dir: ./images/build/go-runner
     env:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature cleanup
/area dependency

#### What this PR does / why we need it:

- images: Update env to k8s-testimages/gcb-docker-gcloud:v20200824-5d057db

- kube-cross: Enable building via docker buildx

  Use go-runner Makefile pattern for multi-arch
  
- images: Use shell for loops to "simplify" platform building/pushing

- images: Standardize Makefiles for build images
  
  Here we create a few "common" Makefiles for image building:
  - images/Makefile.common-image
  - images/build/Makefile.build-image
  
  Makefile.common-image takes the targets from the go-runner Makefile and
  makes them reusable for both go-runner and kube-cross.
  
  Makefile.build-image is intended to contain information specific to
  images that will be built in the k8s-staging-build-image GCP project.
  Right now, it only contains the target Google Container Registry.
  
  images/build/{go-runner,kube-cross}/Makefile now only contains variables
  specific to the image and includes the aforementioned "common" Makefiles
  via the 'include' directive.
  
  (This is borrowed from how k-sigs/kind handles their image building.)

- go-runner: Drop extraneous pre-build step in Dockerfile
  
  This seems like it might be causing build failures on s390x.

- images: Fix image manifests annotating 'os/arch' instead of 'arch'
  
  Use make functions for string substitution instead of sed.
  Frankly, the sed was hard for me for comprehend.
  
  For amending manifests to the final manifest list, we were previously
  pushing images with the full platform name:
  
  e.g., "linux/amd64" (OS/architecture) instead of "amd64" (just arch)
  
  This commit properly strips the OS during manifest list creation.
  
  (The same issue was fixed for image tags in a previous commit.)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

Accompanying k/test-infra PR is here: https://github.com/kubernetes/test-infra/pull/19176

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Update env to k8s-testimages/gcb-docker-gcloud:v20200824-5d057db

- kube-cross: Enable building via docker buildx

  Use go-runner Makefile pattern for multi-arch
  
- images: Use shell for loops to "simplify" platform building/pushing

- images: Standardize Makefiles for build images
  
  Here we create a few "common" Makefiles for image building:
  - images/Makefile.common-image
  - images/build/Makefile.build-image
  
  Makefile.common-image takes the targets from the go-runner Makefile and
  makes them reusable for both go-runner and kube-cross.
  
  Makefile.build-image is intended to contain information specific to
  images that will be built in the k8s-staging-build-image GCP project.
  Right now, it only contains the target Google Container Registry.
  
  images/build/{go-runner,kube-cross}/Makefile now only contains variables
  specific to the image and includes the aforementioned "common" Makefiles
  via the 'include' directive.
  
  (This is borrowed from how k-sigs/kind handles their image building.)

- go-runner: Drop extraneous pre-build step in Dockerfile
  
  This seems like it might be causing build failures on s390x.

- images: Fix image manifests annotating 'os/arch' instead of 'arch'
  
  Use make functions for string substitution instead of sed.
  Frankly, the sed was hard for me for comprehend.
  
  For amending manifests to the final manifest list, we were previously
  pushing images with the full platform name:
  
  e.g., "linux/amd64" (OS/architecture) instead of "amd64" (just arch)
  
  This commit properly strips the OS during manifest list creation.
  
  (The same issue was fixed for image tags in a previous commit.)
```
