### PR TITLE
Remove `release-version` flag and option

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -676,7 +676,6 @@ func releaseNotesJSON(tag string) (string, error) {
 	notesOptions.StartRev = startTag
 	notesOptions.EndRev = tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
-	notesOptions.ReleaseVersion = util.TrimTagPrefix(tag)
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
@@ -716,7 +715,6 @@ func releaseNotesFrom(startTag string) (*releaseNotesResult, error) {
 	notesOptions.StartRev = startTag
 	notesOptions.EndRev = releaseNotesOpts.tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
-	notesOptions.ReleaseVersion = util.TrimTagPrefix(releaseNotesOpts.tag)
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -89,7 +89,6 @@ level=debug timestamp=2019-07-30T04:02:44.3716249Z caller=notes.go:497 msg="Excl
 | output                  | OUTPUT          |                     | No       | The path where the release notes will be written                                                                                  |
 | format                  | FORMAT          | markdown            | No       | The format for notes output (options: json, markdown)                                                                             |
 | go-template             | GO_TEMPLATE     | go-template:default | No       | The go template if `--format=markdown` (options: go-template:default, go-template:inline:<template-string> go-template:<file.template>) |
-| release-version         | RELEASE_VERSION |                     | No       | The release version to tag the notes with                                                                                         |
 | dependencies            |                 | true                | No       | Add dependency report                                                                                                             |
 | **LOG OPTIONS**         |
 | debug                   | DEBUG           | false               | No       | Enable debug logging (options: true, false)                                                                                       |

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -136,14 +136,6 @@ func init() {
 		"Path to a local Kubernetes repository, used only for tag discovery.",
 	)
 
-	// releaseVersion is the version number you want to tag the notes with.
-	cmd.PersistentFlags().StringVar(
-		&opts.ReleaseVersion,
-		"release-version",
-		util.EnvDefault("RELEASE_VERSION", ""),
-		"Which release version to tag the entries as.",
-	)
-
 	// format is the output format to produce the notes in.
 	cmd.PersistentFlags().StringVar(
 		&opts.Format,

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -129,10 +129,6 @@ type ReleaseNote struct {
 	// label was set on the PR
 	ActionRequired bool `json:"action_required,omitempty"`
 
-	// Tags each note with a release version if specified
-	// If not specified, omitted
-	ReleaseVersion string `json:"release_version,omitempty"`
-
 	// DataFields a key indexed map of data fields
 	DataFields map[string]ReleaseNotesDataField `json:"data_fields,omitempty"`
 }
@@ -283,7 +279,7 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 			}
 		}
 
-		note, err := g.ReleaseNoteFromCommit(result, g.options.ReleaseVersion)
+		note, err := g.ReleaseNoteFromCommit(result)
 		if err != nil {
 			logrus.Errorf(
 				"Getting the release note from commit %s (PR #%d): %v",
@@ -411,7 +407,7 @@ func classifyURL(u *url.URL) DocType {
 
 // ReleaseNoteFromCommit produces a full contextualized release note given a
 // GitHub commit API resource.
-func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*ReleaseNote, error) {
+func (g *Gatherer) ReleaseNoteFromCommit(result *Result) (*ReleaseNote, error) {
 	pr := result.pullRequest
 
 	prBody := pr.GetBody()
@@ -469,7 +465,6 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result, relVer string) (*Releas
 		Duplicate:      isDuplicateSIG,
 		DuplicateKind:  isDuplicateKind,
 		ActionRequired: isActionRequired(pr),
-		ReleaseVersion: relVer,
 	}, nil
 }
 
@@ -1011,10 +1006,6 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap) error {
 
 	if noteMap.ReleaseNote.ActionRequired != nil {
 		rn.ActionRequired = *noteMap.ReleaseNote.ActionRequired
-	}
-
-	if noteMap.ReleaseNote.ReleaseVersion != nil {
-		rn.ReleaseVersion = *noteMap.ReleaseNote.ReleaseVersion
 	}
 
 	// If there are datafields, add them

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -106,10 +106,6 @@ type ReleaseNotesMap struct {
 		// ActionRequired indicates whether or not the release-note-action-required
 		// label was set on the PR
 		ActionRequired *bool `json:"action_required,omitempty"`
-
-		// Tags each note with a release version if specified
-		// If not specified, omitted
-		ReleaseVersion *string `json:"release_version,omitempty"`
 	} `json:"releasenote"`
 
 	DataFields map[string]ReleaseNotesDataField `json:"datafields"`

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -74,7 +74,7 @@ func TestReleaseNoteParsing(t *testing.T) {
 		require.NoError(t, err)
 		prs, err := gatherer.prsFromCommit(commit)
 		require.NoError(t, err)
-		_, err = gatherer.ReleaseNoteFromCommit(&Result{commit: commit, pullRequest: prs[0]}, "0.1")
+		_, err = gatherer.ReleaseNoteFromCommit(&Result{commit: commit, pullRequest: prs[0]})
 		require.NoError(t, err)
 	}
 }

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -62,11 +62,6 @@ type Options struct {
 	// valid git revision. Should not be used together with EndSHA.
 	EndRev string
 
-	// ReleaseVersion is the version of the release. This option is just passed
-	// through into the resulting ReleaseNote struct for identifying releases
-	// on JSON output.
-	ReleaseVersion string
-
 	// Format specifies the format of the release notes. Can be either
 	// `json` or `markdown`.
 	Format string


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
This flag has only been used for the website, where we can retrieve this
value directly from the asset path. The option was always confusing for
users because there is no real logic related to it.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Requires https://github.com/kubernetes-sigs/release-notes/pull/190
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed `release-notes` `--release-version` option since it has only being used for the JSON blob in the website
```
