### PR TITLE
k8s-cloud-builder: Build on kube-cross:v1.15.0-rc.2-1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.15.0-rc.1-1
+    version: v1.15.0-rc.2-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,8 +1,4 @@
 variants:
-  canary:
-    CONFIG: 'canary'
-    KUBE_CROSS_VERSION: 'v1.15.0-rc.2-canary-1'
-    SKOPEO_VERSION: 'v0.2.0'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.0-rc.2-1'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   canary:
     CONFIG: 'canary'
-    KUBE_CROSS_VERSION: 'v1.15.0-rc.1-canary-1'
+    KUBE_CROSS_VERSION: 'v1.15.0-rc.2-canary-1'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.0-rc.1-1'
+    KUBE_CROSS_VERSION: 'v1.15.0-rc.2-1'
     SKOPEO_VERSION: 'v0.2.0'
   cross1.14:
     CONFIG: 'cross1.14'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Updates k8s-cloud-builder to pick up the new `kube-cross:v1.15.0-rc.2-1` images (ref: https://github.com/kubernetes/release/pull/1482, https://github.com/kubernetes/k8s.io/pull/1129)

- Drop 'canary' variant
  
  'canary' variant image builds are failing because kube-cross canary
  images are not promoted to production (nor do I think they should be).
  
  We can refactor some of this later and reintroduce the k8s-cloud-builder
  canary image, but for now, let's not unintentionally mask other
  failures by having the canary variant here.

  example: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1292272548595109889

Part of go1.15 updates: https://github.com/kubernetes/release/issues/1421

/assign @tpepper @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder: Build on kube-cross:v1.15.0-rc.2-1
```
