### PR TITLE
Fix note exclusion regex to be more strict

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -567,7 +567,7 @@ var noteExclusionFilters = []*regexp.Regexp{
 	// 'none','n/a','na' case insensitive with optional trailing
 	// whitespace, wrapped in ``` with/without release-note identifier
 	// the 'none','n/a','na' can also optionally be wrapped in quotes ' or "
-	regexp.MustCompile("(?i)```(release-note[s]?\\s*)?('|\")?(none|n/a|na)?('|\")?\\s*```"),
+	regexp.MustCompile("(?i)```release-note[s]?\\s*('|\")?(none|n/a|na)?('|\")?\\s*```"),
 
 	// simple '/release-note-none' tag
 	regexp.MustCompile("/release-note-none"),

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -292,3 +292,55 @@ func TestNoteTextFromString(t *testing.T) {
 		tc.expect(noteTextFromString(tc.input))
 	}
 }
+
+func TestMatchesExcludeFilter(t *testing.T) {
+	for _, tc := range []struct {
+		input         string
+		shouldExclude bool
+	}{
+		{
+			input:         "some test input",
+			shouldExclude: false,
+		},
+		{
+			input:         "```release-note\nnone\n```",
+			shouldExclude: true,
+		},
+		{
+			input:         "```release-note\nn/a\n```",
+			shouldExclude: true,
+		},
+		{
+			input:         "```release-note\nNA\n```",
+			shouldExclude: true,
+		},
+		{
+			input:         "```release-note\nthis none should\n```",
+			shouldExclude: false,
+		},
+		{
+			input: `@kubernetes/sig-auth-pr-reviews 
+/milestone v1.19
+/priority important-longterm
+/kind cleanup
+/kind deprecation
+
+xref: #81126
+xref: #81152
+xref: https://github.com/kubernetes/website/pull/19630
+
+` + "```" + `release-note
+Action Required: Support for basic authentication via the --basic-auth-file flag has been removed.  Users should migrate to --token-auth-file for similar functionality.
+` + "```" + `
+
+` + "```" + `docs
+Removed "Static Password File" section from https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-password-file
+https://github.com/kubernetes/website/pull/19630
+` + "```",
+			shouldExclude: false,
+		},
+	} {
+		res := MatchesExcludeFilter(tc.input)
+		require.Equal(t, tc.shouldExclude, res)
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The exclusion regex makes the `release-note[s]` optional, which can
cause notes to be excluded early on, without checking for any additional
content.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/1506
#### Special notes for your reviewer:
Demo:
```
> export SHA=f899ad704ae6bd87560a3e21b9cfbb8bdeef404e && \
  go run ./cmd/release-notes --dependencies=false  --start-sha=$SHA --end-sha=$SHA --output=out.md && \
   cat out.md
INFO Using output format: markdown
INFO Gathering release notes
INFO Starting to process commit 1 of 1 (100.00%): f899ad704ae6bd87560a3e21b9cfbb8bdeef404e
INFO Got PR #89069 for commit: f899ad704ae6bd87560a3e21b9cfbb8bdeef404e
INFO PR #89069 seems to contain a release note
INFO Got 1 release notes, performing rendering
INFO Release notes written to file: out.md
# Release notes for

[Documentation](https://docs.k8s.io/docs/home)
# Changelog since

## Changes by Kind

### Deprecation

- Support for basic authentication via the --basic-auth-file flag has been removed.  Users should migrate to --token-auth-file for similar functionality. ([#89069](https://github.com/kubernetes/kubernetes/pull/89069), [@enj](https://github.com/enj)) [SIG API Machinery, Auth, Cluster Lifecycle, Scalability, Scheduling and Testing]
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed notes exclude regular expression which caused to skip release-notes too early.
```
