### PR TITLE
Skip release-notes dependency report if start and end SHA are equal

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -321,14 +321,18 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 
 		const nl = "\n"
 		if releaseNotesOpts.dependencies {
-			url := git.GetRepoURL(opts.GithubOrg, opts.GithubRepo, false)
-			deps, err := notes.NewDependencies().ChangesForURL(
-				url, opts.StartSHA, opts.EndSHA,
-			)
-			if err != nil {
-				return errors.Wrap(err, "generating dependency report")
+			if opts.StartSHA == opts.EndSHA {
+				logrus.Info("Skipping dependency report because start and end SHA are the same")
+			} else {
+				url := git.GetRepoURL(opts.GithubOrg, opts.GithubRepo, false)
+				deps, err := notes.NewDependencies().ChangesForURL(
+					url, opts.StartSHA, opts.EndSHA,
+				)
+				if err != nil {
+					return errors.Wrap(err, "generating dependency report")
+				}
+				markdown += strings.Repeat(nl, 2) + deps
 			}
-			markdown += strings.Repeat(nl, 2) + deps
 		}
 
 		if releaseNotesOpts.tableOfContents {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This makes working with the tool easier if it's just about generating
the release notes for a single commit. Unusual use-case, but we
sometimes need it.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added automatic skip for dependency report if `release-notes` start and end SHA are the same.
```
