### PR TITLE
krel/announcement: Add krel command to build the Kubernetes announcement file

### DIFF
--- a/anago
+++ b/anago
@@ -838,59 +838,25 @@ push_git_objects () {
 }
 
 ###############################################################################
-# generate the announcement text to be mailed and published
-branch_announcement_text () {
-  cat <<EOF
-Kubernetes Community,
-<P>
-Kubernetes' $RELEASE_BRANCH branch has been created.
-<P>
-The release owner will be sending updates on how to interact with this branch shortly.  The <A HREF=https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md>Cherrypick Guide</A> has some general guidance on how things will proceed.
-<P>
-Announced by your <A HREF=https://git.k8s.io/sig-release/release-managers.md>Kubernetes Release Managers</A>.
-EOF
-}
-
-###############################################################################
-# generate the announcement text to be mailed and published
-release_announcement_text () {
-  local GOLANG_VERSION=$(go version | cut -d' ' -f 3)
-  cat <<EOF
-Kubernetes Community,
-<P>
-Kubernetes $RELEASE_VERSION_PRIME has been built and pushed using Golang version $GOLANG_VERSION.
-<P>
-The release notes have been updated in <A HREF=https://git.k8s.io/kubernetes/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A>, with a pointer to them on <A HREF=https://github.com/kubernetes/kubernetes/releases/tag/$RELEASE_VERSION_PRIME>github</A>:
-<P>
-<HR>
-$(cat $RELEASE_NOTES_HTML)
-<HR>
-<P><BR>
-Contributors, the <A HREF=https://git.k8s.io/kubernetes/$CHANGELOG_FILEPATH/#${RELEASE_VERSION_PRIME//\./}>$CHANGELOG_FILE</A> has been bootstrapped with $RELEASE_VERSION_PRIME release notes and you may edit now as needed.
-<P><BR><BR>
-Published by your <A HREF=https://git.k8s.io/sig-release/release-managers.md>Kubernetes Release Managers</A>.
-EOF
-}
-
-###############################################################################
 # Construct META for the announcement and send it out
 # @optparam --branch - Default announcement type is 'release' or --branch.
 PROGSTEP[announce]="ANNOUNCE BRANCH OR RELEASE"
 announce () {
   local arg="$1"
-  local announcement_file="${WORKDIR}/announcement.html"
-  local subject_file="${WORKDIR}/announcement-subject.txt"
   local nomock_flag=""
   local pubotRc=0
   local pubotIssue=''
+  local changelog_path="${$CHANGELOG_FILEPATH}/${CHANGELOG_FILE}"
 
   logecho "Creating k8s ${RELEASE_VERSION_PRIME} announcement in ${WORKDIR} ..."
 
   if [[ "$arg" == "--branch" ]]; then
-    echo "Kubernetes ${RELEASE_BRANCH} branch has been created" > "$subject_file"
-    branch_announcement_text > "$announcement_file"
-    logecho "Kubernetes ${RELEASE_BRANCH} branch creation announcement created."
+    logrun -v krel announce build branch \
+    --branch ${RELEASE_BRANCH} \
+    --workdir ${WORKDIR} \
+    || return 1
 
+    logecho "Kubernetes ${RELEASE_BRANCH} branch creation announcement created."
     # When we create a new branch, we notify the publishing-bot folks by
     # creating an issue for them
     pubotIssue="$( gitlib::create_publishing_bot_issue "$RELEASE_BRANCH" | gitlib::get_issue_url )" || pubotRc=$?
@@ -900,8 +866,13 @@ announce () {
       logecho "${OK}: publishing-bot update issue created: ${pubotIssue}"
     fi
   else
-    echo "Kubernetes ${RELEASE_VERSION_PRIME} is live!" > "$subject_file"
-    release_announcement_text > "$announcement_file"
+    logrun -v krel announce build release \
+    --changelog-file-path "$changelog_path" \
+    --tag ${RELEASE_VERSION_PRIME} \
+    --changelog-html-file ${RELEASE_NOTES_HTML} \
+    --workdir ${WORKDIR} \
+    || return 1
+
     logecho "Kubernetes ${RELEASE_VERSION_PRIME} release announcement created."
   fi
 
@@ -933,7 +904,7 @@ announce () {
   # so values > 0 are actually truthy
   ((FLAGS_nomock)) && nomock_flag="--nomock"
 
-  logecho "$ krel announce ${nomock_flag} --tag ${RELEASE_VERSION_PRIME}"
+  logecho "$ krel announce send ${nomock_flag} --tag ${RELEASE_VERSION_PRIME}"
   logecho
 }
 

--- a/cmd/krel/cmd/BUILD.bazel
+++ b/cmd/krel/cmd/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "anago.go",
         "announce.go",
+        "announce_build.go",
+        "announce_send.go",
         "changelog.go",
         "ff.go",
         "gcbmgr.go",

--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/command"
+)
+
+const (
+	branchFlag            = "branch"
+	changeLogFilePathFlag = "changelog-file-path"
+	changeLogHTMLFlag     = "changelog-html-file"
+	workDirFlag           = "workdir"
+)
+
+const semVerRegex string = `^?([0-9]+)(\.[0-9]+)?(\.[0-9]+)`
+
+const branchCreationMsg = `Kubernetes Community,
+<p>Kubernetes' {{ .Branch }} branch has been created.</p>
+<p>The release owner will be sending updates on how to interact with this branch shortly.  The <a href=https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md target="_blank">Cherrypick Guide</a> has some general guidance on how things will proceed.</p>
+<p>Announced by your <a href=https://git.k8s.io/sig-release/release-managers.md target="_blank">Kubernetes Release Managers</a>.</p>
+`
+
+const releaseAnnouncementMsg = `Kubernetes Community,
+<p>Kubernetes <b>{{ .Tag }}</b> has been built and pushed using Golang version <b>{{ .GoVersion }}</b> .</p>
+<p>The release notes have been updated in <a href=https://git.k8s.io/kubernetes/{{ .ChangelogFilePath }}/#{{ .StrippedTag }} target="_blank">{{ .ChangelogFileName }}</a>, with a pointer to them on <a href=https://github.com/kubernetes/kubernetes/releases/tag/{{ .Tag }} target="_blank">github</a>:</p>
+<p><hr>{{ .ChangelogHTML }}<hr></p>
+
+<p><br>Contributors, the <a href=https://git.k8s.io/kubernetes/{{ .ChangelogFilePath }}/#{{ .StrippedTag }} target="_blank">{{ .ChangelogFileName }}</a> has been bootstrapped with {{ .Tag }} release notes and you may edit now as needed.</p>
+<p><br><br>Published by your <a href=https://git.k8s.io/sig-release/release-managers.md href target="_blank">Kubernetes Release Managers</a>.</p>
+`
+
+// buildAnnounceCmd represents the subcommand for `krel announce build`
+var buildAnnounceCmd = &cobra.Command{
+	Use:           "build",
+	Short:         "Build the announcement Kubernetes releases",
+	Long:          "krel announce build",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var buildBranchAnnounceCmd = &cobra.Command{
+	Use:           "branch",
+	Short:         "Build the announcement Kubernetes for branch creation",
+	Long:          "krel announce build branch",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runBuildBranchAnnounce(buildBranchAnnounceOpts, buildAnnounceOpts)
+	},
+}
+
+var buildReleaseAnnounceCmd = &cobra.Command{
+	Use:           "release",
+	Short:         "Build the announcement Kubernetes for new releases",
+	Long:          "krel announce build release",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runBuildReleaseAnnounce(buildReleaseAnnounceOpts, buildAnnounceOpts, announceOpts)
+	},
+}
+
+type buildAnnounceOptions struct {
+	workDir string
+}
+
+type buildBranchAnnounceOptions struct {
+	branch string
+}
+
+type buildReleaseAnnounceOptions struct {
+	changelogFilePath string
+	changelogHTML     string
+}
+
+var buildAnnounceOpts = &buildAnnounceOptions{}
+var buildBranchAnnounceOpts = &buildBranchAnnounceOptions{}
+var buildReleaseAnnounceOpts = &buildReleaseAnnounceOptions{}
+
+func init() {
+	buildBranchAnnounceCmd.PersistentFlags().StringVarP(
+		&buildBranchAnnounceOpts.branch,
+		branchFlag,
+		"b",
+		"",
+		"set this flag when need to build the annoucement for the branch creation, ie. release-1.19",
+	)
+
+	buildReleaseAnnounceCmd.PersistentFlags().StringVarP(
+		&buildReleaseAnnounceOpts.changelogFilePath,
+		changeLogFilePathFlag,
+		"",
+		"",
+		"changelog path including the filename",
+	)
+
+	buildReleaseAnnounceCmd.PersistentFlags().StringVarP(
+		&buildReleaseAnnounceOpts.changelogHTML,
+		changeLogHTMLFlag,
+		"",
+		"",
+		"contents of the changelog",
+	)
+
+	buildAnnounceCmd.PersistentFlags().StringVarP(
+		&buildAnnounceOpts.workDir,
+		workDirFlag,
+		"",
+		"",
+		"working directory to store the annoucement files",
+	)
+
+	if err := buildAnnounceCmd.MarkPersistentFlagRequired(workDirFlag); err != nil {
+		logrus.Fatal(err)
+	}
+
+	// Check flags for krel announcement build branch command
+	if err := buildBranchAnnounceCmd.MarkPersistentFlagRequired(branchFlag); err != nil {
+		logrus.Fatal(err)
+	}
+
+	// Check flags for krel announcement build release command
+	if err := buildReleaseAnnounceCmd.MarkPersistentFlagRequired(changeLogFilePathFlag); err != nil {
+		logrus.Fatal(err)
+	}
+
+	if err := buildReleaseAnnounceCmd.MarkPersistentFlagRequired(changeLogHTMLFlag); err != nil {
+		logrus.Fatal(err)
+	}
+
+	buildAnnounceCmd.AddCommand(buildBranchAnnounceCmd)
+	buildAnnounceCmd.AddCommand(buildReleaseAnnounceCmd)
+	announceCmd.AddCommand(buildAnnounceCmd)
+}
+
+// runBuildBranchAnnounce build the announcement file when creating the Kubernetes release branch
+func runBuildBranchAnnounce(opts *buildBranchAnnounceOptions, buildOpts *buildAnnounceOptions) error {
+	logrus.Info("Building release announcement for branch creation")
+
+	t, err := template.New("announcement-branch").Parse(branchCreationMsg)
+	if err != nil {
+		return err
+	}
+	annoucement := bytes.Buffer{}
+	if err := t.Execute(&annoucement, struct {
+		Branch string
+	}{opts.branch}); err != nil {
+		return errors.Wrap(err, "generating the announcement html file")
+	}
+
+	announcementSubject := fmt.Sprintf("Kubernetes %s branch has been created", opts.branch)
+	return buildOpts.saveAnnouncement(announcementSubject, annoucement)
+}
+
+// runBuildReleaseAnnounce build the announcement file when creating a new Kubernetes release
+func runBuildReleaseAnnounce(opts *buildReleaseAnnounceOptions, buildOpts *buildAnnounceOptions, announceOpts *announceOptions) error {
+	if err := announceOpts.Validate(); err != nil {
+		return errors.Wrap(err, "validating annoucement send options")
+	}
+
+	logrus.Info("Building release announcement for new release")
+
+	t, err := template.New("announcement-release").Parse(releaseAnnouncementMsg)
+	if err != nil {
+		return err
+	}
+
+	goVersion, err := getGoVersion()
+	if err != nil {
+		return err
+	}
+
+	changelogHTML, err := ioutil.ReadFile(opts.changelogHTML)
+	if err != nil {
+		return err
+	}
+
+	annoucement := bytes.Buffer{}
+	if err := t.Execute(&annoucement, struct {
+		Tag               string
+		StrippedTag       string
+		GoVersion         string
+		ChangelogFilePath string
+		ChangelogFileName string
+		ChangelogHTML     string
+	}{
+		announceOpts.tag,
+		strings.ReplaceAll(announceOpts.tag, ".", ""),
+		goVersion,
+		opts.changelogFilePath,
+		filepath.Base(opts.changelogFilePath),
+		string(changelogHTML),
+	}); err != nil {
+		return errors.Wrap(err, "generating the announcement html file")
+	}
+
+	announcementSubject := fmt.Sprintf("Kubernetes %s is live!", announceOpts.tag)
+
+	return buildOpts.saveAnnouncement(announcementSubject, annoucement)
+}
+
+func (opts *buildAnnounceOptions) saveAnnouncement(announcementSubject string, annoucement bytes.Buffer) error {
+	logrus.Info("Creating announcement files")
+
+	absOutputPath := filepath.Join(opts.workDir, "announcement.html")
+	logrus.Infof("Writing HTML file to %s", absOutputPath)
+	err := ioutil.WriteFile(absOutputPath, annoucement.Bytes(), os.FileMode(0644))
+	if err != nil {
+		return errors.Wrap(err, "saving announcement.html")
+	}
+
+	absOutputPath = filepath.Join(opts.workDir, "announcement-subject.txt")
+	logrus.Infof("Writing announcement subject to %s", absOutputPath)
+	err = ioutil.WriteFile(absOutputPath, []byte(announcementSubject), os.FileMode(0644))
+	if err != nil {
+		return errors.Wrap(err, "saving announcement-subject.txt")
+	}
+
+	logrus.Info("Kubernetes Announcement created.")
+	return nil
+}
+
+func getGoVersion() (string, error) {
+	cmdStatus, err := command.New(
+		"go", "version").
+		RunSilentSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "get go version")
+	}
+
+	versionRegex := regexp.MustCompile(semVerRegex)
+	return versionRegex.FindString(strings.TrimSpace(cmdStatus.Output())), nil
+}

