### PR TITLE
New functions git.GetUserName and git.GetUserEmail

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -748,18 +748,37 @@ func (r *Repo) Add(filename string) error {
 	)
 }
 
+// GetUserName Reads the local user's name from the git configuration
+func GetUserName() (string, error) {
+	// Retrieve username from git
+	userName, err := command.New(gitExecutable, "config", "--get", "user.name").RunSilentSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "reading the user name from git")
+	}
+	return userName.OutputTrimNL(), nil
+}
+
+// GetUserEmail reads the user's name from git
+func GetUserEmail() (string, error) {
+	userEmail, err := command.New(gitExecutable, "config", "--get", "user.email").RunSilentSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "reading the user's email from git")
+	}
+	return userEmail.OutputTrimNL(), nil
+}
+
 // UserCommit makes a commit using the local user's config as well as adding
 // the Signed-off-by line to the commit message
 func (r *Repo) UserCommit(msg string) error {
 	// Retrieve username and mail
-	userName, err := command.New("git", "config", "--get", "user.name").RunSilentSuccessOutput()
+	userName, err := GetUserName()
 	if err != nil {
-		return errors.Wrap(err, "get the user's name")
+		return errors.Wrap(err, "getting the user's name")
 	}
 
-	userEmail, err := command.New("git", "config", "--get", "user.email").RunSilentSuccessOutput()
+	userEmail, err := GetUserEmail()
 	if err != nil {
-		return errors.Wrap(err, "get the user's email")
+		return errors.Wrap(err, "getting the user's email")
 	}
 
 	// Add signed-off-by line
@@ -767,8 +786,8 @@ func (r *Repo) UserCommit(msg string) error {
 
 	if err := r.CommitWithOptions(msg, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  userName.OutputTrimNL(),
-			Email: userEmail.OutputTrimNL(),
+			Name:  userName,
+			Email: userEmail,
 			When:  time.Now(),
 		},
 	}); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind feature

#### What this PR does / why we need it:

This PR introduces two new functions to the got package: `git.GetUserName` and `git.GetUserEmail` to be able to get the user's information outside of the git package.

Tests for both functions are included in the git_test.go file

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Test for the functions will create an empty git repository, configure it with the user's data and call the functions in the git package. 

#### Does this PR introduce a user-facing change?

```release-note
New standaolne functions `git.GetUserName()` and `git.GetUserEmail()`
```

Signed-off-by: Adolfo García Veytia <adolfo.garcia@uservers.net>
