### PR TITLE
anago: set the Golang version used to build the release when creating the announcement

### DIFF
--- a/anago
+++ b/anago
@@ -857,10 +857,11 @@ EOF
 ###############################################################################
 # generate the announcement text to be mailed and published
 release_announcement_text () {
+  local GOLANG_VERSION=$(go version | cut -d' ' -f 3)
   cat <<EOF
 Kubernetes Community,
 <P>
-Kubernetes $RELEASE_VERSION_PRIME has been built and pushed.
+Kubernetes $RELEASE_VERSION_PRIME has been built and pushed using Golang version $GOLANG_VERSION.
 <P>
 The release notes have been updated in <A HREF=https://git.k8s.io/kubernetes/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A>, with a pointer to them on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
 <P>


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add the Golang version that was used to build the K8s release. Add the information in the announcement text.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/release/issues/1447

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
anago: set the Golang version used to build the release when creating the announcement
```

/assign @saschagrunert @justaugustus 
/cc @kubernetes/release-managers @dims 