### PR TITLE
Update CNI plugins to v0.8.7

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,8 +10,8 @@ dependencies:
   #    match: https://github.com/kubernetes/repo-infra/archive/v\d+.\d+.\d+.tar.gz
 
   # CNI plugins
-  - name: "cni"
-    version: 0.8.6
+  - name: "CNI plugins"
+    version: 0.8.7
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: CNI_VERSION\?=
@@ -19,10 +19,18 @@ dependencies:
       match: currentCNIVersion\s+= "\d+\.\d+.\d+"
     - path: packages/rpm/kubelet.spec
       match: \%global CNI_VERSION \d+\.\d+.\d+
+    - path: pkg/kubepkg/kubepkg.go
+      match: CurrentCNIVersion\s+= "\d+\.\d+.\d+"
+
+  - name: "CNI plugins: minimum version"
+    version: 0.8.6
+    refPaths:
+    - path: packages/deb/build.go
+      match: minimumCNIVersion\s+= "\d+\.\d+.\d+"
     - path: packages/rpm/kubelet.spec
       match: kubernetes-cni >= \d+\.\d+.\d+
     - path: pkg/kubepkg/kubepkg.go
-      match: CurrentCNIVersion\s+= "\d+\.\d+.\d+"
+      match: MinimumCNIVersion\s+= "\d+\.\d+.\d+"
 
   # CRI Tools
   # TODO(deps): Not active yet

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -94,7 +94,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/debian-hyperkube-base"
-    version: buster-v1.1.3
+    version: buster-v1.1.4
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: TAG\?=[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/k8s-staging-build-image
 IMAGE?=$(REGISTRY)/debian-hyperkube-base
 # TODO(debian-base): Need to update to new version format ('codename-v0.0.0')
 #                    on next image bump
-TAG?=buster-v1.1.3
+TAG?=buster-v1.1.4
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
@@ -29,7 +29,7 @@ BASE_REGISTRY?=k8s.gcr.io/build-image
 # TODO(debian-base): Need to update to new version format ('codename-v0.0.0')
 #                    on next image bump
 BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.2
-CNI_VERSION?=v0.8.6
+CNI_VERSION?=v0.8.7
 
 TEMP_DIR:=$(shell mktemp -d)
 CNI_TARBALL=cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -41,7 +41,7 @@ const (
 	ChannelUnstable ChannelType = "unstable"
 	ChannelNightly  ChannelType = "nightly"
 
-	currentCNIVersion  = "0.8.6"
+	currentCNIVersion  = "0.8.7"
 	minimumCNIVersion  = "0.8.6"
 	criToolsVersion    = "1.13.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
@@ -371,7 +371,7 @@ func getCNIVersion(v version) (string, error) {
 		return "", err
 	}
 
-	if int(sv.Minor) == 16 {
+	if int(sv.Minor) <= 16 {
 		return minimumCNIVersion, nil
 	}
 

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -11,7 +11,7 @@
 %define semver() (%1 * 256 * 256 + %2 * 256 + %3)
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
-%global CNI_VERSION 0.8.6
+%global CNI_VERSION 0.8.7
 %global CRI_TOOLS_VERSION 1.13.0
 
 Name: kubelet
@@ -157,6 +157,9 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Wed Sep 2 2020 Stephen Augustus <saugustus@vmware.com> - 1.19.1
+- Update CNI plugins to v0.8.7
+
 * Mon Jun 22 2020 Stephen Augustus <saugustus@vmware.com> - 1.18.4
 - Unbundle CNI plugins (v0.8.6) from kubelet package and release as kubernetes-cni
 

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -45,7 +45,7 @@ const (
 	ChannelNightly ChannelType = "nightly"
 
 	minimumKubernetesVersion = "1.13.0"
-	CurrentCNIVersion        = "0.8.6"
+	CurrentCNIVersion        = "0.8.7"
 	MinimumCNIVersion        = "0.8.6"
 
 	kubeadmConf = "10-kubeadm.conf"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- packages: Update to CNI plugins v0.8.7
- images: Build debian-hyperkube-base:buster-v1.1.4
  - Update CNI plugins to v0.8.7

/assign @saschagrunert @cpanato @hasheddan 
cc: @kubernetes/release-engineering 

Continuation of https://github.com/kubernetes/kubernetes/pull/94367.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- packages: Update to CNI plugins v0.8.7
- images: Build debian-hyperkube-base:buster-v1.1.4
  - Update CNI plugins to v0.8.7
```
