### PR TITLE
revert 1.19.0-rc2 Anago hacks

### DIFF
--- a/anago
+++ b/anago
@@ -1407,10 +1407,9 @@ push_all_artifacts () {
       common::runstep copy_staged_from_gcs $label $STAGED_BUCKET \
                                            $RELEASE_BUCKET || return 1
     else
-      logecho "HACK: Skipping GCS push"
-#      common::runstep release::gcs::push_release_artifacts \
-#       $BUILD_OUTPUT-$version/gcs-stage/$version \
-#       gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
+      common::runstep release::gcs::push_release_artifacts \
+       $BUILD_OUTPUT-$version/gcs-stage/$version \
+       gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
 
     # When we are no-mock mode we need to perform an image promotion, so
@@ -1476,15 +1475,14 @@ common::stepindex "local_kube_cross"
 if ((FLAGS_buildonly)); then
   common::stepindex "make_cross"
 elif ! ((FLAGS_prebuild)); then
-  logecho "HACK: Skipping buildy bits"
-#  common::stepindex "make_cross"
-#  common::stepindex "build_tree" "generate_release_notes"
-#  if ((FLAGS_stage)); then
-#    common::stepindex "stage_source_tree"
-#  else
-#    logecho "Revert this bug workaround:  temporarily not calling push_git_objects"
-#    # common::stepindex "push_git_objects"
-#  fi
+  common::stepindex "make_cross"
+  common::stepindex "build_tree" "generate_release_notes"
+  if ((FLAGS_stage)); then
+    common::stepindex "stage_source_tree"
+  else
+    logecho "Revert this bug workaround:  temporarily not calling push_git_objects"
+    # common::stepindex "push_git_objects"
+  fi
   common::stepindex "push_all_artifacts"
   if ! ((FLAGS_stage)); then
     common::stepindex "announce"
@@ -1560,15 +1558,14 @@ if [[ $RELEASE_BRANCH =~ release- ]] &&
 fi
 
 # No need to pre-check this for mock or staging runs.  Overwriting OK.
-logecho "HACK: skipping GCS TARGET CHECK"
-#if ((FLAGS_nomock)) && ! ((FLAGS_stage)); then
-#  common::stepheader "GCS TARGET CHECK"
-#  # Ensure GCS destinations are clear before continuing
-#  for v in ${RELEASE_VERSION[@]}; do
-#    release::gcs::destination_empty \
-#     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$v || common::exit 1 "Exiting..."
-#  done
-#fi
+if ((FLAGS_nomock)) && ! ((FLAGS_stage)); then
+  common::stepheader "GCS TARGET CHECK"
+  # Ensure GCS destinations are clear before continuing
+  for v in ${RELEASE_VERSION[@]}; do
+    release::gcs::destination_empty \
+     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$v || common::exit 1 "Exiting..."
+  done
+fi
 
 common::stepheader "SESSION VALUES"
 # Show versions and ask for confirmation to continue

--- a/anago
+++ b/anago
@@ -601,8 +601,7 @@ prepare_tree () {
   # Tagging
   commit_string="Kubernetes $label_common release ${RELEASE_VERSION[$label]}"
   logecho -n "Tagging $commit_string on $branch: "
-  logecho "Revert this bug workaround: temporarily skipping check for existing tag"
-  # logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
+  logrun -s git tag -a -m "$commit_string" "${RELEASE_VERSION[$label]}" || return 1
 }
 
 ##############################################################################
@@ -1254,15 +1253,14 @@ set_release_values () {
                                 $PARENT_BRANCH \
    || return 1
 
-  logecho "Revert this bug workaround: temporarily skipping check for existing tag"
   # Check that this tag doesn't exist. Staged builds may be old
-  # if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
-  #       $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
-  #    logecho
-  #    logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
-  #    logecho "An old --buildversion was specified on the command-line."
-  #    return 1
-  # fi
+  if [[ "$($GHCURL $K8S_GITHUB_API/tags |jq -r '.[] .name')" =~ \
+        $'\n'$RELEASE_VERSION_PRIME$'\n' ]]; then
+     logecho
+     logecho "$FATAL: The tag $RELEASE_VERSION_PRIME already exists on github."
+     logecho "An old --buildversion was specified on the command-line."
+     return 1
+  fi
 
 }
 
@@ -1480,7 +1478,7 @@ elif ! ((FLAGS_prebuild)); then
   if ((FLAGS_stage)); then
     common::stepindex "stage_source_tree"
   else
-    # common::stepindex "push_git_objects"
+    common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"
   if ! ((FLAGS_stage)); then

--- a/anago
+++ b/anago
@@ -1480,7 +1480,6 @@ elif ! ((FLAGS_prebuild)); then
   if ((FLAGS_stage)); then
     common::stepindex "stage_source_tree"
   else
-    logecho "Revert this bug workaround:  temporarily not calling push_git_objects"
     # common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"


### PR DESCRIPTION
This PR combines a set of reverts to remove today's temporary hack workarounds to get 1.19.0-rc2 out the door.

/kind cleanup