### PR TITLE
Add CVE Information to Release Notes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/spiegel-im-spiegel/go-cvss v0.4.0
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/goldmark v1.3.1
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,10 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spiegel-im-spiegel/errs v1.0.2 h1:v4amEwRDqRWjKHOILQnJSovYhZ4ZttEnBBXNXEzS6Sc=
+github.com/spiegel-im-spiegel/errs v1.0.2/go.mod h1:UoasJYYujMcdkbT9USv8dfZWoMyaY3btqQxoLJImw0A=
+github.com/spiegel-im-spiegel/go-cvss v0.4.0 h1:A+S9I01wkiEo6e66xFbxtz9LfXdsGUr5FppYozUAmmI=
+github.com/spiegel-im-spiegel/go-cvss v0.4.0/go.mod h1:VrcmtyfJ7OJF3/O08MQnxq+kqyPMjstExKdv02TPx+M=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -253,7 +253,10 @@ func New(
 					cve.LinkedPRs = append(cve.LinkedPRs, prid.(int))
 				}
 			}
-			// TODO: Add a validation function to check the struct
+			// Verify that CVE data has the minimum fields defined
+			if err := cve.Validate(); err != nil {
+				return nil, errors.Wrapf(err, "checking CVE map file for PR #%d", pr)
+			}
 			doc.CVEList = append(doc.CVEList, cve)
 		}
 

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -231,24 +231,29 @@ func New(
 			if val, ok := cvedata.(map[interface{}]interface{})["title"].(string); ok {
 				cve.Title = val
 			}
+			if val, ok := cvedata.(map[interface{}]interface{})["issue"].(string); ok {
+				cve.TrackingIssue = val
+			}
+			if val, ok := cvedata.(map[interface{}]interface{})["vector"].(string); ok {
+				cve.CVSSVector = val
+			}
+			if val, ok := cvedata.(map[interface{}]interface{})["score"].(float64); ok {
+				cve.CVSSScore = float32(val)
+			}
+			if val, ok := cvedata.(map[interface{}]interface{})["rating"].(string); ok {
+				cve.CVSSRating = val
+			}
+			if val, ok := cvedata.(map[interface{}]interface{})["description"].(string); ok {
+				cve.Description = val
+			}
+			// Linked PRs is a list of the PR IDs
 			if val, ok := cvedata.(map[interface{}]interface{})["linkedPRs"].([]interface{}); ok {
 				cve.LinkedPRs = []int{}
 				for _, prid := range val {
 					cve.LinkedPRs = append(cve.LinkedPRs, prid.(int))
 				}
 			}
-			if val, ok := cvedata.(map[interface{}]interface{})["published"].(string); ok {
-				cve.Published = val
-			}
-			if val, ok := cvedata.(map[interface{}]interface{})["score"].(float64); ok {
-				cve.Score = float32(val)
-			}
-			if val, ok := cvedata.(map[interface{}]interface{})["rating"].(string); ok {
-				cve.Rating = val
-			}
-			if val, ok := cvedata.(map[interface{}]interface{})["description"].(string); ok {
-				cve.Description = val
-			}
+			// TODO: Add a validation function to check the struct
 			doc.CVEList = append(doc.CVEList, cve)
 		}
 

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -72,8 +72,11 @@ This release contains changes that address the following vulnerabilities:
 
 {{.Description}}
 
-**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) [{{.CVSSVector}}]({{.CalcLink}})<br>
+**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) [{{.CVSSVector}}]({{.CalcLink}})
+{{- if .TrackingIssue -}}
+<br>
 **Tracking Issue:** {{.TrackingIssue}}
+{{- end }}
 
 {{ end }}
 {{- end -}}

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -72,7 +72,7 @@ This release contains changes that address the following vulnerabilities:
 
 {{.Description}}
 
-**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) {{.CVSSVector}}<br>
+**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) [{{.CVSSVector}}]({{.CalcLink}})<br>
 **Tracking Issue:** {{.TrackingIssue}}
 
 {{ end }}

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -68,12 +68,12 @@ filename | sha512 hash
 
 This release contains changes that address the following vulnerabilities:
 {{range .}}
-### {{.ID}} {{.Title}}
+### {{.ID}}: {{.Title}}
 
 {{.Description}}
 
-CVSS Rating: {{.CVSSRating}} ({{.CVSSScore}}) {{.CVSSVector}}
-Tracking Issue: {{.TrackingIssue}}
+**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) {{.CVSSVector}}<br>
+**Tracking Issue:** {{.TrackingIssue}}
 
 {{ end }}
 {{- end -}}

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -63,6 +63,21 @@ filename | sha512 hash
 {{- end -}}
 # Changelog since {{$PreviousRevision}}
 
