### PR TITLE
Split go template and format in options

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -371,7 +371,7 @@ func generateReleaseNotes(opts *changelogOptions, branch, startRev, endRev strin
 
 	markdown, err := doc.RenderMarkdownTemplate(
 		opts.bucket, opts.tars,
-		options.FormatSpecGoTemplateInline+releaseNotesTemplate,
+		options.GoTemplateInline+releaseNotesTemplate,
 	)
 	if err != nil {
 		return "", errors.Wrapf(

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -732,7 +732,7 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 
 	// Create the markdown
 	markdown, err := doc.RenderMarkdownTemplate(
-		"", "", options.FormatSpecDefaultGoTemplate,
+		"", "", options.GoTemplateDefault,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -87,7 +87,8 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | release-tars            | RELEASE_TARS    |                     | No       | Directory of tars to sha512 sum for display                                                                                       |
 | **OUTPUT OPTIONS**      |
 | output                  | OUTPUT          |                     | No       | The path where the release notes will be written                                                                                  |
-| format                  | FORMAT          | go-template:default | Yes      | The format for notes output (options: json, go-template:inline:<template-string> go-template:path/to/template.file)               |
+| format                  | FORMAT          | markdown            | No       | The format for notes output (options: json, markdown)                                                                             |
+| go-template             | GO_TEMPLATE     | go-template:default | No       | The go template if `--format=markdown` (options: go-template:default, go-template:inline:<template-string> go-template:<file.template>) |
 | release-version         | RELEASE_VERSION |                     | No       | The release version to tag the notes with                                                                                         |
 | dependencies            |                 | true                | No       | Add dependency report                                                                                                             |
 | **LOG OPTIONS**         |

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -443,14 +443,14 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 	}{
 		{
 			"render default template and downloads",
-			options.FormatSpecDefaultGoTemplate,
+			options.GoTemplateDefault,
 			false,
 			true,
 			"document.md.golden",
 		},
 		{
 			"render default template and no downloads",
-			options.FormatSpecDefaultGoTemplate,
+			options.GoTemplateDefault,
 			false,
 			false,
 			"document_without_downloads.md.golden",

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -67,8 +68,13 @@ type Options struct {
 	ReleaseVersion string
 
 	// Format specifies the format of the release notes. Can be either
-	// FormatSpecNone, FormatSpecJSON, or FormatSpecDefaultGoTemplate
+	// `json` or `markdown`.
 	Format string
+
+	// If the `Format` is `markdown`, then this specifies the selected go
+	// template. Can be `go-template:default`, `go-template:<file.template>` or
+	// `go-template:inline:<template>`.
+	GoTemplate string
 
 	// RequiredAuthor can be used to filter the release notes by the commit
 	// author
@@ -121,11 +127,13 @@ const (
 )
 
 const (
-	FormatSpecNone              = ""
-	FormatSpecJSON              = "json"
-	FormatSpecDefaultGoTemplate = GoTemplatePrefix + "default"
-	FormatSpecGoTemplateInline  = GoTemplatePrefix + "inline:"
-	GoTemplatePrefix            = "go-template:"
+	FormatJSON     = "json"
+	FormatMarkdown = "markdown"
+
+	GoTemplatePrefix       = "go-template:"
+	GoTemplatePrefixInline = "inline:"
+	GoTemplateDefault      = GoTemplatePrefix + "default"
+	GoTemplateInline       = GoTemplatePrefix + GoTemplatePrefixInline
 )
 
 // New creates a new Options instance with the default values
@@ -134,6 +142,8 @@ func New() *Options {
 		DiscoverMode: RevisionDiscoveryModeNONE,
 		GithubOrg:    git.DefaultGithubOrg,
 		GithubRepo:   git.DefaultGithubRepo,
+		Format:       FormatMarkdown,
+		GoTemplate:   GoTemplateDefault,
 		Pull:         true,
 		gitCloneFn:   git.CloneOrOpenGitHubRepo,
 	}
@@ -154,7 +164,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 
 	// Recover for replay if needed
 	if o.ReplayDir != "" {
-		logrus.Info("using replay mode")
+		logrus.Info("Using replay mode")
 		return nil
 	}
 
@@ -197,7 +207,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.StartRev)
 			}
-			logrus.Infof("using found start SHA: %s", sha)
+			logrus.Infof("Using found start SHA: %s", sha)
 			o.StartSHA = sha
 		}
 		if o.EndRev != "" && o.EndSHA == "" {
@@ -205,22 +215,26 @@ func (o *Options) ValidateAndFinish() (err error) {
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.EndRev)
 			}
-			logrus.Infof("using found end SHA: %s", sha)
+			logrus.Infof("Using found end SHA: %s", sha)
 			o.EndSHA = sha
 		}
 	}
 
 	// Create the record dir
 	if o.RecordDir != "" {
-		logrus.Info("using record mode")
+		logrus.Info("Using record mode")
 		if err := os.MkdirAll(o.RecordDir, os.FileMode(0755)); err != nil {
 			return err
 		}
 	}
 
-	// Set the format
-	if o.Format == FormatSpecNone {
-		o.Format = FormatSpecDefaultGoTemplate
+	// Validate the output format and template
+	logrus.Infof("Using output format: %s", o.Format)
+	if o.Format == FormatMarkdown && !strings.HasPrefix(o.GoTemplate, GoTemplatePrefix) {
+		return errors.Errorf("go template has to be prefixed with %q", GoTemplatePrefix)
+	}
+	if o.Format != FormatJSON && o.Format != FormatMarkdown {
+		return errors.Errorf("invalid format: %s", o.Format)
 	}
 
 	return nil
@@ -251,18 +265,18 @@ func (o *Options) resolveDiscoverMode() error {
 	o.EndSHA = result.EndSHA()
 	o.EndRev = result.EndRev()
 
-	logrus.Infof("discovered start SHA %s", o.StartSHA)
-	logrus.Infof("discovered end SHA %s", o.EndSHA)
+	logrus.Infof("Discovered start SHA %s", o.StartSHA)
+	logrus.Infof("Discovered end SHA %s", o.EndSHA)
 
-	logrus.Infof("using start revision %s", o.StartRev)
-	logrus.Infof("using end revision %s", o.EndRev)
+	logrus.Infof("Using start revision %s", o.StartRev)
+	logrus.Infof("Using end revision %s", o.EndRev)
 
 	return nil
 }
 
 func (o *Options) repo() (repo *git.Repo, err error) {
 	if o.Pull {
-		logrus.Infof("cloning/updating repository %s/%s", o.GithubOrg, o.GithubRepo)
+		logrus.Infof("Cloning/updating repository %s/%s", o.GithubOrg, o.GithubRepo)
 		repo, err = o.gitCloneFn(
 			o.RepoPath,
 			o.GithubOrg,
@@ -270,7 +284,7 @@ func (o *Options) repo() (repo *git.Repo, err error) {
 			false,
 		)
 	} else {
-		logrus.Infof("re-using local repo %s", o.RepoPath)
+		logrus.Infof("Re-using local repo %s", o.RepoPath)
 		repo, err = git.OpenRepo(o.RepoPath)
 	}
 	if err != nil {

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -64,6 +64,8 @@ func newTestOptions(t *testing.T) *testOptions {
 			DiscoverMode: RevisionDiscoveryModeNONE,
 			StartSHA:     "0",
 			EndSHA:       "0",
+			Format:       FormatMarkdown,
+			GoTemplate:   GoTemplateDefault,
 			Pull:         true,
 			gitCloneFn: func(string, string, string, bool) (*kgit.Repo, error) {
 				return testRepo.sut, nil
@@ -379,25 +381,24 @@ func TestValidateAndFinishFailureDiscoveryModePatchToPatchNoBranch(t *testing.T)
 	require.NotNil(t, options.ValidateAndFinish())
 }
 
-func TestValidateAndFinishSuccessDefaultTemplate(t *testing.T) {
+func TestValidateAndFinishFailureFormat(t *testing.T) {
 	options := newTestOptions(t)
 	defer options.testRepo.cleanup(t)
 
 	// Given
-	options.Format = FormatSpecNone
+	options.Format = "wrong"
 
 	// When
-	require.Nil(t, options.ValidateAndFinish())
+	require.NotNil(t, options.ValidateAndFinish())
+}
 
-	// Then
-	require.Equal(t, options.Format, FormatSpecDefaultGoTemplate)
+func TestValidateAndFinishFailureGoTemplate(t *testing.T) {
+	options := newTestOptions(t)
+	defer options.testRepo.cleanup(t)
 
 	// Given
-	options.Format = FormatSpecNone
+	options.GoTemplate = "wrong"
 
 	// When
-	require.Nil(t, options.ValidateAndFinish())
-
-	// Then
-	require.Equal(t, options.Format, FormatSpecDefaultGoTemplate)
+	require.NotNil(t, options.ValidateAndFinish())
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The split-up of the go template and the format allows a more streamlined
command line interface for the `release-notes` tool. We now only support
two formats:

```
--format string         The format for notes output (options: json, markdown)
                        (default "markdown")
```

And a new `--go-template` flag can now be utilized to specify the
template:

```
--go-template string    The go template to be used if --format=markdown
                        (options: go-template:default,
                         go-template:inline:<template>,
                        go-template:<file.template>)
                        (default "go-template:default")
```

#### Which issue(s) this PR fixes:

Follow-up of https://github.com/kubernetes/release/pull/1412
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `release-notes` `--format` flag to only support `markdown` and `json`.
  Added a new `release-notes` flag `--go-template` which can be used to specify
  the golang template when `--format=markdown`.
```
