### PR TITLE
Unlist release notes during processing

### DIFF
--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -224,6 +224,7 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 		})
 	}
 }
+
 func TestPrettySIG(t *testing.T) {
 	cases := map[string]string{
 		"scheduling":        "Scheduling",
@@ -237,5 +238,57 @@ func TestPrettySIG(t *testing.T) {
 
 	for input, expected := range cases {
 		require.Equal(t, expected, (prettySIG(input)))
+	}
+}
+
+func TestNoteTextFromString(t *testing.T) {
+	noteBlock := func(note string) string {
+		return "```release-note\n" + note + "\n```"
+	}
+	for _, tc := range []struct {
+		input  string
+		expect func(string, error)
+	}{
+		{
+			noteBlock("test"),
+			func(res string, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "test", res)
+			},
+		},
+		{
+			noteBlock("test\ntest\ntest"),
+			func(res string, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "test\ntest\ntest", res)
+			},
+		},
+		{
+			noteBlock("Action Required: test"),
+			func(res string, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "test", res)
+			},
+		},
+		{
+			noteBlock(
+				"- item\n  item\n  item",
+			),
+			func(res string, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "item\nitem\nitem", res)
+			},
+		},
+		{
+			noteBlock(
+				"- item\n  item\n- item\n  item",
+			),
+			func(res string, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "item\nitem\n- item\n  item", res)
+			},
+		},
+	} {
+		tc.expect(noteTextFromString(tc.input))
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Some release notes look like this:

````
```release-note
This is a release note
which fills multiple
lines in the block.
```
````

whereas others look like this:

````
```release-note
- This is a release note
  which fills multiple
  lines in the block.
```
````

After this patch both will look the same after processing. This provides
the benefit for a more uniform formatting for the website as well as a
better default markdown formatting.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Improved release notes processing to automatically flatten lists if a release note is written as list entry
```
