### PR TITLE
hack/anago: temporary remove the tag check

### DIFF
--- a/anago
+++ b/anago
@@ -601,7 +601,8 @@ prepare_tree () {
   # Tagging
   commit_string="Kubernetes $label_common release ${RELEASE_VERSION[$label]}"
   logecho -n "Tagging $commit_string on $branch: "
-  logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
+  logecho "Revert this bug workaround: temporarily skipping check for existing tag"
+  # logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
 }
 
 ##############################################################################
@@ -1253,14 +1254,15 @@ set_release_values () {
                                 $PARENT_BRANCH \
    || return 1
 
+  logecho "Revert this bug workaround: temporarily skipping check for existing tag"
   # Check that this tag doesn't exist. Staged builds may be old
-  if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
-        $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
-     logecho
-     logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
-     logecho "An old --buildversion was specified on the command-line."
-     return 1
-  fi
+  # if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
+  #       $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
+  #    logecho
+  #    logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
+  #    logecho "An old --buildversion was specified on the command-line."
+  #    return 1
+  # fi
 
 }
 
@@ -1478,7 +1480,7 @@ elif ! ((FLAGS_prebuild)); then
   if ((FLAGS_stage)); then
     common::stepindex "stage_source_tree"
   else
-    common::stepindex "push_git_objects"
+    # common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"
   if ! ((FLAGS_stage)); then


### PR DESCRIPTION
#### What type of PR is this?
/kind bug hack

#### What this PR does / why we need it:
This commit needs to be reverted ASAP.

This does not check the tag in GitHub because it was published in the previous job that failed.
### We will plan and make a better solution instead of open hack PRs all the time


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/priority critical-urgent
