### PR TITLE
images: Migrate Debian base image building to k/release

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -75,7 +75,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base"
-    version: 2.1.1
+    version: 2.1.2
     refPaths:
     - path: build/debian-base/Makefile
       match: TAG \?=

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,218 @@
+dependencies:
+  # Bazel
+  - name: "repo-infra"
+    version: 0.0.10
+    refPaths:
+    - path: build/root/WORKSPACE
+      match: strip_prefix = "repo-infra-\d+.\d+.\d+"
+    - path: build/root/WORKSPACE
+      match: https://github.com/kubernetes/repo-infra/archive/v\d+.\d+.\d+.tar.gz
+
+  # CNI plugins
+  - name: "cni"
+    version: 0.8.6
+    refPaths:
+    - path: build/workspace.bzl
+      match: CNI_VERSION =
+    - path: cluster/gce/gci/configure.sh
+      match: DEFAULT_CNI_VERSION=
+    - path: cluster/gce/config-common.sh
+      match: WINDOWS_CNI_VERSION=
+    - path: test/e2e_node/remote/utils.go
+      match: cniVersion[\t\n\f\r ]*=
+
+  # CoreDNS
+  - name: "coredns-kube-up"
+    version: 1.7.0
+    refPaths:
+    - path: cluster/addons/dns/coredns/coredns.yaml.base
+      match: k8s.gcr.io/coredns
+    - path: cluster/addons/dns/coredns/coredns.yaml.in
+      match: k8s.gcr.io/coredns
+    - path: cluster/addons/dns/coredns/coredns.yaml.sed
+      match: k8s.gcr.io/coredns
+
+  - name: "coredns-kubeadm"
+    version: 1.7.0
+    refPaths:
+    - path: cmd/kubeadm/app/constants/constants.go
+      match: CoreDNSVersion =
+
+  # CRI Tools
+  - name: "crictl"
+    version: 1.18.0
+    refPaths:
+    - path: build/workspace.bzl
+      match: CRI_TOOLS_VERSION =
+    - path: cluster/gce/gci/configure.sh
+      match: DEFAULT_CRICTL_VERSION=
+    - path: cluster/gce/windows/k8s-node-setup.psm1
+      match: CRICTL_VERSION =
+
+  # Docker
+  - name: "docker"
+    version: 19.03
+    refPaths:
+    - path: vendor/k8s.io/system-validators/validators/docker_validator.go
+      match: latestValidatedDockerVersion
+
+  # etcd
+  - name: "etcd"
+    version: 3.4.9
+    refPaths:
+    - path: cluster/gce/manifests/etcd.manifest
+      match: etcd_docker_tag|etcd_version
+    - path: build/workspace.bzl
+      match: ETCD_VERSION
+    - path: cluster/gce/upgrade-aliases.sh
+      match: ETCD_IMAGE|ETCD_VERSION
+    - path: cmd/kubeadm/app/constants/constants.go
+    - path: hack/lib/etcd.sh
+      match: ETCD_VERSION=
+    - path: staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+      match: quay.io/coreos/etcd
+    - path: test/e2e/framework/nodes_util.go
+      match: const etcdImage
+
+  - name: "etcd-image"
+    version: 3.4.9
+    refPaths:
+    - path: cluster/images/etcd/Makefile
+      match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?
+    - path: cluster/images/etcd/migrate/options.go
+
+  # Golang
+  - name: "golang"
+    version: 1.15.0-rc.1
+    refPaths:
+    - path: build/build-image/cross/VERSION
+    - path: build/root/WORKSPACE
+      match: (override_)?go_version = "((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"
+
+  - name: "golang: upstream container image"
+    version: 1.15rc1
+    refPaths:
+    - path: test/images/Makefile
+      match: GOLANG_VERSION=\d+.\d+(alpha|beta|rc)\d+
+
+  - name: "k8s.gcr.io/kube-cross: dependents"
+    version: v1.15.0-rc.1-1
+    refPaths:
+    - path: build/build-image/cross/VERSION
+    - path: test/images/sample-apiserver/Dockerfile
+      match: k8s\.gcr\.io\/build-image\/kube-cross:v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
+  # Base images
+  - name: "k8s.gcr.io/debian-base"
+    version: 2.1.1
+    refPaths:
+    - path: build/debian-base/Makefile
+      match: TAG \?=
+
+  - name: "k8s.gcr.io/debian-base: dependents"
+    version: 2.1.0
+    refPaths:
+    - path: build/common.sh
+      match: debian_base_version=
+    - path: build/workspace.bzl
+      match: tag =
+    - path: build/debian-iptables/Makefile
+      match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-base-\$\(ARCH\)
+    - path: cluster/images/etcd/Makefile
+      match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base:v\d+\.\d+\.\d+
+    - path: cluster/images/etcd/Makefile
+      match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-arm:v\d+\.\d+\.\d+
+    - path: cluster/images/etcd/Makefile
+      match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-arm64:v\d+\.\d+\.\d+
+    - path: cluster/images/etcd/Makefile
+      match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-ppc64le:v\d+\.\d+\.\d+
+    - path: cluster/images/etcd/Makefile
+      match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:v\d+\.\d+\.\d+
+
+  - name: "k8s.gcr.io/debian-iptables"
+    version: 12.1.0
+    refPaths:
+    - path: build/debian-iptables/Makefile
+      match: TAG\?=
+
+  - name: "k8s.gcr.io/debian-iptables: dependents"
+    version: 12.1.0
+    refPaths:
+    - path: build/common.sh
+      match: debian_iptables_version=
+    - path: build/workspace.bzl
+      match: tag =
+    - path: test/utils/image/manifest.go
+      match: configs\[DebianIptables\] = Config{buildImageRegistry, "debian-iptables", "v\d+\.\d+.\d+"}
+
+  - name: "k8s.gcr.io/go-runner"
+    version: 0.1.1
+    refPaths:
+    - path: build/go-runner/Makefile
+      match: TAG \?=
+
+  - name: "k8s.gcr.io/go-runner: dependents"
+    version: 0.1.1
+    refPaths:
+    - path: build/common.sh
+      match: go_runner_version=
+    - path: build/workspace.bzl
+      match: tag =
+
+  - name: "k8s.gcr.io/pause"
+    version: 3.3
+    refPaths:
+    - path: build/pause/Makefile
+      match: TAG =
+
+  - name: "k8s.gcr.io/pause: dependents"
+    version: 3.2
+    refPaths:
+    - path: cmd/kubeadm/app/constants/constants_unix.go
+      match: PauseVersion\s+=
+    - path: cmd/kubeadm/app/util/template_test.go
+      match: validTmpl\s+=
+    - path: cmd/kubeadm/app/util/template_test.go
+      match: validTmplOut\s+=
+    - path: cmd/kubeadm/app/util/template_test.go
+      match: doNothing\s+=
+    - path: cmd/kubelet/app/options/container_runtime.go
+      match: defaultPodSandboxImageVersion\s+=
+    - path: hack/testdata/pod-with-precision.json
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: pkg/kubelet/dockershim/docker_sandbox.go
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/cmd/core.sh
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/benchmark-controller.json
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-default.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/utils/runners.go
+      match: k8s.gcr.io\/pause:\d+\.\d+
+    - path: test/utils/image/manifest.go
+      match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+"}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -12,6 +12,8 @@ dependencies:
   - name: "cni"
     version: 0.8.6
     refPaths:
