### PR TITLE
anago: Push images during staging and validate manifests during release

### DIFF
--- a/anago
+++ b/anago
@@ -1390,6 +1390,9 @@ push_all_artifacts () {
     common::runstep release::gcs::push_release_artifacts \
      $BUILD_OUTPUT-${RELEASE_VERSION[$label]}/release-images \
      gs://$RELEASE_BUCKET/$BUCKET_TYPE/$jbv/$version/release-images || return 1
+
+    common::runstep release::docker::release \
+      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
   else
     if [[ $STAGED_LOCATION == "gcs" ]]; then
       common::runstep copy_staged_from_gcs $label $STAGED_BUCKET \
@@ -1399,17 +1402,6 @@ push_all_artifacts () {
        $BUILD_OUTPUT-$version/gcs-stage/$version \
        gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
-
-    # When we are no-mock mode we need to perform an image promotion, so
-    # instead of pushing to the production container registry, we validate
-    # that the manifest is populated on the remote registry.
-    if ! ((FLAGS_nomock)); then
-      common::runstep release::docker::release \
-      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
-    fi
-
-    common::runstep release::docker::validate_remote_manifests \
-      $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1
 
     common::runstep release::gcs::publish_version \
      $BUCKET_TYPE $version $BUILD_OUTPUT-$version $RELEASE_BUCKET || return 1
@@ -1669,6 +1661,16 @@ else
        logecho "$ATTENTION: Skipping $entry step executed during staging"
        common::check_state -a $entry
      fi
+  done
+fi
+
+# Validate container image manifests for each release version of this session
+if ! ((FLAGS_stage)); then
+  for label in "${ORDERED_RELEASE_KEYS[@]}"; do
+    common::run_stateful release::docker::validate_remote_manifests \
+      "$KUBE_DOCKER_REGISTRY" \
+      "${RELEASE_VERSION[$label]}" \
+      "$BUILD_OUTPUT-${RELEASE_VERSION[$label]}"
   done
 fi
 

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"
@@ -56,7 +56,7 @@ steps:
   - "--tmpdir=/workspace/tmp"
   - "--type=${_TYPE}"
 
-- name: us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:local
+- name: k8s.gcr.io/build-image/kube-cross:local
   dir: "go/src/k8s.io/release"
   env:
   - "TOOL_ORG=${_TOOL_ORG}"

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 STAGING_REGISTRY?=gcr.io/k8s-staging-build-image
-PROD_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+PROD_REGISTRY?=k8s.gcr.io/build-image
 IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG KUBE_CROSS_VERSION
-FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:${KUBE_CROSS_VERSION}
+FROM k8s.gcr.io/build-image/kube-cross:${KUBE_CROSS_VERSION}
 
 ##------------------------------------------------------------
 # global ARGs & ENVs

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1304,7 +1304,11 @@ release::set_globals () {
     BUCKET_TYPE="release"
   fi
 
-  GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_STAGING}"
+  if ((FLAGS_nomock)); then
+    GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_STAGING}"
+  else
+    GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_MOCK}"
+  fi
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -33,9 +33,10 @@ readonly GCRIO_PATH_PROD="k8s.gcr.io"
 readonly GCRIO_PATH_PROD_GEO_ASIA="asia.gcr.io/k8s-artifacts-prod"
 readonly GCRIO_PATH_PROD_GEO_EU="eu.gcr.io/k8s-artifacts-prod"
 readonly GCRIO_PATH_PROD_GEO_US="us.gcr.io/k8s-artifacts-prod"
-readonly GCRIO_PATH_TEST="gcr.io/k8s-staging-kubernetes"
+readonly GCRIO_PATH_STAGING="gcr.io/k8s-staging-kubernetes"
+readonly GCRIO_PATH_MOCK="${GCRIO_PATH_STAGING}/mock"
 
-readonly KUBE_CROSS_REGISTRY="us.gcr.io/k8s-artifacts-prod/build-image"
+readonly KUBE_CROSS_REGISTRY="${GCRIO_PATH_PROD}/build-image"
 readonly KUBE_CROSS_IMAGE="${KUBE_CROSS_REGISTRY}/kube-cross"
 readonly KUBE_CROSS_CONFIG_LOCATION="build/build-image/cross"
 
@@ -1303,7 +1304,7 @@ release::set_globals () {
     BUCKET_TYPE="release"
   fi
 
-  GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_TEST}"
+  GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_STAGING}"
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug regression
/priority critical-urgent

#### What this PR does / why we need it:

Establishes the following:

##### Mock stage

Push instead to a subdirectory of the core image staging repo: `gcr.io/k8s-staging-kubernetes/mock`

##### Mock release

Validate image manifests from the mock push location as one of the prerequisites.

##### Official stage

Build and push to `gcr.io/k8s-staging-kubernetes`.
(This means the images are now built against the real release commit instead of the mock one.)

##### Image promotion

After the official stage is complete:
- Generate a PR to handle the image promotion
- Ensure the images have been promoted to `k8s-artifacts-prod` endpoints **BEFORE** starting the official release

##### Official release

Validate image manifests have been promoted as one of the prerequisites.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/1438

/assign @saschagrunert @tpepper
cc: @kubernetes/release-engineering 
/hold for testing

#### Special notes for your reviewer:

Note that the `release::docker::validate_remote_manifests` step comes before `push_git_objects`, so we avoid instances where a release is pushed to GitHub before the container images have been promoted.
ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1595348328271900 / https://github.com/kubernetes/sig-release/issues/1156

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- anago: Push images during staging and validate manifests during release
-  lib/release: Cleanup container registry variables
  - Use GCRIO_PATH_PROD to construct KUBE_CROSS_REGISTRY
  - Rename GCRIO_PATH_TEST to GCRIO_PATH_STAGING
  - Add GCRIO_PATH_MOCK (gcr.io/k8s-staging-kubernetes/mock) for mocks
- lib/release: Use a mock location for images when running mock stages
```
