### PR TITLE
HACK/REMOVE: Temporarily comment out the GCS target check

### DIFF
--- a/anago
+++ b/anago
@@ -1548,15 +1548,17 @@ if [[ $RELEASE_BRANCH =~ release- ]] &&
   gitlib::pending_prs $RELEASE_BRANCH
 fi
 
+# TODO(hack): Temporarily comment out the GCS target check to allow an override
+#             of nomock artifacts for 1.18.7 and 1.17.10 releases.
 # No need to pre-check this for mock or staging runs.  Overwriting OK.
-if ((FLAGS_nomock)) && ! ((FLAGS_stage)); then
-  common::stepheader "GCS TARGET CHECK"
-  # Ensure GCS destinations are clear before continuing
-  for v in ${RELEASE_VERSION[@]}; do
-    release::gcs::destination_empty \
-     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$v || common::exit 1 "Exiting..."
-  done
-fi
+#if ((FLAGS_nomock)) && ! ((FLAGS_stage)); then
+#  common::stepheader "GCS TARGET CHECK"
+#  # Ensure GCS destinations are clear before continuing
+#  for v in ${RELEASE_VERSION[@]}; do
+#    release::gcs::destination_empty \
+#     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$v || common::exit 1 "Exiting..."
+#  done
+#fi
 
 common::stepheader "SESSION VALUES"
 # Show versions and ask for confirmation to continue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/priority critical-urgent

#### What this PR does / why we need it:

Allows an override of nomock artifacts for 1.18.7 and 1.17.10 releases.
https://console.cloud.google.com/cloud-build/builds/fb590ccb-f44c-4db5-af20-94dac6a87815?project=kubernetes-release-test
https://console.cloud.google.com/cloud-build/builds/e58f9e1a-8210-4369-b37d-907d662e11d6?project=kubernetes-release-test

Listed above, the 1.18.7 and 1.17.10 are failing because the RC images were not promoted and the manifest check happens after the artifacts are pushed to prod. Subsequent runs will fail on the GCS TARGET CHECK (`release::gcs::destination_empty`) step without this.

Previous failures:
- https://console.cloud.google.com/cloud-build/builds/aa7cc548-8bb1-4dc2-8e16-b9d8bcb2406c?project=kubernetes-release-test
- https://console.cloud.google.com/cloud-build/builds/2790ba40-65cf-43d9-8ffc-a6cdc4b05399?project=kubernetes-release-test

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
