### PR TITLE
Added schedule of recurring work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 - [Kubernetes Release](#kubernetes-release)
   - [Intro](#intro)
   - [Tools](#tools)
+  - [Schedule of Recurring Work](#schedule-of-recurring-work)
   - [Release Notes Gathering](#release-notes-gathering)
   - [Building Linux Packages](#building-linux-packages)
   - [Contributing](#contributing)
@@ -38,6 +39,24 @@ For information on how to use `krel` and `anago`, see the [Branch Manager Handbo
 [kubernetes/kubernetes]: https://git.k8s.io/kubernetes
 [Branch Manager Handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
 [shot-issue]: https://github.com/kubernetes/sig-release/issues/756#issuecomment-520721968
+
+## Schedule of Recurring Work
+These topics recur for release engineering during every release cycle. To keep the team’s workflow more manageable, it’s advisable to account for this work as part of the time/planning budget:
+
+**Quarterly**:
+- new minor releases
+**Monthly**: 
+- patch releases
+  - cut the three most recent minor versions
+  - a week before each patch deadline, have an updated status report on all cherry picks
+**Weekly**:
+- Cherry pick triage and approval
+- Provide status updates at Release Team meetings
+**Ongoing**: 
+- Cut prereleases (alpha, beta, release candidate) for the minor release in development
+**Ad hoc**:
+- Update Golang versions in Kubernetes
+- Update core Kubernetes base images
 
 ## Release Notes Gathering
 


### PR DESCRIPTION
This new section offers details about the recurring work topics that Release Engineering must manage and plan.

/kind documentation
/area/release-eng
/sig/release