### PR TITLE
base-images: Build debian-hyperkube-base:v1.1.3

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-hyperkube-base"
-    version: 1.1.2
+    version: 1.1.3
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: TAG\?=
@@ -94,7 +94,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: 12.1.1
+    version: 12.1.2
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):v\d+\.\d+\.\d+

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -19,12 +19,12 @@
 
 REGISTRY?=gcr.io/k8s-staging-build-image
 IMAGE?=$(REGISTRY)/debian-hyperkube-base
-TAG?=v1.1.2
+TAG?=v1.1.3
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 BASE_REGISTRY?=k8s.gcr.io/build-image
-BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.1
+BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.2
 CNI_VERSION?=v0.8.6
 
 TEMP_DIR:=$(shell mktemp -d)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1480.

/assign @tpepper @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
base-images: Build debian-hyperkube-base:v1.1.3
```
