### PR TITLE
Version markers fix

### DIFF
--- a/push-build.sh
+++ b/push-build.sh
@@ -173,7 +173,7 @@ GCS_DEST="devel"
 ((FLAGS_ci)) && GCS_DEST="ci"
 GCS_DEST=${FLAGS_release_type:-$GCS_DEST}
 GCS_DEST+="$FLAGS_gcs_suffix"
-GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:${FLAGS_extra_publish_file:-}}"
+GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:-${FLAGS_extra_publish_file:-}}"
 
 logecho
 logecho "Extra version markers string: $GCS_EXTRA_VERSION_MARKERS_STRING"

--- a/push-build.sh
+++ b/push-build.sh
@@ -175,16 +175,13 @@ GCS_DEST=${FLAGS_release_type:-$GCS_DEST}
 GCS_DEST+="$FLAGS_gcs_suffix"
 GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:-${FLAGS_extra_publish_file:-}}"
 
-logecho
-logecho "Extra version markers string: $GCS_EXTRA_VERSION_MARKERS_STRING"
-logecho
 
 PREVIOUS_IFS=$IFS
 IFS=',' read -ra GCS_EXTRA_VERSION_MARKERS <<< "$GCS_EXTRA_VERSION_MARKERS_STRING"
 IFS=$PREVIOUS_IFS
 
 logecho
-logecho "Extra version markers array: ${GCS_EXTRA_VERSION_MARKERS[*]}"
+logecho "Will publish extra version markers: ${GCS_EXTRA_VERSION_MARKERS[*]}"
 logecho
 
 if ((FLAGS_nomock)); then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

Fixes issue where version markers are not being set correctly.

#### Which issue(s) this PR fixes:

None

xref #1471 

#### Special notes for your reviewer:

Example test script:
```bash
#!/usr/bin/env bash

FLAGS_extra_publish_file="k8s-beta"
# FLAGS_extra_version_markers="k8s-alpha"

GCS_EXTRA_VERSION_MARKERS_STRING="${FLAGS_extra_version_markers:-${FLAGS_extra_publish_file:-}}"

echo
echo "Extra version markers string: $GCS_EXTRA_VERSION_MARKERS_STRING"
echo

PREVIOUS_IFS=$IFS
IFS=',' read -ra GCS_EXTRA_VERSION_MARKERS <<< "$GCS_EXTRA_VERSION_MARKERS_STRING"
IFS=$PREVIOUS_IFS

echo
echo "Extra version markers array: ${GCS_EXTRA_VERSION_MARKERS[*]}"
echo
```

Also cleaned up some of the logs that were added.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/cc @justaugustus @kubernetes/release-engineering 