### PR TITLE
images: Build k8s-cloud-builder:v1.15.1-1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/kube-cross: dependents"
-    version: v1.15.0-1
+    version: v1.15.1-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.0-1'
+    KUBE_CROSS_VERSION: 'v1.15.1-1'
     SKOPEO_VERSION: 'v1.1.1'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -2,4 +2,4 @@ variants:
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.0-1'
-    SKOPEO_VERSION: 'v0.2.0'
+    SKOPEO_VERSION: 'v1.1.1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- images: Build k8s-cloud-builder:v1.15.1-1
  - Update to go1.15.1
  - Update skopeo to v1.1.1

Continuation of https://github.com/kubernetes/release/pull/1514.

/assign @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build k8s-cloud-builder:v1.15.1-1
  - Update to go1.15.1
  - Update skopeo to v1.1.1
```
