### PR TITLE
Change ReleaseNotes to an own struct

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -674,13 +674,13 @@ func releaseNotesJSON(tag string) (string, error) {
 	}
 
 	// Fetch the notes
-	releaseNotes, history, err := notes.GatherReleaseNotes(notesOptions)
+	releaseNotes, err := notes.GatherReleaseNotes(notesOptions)
 	if err != nil {
 		return "", errors.Wrapf(err, "gathering release notes")
 	}
 
 	doc, err := document.New(
-		releaseNotes, history, notesOptions.StartRev, notesOptions.EndRev,
+		releaseNotes, notesOptions.StartRev, notesOptions.EndRev,
 	)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating release note document")
@@ -689,7 +689,7 @@ func releaseNotesJSON(tag string) (string, error) {
 	doc.CurrentRevision = tag
 
 	// Create the JSON
-	j, err := json.Marshal(releaseNotes)
+	j, err := json.Marshal(releaseNotes.ByPR())
 	if err != nil {
 		return "", errors.Wrapf(err, "generating release notes JSON")
 	}
@@ -716,13 +716,13 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	logrus.Infof("Using end tag %v", releaseNotesOpts.tag)
 
 	// Fetch the notes
-	releaseNotes, history, err := notes.GatherReleaseNotes(notesOptions)
+	releaseNotes, err := notes.GatherReleaseNotes(notesOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "gathering release notes")
 	}
 
 	doc, err := document.New(
-		releaseNotes, history, notesOptions.StartRev, notesOptions.EndRev,
+		releaseNotes, notesOptions.StartRev, notesOptions.EndRev,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating release note document")
@@ -753,7 +753,7 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	}
 
 	// Create the JSON
-	j, err := json.Marshal(releaseNotes)
+	j, err := json.Marshal(releaseNotes.ByPR())
 	if err != nil {
 		return nil, errors.Wrapf(err, "generating release notes JSON")
 	}

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -185,12 +185,12 @@ var kindMap = map[notes.Kind]notes.Kind{
 func GatherReleaseNotesDocument(
 	opts *options.Options, previousRev, currentRev string,
 ) (*Document, error) {
-	releaseNotes, history, err := notes.GatherReleaseNotes(opts)
+	releaseNotes, err := notes.GatherReleaseNotes(opts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "gathering release notes")
 	}
 
-	doc, err := New(releaseNotes, history, previousRev, currentRev)
+	doc, err := New(releaseNotes, previousRev, currentRev)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating release note document")
 	}
@@ -200,8 +200,7 @@ func GatherReleaseNotesDocument(
 
 // New assembles an organized document from an unorganized set of release notes
 func New(
-	releaseNotes notes.ReleaseNotes,
-	history notes.ReleaseNotesHistory,
+	releaseNotes *notes.ReleaseNotes,
 	previousRev, currentRev string,
 ) (*Document, error) {
 	doc := &Document{
@@ -219,8 +218,8 @@ func New(
 	}
 
 	kindCategory := make(map[notes.Kind]NoteCategory)
-	for _, pr := range history {
-		note := releaseNotes[pr]
+	for _, pr := range releaseNotes.History() {
+		note := releaseNotes.Get(pr)
 
 		// TODO: Refactor the logic here and add testing.
 		if note.DuplicateKind {


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
This gives us the possibility to streamline the API surface to:

```
releaseNotes, err := notes.GatherReleaseNotes(notesOptions)
if err != nil { … }

doc, err := document.New(
    releaseNotes, notesOptions.StartRev, notesOptions.EndRev,
)
if err != nil { … }
```

The ReleaseNotesHistory is mostly not used by consumers and wrapping it
in a struct makes it easier to understand for readers.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
/assign @puerco 
#### Does this PR introduce a user-facing change?


```release-note
- Changed `notes.ReleaseNotes` to be a wrapper struct which now contains the notes by PR and the history.
  Necessary API fields to retrieve and set the notes have been added as well, like `notes.NewReleaseNotes()`.
```