+    - path: build/debian-hyperkube-base/Makefile
+      match: CNI_VERSION\?=
     - path: build/workspace.bzl
       match: CNI_VERSION =
     - path: cluster/gce/gci/configure.sh
@@ -129,6 +131,12 @@ dependencies:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:v\d+\.\d+\.\d+
 
+  - name: "k8s.gcr.io/debian-hyperkube-base"
+    version: 1.1.1
+    refPaths:
+    - path: build/debian-hyperkube-base/Makefile
+      match: TAG\?=
+
   - name: "k8s.gcr.io/debian-iptables"
     version: 12.1.0
     refPaths:
@@ -140,6 +148,8 @@ dependencies:
     refPaths:
     - path: build/common.sh
       match: debian_iptables_version=
+    - path: build/debian-hyperkube-base/Makefile
+      match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):v\d+\.\d+\.\d+
     - path: build/workspace.bzl
       match: tag =
     - path: test/utils/image/manifest.go

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -23,23 +23,6 @@ dependencies:
     - path: test/e2e_node/remote/utils.go
       match: cniVersion[\t\n\f\r ]*=
 
-  # CoreDNS
-  - name: "coredns-kube-up"
-    version: 1.7.0
-    refPaths:
-    - path: cluster/addons/dns/coredns/coredns.yaml.base
-      match: k8s.gcr.io/coredns
-    - path: cluster/addons/dns/coredns/coredns.yaml.in
-      match: k8s.gcr.io/coredns
-    - path: cluster/addons/dns/coredns/coredns.yaml.sed
-      match: k8s.gcr.io/coredns
-
-  - name: "coredns-kubeadm"
-    version: 1.7.0
-    refPaths:
-    - path: cmd/kubeadm/app/constants/constants.go
-      match: CoreDNSVersion =
-
   # CRI Tools
   - name: "crictl"
     version: 1.18.0
@@ -76,13 +59,6 @@ dependencies:
     - path: test/e2e/framework/nodes_util.go
       match: const etcdImage
 
-  - name: "etcd-image"
-    version: 3.4.9
-    refPaths:
-    - path: cluster/images/etcd/Makefile
-      match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?
-    - path: cluster/images/etcd/migrate/options.go
-
   # Golang
   - name: "golang"
     version: 1.15.0-rc.1
@@ -96,13 +72,6 @@ dependencies:
     refPaths:
     - path: test/images/Makefile
       match: GOLANG_VERSION=\d+.\d+(alpha|beta|rc)\d+
-
-  - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.15.0-rc.1-1
-    refPaths:
-    - path: build/build-image/cross/VERSION
-    - path: test/images/sample-apiserver/Dockerfile
-      match: k8s\.gcr\.io\/build-image\/kube-cross:v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # Base images
   - name: "k8s.gcr.io/debian-base"
@@ -154,75 +123,3 @@ dependencies:
       match: tag =
     - path: test/utils/image/manifest.go
       match: configs\[DebianIptables\] = Config{buildImageRegistry, "debian-iptables", "v\d+\.\d+.\d+"}
