### PR TITLE
k8s-cloud-builder: Build on kube-cross:v1.14.7-1 and v1.13.15-1

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -9,9 +9,9 @@ variants:
     SKOPEO_VERSION: 'v0.2.0'
   cross1.14:
     CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.6-1'
+    KUBE_CROSS_VERSION: 'v1.14.7-1'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.13:
     CONFIG: 'cross1.13'
-    KUBE_CROSS_VERSION: 'v1.13.14-1'
+    KUBE_CROSS_VERSION: 'v1.13.15-1'
     SKOPEO_VERSION: 'v0.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Updates k8s-cloud-builder to pick up the new `kube-cross:v1.14.7-1` and `kube-cross:v1.13.15-1` images
ref: https://github.com/kubernetes/release/pull/1473, https://github.com/kubernetes/release/issues/1474

/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

/hold for image promotion in https://github.com/kubernetes/k8s.io/pull/1119 / https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-cip/1291635300468002816

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build on kube-cross:v1.14.7-1 and v1.13.15-1
```
