### PR TITLE
images: Build debian-base:buster-v1.1.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base"
-    version: buster-v1.1.3
+    version: buster-v1.1.4
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.1.3
+IMAGE_VERSION ?= buster-v1.1.4
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.1.3'
+    IMAGE_VERSION: 'buster-v1.1.4'
   stretch:
     CONFIG: 'stretch'
     IMAGE_VERSION: 'stretch-v1.1.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:

Build debian-base:buster-v1.1.4

/assign @tpepper @hasheddan @saschagrunert @cpanato 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Starting a series of Kubernetes v1.20 updates, to also include CNI plugins @ v0.8.7 --> https://github.com/kubernetes/kubernetes/pull/94367

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
images: Build debian-base:buster-v1.1.4
```
