### PR TITLE
Bootstrap docker buildx usage for multiarch containers

### DIFF
--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# Expected builder output
+#
+# Name:   k-release-multiarch
+# Driver: docker-container
+#
+# Nodes:
+# Name:      k-release-multiarch0
+# Endpoint:  unix:///var/run/docker.sock
+# Status:    running
+# Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+current_builder="$(docker buildx inspect)"
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the "docker" driver, which doesn't work
+if ! grep -q "^Driver: docker$"  <<<"${current_builder}" \
+  && grep -q "linux/amd64" <<<"${current_builder}" \
+  && grep -q "linux/arm" <<<"${current_builder}" \
+  && grep -q "linux/arm64" <<<"${current_builder}" \
+  && grep -q "linux/ppc64le" <<<"${current_builder}" \
+  && grep -q "linux/s390x" <<<"${current_builder}"; then
+  exit 0
+fi
+
+# Ensure qemu is in binfmt_misc
+# NOTE: Please always pin this to a digest for predictability/auditability
+# Last updated: 08/21/2020
+if [ "$(uname)" == 'Linux' ]; then
+  docker run --rm --privileged multiarch/qemu-user-static@sha256:c772ee1965aa0be9915ee1b018a0dd92ea361b4fa1bcab5bbc033517749b2af4 --reset -p yes
+fi
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx rm k-release-multiarch || true
+docker buildx create --use --name=k-release-multiarch
+docker buildx inspect --bootstrap

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -77,17 +77,7 @@ manifest: push
 	@for arch in $(PLATFORMS); do docker manifest annotate --arch "$${arch##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
 	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
 
+# enable buildx
 .PHONY: init-docker-buildx
 init-docker-buildx:
-ifneq ($(shell docker buildx 2>&1 >/dev/null; echo $?),)
-	$(error "buildx not vailable. Docker 19.03 or higher is required")
-endif
-	# Ensure qemu is in binfmt_misc
-	# NOTE: Please always pin this to a digest for predictability/auditability
-	# Last updated: 08/21/2020
-	docker run --rm --privileged multiarch/qemu-user-static@sha256:c772ee1965aa0be9915ee1b018a0dd92ea361b4fa1bcab5bbc033517749b2af4 --reset -p yes
-
-	# Ensure we use a builder that can leverage it (the default on linux will not)
-	docker buildx rm multiarch-go-runner || true
-	docker buildx create --name multiarch-go-runner --use
-	docker buildx inspect --bootstrap
+	./../../../hack/init-buildx.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind feature cleanup

#### What this PR does / why we need it:

- hack: Add init-buildx.sh to bootstrap multiarch image building

  init-buildx.sh is borrowed from https://github.com/kubernetes-sigs/kind/blob/8d02d178ca95f58e169f0f5789b318831eab014f/hack/build/init-buildx.sh.

  It does the following:
  - exports the `DOCKER_CLI_EXPERIMENTAL=enabled` env var (which enables the
    usage of docker buildx)
  - checks for and exits if the current builder has multiarch support
  - ensures qemu is in binfmt_misc using the multiarch/qemu-user-static
    image (currently at the following digest:
    `c772ee1965aa0be9915ee1b018a0dd92ea361b4fa1bcab5bbc033517749b2af4`)
  - creates a docker builder instance
- images/go-runner: Use hack/init-buildx.sh

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Bootstrap docker buildx usage for multiarch containers
```
