### PR TITLE
lib/release: Only publish ci/latest-fast marker during CI fast builds

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -816,8 +816,6 @@ release::gcs::publish_version () {
   if ((FLAGS_fast)); then
     publish_files=(
       "$type-fast"
-      "$type-$version_major-fast"
-      "$type-$version_major.$version_minor-fast"
     )
   else
     publish_files=(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

With the newly-established `latest-fast` markers (ref: https://github.com/kubernetes/release/pull/1389, https://github.com/kubernetes/test-infra/pull/18290), we now publish the
following to `gs://kubernetes-release/dev/ci`:
- `latest-fast`
- `latest-1-fast`
- `latest-1.20-fast`

However, because we do not run `--fast` jobs on release branches, I want
to avoid any misconception that `latest-x.y-fast` markers will remain
up-to-date once a release branch is cut.

Removing `latest-1-fast` as well to minimize cruft (no one really uses the
latest-1 marker today).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/sig-release/issues/850

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
lib/release: Only publish ci/latest-fast marker during CI fast builds
```
