### PR TITLE
Rename release-notes --github-org/repo flags

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -73,8 +73,8 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | ----------------------- | --------------- | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | **GITHUB REPO OPTIONS** |
 |                         | GITHUB_TOKEN    |                     | Yes      | A personal GitHub access token                                                                                                    |
-| github-org              | GITHUB_ORG      | kubernetes          | Yes      | Name of GitHub organization                                                                                                       |
-| github-repo             | GITHUB_REPO     | kubernetes          | Yes      | Name of GitHub repository                                                                                                         |
+| org                     | ORG             | kubernetes          | Yes      | Name of GitHub organization                                                                                                       |
+| repo                    | REPO            | kubernetes          | Yes      | Name of GitHub repository                                                                                                         |
 | required-author         | REQUIRED_AUTHOR | k8s-ci-robot        | Yes      | Only commits from this GitHub user are considered. Set to empty string to include all users                                       |
 | branch                  | BRANCH          | master              | Yes      | The GitHub repository branch to scrape                                                                                            |
 | start-sha               | START_SHA       |                     | Yes      | The commit hash to start processing from (inclusive)                                                                              |

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -62,16 +62,16 @@ func init() {
 	// githubOrg contains name of github organization that holds the repo to scrape.
 	cmd.PersistentFlags().StringVar(
 		&opts.GithubOrg,
-		"github-org",
-		util.EnvDefault("GITHUB_ORG", notes.DefaultOrg),
+		"org",
+		util.EnvDefault("ORG", notes.DefaultOrg),
 		"Name of github organization",
 	)
 
 	// githubRepo contains name of github repository to scrape.
 	cmd.PersistentFlags().StringVar(
 		&opts.GithubRepo,
-		"github-repo",
-		util.EnvDefault("GITHUB_REPO", notes.DefaultRepo),
+		"repo",
+		util.EnvDefault("REPO", notes.DefaultRepo),
 		"Name of github repository",
 	)
 


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
We should drop the `github` prefix from those flags to allow a less
verbose usage.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `release-notes` `--github-[org,repo]` flags to be just `--org` and `--repo`
```
