### PR TITLE
Remove release-notes --start-sha/--end-sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,32 @@ Once the tool is installed, use `-h` or `--help` to see the command usage:
 
 ```
 $ release-notes -h
-Usage of release-notes:
-  -end-sha string
-        The commit hash to end at
-  -format string
-        The format for notes output (options: markdown, json) (default "markdown")
-  -github-token string
-        A personal GitHub access token (required)
-  -output string
-        The path to the where the release notes will be printed
-  -start-sha string
-        The commit hash to start at
+release-notes - The Kubernetes Release Notes Generator
+
+Usage:
+  release-notes [flags]
+
+Flags:
+      --branch master            Select which branch to scrape. Defaults to master (default "master")
+      --debug                    Enable debug logging
+      --dependencies             Add dependency report (default true)
+      --discover string          The revision discovery mode for automatic revision retrieval (options: none, mergebase-to-latest, patch-to-patch, minor-to-minor) (default "none")
+      --end-rev string           The git revision to end at.
+      --format string            The format for notes output (options: json, markdown) (default "markdown")
+      --github-org string        Name of github organization (default "kubernetes")
+      --github-repo string       Name of github repository (default "kubernetes")
+      --go-template string       The go template to be used if --format=markdown (options: go-template:default, go-template:inline:<template>, go-template:<file.template>) (default "go-template:default")
+  -h, --help                     help for release-notes
+      --output string            The path to the where the release notes will be printed
+      --record string            Record the API into a directory
+      --release-bucket string    Specify gs bucket to point to in generated notes (default "kubernetes-release")
+      --release-tars string      Directory of tars to sha512 sum for display
+      --release-version string   Which release version to tag the entries as.
+      --replay string            Replay a previously recorded API from a directory
+      --repo-path string         Path to a local Kubernetes repository, used only for tag discovery. (default "/tmp/k8s-repo")
+      --required-author string   Only commits from this GitHub user are considered. Set to empty string to include all users (default "k8s-ci-robot")
+      --start-rev string         The git revision to start at.
+      --toc                      Enable the rendering of the table of contents
 ```
 
 ## Building Linux Packages

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -18,16 +18,9 @@ To generate release notes for a commit range, run:
 
 ```bash
 $ export GITHUB_TOKEN=a_github_api_token
-$ release-notes \
-  -start-sha 02dc3d713dd7f945a8b6f7ef3e008f3d29c2d549 \
-  -end-sha   23649560c060ad6cd82da8da42302f8f7e38cf1e
-
-level=info timestamp=2019-07-30T04:02:30.9452687Z caller=main.go:139 msg="fetching all commits. this might take a while..."
-level=info timestamp=2019-07-30T04:02:43.8454168Z caller=notes.go:446 msg="[1/1679 - 0.06%]"
-...
-level=info timestamp=2019-07-30T04:09:30.3491553Z caller=notes.go:446 msg="[1679/1679 - 100.00%]"
-level=info timestamp=2019-07-30T04:11:38.8033378Z caller=main.go:159 msg="got the commits, performing rendering"
-level=info timestamp=2019-07-30T04:11:38.8059129Z caller=main.go:228 msg="release notes written to file" path=/tmp/release-notes-509576676 format=markdown
+$ release-notes --start-rev v1.18.1 --end-rev v1.18.2 --branch release-1.18
+…
+INFO release notes written to file  	format=markdown path=/tmp/release-notes-659889201
 ```
 
 You can also generate the raw notes data into JSON. You can then use a variety of tools (such as `jq`) to slice and dice the output:
