### PR TITLE
Fix dependency report generation for new minor releases

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -250,10 +250,10 @@ func (c *Changelog) run(opts *changelogOptions, rootOpts *rootOptions) error {
 			})
 
 			startRev = startTag
-			endRev = opts.tag
+			endRev = head
 
 			if err := document.CreateDownloadsTable(
-				downloadsTable, opts.bucket, opts.tars, startRev, endRev,
+				downloadsTable, opts.bucket, opts.tars, startRev, opts.tag,
 			); err != nil {
 				return errors.Wrapf(err, "create downloads table")
 			}
@@ -489,7 +489,7 @@ func lookupRemoteReleaseNotes(branch string) (string, error) {
 			"fetching release notes from remote: %s", remote,
 		)
 	}
-	logrus.Info("Found release notes")
+	logrus.Infof("Found remote release notes on: %s", remote)
 	return response, nil
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
This fixes the generation of the dependency report for new, non-patch
minor releases where the release notes are just being retrieved from the
remote location. The mentioned `endRev` has to be the latest git commit
of the release branch, because the tag does not even exist on
generation.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed golang dependency generation for new minor releases.
```
/priority critical-urgent
