### PR TITLE
Fix wrong Sign-off-by line for git commits

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -752,23 +752,25 @@ func (r *Repo) Add(filename string) error {
 // the Signed-off-by line to the commit message
 func (r *Repo) UserCommit(msg string) error {
 	// Retrieve username and mail
-	userName, err := command.New("git", "config", "--get", "user.name").RunSilentSuccessOutput()
+	userNameOutput, err := command.New("git", "config", "--get", "user.name").RunSilentSuccessOutput()
 	if err != nil {
 		return errors.Wrap(err, "get the user's name")
 	}
+	userName := userNameOutput.OutputTrimNL()
 
-	userEmail, err := command.New("git", "config", "--get", "user.email").RunSilentSuccessOutput()
+	userEmailOutput, err := command.New("git", "config", "--get", "user.email").RunSilentSuccessOutput()
 	if err != nil {
 		return errors.Wrap(err, "get the user's email")
 	}
+	userEmail := userEmailOutput.OutputTrimNL()
 
 	// Add signed-off-by line
 	msg += fmt.Sprintf("\n\nSigned-off-by: %s <%s>", userName, userEmail)
 
 	if err := r.CommitWithOptions(msg, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  userName.OutputTrimNL(),
-			Email: userEmail.OutputTrimNL(),
+			Name:  userName,
+			Email: userEmail,
 			When:  time.Now(),
 		},
 	}); err != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
We should unpack the output before actually using it, which fixes that
the Sign-off-by line was empty in the first place.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed wrong `Sign-off-by` in the `git.UserCommit()` command
```