--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/http"
+	"k8s.io/release/pkg/mail"
+	"k8s.io/release/pkg/release"
+	"k8s.io/release/pkg/util"
+)
+
+const (
+	sendgridAPIKeyEnvKey = "SENDGRID_API_KEY"
+	nameFlag             = "name"
+	emailFlag            = "email"
+)
+
+// announceCmd represents the subcommand for `krel announce`
+var sendAnnounceCmd = &cobra.Command{
+	Use:   "send",
+	Short: "Announce Kubernetes releases",
+	Long: fmt.Sprintf(`krel announce send
+
+krel announce send can be used to mail an announcement of an already
+built Kubernetes release to the %q and %q Google Groups.
+
+By default the mail will be sent only to a test Google Group %q,
+ie: the announcement run will only be a mock run.  To do an
+official announcement, use the --nomock flag.
+
+It is necessary to export the $%s environment variable. An API key can be created by
+registering a sendgrid.com account and adding the key here:
+
+https://app.sendgrid.com/settings/api_keys
+
+Beside this, if the flags for a valid sender name (--%s,-n) and sender email
+address (--%s,-e) are not set, then it tries to retrieve those values directly
+from the Sendgrid API.
+
+Setting a valid Kubernetes tag (--%s,-t) is always necessary.
+
+If --%s,-p is given, then krel announce will only print the email content
+without doing anything else.`,
+		mail.KubernetesAnnounceGoogleGroup,
+		mail.KubernetesDevGoogleGroup,
+		mail.KubernetesAnnounceTestGoogleGroup,
+		sendgridAPIKeyEnvKey,
+		nameFlag,
+		emailFlag,
+		tagFlag,
+		printOnlyFlag,
+	),
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAnnounce(sendAnnounceOpts, announceOpts, rootOpts)
+	},
+}
+
+type sendAnnounceOptions struct {
+	sendgridAPIKey string
+	name           string
+	email          string
+}
+
+var sendAnnounceOpts = &sendAnnounceOptions{}
+
+func init() {
+	sendAnnounceOpts.sendgridAPIKey = util.EnvDefault(sendgridAPIKeyEnvKey, "")
+
+	sendAnnounceCmd.PersistentFlags().StringVarP(
+		&sendAnnounceOpts.name,
+		nameFlag,
+		"n",
+		"",
+		"mail sender name",
+	)
+
+	sendAnnounceCmd.PersistentFlags().StringVarP(
+		&sendAnnounceOpts.email,
+		emailFlag,
+		"e",
+		"",
+		"email address",
+	)
+
+	announceCmd.AddCommand(sendAnnounceCmd)
+}
+
+func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, rootOpts *rootOptions) error {
+	if err := announceRootOpts.Validate(); err != nil {
+		return errors.Wrap(err, "validating annoucement send options")
+	}
+	logrus.Info("Retrieving release announcement from Google Cloud Bucket")
+
+	tag := util.AddTagPrefix(announceRootOpts.tag)
+	u := fmt.Sprintf(
+		"%s/archive/anago-%s/announcement.html",
+		release.URLPrefixForBucket(release.ProductionBucket), tag,
+	)
+	logrus.Infof("Using announcement remote URL: %s", u)
+
+	content, err := http.GetURLResponse(u, false)
+	if err != nil {
+		return errors.Wrapf(err,
+			"unable to retrieve release announcement form url: %s", u,
+		)
+	}
+
+	if announceRootOpts.printOnly {
+		logrus.Infof("The email content is:")
+		fmt.Print(content)
+		return nil
+	}
+
+	if opts.sendgridAPIKey == "" {
+		return errors.Errorf(
+			"$%s is not set", sendgridAPIKeyEnvKey,
+		)
+	}
+
+	logrus.Info("Preparing mail sender")
+	m := mail.NewSender(opts.sendgridAPIKey)
+
+	if opts.name != "" && opts.email != "" {
+		if err := m.SetSender(opts.name, opts.email); err != nil {
+			return errors.Wrap(err, "unable to set mail sender")
+		}
+	} else {
+		logrus.Info("Retrieving default sender from sendgrid API")
+		if err := m.SetDefaultSender(); err != nil {
+			return errors.Wrap(err, "setting default sender")
+		}
+	}
+
+	groups := []mail.GoogleGroup{mail.KubernetesAnnounceTestGoogleGroup}
+	if rootOpts.nomock {
+		groups = []mail.GoogleGroup{
+			mail.KubernetesAnnounceGoogleGroup,
+			mail.KubernetesDevGoogleGroup,
+		}
+	}
+	logrus.Infof("Using Google Groups as announcement target: %v", groups)
+
+	if err := m.SetGoogleGroupRecipients(groups...); err != nil {
+		return errors.Wrap(err, "unable to set mail recipients")
+	}
+
+	logrus.Info("Sending mail")
+	subject := fmt.Sprintf("Kubernetes %s is live!", tag)
+	if err := m.Send(content, subject); err != nil {
+		return errors.Wrap(err, "unable to send mail")
+	}
+
+	return nil
+}
+
+func (o *announceOptions) Validate() error {
+	if o.tag == "" {
+		return errors.New("need to specify a tag value")
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adding the build announcement command to krel to build the Kubernetes announcement.

- refactor the `krel announcement` command to have two subcommands, one to send the announcement and others to build the announcement.

To send the announcement continues the same as before just have a specific subcommand now:

```shell
krel announce send --tag MY_K8S_RELEASE_TAG [--nomock]
```

Now the new command is to build the K8s announcement

To build the announcement for a branch creation

```shell
krel announce build branch --branch release-9.99 --workdir PATH_WHERE_TO_SAVE_THE_ANNOUNCEMENT
```

To build the announcement for a release cut

```shell
krel announce build release  --changelog-file-path CHANGELOG/CHANGELOG-1.19.md  --tag v1.19.0-rc.4 --changelog-html-file CHANGELOG_FILE --workdir PATH_WHERE_TO_SAVE_THE_ANNOUNCEMENT
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/1452



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel/announcement: Add krel command to build the Kubernetes announcement file
```

/hold for the initial review
# Need to update anago but I would like to get feedback first