### PR TITLE
gh2gcs: when copying the package to cloud storage use the tag to set the path in the destination

### DIFF
--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -76,11 +76,11 @@ func DownloadReleases(releaseCfg *ReleaseConfig, ghClient *github.GitHub, output
 // Assets to upload are derived from the tags specified in `ReleaseConfig`.
 func Upload(releaseCfg *ReleaseConfig, ghClient *github.GitHub, outputDir string) error {
 	uploadBase := filepath.Join(outputDir, releaseCfg.Org, releaseCfg.Repo)
-	gcsPath := filepath.Join(releaseCfg.GCSBucket, releaseCfg.ReleaseDir)
 
 	tags := releaseCfg.Tags
 	for _, tag := range tags {
 		srcDir := filepath.Join(uploadBase, tag)
+		gcsPath := filepath.Join(releaseCfg.GCSBucket, releaseCfg.ReleaseDir, tag)
 		if err := gcs.CopyToGCS(srcDir, gcsPath, releaseCfg.GCSCopyOptions); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
when copying a single tag to cloud storage it was not setting the package in the tag directory. with this fix it set the package in his own directory

Before:
command used: `gh2gcs --org kubernetes --repo kubernetes --bucket carlos-test-gcb --release-dir release --tags v1.18.0`
<img width="479" alt="Screenshot 2020-08-06 at 13 31 32" src="https://user-images.githubusercontent.com/4115580/89527740-1e5dbc00-d7ea-11ea-9b17-8bb056edec9d.png">

After the fix:
command used: `gh2gcs --org kubernetes --repo kubernetes --bucket carlos-test-gcb --release-dir release --tags v1.18.0`
<img width="627" alt="Screenshot 2020-08-06 at 13 29 25" src="https://user-images.githubusercontent.com/4115580/89527764-287fba80-d7ea-11ea-8dad-6423085e1067.png">


with multiple tags:
command used: `gh2gcs --org kubernetes --repo kubernetes --bucket carlos-test-gcb --release-dir release --tags v1.18.0,v1.16.0,v1.19.0-rc.3`

<img width="706" alt="Screenshot 2020-08-06 at 13 30 18" src="https://user-images.githubusercontent.com/4115580/89527825-49e0a680-d7ea-11ea-98fa-9599c65cdc4d.png">



#### Which issue(s) this PR fixes:

 - Fixes partially https://github.com/kubernetes/release/issues/1320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gh2gcs: when copying the package to cloud storage use the tag to set the path in the destination
```

/assign @justaugustus 
