### PR TITLE
lib/release: Ensure production images have been promoted in validation step

### DIFF
--- a/anago
+++ b/anago
@@ -1403,6 +1403,17 @@ push_all_artifacts () {
        gs://$RELEASE_BUCKET/$BUCKET_TYPE/$version || return 1
     fi
 
+    # Validate container image manifests for each release version
+    # Ideally image validation would exist outside of this function, but
+    # because it depends on tags derived from the source tree, this is the
+    # easiest place to put this logic for now.
+    #
+    # TODO: Consider splitting this out when we refactor anago in Go
+    common::runstep release::docker::validate_remote_manifests \
+      "$KUBE_DOCKER_REGISTRY" \
+      "$version" \
+      "$BUILD_OUTPUT-$version" || return 1
+
     common::runstep release::gcs::publish_version \
      $BUCKET_TYPE $version $BUILD_OUTPUT-$version $RELEASE_BUCKET || return 1
   fi
@@ -1661,16 +1672,6 @@ else
        logecho "$ATTENTION: Skipping $entry step executed during staging"
        common::check_state -a $entry
      fi
-  done
-fi
-
-# Validate container image manifests for each release version of this session
-if ! ((FLAGS_stage)); then
-  for label in "${ORDERED_RELEASE_KEYS[@]}"; do
-    common::run_stateful release::docker::validate_remote_manifests \
-      "$KUBE_DOCKER_REGISTRY" \
-      "${RELEASE_VERSION[$label]}" \
-      "$BUILD_OUTPUT-${RELEASE_VERSION[$label]}"
   done
 fi
 

--- a/anago
+++ b/anago
@@ -1677,14 +1677,16 @@ fi
 
 if ((FLAGS_stage)); then
   common::run_stateful stage_source_tree
-else
-  common::run_stateful push_git_objects
 fi
 
 # Push for each release version of this session
 for label in "${ORDERED_RELEASE_KEYS[@]}"; do
   common::run_stateful "push_all_artifacts $label" RELEASE_VERSION[$label]
 done
+
+if ! ((FLAGS_stage)); then
+  common::run_stateful push_git_objects
+fi
 
 # if --stage, we're done
 if ((FLAGS_stage)); then

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1314,8 +1314,6 @@ release::set_globals () {
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"
-
-    GCRIO_PATH="${FLAGS_gcrio_path:-$GCRIO_PATH_PROD}"
   elif ((FLAGS_gcb)); then
     RELEASE_BUCKET="$TEST_BUCKET"
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -30,9 +30,6 @@ readonly TEST_BUCKET="kubernetes-release-gcb"
 readonly CI_BUCKET="kubernetes-release-dev"
 
 readonly GCRIO_PATH_PROD="k8s.gcr.io"
-readonly GCRIO_PATH_PROD_GEO_ASIA="asia.gcr.io/k8s-artifacts-prod"
-readonly GCRIO_PATH_PROD_GEO_EU="eu.gcr.io/k8s-artifacts-prod"
-readonly GCRIO_PATH_PROD_GEO_US="us.gcr.io/k8s-artifacts-prod"
 readonly GCRIO_PATH_STAGING="gcr.io/k8s-staging-kubernetes"
 readonly GCRIO_PATH_MOCK="${GCRIO_PATH_STAGING}/mock"
 

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -1121,9 +1121,11 @@ release::docker::validate_remote_manifests () {
 
   common::argc_validate 3
 
-  if [[ "$registry" == "$GCRIO_PATH_PROD" ]]; then
-    # Validate images against one of the geographical endpoints for k8s.gcr.io
-    target_registry="$GCRIO_PATH_PROD_GEO_US"
+  # In an official release, we want to ensure that container images have been
+  # promoted from staging to production, so we do the image manifest validation
+  # against production instead of staging.
+  if [[ "$registry" == "$GCRIO_PATH_STAGING" ]]; then
+    target_registry="$GCRIO_PATH_PROD"
   fi
 
   logecho "Validating image manifests in $target_registry..."


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

- lib/release: Ensure production images have been promoted in validation
  
  In an official release, we want to ensure that container images have
  been promoted from staging to production, so we do the image manifest
  validation against production instead of staging.

- lib/release: Only set GCRIO_PATH once during release::set_globals
- lib/release: Remove unused geo endpoints for k8s.gcr.io
- anago: Move image validation back into push_all_artifacts

  Ideally image validation would exist outside of this function, but
  because it depends on tags derived from the source tree, this is the
  easiest place to put this logic for now.

  Consider splitting this out when we refactor anago in Go.

- anago: Push git objects after GCS/GCR artifacts

  Pushing artifacts to GitHub signifies for a lot of consumers, especially
  those that watch kubernetes/kubernetes releases that a release is
  complete.

  We've had recent instances where there were intermittent issues with
  GCS/GCR artifacts which required us to workaround the GitHub tag checks,
  so this should partially mitigate that.

This was the cleanup I was referring to in https://github.com/kubernetes/release/pull/1455#issuecomment-667981644.

/assign @tpepper @hasheddan 
cc: @kubernetes/release-engineering 
/hold for testing

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

**This needs to merge before another RC is cut.** 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
lib/release: Ensure production images have been promoted in validation
```
