### PR TITLE
kube-cross: Build v1.15.0-beta.1-1 image

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -5,6 +5,12 @@ variants:
     KUBE_CROSS_VERSION: 'v1.15.0-beta.1-canary-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
+  go1.15:
+    CONFIG: 'go1.15'
+    GO_VERSION: '1.15beta1'
+    KUBE_CROSS_VERSION: 'v1.15.0-beta.1-1'
+    PROTOBUF_VERSION: '3.0.2'
+    ETCD_VERSION: 'v3.4.9'
   go1.14:
     CONFIG: 'go1.14'
     GO_VERSION: '1.14.6'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency
/priority important-soon

#### What this PR does / why we need it:

- kube-cross: Update GCB image to gcb-docker-gcloud:v20200713-e9b3d9d
- kube-cross: Build v1.13.14-1 image
- kube-cross: Add canary variant to test Golang pre-releases
- kube-cross: Add tags to GCB jobs 

Continuation of https://github.com/kubernetes/release/issues/1410.
ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1595264491047100

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @hasheddan @cpanato @dims @liggitt 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/hold for testing

#### Does this PR introduce a user-facing change?

```release-note
kube-cross: Build v1.15.0-beta.1-1 image
```
