### PR TITLE
schedule-builder: fix bug when path release is next and are in the previous patch list

### DIFF
--- a/cmd/schedule-builder/README.md
+++ b/cmd/schedule-builder/README.md
@@ -26,7 +26,7 @@ To run this tool you can just do, assuming you have cloned both `SIG-Release` an
 ```
 
 ```bash
-$ schedule-builder --schedule-path ../sig-release/releases/schedule.yaml
+$ schedule-builder --config-path ../sig-release/releases/schedule.yaml
 ```
 
 The output will be something similiar to this
@@ -87,5 +87,5 @@ End of Life for **1.16** is **TBD**
 Also can save the schedule in a file, to do that, you can set the `--output-file` flag together with the filename.
 
 ```
-$ schedule-builder --schedule-path ../sig-release/releases/schedule.yaml --output-file my-schedule.md
+$ schedule-builder --config-path ../sig-release/releases/schedule.yaml --output-file my-schedule.md
 ```

--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -36,7 +36,11 @@ func parseSchedule(patchSchedule PatchSchedule) string {
 		table := tablewriter.NewWriter(tableString)
 		table.SetAutoWrapText(false)
 		table.SetHeader([]string{"Patch Release", "Cherry Pick Deadline", "Target Date"})
-		table.Append([]string{strings.TrimSpace(releaseSchedule.Next), strings.TrimSpace(releaseSchedule.CherryPickDeadline), strings.TrimSpace(releaseSchedule.TargetDate)})
+
+		// Check if the next patch release is in the Previous Patch list, if yes dont read in the output
+		if !patchReleaseInPreviousList(releaseSchedule.Next, releaseSchedule.PreviousPatches) {
+			table.Append([]string{strings.TrimSpace(releaseSchedule.Next), strings.TrimSpace(releaseSchedule.CherryPickDeadline), strings.TrimSpace(releaseSchedule.TargetDate)})
+		}
 
 		for _, previous := range releaseSchedule.PreviousPatches {
 			table.Append([]string{strings.TrimSpace(previous.Release), strings.TrimSpace(previous.CherryPickDeadline), strings.TrimSpace(previous.TargetDate)})
@@ -54,4 +58,13 @@ func parseSchedule(patchSchedule PatchSchedule) string {
 	println(scheduleOut)
 
 	return scheduleOut
+}
+
+func patchReleaseInPreviousList(a string, previousPatches []PreviousPatches) bool {
+	for _, b := range previousPatches {
+		if b.Release == a {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,30 +39,72 @@ End of Life for **X.Y** is **NOW**
 `
 
 func TestParseSchedule(t *testing.T) {
-	patchSchedule := PatchSchedule{
-		Schedules: []Schedule{
-			{
-				Release:            "X.Y",
-				Next:               "X.Y.ZZZ",
-				CherryPickDeadline: "2020-06-12",
-				TargetDate:         "2020-06-17",
-				EndOfLifeDate:      "NOW",
-				PreviousPatches: []PreviousPatches{
+	testcases := []struct {
+		name     string
+		schedule PatchSchedule
+	}{
+		{
+			name: "next patch is not in previous patch list",
+			schedule: PatchSchedule{
+				Schedules: []Schedule{
 					{
-						Release:            "X.Y.XXX",
-						CherryPickDeadline: "2020-05-15",
-						TargetDate:         "2020-05-20",
+						Release:            "X.Y",
+						Next:               "X.Y.ZZZ",
+						CherryPickDeadline: "2020-06-12",
+						TargetDate:         "2020-06-17",
+						EndOfLifeDate:      "NOW",
+						PreviousPatches: []PreviousPatches{
+							{
+								Release:            "X.Y.XXX",
+								CherryPickDeadline: "2020-05-15",
+								TargetDate:         "2020-05-20",
+							},
+							{
+								Release:            "X.Y.YYY",
+								CherryPickDeadline: "2020-04-13",
+								TargetDate:         "2020-04-16",
+							},
+						},
 					},
+				},
+			},
+		},
+		{
+			name: "next patch is in previous patch list",
+			schedule: PatchSchedule{
+				Schedules: []Schedule{
 					{
-						Release:            "X.Y.YYY",
-						CherryPickDeadline: "2020-04-13",
-						TargetDate:         "2020-04-16",
+						Release:            "X.Y",
+						Next:               "X.Y.ZZZ",
+						CherryPickDeadline: "2020-06-12",
+						TargetDate:         "2020-06-17",
+						EndOfLifeDate:      "NOW",
+						PreviousPatches: []PreviousPatches{
+							{
+								Release:            "X.Y.ZZZ",
+								CherryPickDeadline: "2020-06-12",
+								TargetDate:         "2020-06-17",
+							},
+							{
+								Release:            "X.Y.XXX",
+								CherryPickDeadline: "2020-05-15",
+								TargetDate:         "2020-05-20",
+							},
+							{
+								Release:            "X.Y.YYY",
+								CherryPickDeadline: "2020-04-13",
+								TargetDate:         "2020-04-16",
+							},
+						},
 					},
 				},
 			},
 		},
 	}
 
-	out := parseSchedule(patchSchedule)
-	require.Equal(t, out, expectedPatchSchedule)
+	for _, tc := range testcases {
+		fmt.Printf("Test case: %s\n", tc.name)
+		out := parseSchedule(tc.schedule)
+		require.Equal(t, out, expectedPatchSchedule)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
schedule-builder: fix bug when path release is next and are in the previous patch list

before the fix by having this sample yaml config file
```yaml
schedules:
- release: 1.19
  next: 1.19.1
  cherryPickDeadline: 2020-09-04
  targetDate: 2020-09-09
  endOfLifeDate: 2021-09-30
  previousPatches:
    - release: 1.19.2
      cherryPickDeadline: 2020-09-11
      targetDate: 2020-09-16
    - release: 1.19.1
      cherryPickDeadline: 2020-09-04
      targetDate: 2020-09-09
```

output:
``` 
### Timeline

### 1.19

Next patch release is **1.19.1**

End of Life for **1.19** is **2021-09-30**

| PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
|---------------|----------------------|-------------|
| 1.19.1        | 2020-09-04           | 2020-09-09  |
| 1.19.2        | 2020-09-11           | 2020-09-16  |
| 1.19.1        | 2020-09-04           | 2020-09-09  |
```

after the fix:
```
### Timeline

### 1.19

Next patch release is **1.19.1**

End of Life for **1.19** is **2021-09-30**

| PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
|---------------|----------------------|-------------|
| 1.19.2        | 2020-09-11           | 2020-09-16  |
| 1.19.1        | 2020-09-04           | 2020-09-09  |
```


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/release/issues/1518



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
schedule-builder: fix bug when path release is next and are in the previous patch list
```


/cc @justaugustus @tpepper 