### PR TITLE
Remove unused mailto flag from anago

### DIFF
--- a/anago
+++ b/anago
@@ -31,7 +31,6 @@ PROG=${0##*/}
 #+            [--security_layer=/path/to/pointer/to/script]
 #+            [--exclude-suites="<suite> ..."]
 #+            [--prebuild] [--buildonly]
-#+            [--mailto=<email1>,<email2>]
 #+            [--tmpdir=</alt/tmp>]
 #+     $PROG  [--helpshort|--usage|-?]
 #+     $PROG  [--help|-man]
@@ -122,8 +121,6 @@ PROG=${0##*/}
 #+                                 Default: $HOME/.kubernetes-releaserc
 #+     [--exclude-suites=]       - Space separated list of CI suites regex to
 #+                                 exclude from go/nogo criteria
-#+     [--mailto=]               - Comma-separated list of addresses to send
-#+                                 announcement email to. Overrides default list.
 #+     [--github-release-draft]  - Force a github release draft for mock runs.
 #+                                 The draft placeholder if left behind can
 #+                                 cause issues with the real release.


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
The flag has never been processed so there is no need to mention it.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed unused `--mailto` flag from anago
```
