### PR TITLE
Release-notes bugfix + add template option validation

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -301,7 +301,7 @@ func WriteReleaseNotes(releaseNotes notes.ReleaseNotes, history notes.ReleaseNot
 			return errors.Wrapf(err, "creating release note document")
 		}
 
-		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, opts.Format)
+		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, opts.GoTemplate)
 		if err != nil {
 			return errors.Wrapf(err, "rendering release note document with template")
 		}


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug
> /kind feature

#### What this PR does / why we need it:

This PR fixes a bug where the recent template value defined with the new flag `--go-template` was not carried forward when calling `RenderMarkdownTemplate()`

It also adds more validation to make sure the specified format exists in order to fail early and avoid running the whole release-notes process if the template is wrongly specified. Added a new check to make sure a template is not specified when running with `--format=json`

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Make sure go template file exists early to avoid running the gathering process with a faulty template
```