-
-  - name: "k8s.gcr.io/go-runner"
-    version: 0.1.1
-    refPaths:
-    - path: build/go-runner/Makefile
-      match: TAG \?=
-
-  - name: "k8s.gcr.io/go-runner: dependents"
-    version: 0.1.1
-    refPaths:
-    - path: build/common.sh
-      match: go_runner_version=
-    - path: build/workspace.bzl
-      match: tag =
-
-  - name: "k8s.gcr.io/pause"
-    version: 3.3
-    refPaths:
-    - path: build/pause/Makefile
-      match: TAG =
-
-  - name: "k8s.gcr.io/pause: dependents"
-    version: 3.2
-    refPaths:
-    - path: cmd/kubeadm/app/constants/constants_unix.go
-      match: PauseVersion\s+=
-    - path: cmd/kubeadm/app/util/template_test.go
-      match: validTmpl\s+=
-    - path: cmd/kubeadm/app/util/template_test.go
-      match: validTmplOut\s+=
-    - path: cmd/kubeadm/app/util/template_test.go
-      match: doNothing\s+=
-    - path: cmd/kubelet/app/options/container_runtime.go
-      match: defaultPodSandboxImageVersion\s+=
-    - path: hack/testdata/pod-with-precision.json
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: pkg/kubelet/dockershim/docker_sandbox.go
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/cmd/core.sh
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/benchmark-controller.json
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-default.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/utils/runners.go
-      match: k8s.gcr.io\/pause:\d+\.\d+
-    - path: test/utils/image/manifest.go
-      match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+"}

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"
@@ -56,7 +56,7 @@ steps:
   - "--tmpdir=/workspace/tmp"
   - "--type=${_TYPE}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:local
+- name: k8s.gcr.io/build-image/kube-cross:local
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 STAGING_REGISTRY?=gcr.io/k8s-staging-build-image
-PROD_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+PROD_REGISTRY?=k8s.gcr.io/build-image
 IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)

