### PR TITLE
images: Build go1.15.1 images (kube-cross, go-runner)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -45,14 +45,14 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15.0
+    version: 1.15
     refPaths:
     - path: images/build/cross/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?\d+
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/Makefile
-      match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?\d+
+      match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?\d+
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "k8s.gcr.io/kube-cross"
     version: v1.15.0-1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -45,8 +45,10 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15
+    version: 1.15.1
     refPaths:
+    - path: images/build/cross/Makefile
+      match: GO_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/cross/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/Makefile
@@ -55,10 +57,18 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "k8s.gcr.io/kube-cross"
-    version: v1.15.0-1
+    version: v1.15.1-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
+
+  - name: "k8s.gcr.io/kube-cross: config variant"
+    version: go1.15
+    refPaths:
+    - path: images/build/cross/Makefile
+      match: CONFIG\?=go\d+.\d+
+    - path: images/build/cross/variants.yaml
+      match: go\d+.\d+
 
   - name: "k8s.gcr.io/kube-cross: dependents"
     version: v1.15.0-1
@@ -104,7 +114,7 @@ dependencies:
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):v\d+\.\d+\.\d+
 
   - name: "k8s.gcr.io/go-runner"
-    version: buster-v2.0.0
+    version: buster-v2.0.1
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -36,7 +36,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.4.9
+    version: 3.4.13
     refPaths:
     - path: images/build/cross/Makefile
       match: ETCD_VERSION\?=v\d+\.\d+.\d+

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -19,11 +19,11 @@ PROD_REGISTRY?=k8s.gcr.io/build-image
 IMAGE=kube-cross
 
 TAG?=$(shell git describe --tags --always --dirty)
-CONFIG?=go1.14
-KUBE_CROSS_VERSION?=v1.14.6-1
+CONFIG?=go1.15
+KUBE_CROSS_VERSION?=v1.15.1-1
 
 # Build args
-GO_VERSION?=1.14.6
+GO_VERSION?=1.15.1
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -25,7 +25,7 @@ KUBE_CROSS_VERSION?=v1.14.6-1
 # Build args
 GO_VERSION?=1.14.6
 PROTOBUF_VERSION?=3.0.2
-ETCD_VERSION?=v3.4.9
+ETCD_VERSION?=v3.4.13
 
 # TODO: Support multi-arch kube-cross images
 #       ref:

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.0'
-    KUBE_CROSS_VERSION: 'v1.15.0-canary-1'
+    GO_VERSION: '1.15.1'
+    KUBE_CROSS_VERSION: 'v1.15.1-canary-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.0'
-    KUBE_CROSS_VERSION: 'v1.15.0-1'
+    GO_VERSION: '1.15.1'
+    KUBE_CROSS_VERSION: 'v1.15.1-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -11,9 +11,3 @@ variants:
     KUBE_CROSS_VERSION: 'v1.15.0-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
-  go1.14:
-    CONFIG: 'go1.14'
-    GO_VERSION: '1.14.7'
-    KUBE_CROSS_VERSION: 'v1.14.7-1'
-    PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.9'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -17,9 +17,3 @@ variants:
     KUBE_CROSS_VERSION: 'v1.14.7-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.9'
-  go1.13:
-    CONFIG: 'go1.13'
-    GO_VERSION: '1.13.15'
-    KUBE_CROSS_VERSION: 'v1.13.15-1'
-    PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.9'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -4,10 +4,10 @@ variants:
     GO_VERSION: '1.15.0'
     KUBE_CROSS_VERSION: 'v1.15.0-canary-1'
     PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.9'
+    ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
     GO_VERSION: '1.15.0'
     KUBE_CROSS_VERSION: 'v1.15.0-1'
     PROTOBUF_VERSION: '3.0.2'
-    ETCD_VERSION: 'v3.4.9'
+    ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -20,11 +20,11 @@ IMGNAME = go-runner
 IMAGE = $(REGISTRY)/$(IMGNAME)
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v2.0.0
+IMAGE_VERSION ?= buster-v2.0.1
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.15
+GO_VERSION ?= 1.15.1
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.0.0'
-    GO_VERSION: '1.15'
+    IMAGE_VERSION: 'buster-v2.0.1'
+    GO_VERSION: '1.15.1'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -7,7 +7,3 @@ variants:
     CONFIG: 'cross1.14'
     KUBE_CROSS_VERSION: 'v1.14.7-1'
     SKOPEO_VERSION: 'v0.2.0'
-  cross1.13:
-    CONFIG: 'cross1.13'
-    KUBE_CROSS_VERSION: 'v1.13.15-1'
-    SKOPEO_VERSION: 'v0.2.0'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -3,7 +3,3 @@ variants:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.0-1'
     SKOPEO_VERSION: 'v0.2.0'
-  cross1.14:
-    CONFIG: 'cross1.14'
-    KUBE_CROSS_VERSION: 'v1.14.7-1'
-    SKOPEO_VERSION: 'v0.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

go1.15.1 is now available: https://groups.google.com/d/topic/golang-announce/8wqlSbkLdPs/discussion

- images: Build go1.15.1 images (kube-cross, go-runner)
  - kube-cross:v1.15.1-1
    - etcd updated to v3.4.13
  - go-runner:buster-v2.0.1
- kube-cross: Remove variant building for go1.13 (which is out of support)
- kube-cross: Remove variant building for go1.14 (which is unused in k/k)

/assign @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build go1.15.1 images (kube-cross, go-runner)
  - kube-cross:v1.15.1-1
    - etcd updated to v3.4.13
  - go-runner:buster-v2.0.1
- kube-cross: Remove variant building for go1.13 (which is out of support)
- kube-cross: Remove variant building for go1.14 (which is unused in k/k)
```