@@ -50,23 +43,6 @@ You can also generate the raw notes data into JSON. You can then use a variety o
 ]
 ```
 
-if you would like to debug a run, use the `-debug` flag:
-
-```bash
-$ export GITHUB_TOKEN=a_github_api_token
-$ release-notes \
-  -start-sha 02dc3d713dd7f945a8b6f7ef3e008f3d29c2d549 \
-  -end-sha   23649560c060ad6cd82da8da42302f8f7e38cf1e \
-  -debug 
-
-level=debug timestamp=2019-07-30T04:02:43.8453116Z caller=notes.go:445 msg=################################################
-level=info timestamp=2019-07-30T04:02:43.8454168Z caller=notes.go:446 msg="[1/1679 - 0.06%]"
-level=debug timestamp=2019-07-30T04:02:43.8454701Z caller=notes.go:447 msg="Processing commit" func=ListCommitsWithNotes sha=23649560c060ad6cd82da8da42302f8f7e38cf1e
-level=debug timestamp=2019-07-30T04:02:44.3711956Z caller=notes.go:464 msg="Obtaining PR associated with commit sha '23649560c060ad6cd82da8da42302f8f7e38cf1e'." func=ListCommitsWithNotes prno=80301 prbody="**What type of PR is this?**\r\n> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:\r\n>\r\n> /kind api-change\r\n> /kind bug\r\n\r\n/kind cleanup\r\n\r\n> /kind design\r\n> /kind documentation\r\n> /kind failing-test\r\n> /kind feature\r\n> /kind flake\r\n\r\n**What this PR does / why we need it**:\r\n\r\nBased on the feedback from https://docs.google.com/document/d/1g5Aqa0BncQGRedSJH0TJQWq3mw3VxpJ_ufO1qokJ1LE we have decided to rename the `preferred` policy of the `TopologyManager` to `best-effort`.  The reasoning for this is outlined in the document.\r\n\r\nSince this change is coming before the `TopologyManager` was ever part of a release, this does not introduce a user-facing change.\r\n\r\n**Does this PR introduce a user-facing change?**:\r\n<!--\r\nIf no, just write \"NONE\" in the release-note block below.\r\nIf yes, a release note is required:\r\nEnter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string \"action required\".\r\n-->\r\n```release-note\r\nNONE\r\n```"
-level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excluding notes for PR based on the exclusion filter." func=ListCommitsWithNotes filter="(?i)```(release-note\\s*)?('|\")?(none|n/a)?('|\")?\\s*```"
-...
-```
-
 ## Options
 
 | Flag                    | Env Variable    | Default Value       | Required | Description                                                                                                                       |
@@ -77,11 +53,9 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | github-repo             | GITHUB_REPO     | kubernetes          | Yes      | Name of GitHub repository                                                                                                         |
 | required-author         | REQUIRED_AUTHOR | k8s-ci-robot        | Yes      | Only commits from this GitHub user are considered. Set to empty string to include all users                                       |
 | branch                  | BRANCH          | master              | Yes      | The GitHub repository branch to scrape                                                                                            |
-| start-sha               | START_SHA       |                     | Yes      | The commit hash to start processing from (inclusive)                                                                              |
-| end-sha                 | END_SHA         |                     | Yes      | The commit hash to end processing at (inclusive)                                                                                  |
 | repo-path               | REPO_PATH       | /tmp/k8s-repo       | No       | Path to a local Kubernetes repository, used only for tag discovery                                                                |
-| start-rev               | START_REV       |                     | No       | The git revision to start at. Can be used as alternative to start-sha                                                             |
-| env-rev                 | END_REV         |                     | No       | The git revision to end at. Can be used as alternative to end-sha                                                                 |
+| start-rev               | START_REV       |                     | No       | The git revision to start at.
+| env-rev                 | END_REV         |                     | No       | The git revision to end at.
 | discover                | DISCOVER        | none                | No       | The revision discovery mode for automatic revision retrieval (options: none, mergebase-to-latest, patch-to-patch, patch-to-latest, minor-to-minor) |
 | release-bucket          | RELEASE_BUCKET  | kubernetes-release  | No       | Specify gs bucket to point to in generated notes (default "kubernetes-release")                                                   |
 | release-tars            | RELEASE_TARS    |                     | No       | Directory of tars to sha512 sum for display                                                                                       |

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -92,39 +92,22 @@ func init() {
 		"Select which branch to scrape. Defaults to `master`",
 	)
 
-	// startSHA contains the commit SHA where the release note generation
-	// begins.
-	cmd.PersistentFlags().StringVar(
-		&opts.StartSHA,
-		"start-sha",
-		util.EnvDefault("START_SHA", ""),
-		"The commit hash to start at",
-	)
-
-	// endSHA contains the commit SHA where the release note generation ends.
-	cmd.PersistentFlags().StringVar(
-		&opts.EndSHA,
-		"end-sha",
-		util.EnvDefault("END_SHA", ""),
-		"The commit hash to end at",
-	)
-
 	// startRev contains any valid git object where the release note generation
-	// begins. Can be used as alternative to start-sha.
+	// begins.
 	cmd.PersistentFlags().StringVar(
 		&opts.StartRev,
 		"start-rev",
 		util.EnvDefault("START_REV", ""),
-		"The git revision to start at. Can be used as alternative to start-sha.",
+		"The git revision to start at.",
 	)
 
 	// endRev contains any valid git object where the release note generation
-	// ends. Can be used as alternative to start-sha.
+	// ends.
 	cmd.PersistentFlags().StringVar(
 		&opts.EndRev,
 		"end-rev",
 		util.EnvDefault("END_REV", ""),
-		"The git revision to end at. Can be used as alternative to end-sha.",
+		"The git revision to end at.",
 	)
 
 	// repoPath contains the path to a local Kubernetes repository to avoid the
@@ -243,7 +226,10 @@ func init() {
 }
 
 func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
-	logrus.Info("Got the commits, performing rendering")
+	logrus.Infof(
+		"Got %d release notes, performing rendering",
+		len(releaseNotes.History()),
+	)
 
 	var (
 		// Open a handle to the file which will contain the release notes output

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -243,10 +243,11 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "listing commits")
 	}
+	logrus.Infof("Got %d commits", len(commits))
 
 	results, err := g.gatherNotes(commits)
 	if err != nil {
-		return nil, errors.Wrap(err, "gatherin notes")
+		return nil, errors.Wrap(err, "gathering notes")
 	}
 
 	dedupeCache := map[string]struct{}{}

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -300,7 +300,10 @@ func (o *Options) resolveDiscoverMode() error {
 
 func (o *Options) repo() (repo *git.Repo, err error) {
 	if o.Pull {
-		logrus.Infof("Cloning/updating repository %s/%s", o.GithubOrg, o.GithubRepo)
+		logrus.Infof(
+			"Cloning/updating repository %s/%s in %s",
+			o.GithubOrg, o.GithubRepo, o.RepoPath,
+		)
 		repo, err = o.gitCloneFn(
 			o.RepoPath,
 			o.GithubOrg,


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
We mostly always use `--start-rev` and `--end-rev` which accept any git
revision than just a valid SHA. This means we now can remove them and
update the docs around them. Logging has been improved in some places,
too.
#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

```release-note
- Removed the `release-notes` flags ` --start-sha/--end-sha` in favor of ` --start-rev/--end-rev`
```
