### PR TITLE
k8s-cloud-builder: Build on kube-cross:v1.15.0-rc.1-1 and add canary

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,12 @@
 variants:
+  canary:
+    CONFIG: 'canary'
+    KUBE_CROSS_VERSION: 'v1.15.0-rc.1-canary-1'
+    SKOPEO_VERSION: 'v0.2.0'
+  cross1.15:
+    CONFIG: 'cross1.15'
+    KUBE_CROSS_VERSION: 'v1.15.0-rc.1-1'
+    SKOPEO_VERSION: 'v0.2.0'
   cross1.14:
     CONFIG: 'cross1.14'
     KUBE_CROSS_VERSION: 'v1.14.6-1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Updates k8s-cloud-builder to pick up the new `kube-cross:v1.15.0-rc.1-1` images (ref: https://github.com/kubernetes/release/pull/1437, https://github.com/kubernetes/k8s.io/pull/1063)

Part of go1.15 updates: https://github.com/kubernetes/release/issues/1421
/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build on kube-cross:v1.15.0-rc.1-1 and add canary
```