--- a/images/build/debian-base/Dockerfile
+++ b/images/build/debian-base/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/images/build/debian-base/Dockerfile.build
+++ b/images/build/debian-base/Dockerfile.build
@@ -1,0 +1,88 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so
+# e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Smaller package install size.
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+# Convenience script for building on this base image.
+COPY clean-install /usr/local/bin/clean-install
+
+# Update system packages.
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+# Hold required packages to avoid breaking the installation of packages
+RUN apt-mark hold apt gnupg adduser passwd libsemanage1 libcap2
+
+# Remove unnecessary packages.
+# This list was generated manually by listing the installed packages (`apt list --installed`),
+# then running `apt-cache rdepends --installed --no-recommends` to find the "root" packages.
+# The root packages were evaluated based on whether they were needed in the container image.
+# Several utilities (e.g. ping) were kept for usefulness, but may be removed in later versions.
+RUN echo "Yes, do as I say!" | apt-get purge \
+    bash \
+    e2fsprogs \
+    libcap2-bin \
+    libmount1 \
+    libsmartcols1 \
+    libblkid1 \
+    libss2 \
+    ncurses-base \
+    ncurses-bin \
+    tzdata
+
+# No-op stubs replace some unnecessary binaries that may be depended on in the install process (in
+# particular we don't run an init process).
+WORKDIR /usr/local/bin
+RUN touch noop && \
+    chmod 555 noop && \
+    ln -s noop runlevel && \
+    ln -s noop invoke-rc.d && \
+    ln -s noop update-rc.d
+WORKDIR /
+
+# Cleanup cached and unnecessary files.
+RUN apt-get autoremove -y && \
+    apt-get clean -y && \
+    tar -czf /usr/share/copyrights.tar.gz /usr/share/common-licenses /usr/share/doc/*/copyright && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /usr/share/common-licenses* \
+        /usr/share/bash-completion \
+        ~/.bashrc \
+        ~/.profile \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    mkdir -p /usr/share/man/man1 /usr/share/man/man2 \
+        /usr/share/man/man3 /usr/share/man/man4 \
+        /usr/share/man/man5 /usr/share/man/man6 \
+        /usr/share/man/man7 /usr/share/man/man8

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= gcr.io/k8s-staging-build-image
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= v2.1.1
+TAG ?= v2.1.2
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -82,7 +82,7 @@ ifeq ($(ARCH),amd64)
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
 	# Ensure we don't get surprised by umask settings
 	chmod 0755 $(TEMP_DIR)/qemu-$(QEMUARCH)-static

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -1,0 +1,105 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: all-build
+
+REGISTRY ?= gcr.io/k8s-staging-build-image
+IMAGE ?= $(REGISTRY)/debian-base
+BUILD_IMAGE ?= debian-build
+
+TAG ?= v2.1.1
+
+TAR_FILE ?= rootfs.tar
+ARCH?=amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+
+TEMP_DIR:=$(shell mktemp -d)
+QEMUVERSION=v4.2.0-6
+
+SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:buster-slim
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=arm32v7/debian:buster-slim
+	QEMUARCH=arm
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=arm64v8/debian:buster-slim
+	QEMUARCH=aarch64
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:buster-slim
+	QEMUARCH=ppc64le
+endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:buster-slim
+	QEMUARCH=s390x
+endif
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
+
+all-push: all-push-images push-manifest
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push --purge ${IMAGE}:${TAG}
+
+build: clean
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.build \
+		| sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+		| sed "s|ARCH|$(QEMUARCH)|g" \
+		> $(TEMP_DIR)/Dockerfile.build
+
+ifeq ($(ARCH),amd64)
+	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
+	sed "/CROSS_BUILD_/d" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
+else
+	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# Ensure we don't get surprised by umask settings
+	chmod 0755 $(TEMP_DIR)/qemu-$(QEMUARCH)-static
+	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
+endif
+	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build
+
+	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
+	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
+	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(TAR_FILE)
+	docker build -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+push: build
+	docker push $(IMAGE)-$(ARCH):$(TAG)
+
+clean:
+	docker rmi -f $(IMAGE)-$(ARCH):$(TAG) || true
+	docker rmi -f $(BUILD_IMAGE)   || true
+	docker rm  -f $(BUILD_IMAGE)   || true

--- a/images/build/debian-base/OWNERS
+++ b/images/build/debian-base/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - build-image-reviewers
+  - BenTheElder
+  - mkumatag
+  - tallclair
+approvers:
+  - build-image-approvers
+  - BenTheElder
+  - mkumatag
+  - tallclair

--- a/images/build/debian-base/README.md
+++ b/images/build/debian-base/README.md
@@ -1,0 +1,12 @@
+# Kubernetes Debian Base
+
+The Kubernetes debian-base image provides a common base for Kubernetes system images that require
+external dependencies (such as `iptables`, `sh`, or anything that is more than a static go-binary).
+
+This image differs from the standard debian image by removing a lot of packages and files that are
+generally not necessary in containers. The end result is an image that is just over 40 MB, down from
+123 MB.
+
+The image also provides a convenience script `/usr/local/bin/clean-install` that encapsulates the
+process of updating apt repositories, installing the packages, and then cleaning up unnecessary
+caches & logs.

--- a/images/build/debian-base/clean-install
+++ b/images/build/debian-base/clean-install
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -1,0 +1,16 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+    entrypoint: make
+    dir: ./build/debian-base
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - REGISTRY=gcr.io/$PROJECT_ID
+      - IMAGE=gcr.io/$PROJECT_ID/debian-base
+      - BUILD_IMAGE=debian-build
+    args:
+      - all-push

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
     entrypoint: make
-    dir: ./build/debian-base
+    dir: ./images/build/debian-base
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID

--- a/images/build/debian-base/excludes
+++ b/images/build/debian-base/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/man/*

--- a/images/build/debian-hyperkube-base/.gitignore
+++ b/images/build/debian-hyperkube-base/.gitignore
@@ -1,0 +1,1 @@
+/cni-tars

--- a/images/build/debian-hyperkube-base/Dockerfile
+++ b/images/build/debian-hyperkube-base/Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+RUN ln -s /hyperkube /apiserver \
+    && ln -s /hyperkube /cloud-controller-manager \
+    && ln -s /hyperkube /controller-manager \
+    && ln -s /hyperkube /kubectl \
+    && ln -s /hyperkube /kubelet \
+    && ln -s /hyperkube /proxy \
+    && ln -s /hyperkube /scheduler \
+    && ln -s /hyperkube /usr/local/bin/cloud-controller-manager \
+    && ln -s /hyperkube /usr/local/bin/kube-apiserver \
+    && ln -s /hyperkube /usr/local/bin/kube-controller-manager \
+    && ln -s /hyperkube /usr/local/bin/kube-proxy \
+    && ln -s /hyperkube /usr/local/bin/kube-scheduler \
+    && ln -s /hyperkube /usr/local/bin/kubectl \
+    && ln -s /hyperkube /usr/local/bin/kubelet
+
+RUN clean-install bash
+
+# The samba-common, cifs-utils, and nfs-common packages depend on
+# ucf, which itself depends on /bin/bash.
+RUN echo "dash dash/sh boolean false" | debconf-set-selections
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+RUN clean-install \
+    ca-certificates \
+    ceph-common \
+    cifs-utils \
+    e2fsprogs \
+    ethtool \
+    git \
+    glusterfs-client \
+    iproute2 \
+    jq \
+    nfs-common \
+    openssh-client \
+    socat \
+    udev \
+    util-linux \
+    xfsprogs
+
+COPY cni-bin/bin /opt/cni/bin

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -72,7 +72,7 @@ build: cni-tars/$(CNI_TARBALL)
 
 ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
 	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -23,7 +23,7 @@ TAG?=v1.1.1
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
-BASE_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+BASE_REGISTRY?=k8s.gcr.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.0
 CNI_VERSION?=v0.8.6
 

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -1,0 +1,81 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the hyperkube base image. This image is used to build the hyperkube image.
+#
+# Usage:
+#   [ARCH=amd64] [REGISTRY="staging-k8s.gcr.io"] make (build|push)
+
+REGISTRY?=gcr.io/k8s-staging-build-image
+IMAGE?=$(REGISTRY)/debian-hyperkube-base
+TAG?=v1.1.1
+ARCH?=amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+
+BASE_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.0
+CNI_VERSION?=v0.8.6
+
+TEMP_DIR:=$(shell mktemp -d)
+CNI_TARBALL=cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
+
+.PHONY: all build push clean all-build all-push-images all-push push-manifest
+
+all: all-push
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
+
+all-push: all-push-images push-manifest
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push --purge ${IMAGE}:${TAG}
+
+cni-tars/$(CNI_TARBALL):
+	mkdir -p cni-tars/
+	cd cni-tars/ && curl -sSLO --retry 5 https://storage.googleapis.com/k8s-artifacts-cni/release/${CNI_VERSION}/${CNI_TARBALL}
+
+clean:
+	rm -rf cni-tars/
+
+build: cni-tars/$(CNI_TARBALL)
+	cp Dockerfile $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+	mkdir -p ${TEMP_DIR}/cni-bin/bin
+	tar -xz -C ${TEMP_DIR}/cni-bin/bin -f "cni-tars/${CNI_TARBALL}"
+
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+endif
+	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+push: build
+	docker push $(IMAGE)-$(ARCH):$(TAG)

--- a/images/build/debian-hyperkube-base/OWNERS
+++ b/images/build/debian-hyperkube-base/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - BenTheElder
+  - mkumatag
+  - tallclair
+approvers:
+  - BenTheElder
+  - mkumatag
+  - tallclair
+labels:
+- sig/release

--- a/images/build/debian-hyperkube-base/README.md
+++ b/images/build/debian-hyperkube-base/README.md
@@ -1,0 +1,25 @@
+### debian-hyperkube-base
+
+Serves as the base image for `k8s.gcr.io/hyperkube-${ARCH}`
+images.
+
+This image is compiled for multiple architectures.
+
+#### How to release
+
+If you're editing the Dockerfile or some other thing, please bump the `TAG` in the Makefile.
+
+```console
+# Build and  push images for all the architectures
+$ make all-push
+# ---> staging-k8s.gcr.io/debian-hyperkube-base-amd64:TAG
+# ---> staging-k8s.gcr.io/debian-hyperkube-base-arm:TAG
+# ---> staging-k8s.gcr.io/debian-hyperkube-base-arm64:TAG
+# ---> staging-k8s.gcr.io/debian-hyperkube-base-ppc64le:TAG
+# ---> staging-k8s.gcr.io/debian-hyperkube-base-s390x:TAG
+```
+
+If you don't want to push the images, run `make all-build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/build/debian-hyperkube-base/README.md?pixel)]()

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -1,0 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 14400s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+    entrypoint: make
+    dir: ./build/debian-hyperkube-base
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - REGISTRY=gcr.io/$PROJECT_ID
+      - IMAGE=gcr.io/$PROJECT_ID/debian-hyperkube-base
+    args:
+      - all-push

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
     entrypoint: make
-    dir: ./build/debian-hyperkube-base
+    dir: ./images/build/debian-hyperkube-base
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID

--- a/images/build/debian-iptables/Dockerfile
+++ b/images/build/debian-iptables/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# Install latest iptables package from buster-backports
+RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list; \
+    apt-get update; \
+    apt-get -t buster-backports -y --no-install-recommends install iptables
+
+# Install other dependencies and then clean up apt caches
+RUN clean-install \
+    conntrack \
+    ebtables \
+    ipset \
+    kmod \
+    netbase
+
+# Install iptables wrapper scripts to detect the correct iptables mode
+# the first time any of them is run
+COPY iptables-wrapper /usr/sbin/iptables-wrapper
+
+RUN update-alternatives \
+	--install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+RUN update-alternatives \
+	--install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -35,7 +35,7 @@ build:
 
 ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
 
 	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -1,0 +1,63 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY:	build push all all-build all-push-images all-push push-manifest
+
+REGISTRY?="gcr.io/k8s-staging-build-image"
+IMAGE=$(REGISTRY)/debian-iptables
+TAG?=v12.1.0
+ARCH?=amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+TEMP_DIR:=$(shell mktemp -d)
+
+BASE_REGISTRY?=k8s.gcr.io/build-image
+BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):v2.1.0
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
+
+build:
+	cp ./* $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+endif
+
+	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+
+push: build
+	docker push $(IMAGE)-$(ARCH):$(TAG)
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
+
+all-push: all-push-images push-manifest
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push --purge ${IMAGE}:${TAG}
+
+all: all-push

--- a/images/build/debian-iptables/OWNERS
+++ b/images/build/debian-iptables/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - build-image-reviewers
+  - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
+  - mkumatag
+  - mrhohn
+  - tallclair
+approvers:
+  - build-image-approvers
+  - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
+  - mkumatag
+  - mrhohn
+  - tallclair

--- a/images/build/debian-iptables/README.md
+++ b/images/build/debian-iptables/README.md
@@ -1,0 +1,24 @@
+### debian-iptables
+
+Serves as the base image for `k8s.gcr.io/kube-proxy-${ARCH}` and multiarch (not `amd64`) `k8s.gcr.io/flannel-${ARCH}` images.
+
+This image is compiled for multiple architectures.
+
+#### How to release
+
+If you're editing the Dockerfile or some other thing, please bump the `TAG` in the Makefile.
+
+```console
+Build and  push images for all the architectures
+$ make all-push
+# ---> staging-k8s.gcr.io/debian-iptables-amd64:TAG
+# ---> staging-k8s.gcr.io/debian-iptables-arm:TAG
+# ---> staging-k8s.gcr.io/debian-iptables-arm64:TAG
+# ---> staging-k8s.gcr.io/debian-iptables-ppc64le:TAG
+# ---> staging-k8s.gcr.io/debian-iptables-s390x:TAG
+```
+
+If you don't want to push the images, run `make build ARCH={target_arch}` or `make all-build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/build/debian-iptables/README.md?pixel)]()

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -1,0 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+    entrypoint: make
+    dir: ./build/debian-iptables
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - REGISTRY=gcr.io/$PROJECT_ID
+      - IMAGE=gcr.io/$PROJECT_ID/debian-iptables
+    args:
+      - all-push

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
     entrypoint: make
-    dir: ./build/debian-iptables
+    dir: ./images/build/debian-iptables
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID

--- a/images/build/debian-iptables/iptables-wrapper
+++ b/images/build/debian-iptables/iptables-wrapper
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+
+# Bugs in iptables-nft 1.8.3 may cause it to get stuck in a loop in
+# some circumstances, so we have to run the nft check in a timeout. To
+# avoid hitting that timeout, we only bother to even check nft if
+# legacy iptables was empty / mostly empty.
+
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "${num_legacy_lines}" -ge 10 ]; then
+    mode=legacy
+else
+    num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+	mode=legacy
+    else
+	mode=nft
+    fi
+fi
+
+update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
+
+# Now re-exec the original command with the newly-selected alternative
+exec "$0" "$@"

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG KUBE_CROSS_VERSION
-FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${KUBE_CROSS_VERSION}
+FROM k8s.gcr.io/build-image/kube-cross:${KUBE_CROSS_VERSION}
 
 ##------------------------------------------------------------
 # global ARGs & ENVs

--- a/third_party/multiarch/qemu-user-static/LICENSE
+++ b/third_party/multiarch/qemu-user-static/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Manfred Touron
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/multiarch/qemu-user-static/README.kubernetes
+++ b/third_party/multiarch/qemu-user-static/README.kubernetes
@@ -1,0 +1,1 @@
+Files copied from https://github.com/multiarch/qemu-user-static at commit 22b0013668d2aed4a2cfd21650e85c664b1f21c6.

--- a/third_party/multiarch/qemu-user-static/register/qemu-binfmt-conf.sh
+++ b/third_party/multiarch/qemu-user-static/register/qemu-binfmt-conf.sh
@@ -1,0 +1,367 @@
+#!/bin/sh
+# enable automatic i386/ARM/M68K/MIPS/SPARC/PPC/s390/HPPA/Xtensa/microblaze
+# program execution by the kernel
+#
+# downloaded from https://raw.githubusercontent.com/qemu/qemu/master/scripts/qemu-binfmt-conf.sh
+
+qemu_target_list="i386 i486 alpha arm armeb sparc32plus ppc ppc64 ppc64le m68k \
+mips mipsel mipsn32 mipsn32el mips64 mips64el \
+sh4 sh4eb s390x aarch64 aarch64_be hppa riscv32 riscv64 xtensa xtensaeb microblaze microblazeel"
+
+i386_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00'
+i386_mask='\xff\xff\xff\xff\xff\xfe\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+i386_family=i386
+
+i486_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x06\x00'
+i486_mask='\xff\xff\xff\xff\xff\xfe\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+i486_family=i386
+
+alpha_magic='\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x26\x90'
+alpha_mask='\xff\xff\xff\xff\xff\xfe\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+alpha_family=alpha
+
+arm_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00'
+arm_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+arm_family=arm
+
+armeb_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28'
+armeb_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+armeb_family=armeb
+
+sparc_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x02'
+sparc_mask='\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+sparc_family=sparc
+
+sparc32plus_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x12'
+sparc32plus_mask='\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+sparc32plus_family=sparc
+
+ppc_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14'
+ppc_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+ppc_family=ppc
+
+ppc64_magic='\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x15'
+ppc64_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+ppc64_family=ppc
+
+ppc64le_magic='\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x15\x00'
+ppc64le_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\x00'
+ppc64le_family=ppcle
+
+m68k_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x04'
+m68k_mask='\xff\xff\xff\xff\xff\xff\xfe\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+m68k_family=m68k
+
+# FIXME: We could use the other endianness on a MIPS host.
+
+mips_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08'
+mips_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+mips_family=mips
+
+mipsel_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08\x00'
+mipsel_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+mipsel_family=mips
+
+mipsn32_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08'
+mipsn32_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+mipsn32_family=mips
+
+mipsn32el_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08\x00'
+mipsn32el_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+mipsn32el_family=mips
+
+mips64_magic='\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08'
+mips64_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+mips64_family=mips
+
+mips64el_magic='\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x08\x00'
+mips64el_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+mips64el_family=mips
+
+sh4_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x2a\x00'
+sh4_mask='\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+sh4_family=sh4
+
+sh4eb_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x2a'
+sh4eb_mask='\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+sh4eb_family=sh4
+
+s390x_magic='\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x16'
+s390x_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+s390x_family=s390x
+
+aarch64_magic='\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00'
+aarch64_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+aarch64_family=arm
+
+aarch64_be_magic='\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7'
+aarch64_be_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+aarch64_be_family=armeb
+
+hppa_magic='\x7f\x45\x4c\x46\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x0f'
+hppa_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+hppa_family=hppa
+
+riscv32_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xf3\x00'
+riscv32_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+riscv32_family=riscv
+
+riscv64_magic='\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xf3\x00'
+riscv64_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+riscv64_family=riscv
+
+xtensa_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x5e\x00'
+xtensa_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+xtensa_family=xtensa
+
+xtensaeb_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x5e'
+xtensaeb_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'
+xtensaeb_family=xtensaeb
+
+microblaze_magic='\x7fELF\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xba\xab'
+microblaze_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+microblaze_family=microblaze
+
+microblazeel_magic='\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xab\xba'
+microblazeel_mask='\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'
+microblazeel_family=microblazeel
+
+qemu_get_family() {
+    cpu=${HOST_ARCH:-$(uname -m)}
+    case "$cpu" in
+    amd64|i386|i486|i586|i686|i86pc|BePC|x86_64)
+        echo "i386"
+        ;;
+    mips*)
+        echo "mips"
+        ;;
+    "Power Macintosh"|ppc64|powerpc|ppc)
+        echo "ppc"
+        ;;
+    ppc64el|ppc64le)
+        echo "ppcle"
+        ;;
+    arm|armel|armhf|arm64|armv[4-9]*l|aarch64)
+        echo "arm"
+        ;;
+    armeb|armv[4-9]*b|aarch64_be)
+        echo "armeb"
+        ;;
+    sparc*)
+        echo "sparc"
+        ;;
+    riscv*)
+        echo "riscv"
+        ;;
+    *)
+        echo "$cpu"
+        ;;
+    esac
+}
+
+usage() {
+    cat <<EOF
+Usage: qemu-binfmt-conf.sh [--qemu-path PATH][--debian][--systemd CPU]
+                           [--help][--credential yes|no][--exportdir PATH]
+
+       Configure binfmt_misc to use qemu interpreter
+
+       --help:       display this usage
+       --qemu-path:  set path to qemu interpreter ($QEMU_PATH)
+       --debian:     don't write into /proc,
+                     instead generate update-binfmts templates
+       --systemd:    don't write into /proc,
+                     instead generate file for systemd-binfmt.service
+                     for the given CPU. If CPU is "ALL", generate a
+                     file for all known cpus
+       --exportdir:  define where to write configuration files
+                     (default: $SYSTEMDDIR or $DEBIANDIR)
+       --credential: if yes, credential and security tokens are
+                     calculated according to the binary to interpret
+
+    To import templates with update-binfmts, use :
+
+        sudo update-binfmts --importdir ${EXPORTDIR:-$DEBIANDIR} --import qemu-CPU
+
+    To remove interpreter, use :
+
+        sudo update-binfmts --package qemu-CPU --remove qemu-CPU $QEMU_PATH
+
+    With systemd, binfmt files are loaded by systemd-binfmt.service
+
+    The environment variable HOST_ARCH allows to override 'uname' to generate
+    configuration files for a different architecture than the current one.
+
+    where CPU is one of:
+
+        $qemu_target_list
+
+EOF
+}
+
+qemu_check_access() {
+    if [ ! -w "$1" ] ; then
+        echo "ERROR: cannot write to $1" 1>&2
+        exit 1
+    fi
+}
+
+qemu_check_bintfmt_misc() {
+    # load the binfmt_misc module
+    if [ ! -d /proc/sys/fs/binfmt_misc ]; then
+      if ! /sbin/modprobe binfmt_misc ; then
+          exit 1
+      fi
+    fi
+    if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+      if ! mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc ; then
+          exit 1
+      fi
+    fi
+
+    qemu_check_access /proc/sys/fs/binfmt_misc/register
+}
+
+installed_dpkg() {
+    dpkg --status "$1" > /dev/null 2>&1
+}
+
+qemu_check_debian() {
+    if [ ! -e /etc/debian_version ] ; then
+        echo "WARNING: your system is not a Debian based distro" 1>&2
+    elif ! installed_dpkg binfmt-support ; then
+        echo "WARNING: package binfmt-support is needed" 1>&2
+    fi
+    qemu_check_access "$EXPORTDIR"
+}
+
+qemu_check_systemd() {
+    if ! systemctl -q is-enabled systemd-binfmt.service ; then
+        echo "WARNING: systemd-binfmt.service is missing or disabled" 1>&2
+    fi
+    qemu_check_access "$EXPORTDIR"
+}
+
+qemu_generate_register() {
+    echo ":qemu-$cpu:M::$magic:$mask:$qemu:$FLAGS"
+}
+
+qemu_register_interpreter() {
+    echo "Setting $qemu as binfmt interpreter for $cpu"
+    qemu_generate_register > /proc/sys/fs/binfmt_misc/register
+}
+
+qemu_generate_systemd() {
+    echo "Setting $qemu as binfmt interpreter for $cpu for systemd-binfmt.service"
+    qemu_generate_register > "$EXPORTDIR/qemu-$cpu.conf"
+}
+
+qemu_generate_debian() {
+    cat > "$EXPORTDIR/qemu-$cpu" <<EOF
+package qemu-$cpu
+interpreter $qemu
+magic $magic
+mask $mask
+EOF
+    if [ "$FLAGS" = "OC" ] ; then
+        echo "credentials yes" >> "$EXPORTDIR/qemu-$cpu"
+    fi
+}
+
+qemu_set_binfmts() {
+    # probe cpu type
+    host_family=$(qemu_get_family)
+
+    # register the interpreter for each cpu except for the native one
+
+    for cpu in ${qemu_target_list} ; do
+        magic=$(eval echo \$${cpu}_magic)
+        mask=$(eval echo \$${cpu}_mask)
+        family=$(eval echo \$${cpu}_family)
+
+        if [ "$magic" = "" ] || [ "$mask" = "" ] || [ "$family" = "" ] ; then
+            echo "INTERNAL ERROR: unknown cpu $cpu" 1>&2
+            continue
+        fi
+
+        qemu="$QEMU_PATH/qemu-$cpu-static"
+        if [ "$cpu" = "i486" ] ; then
+            qemu="$QEMU_PATH/qemu-i386-static"
+        fi
+
+        if [ "$host_family" != "$family" ] ; then
+            $BINFMT_SET
+        fi
+    done
+}
+
+CHECK=qemu_check_bintfmt_misc
+BINFMT_SET=qemu_register_interpreter
+
+SYSTEMDDIR="/etc/binfmt.d"
+DEBIANDIR="/usr/share/binfmts"
+
+QEMU_PATH=/usr/local/bin
+FLAGS=""
+
+options=$(getopt -o ds:Q:e:hc: -l debian,systemd:,qemu-path:,exportdir:,help,credential: -- "$@")
+eval set -- "$options"
+
+while true ; do
+    case "$1" in
+    -d|--debian)
+        CHECK=qemu_check_debian
+        BINFMT_SET=qemu_generate_debian
+        EXPORTDIR=${EXPORTDIR:-$DEBIANDIR}
+        ;;
+    -s|--systemd)
+        CHECK=qemu_check_systemd
+        BINFMT_SET=qemu_generate_systemd
+        EXPORTDIR=${EXPORTDIR:-$SYSTEMDDIR}
+        shift
+        # check given cpu is in the supported CPU list
+        if [ "$1" != "ALL" ] ; then
+            for cpu in ${qemu_target_list} ; do
+                if [ "$cpu" = "$1" ] ; then
+                    break
+                fi
+            done
+
+            if [ "$cpu" = "$1" ] ; then
+                qemu_target_list="$1"
+            else
+                echo "ERROR: unknown CPU \"$1\"" 1>&2
+                usage
+                exit 1
+            fi
+        fi
+        ;;
+    -Q|--qemu-path)
+        shift
+        QEMU_PATH="$1"
+        ;;
+    -e|--exportdir)
+        shift
+        EXPORTDIR="$1"
+        ;;
+    -h|--help)
+        usage
+        exit 1
+        ;;
+    -c|--credential)
+        shift
+        if [ "$1" = "yes" ] ; then
+            FLAGS="OC"
+        else
+            FLAGS=""
+        fi
+        ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
+$CHECK
+qemu_set_binfmts

--- a/third_party/multiarch/qemu-user-static/register/register.sh
+++ b/third_party/multiarch/qemu-user-static/register/register.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+QEMU_BIN_DIR=${QEMU_BIN_DIR:-/usr/bin}
+
+
+if [ ! -d /proc/sys/fs/binfmt_misc ]; then
+    echo "No binfmt support in the kernel."
+    echo "  Try: '/sbin/modprobe binfmt_misc' from the host"
+    exit 1
+fi
+
+
+if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+fi
+
+entries="aarch64 aarch64_be alpha arm armeb hppa m68k microblaze microblazeel mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb"
+
+if [ "${1}" = "--reset" ]; then
+    shift
+    (
+    cd /proc/sys/fs/binfmt_misc || exit
+    for file in $entries; do
+        if [ -f "qemu-${file}" ]; then
+            echo -1 > "qemu-${file}"
+        fi
+    done
+    )
+fi
+
+exec $(dirname "${BASH_SOURCE[0]}")/qemu-binfmt-conf.sh --qemu-path="${QEMU_BIN_DIR}" "$@"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Similar to https://github.com/kubernetes/release/pull/1140, I don't believe we need to/should be building the Debian base images from kubernetes/kubernetes.

I [submitted a PR](https://github.com/kubernetes/kubernetes/pull/93562) around 20 hours ago to rebuild the debian-base image to patch a CVE (ref: https://github.com/kubernetes/kubernetes/issues/92616, https://github.com/kubernetes/kubernetes/issues/93114) and it still hasn't merged.

While that is a fix for a medium CVE, this is not a great place to be in from a security standpoint.

This needs to be merged alongside:
- https://github.com/kubernetes/kubernetes/pull/88603
- https://github.com/kubernetes/test-infra/pull/18558

Commits:
- third_party: Add multiarch/qemu-user-static@22b0013
- Add dummy copy of dependencies.yaml from kubernetes/kubernetes
  
  This is not yet active and will be updated in a future commits. We put
  it here as an anchor to begin slotting in version numbers.
- images: Migrate debian-hyperkube-base image to k/release
- images: Initial copy of debian base images from kubernetes/kubernetes
- dependencies.yaml: Remove extraneous entries
  
  The entries left should eventually be updated to match the relevant
  references in this repo.
- images/debian: Fixup directory references
- [VDF] Reference k8s.gcr.io instead of us.gcr.io/k8s-artifacts-prod
- base-images: Build debian-base@v2.1.2

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

We'll also _eventually_ want the same dependency version checking mechanisms that we have in k/k in this repo as well. I'm working on that in https://github.com/kubernetes/release/pull/1449.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Migrate Debian base image building to k/release
- third_party: Add multiarch/qemu-user-static@22b0013
- [VDF] Reference k8s.gcr.io instead of us.gcr.io/k8s-artifacts-prod
- base-images: Build debian-base@v2.1.2
```
