### PR TITLE
push-build: Fix directory listing for fast builds

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -801,7 +801,7 @@ release::gcs::publish_version () {
   local build_output=$3
   local bucket=$4
   local extra_version_markers=$5
-  local release_dir="gs://$bucket/$build_type/$version"
+  local release_dir
   local version_major
   local version_minor
   local publish_file
@@ -811,6 +811,14 @@ release::gcs::publish_version () {
   # For release/ targets, type could be 'stable'
   if [[ "$build_type" == release ]]; then
     [[ "$version" =~ alpha|beta|rc ]] || type="stable"
+  fi
+
+  # Ensure we check for "fast" (linux/amd64-only) build artifacts in the /fast
+  # subdirectory instead of the "root" of the build directory
+  if ((FLAGS_fast)); then
+    release_dir="gs://$bucket/$build_type/fast/$version"
+  else
+    release_dir="gs://$bucket/$build_type/$version"
   fi
 
   if ! logrun $GSUTIL ls $release_dir; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig testing
/priority critical-urgent

#### What this PR does / why we need it:

(Follow-up to https://github.com/kubernetes/test-infra/pull/18290, https://github.com/kubernetes/test-infra/pull/18514)

Ensure we check for "fast" (linux/amd64-only) build artifacts in the
/fast subdirectory instead of the "root" of the build directory when
attempting to write build version markers.

`ci-kubernetes-build-fast` jobs will fail w/o this.

[Example](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build-fast/1288268803028815872): 

```shell
 I0729 00:47:33.228] ================================================================================
I0729 00:47:33.238] UPLOAD to
I0729 00:47:33.245] ================================================================================
I0729 00:47:33.253] 
I0729 00:47:33.256] 
I0729 00:47:33.257] push-build.sh::release::gcs::publish_version(): /google-cloud-sdk/bin/gsutil ls gs://kubernetes-release-dev/ci/v1.20.0-alpha.0.401+d2d8c63a87aaba
I0729 00:47:34.808] CommandException: One or more URLs matched no objects.
I0729 00:47:35.117] Release files don't exist at
I0729 00:47:35.118] gs://kubernetes-release-dev/ci/v1.20.0-alpha.0.401+d2d8c63a87aaba
I0729 00:47:35.127] 
I0729 00:47:35.134] 
I0729 00:47:35.142] Signal ERR caught!
I0729 00:47:35.150] 
I0729 00:47:35.158] Traceback (line function script):
I0729 00:47:35.159] 261 main ../release/push-build.sh
I0729 00:47:35.166] 
I0729 00:47:35.175] Exiting...
I0729 00:47:35.183] 
I0729 00:47:35.188] 
I0729 00:47:35.193] push-build.sh: DONE main on 9c5f2001-d131-11ea-b580-ba995a3d5efd Wed Jul 29 00:47:35 UTC 2020 in 2m1s
W0729 00:47:35.207] Traceback (most recent call last):
W0729 00:47:35.208]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_build.py", line 177, in <module>
W0729 00:47:35.208]     main(ARGS)
W0729 00:47:35.208]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_build.py", line 145, in main
W0729 00:47:35.208]     check(args.push_build_script, *push_build_args)
W0729 00:47:35.208]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_build.py", line 32, in check
W0729 00:47:35.208]     subprocess.check_call(cmd)
W0729 00:47:35.209]   File "/usr/lib/python2.7/subprocess.py", line 190, in check_call
W0729 00:47:35.209]     raise CalledProcessError(retcode, cmd)
W0729 00:47:35.209] subprocess.CalledProcessError: Command '('../release/push-build.sh', '--nomock', '--verbose', '--ci', '--release-kind=kubernetes', '--fast', '--allow-dup')' returned non-zero exit status 2
E0729 00:47:35.210] Command failed
I0729 00:47:35.210] process 484 exited with code 1 after 21.6m
E0729 00:47:35.210] FAIL: ci-kubernetes-build-fast 
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

There's a more elegant way of doing this, but it touches more code paths (and I'd prefer not to risk that right now).

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
push-build: Fix directory listing for fast builds
```
