### PR TITLE
images: Build debian-base:v2.1.3 and debian-iptables:v11.1.0

### DIFF
--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v2:
     CONFIG: 'v2'
-    IMAGE_VERSION: 'v2.1.2'
+    IMAGE_VERSION: 'v2.1.3'
     OS_CODENAME: 'buster'
   v1:
     CONFIG: 'v1'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -6,6 +6,6 @@ variants:
     OS_CODENAME: 'buster'
   v11:
     CONFIG: 'v11'
-    IMAGE_VERSION: 'v11.0.3'
-    DEBIAN_BASE_VERSION: 'v1.0.0'
+    IMAGE_VERSION: 'v11.1.0'
+    DEBIAN_BASE_VERSION: 'v1.1.0'
     OS_CODENAME: 'stretch'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1476, https://github.com/kubernetes/k8s.io/pull/1121, https://github.com/kubernetes/release/issues/1472.

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering @listx @tallclair 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build debian-base:v2.1.3
- images: Build debian-iptables:v11.1.0
```
