### PR TITLE
Make `krel set-release-version` a subcmd of `krel anago`

### DIFF
--- a/anago
+++ b/anago
@@ -1227,7 +1227,7 @@ get_build_candidate () {
 # Also ensures the RELEASE_VERSION_PRIME tag doesn't already exist.
 PROGSTEP[set_release_values]="SET RELEASE VALUES"
 set_release_values () {
-  eval "$(krel set-release-version \
+  eval "$(krel anago set-release-version \
     --release-type "$FLAGS_type" \
     --build-version "${BRANCH_POINT:-$JENKINS_BUILD_VERSION}" \
     --branch "$RELEASE_BRANCH" \

--- a/cmd/krel/cmd/set_release_version.go
+++ b/cmd/krel/cmd/set_release_version.go
@@ -40,7 +40,7 @@ the command might be removed in future releases again if anago is end of life.
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		res, err := runSetReleaseVersion(setReleaseVersionOpts)
+		res, err := runSetReleaseVersion(setReleaseVersionOpts, anagoOpts)
 		if err != nil {
 			return err
 		}
@@ -50,7 +50,6 @@ the command might be removed in future releases again if anago is end of life.
 }
 
 type setReleaseVersionOptions struct {
-	releaseType  string
 	buildVersion string
 	branch       string
 	parentBranch string
@@ -59,20 +58,6 @@ type setReleaseVersionOptions struct {
 var setReleaseVersionOpts = &setReleaseVersionOptions{}
 
 func init() {
-	setReleaseVersionCmd.PersistentFlags().StringVar(
-		&setReleaseVersionOpts.releaseType,
-		"release-type",
-		"",
-		fmt.Sprintf("release type, must be one of: '%s'",
-			strings.Join([]string{
-				release.ReleaseTypeAlpha,
-				release.ReleaseTypeBeta,
-				release.ReleaseTypeRC,
-				release.ReleaseTypeOfficial,
-			}, "', '"),
-		),
-	)
-
 	setReleaseVersionCmd.PersistentFlags().StringVar(
 		&setReleaseVersionOpts.buildVersion,
 		"build-version",
@@ -95,7 +80,6 @@ func init() {
 	)
 
 	for _, f := range []string{
-		"release-type",
 		"build-version",
 		"branch",
 		"parent-branch",
@@ -105,12 +89,15 @@ func init() {
 		}
 	}
 
-	rootCmd.AddCommand(setReleaseVersionCmd)
+	anagoCmd.AddCommand(setReleaseVersionCmd)
 }
 
-func runSetReleaseVersion(opts *setReleaseVersionOptions) (string, error) {
+func runSetReleaseVersion(opts *setReleaseVersionOptions, anagoOpts *release.Options) (string, error) {
 	releaseVersion, err := release.SetReleaseVersion(
-		opts.releaseType, opts.buildVersion, opts.branch, opts.parentBranch,
+		anagoOpts.ReleaseType,
+		opts.buildVersion,
+		opts.branch,
+		opts.parentBranch,
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "set release version")

--- a/cmd/krel/cmd/set_release_version_test.go
+++ b/cmd/krel/cmd/set_release_version_test.go
@@ -27,13 +27,16 @@ import (
 
 func TestRunSetReleaseVersion(t *testing.T) {
 	for _, tc := range []struct {
+		anagoOpts *release.Options
 		opts      *setReleaseVersionOptions
 		shouldErr bool
 		expected  string
 	}{
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeOfficial,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeOfficial,
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       "release-1.19",
 			},
@@ -48,8 +51,10 @@ export RELEASE_VERSION_PRIME=v1.19.1
 `,
 		},
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeRC,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeRC,
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       "release-1.19",
 			},
@@ -62,16 +67,20 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 `,
 		},
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeAlpha,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeAlpha,
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       git.Master,
 			},
 			shouldErr: true,
 		},
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeAlpha,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeAlpha,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       git.Master,
 			},
@@ -84,8 +93,10 @@ export RELEASE_VERSION_PRIME=v1.20.0-alpha.0
 `,
 		},
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeBeta,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeBeta,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       git.Master,
 			},
@@ -98,8 +109,10 @@ export RELEASE_VERSION_PRIME=v1.20.0-beta.0
 `,
 		},
 		{
+			anagoOpts: &release.Options{
+				ReleaseType: release.ReleaseTypeRC,
+			},
 			opts: &setReleaseVersionOptions{
-				releaseType:  release.ReleaseTypeRC,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       "release-1.20",
 				parentBranch: git.Master,
@@ -115,7 +128,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-rc.0
 `,
 		},
 	} {
-		res, err := runSetReleaseVersion(tc.opts)
+		res, err := runSetReleaseVersion(tc.opts, tc.anagoOpts)
 		if tc.shouldErr {
 			require.NotNil(t, err)
 		} else {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This allows us to collect further enhancements around anago as
subcommands of `krel anago` until the conversion to golang has been
finished.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Follow-up of https://github.com/kubernetes/release/pull/1522
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
