### PR TITLE
Use logrus instead of stdOutWriter for verbose commands

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -216,7 +215,6 @@ func (c *Command) RunSilentSuccess() error {
 
 // run is the internal run method
 func (c *Command) run(printOutput bool) (res *Status, err error) {
-	logrus.Debugf("Running command: %v", c.String())
 	var runErr error
 	stdOutBuffer := &bytes.Buffer{}
 	stdErrBuffer := &bytes.Buffer{}
@@ -261,7 +259,7 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 		}
 
 		if c.isVerbose() {
-			fmt.Fprintf(stdOutWriter, "+ %s\n", c.String())
+			logrus.Infof("+ %s", c.String())
 		}
 
 		if err := cmd.Start(); err != nil {

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -64,7 +64,6 @@ func TestFailurePipeWrongArgument(t *testing.T) {
 func TestSuccessVerbose(t *testing.T) {
 	res, err := New("echo", "hi").Verbose().Run()
 	require.Nil(t, err)
-	require.Contains(t, res.stdOut, "echo hi")
 	require.True(t, res.Success())
 	require.Zero(t, res.ExitCode())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We cannot write into the `stdOutWriter` because it will break the
command execution in general. To avoid segfaults as well as other
misbehavior we now use the info logger to print the command. This also
means that we do not have to log the command again in debug mode.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed segmentation fault when running piped verbose commands
```