+{{with .CVEList -}}
+## Important Security Information
+
+This release contains changes that address the following vulnerabilities:
+{{range .}}
+### {{.ID}} {{.Title}}
+
+{{.Description}}
+
+CVSS Rating: {{.CVSSRating}} ({{.CVSSScore}}) {{.CVSSVector}}
+Tracking Issue: {{.TrackingIssue}}
+
+{{ end }}
+{{- end -}}
+
 {{with .NotesWithActionRequired -}}
 ## Urgent Upgrade Notes 
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -60,13 +60,14 @@ type (
 
 // CVEData Information of a linked CVE vulnerability
 type CVEData struct {
-	ID          string  `json:"id"`
-	Title       string  `json:"title"`
-	Published   string  `json:"published"`
-	Score       float32 `json:"score"`
-	Rating      string  `json:"rating"`
-	LinkedPRs   []int   `json:"linkedPRs"`
-	Description string  `json:"description"`
+	ID            string  `json:"id"`          // CVE ID, eg CVE-2019-1010260
+	Title         string  `json:"title"`       // Title of the vulnerability
+	Description   string  `json:"description"` // Description text of the vulnerability
+	TrackingIssue string  `json:"issue"`       // Link to the vulnerability tracking issue
+	CVSSVector    string  `json:"vector"`      // Full CVSS vector string, CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H
+	CVSSScore     float32 `json:"score"`       // Numeric CVSS score (eg 6.2)
+	CVSSRating    string  `json:"rating"`      // Severity bucket (eg Medium)
+	LinkedPRs     []int   `json:"linkedPRs"`   // List of linked PRs (to remove them from the release notes doc)
 }
 
 const (

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1086,3 +1086,41 @@ func (rn *ReleaseNote) ContentHash() (string, error) {
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
+
+// Validate checks the data defined in a CVE map is complete and valid
+func (cve *CVEData) Validate() error {
+	if cve.CVSSRating == "" {
+		return errors.New("CVSS rating missing from CVE data")
+	}
+
+	// Check rating is a valid string
+	if cve.CVSSRating != "None" &&
+		cve.CVSSRating != "Low" &&
+		cve.CVSSRating != "Medium" &&
+		cve.CVSSRating != "High" &&
+		cve.CVSSRating != "Critical" {
+		return errors.New("Invalida CVSS rating")
+	}
+
+	if cve.CVSSVector == "" {
+		return errors.New("CVSS vector string missing from CVE data")
+	}
+
+	if cve.CVSSScore == 0 {
+		return errors.New("CVSS score missing from CVE data")
+	}
+
+	if cve.ID == "" {
+		return errors.New("ID missing from CVE data")
+	}
+
+	if cve.Title == "" {
+		return errors.New("Title missing from CVE data")
+	}
+
+	if cve.Description == "" {
+		return errors.New("CVE description missing from CVE data")
+	}
+
+	return nil
+}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -430,3 +430,74 @@ func TestApplyMap(t *testing.T) {
 		}
 	}
 }
+
+func TestCVEDataValidation(t *testing.T) {
+	var sut CVEData
+	cve := CVEData{
+		ID:            "CVE-2020-8559",
+		Title:         "Privilege escalation from compromised node to cluster",
+		Description:   "If an attacker is able to intercept certain requests to the Kubelet, they",
+		TrackingIssue: "https://github.com/kubernetes/kubernetes/issues/92914",
+		CVSSVector:    "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H",
+		CVSSScore:     6.4,
+		CVSSRating:    "Medium",
+		LinkedPRs:     []int{92941, 92969, 92970, 92971},
+	}
+
+	// As is, the CVE should validate
+	require.Nil(t, cve.Validate())
+
+	// Check each value
+	sut = cve
+	sut.ID = "CVE-123"
+	require.NotNil(t, sut.Validate(), "checking cve id")
+
+	sut = cve
+	sut.Title = ""
+	require.NotNil(t, sut.Validate(), "checking title")
+
+	sut = cve
+	sut.Description = ""
+	require.NotNil(t, sut.Validate(), "checking description")
+
+	sut = cve
+	for _, testVector := range []string{
+		"CVSS:3.1/AV:N/AC:H/P", //  too short
+		"",                     // empty
+		"CVSS:3.1/AV:N/AC:Á/PR:H/UI:R/S:U/C:H/I:H/A:H", //  invalid value
+	} {
+		sut.CVSSVector = testVector // too short
+		require.NotNil(t, sut.Validate(), "checking vector string")
+	}
+
+	sut = cve
+	for _, testScore := range []float32{
+		0,    // cannot be 0 (nil value)
+		-1,   // under
+		10.1, // over
+	} {
+		sut.CVSSScore = testScore
+		require.NotNil(t, sut.Validate(), "checking vector string")
+	}
+
+	sut = cve
+	for _, tc := range []struct {
+		Valid bool
+		Value string
+	}{
+		{true, "None"},
+		{true, "Low"},
+		{true, "Medium"},
+		{true, "High"},
+		{true, "Critical"},
+		{false, ""},
+		{false, "Superbad"},
+	} {
+		sut.CVSSRating = tc.Value // too short
+		if tc.Valid {
+			require.Nil(t, sut.Validate(), "checking valid rating string")
+		} else {
+			require.NotNil(t, sut.Validate(), "checking invalid rating string")
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind design

#### What this PR does / why we need it:

This PR introduces a minor change to the release notes template to add a security section with CVE data read from a map file (see #1373).

This is a WIP intended to discuss the way the information will look like when presented in the release notes document.

When applied, this test will add a new section to the release notes markdown output with information added from a CVE map. A sample of the output can be viewed [here](https://github.com/puerco/lab/blob/master/release-notes/cve-template.md).

Tests are not included, they will be written and added to this PR once we settle on a design.

#### Which issue(s) this PR fixes:

Related to #1373 and kubernetes/enhancements#1833
Closes #1354 

#### Special notes for your reviewer:
/hold for final design, tests and ~until #1373 merges~

#### Does this PR introduce a user-facing change?
```release-note
* Release notes libraries will now recognize CVE information in the `datafields` section of the release notes map files.
* Add CVE vulnerability info to template.go to be rendered when a map defines a `cve` section
```
