### PR TITLE
Replace most of the `master` terminology with git.DefaultBranch

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -69,7 +69,7 @@ the golang based 'release-notes' tool:
    the current working directly as 'CHANGELOG-x.y.html'. Sending the
    announcement is done by another subcommand of 'krel', not 'changelog'.
 
-3. Commit the modified CHANGELOG-x.y.md into the master branch as well as the
+3. Commit the modified CHANGELOG-x.y.md into the main branch as well as the
    corresponding release-branch of kubernetes/kubernetes. The release branch
    will be pruned from all other CHANGELOG-*.md files which do not belong to
    this release branch.
@@ -324,9 +324,9 @@ func (c *Changelog) run(opts *changelogOptions, rootOpts *rootOptions) error {
 		}
 	}()
 
-	logrus.Infof("Checking out %s branch", git.Master)
-	if err := repo.Checkout(git.Master); err != nil {
-		return errors.Wrap(err, "checking out master branch")
+	logrus.Infof("Checking out %s branch", git.DefaultBranch)
+	if err := repo.Checkout(git.DefaultBranch); err != nil {
+		return errors.Wrap(err, "checking out main branch")
 	}
 
 	logrus.Info("Writing markdown")
@@ -480,8 +480,8 @@ func lookupRemoteReleaseNotes(branch string) (string, error) {
 	logrus.Info("Assuming new minor release")
 
 	remote := fmt.Sprintf(
-		"https://raw.githubusercontent.com/kubernetes/sig-release/master/"+
-			"releases/%s/release-notes-draft.md", branch,
+		"https://raw.githubusercontent.com/kubernetes/sig-release/%s/"+
+			"releases/%s/release-notes-draft.md", git.DefaultBranch, branch,
 	)
 	response, err := http.GetURLResponse(remote, false)
 	if err != nil {
@@ -494,7 +494,7 @@ func lookupRemoteReleaseNotes(branch string) (string, error) {
 }
 
 func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
-	// Master branch modifications
+	// main branch modifications
 	releaseChangelog := markdownChangelogFilename(tag)
 	changelogReadme := markdownChangelogReadme()
 
@@ -510,14 +510,14 @@ func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
 		}
 	}
 
-	logrus.Info("Committing changes to master branch in repository")
+	logrus.Info("Committing changes to main branch in repository")
 	if err := repo.Commit(fmt.Sprintf(
 		"CHANGELOG: Update directory for %s release", util.SemverToTagString(tag),
 	)); err != nil {
 		return errors.Wrap(err, "committing changes into repository")
 	}
 
-	if branch != git.Master {
+	if branch != git.DefaultBranch {
 		logrus.Infof("Checking out %s branch", branch)
 		// Release branch modifications
 		if err := repo.Checkout(branch); err != nil {
@@ -533,9 +533,9 @@ func commitChanges(repo *git.Repo, branch string, tag semver.Version) error {
 			}
 		}
 
-		logrus.Info("Checking out changelog from master branch")
-		if err := repo.Checkout(git.Master, releaseChangelog); err != nil {
-			return errors.Wrap(err, "check out master branch changelog")
+		logrus.Info("Checking out changelog from main branch")
+		if err := repo.Checkout(git.DefaultBranch, releaseChangelog); err != nil {
+			return errors.Wrap(err, "check out main branch changelog")
 		}
 
 		logrus.Info("Committing changes to release branch in repository")

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -34,7 +34,7 @@ func (s *sut) getChangelogOptions(tag string) *changelogOptions {
 		replayDir: filepath.Join(testDataDir, "changelog-"+tag),
 		tag:       tag,
 		tars:      ".",
-		branch:    git.Master,
+		branch:    git.DefaultBranch,
 	}
 }
 
@@ -79,7 +79,7 @@ func TestNewPatchRelease(t *testing.T) { // nolint: dupl
 		commitMessage string
 	}{
 		{releaseBranch, "Update CHANGELOG/CHANGELOG-1.16.md for v1.16.3"},
-		{git.Master, "Update directory for v1.16.3 release"},
+		{git.DefaultBranch, "Update directory for v1.16.3 release"},
 	} {
 		// Switch to the test branch
 		require.Nil(t, s.repo.Checkout(x.branch))
@@ -119,7 +119,7 @@ func TestNewAlphaRelease(t *testing.T) {
 	require.Nil(t, os.RemoveAll("CHANGELOG-1.18.html"))
 
 	// Verify commit message
-	lastCommit := s.lastCommit(t, git.Master)
+	lastCommit := s.lastCommit(t, git.DefaultBranch)
 	require.Contains(t, lastCommit, "Anago GCB <nobody@k8s.io>")
 	require.Contains(t, lastCommit, "Update directory for v1.18.0-alpha.3 release")
 
@@ -165,7 +165,7 @@ func TestNewMinorRelease(t *testing.T) { // nolint: dupl
 		require.Nil(t, s.repo.Add(filename))
 	})
 	require.Nil(t, s.repo.Commit("Adding other changelog files"))
-	require.Nil(t, s.repo.Checkout(git.Master))
+	require.Nil(t, s.repo.Checkout(git.DefaultBranch))
 
 	// When
 	require.Nil(t, newChangelog().run(co, ro))
@@ -185,7 +185,7 @@ func TestNewMinorRelease(t *testing.T) { // nolint: dupl
 		commitMessage string
 	}{
 		{releaseBranch, "Update CHANGELOG/CHANGELOG-1.17.md for v1.17.0"},
-		{git.Master, "Update directory for v1.17.0 release"},
+		{git.DefaultBranch, "Update directory for v1.17.0 release"},
 	} {
 		// Switch to the test branch
 		require.Nil(t, s.repo.Checkout(x.branch))

--- a/cmd/krel/cmd/ff_test.go
+++ b/cmd/krel/cmd/ff_test.go
@@ -26,7 +26,7 @@ import (
 
 func (s *sut) getFfOptions() *ffOptions {
 	return &ffOptions{
-		masterRef:      git.Remotify(git.Master),
+		mainRef:        git.Remotify(git.DefaultBranch),
 		nonInteractive: true,
 	}
 }

--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -96,7 +96,7 @@ func init() {
 	gcbmgrCmd.PersistentFlags().StringVar(
 		&gcbmgrOpts.Branch,
 		"branch",
-		git.Master,
+		git.DefaultBranch,
 		"branch to run the specified GCB run against",
 	)
 
@@ -334,7 +334,7 @@ func SetGCBSubstitutions(o *GcbmgrOptions, toolOrg, toolRepo, toolBranch string)
 
 	kubecrossBranches := []string{
 		o.Branch,
-		git.Master,
+		git.DefaultBranch,
 	}
 
 	kubecrossVersion, kubecrossVersionErr := release.GetKubecrossVersion(kubecrossBranches...)
@@ -388,9 +388,9 @@ func (o *GcbmgrOptions) Validate() error {
 		return errors.New("cannot specify both the 'stage' and 'release' flag; resubmit with only one build type selected")
 	}
 
-	if o.Branch == git.Master {
+	if o.Branch == git.DefaultBranch {
 		if o.ReleaseType == release.ReleaseTypeRC || o.ReleaseType == release.ReleaseTypeOfficial {
-			return errors.New("cannot cut a release candidate or an official release from master")
+			return errors.Errorf("cannot cut a release candidate or an official release from %s", git.DefaultBranch)
 		}
 	} else {
 		if o.ReleaseType == release.ReleaseTypeAlpha || o.ReleaseType == release.ReleaseTypeBeta {

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -68,7 +68,7 @@ func TestRunGcbmgrList(t *testing.T) {
 		{
 			name: "list only",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
-				Branch:   "master",
+				Branch:   git.DefaultBranch,
 				GcpUser:  "test-user",
 				LastJobs: 5,
 				Repo:     mockRepo(),
@@ -84,7 +84,7 @@ func TestRunGcbmgrList(t *testing.T) {
 		{
 			name: "error on list jobs",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
-				Branch:   "master",
+				Branch:   git.DefaultBranch,
 				GcpUser:  "test-user",
 				LastJobs: 10,
 				Repo:     mockRepo(),
@@ -160,10 +160,10 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		expected   map[string]string
 	}{
 		{
-			name: "master alpha - stage",
+			name: "main branch alpha - stage",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
 				Stage:       true,
-				Branch:      "master",
+				Branch:      git.DefaultBranch,
 				ReleaseType: release.ReleaseTypeAlpha,
 				GcpUser:     "test-user",
 				Repo:        mockRepo(),
@@ -171,7 +171,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			},
 			expected: map[string]string{
 				"BUILD_AT_HEAD":          "",
-				"RELEASE_BRANCH":         "master",
+				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_BRANCH":            "",
@@ -184,10 +184,10 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			},
 		},
 		{
-			name: "master beta - release",
+			name: "main branch beta - release",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
 				Release:      true,
-				Branch:       "master",
+				Branch:       git.DefaultBranch,
 				ReleaseType:  release.ReleaseTypeBeta,
 				BuildVersion: "v1.33.7",
 				GcpUser:      "test-user",
@@ -195,7 +195,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:      mockVersion("v1.33.7"),
 			},
 			expected: map[string]string{
-				"RELEASE_BRANCH":         "master",
+				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_BRANCH":            "",
@@ -416,18 +416,18 @@ func TestValidateSuccess(t *testing.T) {
 		gcbmgrOpts *cmd.GcbmgrOptions
 	}{
 		{
-			name: "master alpha - stage",
+			name: "main branch alpha - stage",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
 				Stage:       true,
-				Branch:      "master",
+				Branch:      git.DefaultBranch,
 				ReleaseType: release.ReleaseTypeAlpha,
 			},
 		},
 		{
-			name: "master beta - release",
+			name: "main branch beta - release",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
 				Release:      true,
-				Branch:       "master",
+				Branch:       git.DefaultBranch,
 				ReleaseType:  release.ReleaseTypeBeta,
 				BuildVersion: "v1.33.7",
 			},
@@ -472,16 +472,16 @@ func TestValidateFailure(t *testing.T) {
 		gcbmgrOpts *cmd.GcbmgrOptions
 	}{
 		{
-			name: "RC on master",
+			name: "RC on main branch",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
-				Branch:      git.Master,
+				Branch:      git.DefaultBranch,
 				ReleaseType: release.ReleaseTypeRC,
 			},
 		},
 		{
-			name: "official release on master",
+			name: "official release on main branch",
 			gcbmgrOpts: &cmd.GcbmgrOptions{
-				Branch:      git.Master,
+				Branch:      git.DefaultBranch,
 				ReleaseType: release.ReleaseTypeOfficial,
 			},
 		},

--- a/cmd/krel/cmd/set_release_version_test.go
+++ b/cmd/krel/cmd/set_release_version_test.go
@@ -65,7 +65,7 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 			opts: &setReleaseVersionOptions{
 				releaseType:  release.ReleaseTypeAlpha,
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
-				branch:       git.Master,
+				branch:       git.DefaultBranch,
 			},
 			shouldErr: true,
 		},
@@ -73,7 +73,7 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 			opts: &setReleaseVersionOptions{
 				releaseType:  release.ReleaseTypeAlpha,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
-				branch:       git.Master,
+				branch:       git.DefaultBranch,
 			},
 			shouldErr: false,
 			expected: `declare -Ag RELEASE_VERSION
@@ -87,7 +87,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-alpha.0
 			opts: &setReleaseVersionOptions{
 				releaseType:  release.ReleaseTypeBeta,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
-				branch:       git.Master,
+				branch:       git.DefaultBranch,
 			},
 			shouldErr: false,
 			expected: `declare -Ag RELEASE_VERSION
@@ -102,7 +102,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-beta.0
 				releaseType:  release.ReleaseTypeRC,
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       "release-1.20",
-				parentBranch: git.Master,
+				parentBranch: git.DefaultBranch,
 			},
 			shouldErr: false,
 			expected: `declare -Ag RELEASE_VERSION

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -89,7 +89,7 @@ func newSUT(t *testing.T) *sut {
 	)
 	require.Nil(t,
 		command.NewWithWorkDir(baseDir,
-			"git", "checkout", "master",
+			"git", "checkout", git.DefaultBranch,
 		).RunSuccess(),
 	)
 	require.Nil(t,

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -88,8 +88,8 @@ func init() {
 	cmd.PersistentFlags().StringVar(
 		&opts.Branch,
 		"branch",
-		util.EnvDefault("BRANCH", git.Master),
-		"Select which branch to scrape. Defaults to `master`",
+		util.EnvDefault("BRANCH", git.DefaultBranch),
+		fmt.Sprintf("Select which branch to scrape. Defaults to `%s`", git.DefaultBranch),
 	)
 
 	// startSHA contains the commit SHA where the release note generation

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -275,7 +275,7 @@ func TestSuccessHasRemoteBranch(t *testing.T) {
 	defer testRepo.cleanup(t)
 
 	require.Nil(t, testRepo.sut.HasRemoteBranch(testRepo.branchName))
-	require.Nil(t, testRepo.sut.HasRemoteBranch(git.Master))
+	require.Nil(t, testRepo.sut.HasRemoteBranch(git.DefaultBranch))
 }
 
 func TestFailureHasRemoteBranch(t *testing.T) {
@@ -299,7 +299,7 @@ func TestSuccessMerge(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.Merge(git.Master)
+	err := testRepo.sut.Merge(git.DefaultBranch)
 	require.Nil(t, err)
 }
 
@@ -315,7 +315,7 @@ func TestSuccessMergeBase(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	mergeBase, err := testRepo.sut.MergeBase(git.Master, testRepo.branchName)
+	mergeBase, err := testRepo.sut.MergeBase(git.DefaultBranch, testRepo.branchName)
 	require.Nil(t, err)
 	require.Equal(t, mergeBase, testRepo.firstCommit)
 }
@@ -324,9 +324,9 @@ func TestSuccessRevParse(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	masterRev, err := testRepo.sut.RevParse(git.Master)
+	mainRev, err := testRepo.sut.RevParse(git.DefaultBranch)
 	require.Nil(t, err)
-	require.Equal(t, masterRev, testRepo.firstCommit)
+	require.Equal(t, mainRev, testRepo.firstCommit)
 
 	branchRev, err := testRepo.sut.RevParse(testRepo.branchName)
 	require.Nil(t, err)
@@ -349,9 +349,9 @@ func TestSuccessRevParseShort(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	masterRev, err := testRepo.sut.RevParseShort(git.Master)
+	mainRev, err := testRepo.sut.RevParseShort(git.DefaultBranch)
 	require.Nil(t, err)
-	require.Equal(t, masterRev, testRepo.firstCommit[:10])
+	require.Equal(t, mainRev, testRepo.firstCommit[:10])
 
 	branchRev, err := testRepo.sut.RevParseShort(testRepo.branchName)
 	require.Nil(t, err)
@@ -374,7 +374,7 @@ func TestSuccessPush(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.Push(git.Master)
+	err := testRepo.sut.Push(git.DefaultBranch)
 	require.Nil(t, err)
 }
 
@@ -387,8 +387,8 @@ func TestFailurePush(t *testing.T) {
 }
 
 func TestSuccessRemotify(t *testing.T) {
-	newRemote := git.Remotify(git.Master)
-	require.Equal(t, newRemote, git.DefaultRemote+"/"+git.Master)
+	newRemote := git.Remotify(git.DefaultBranch)
+	require.Equal(t, newRemote, git.DefaultRemote+"/"+git.DefaultBranch)
 }
 
 func TestSuccessIsReleaseBranch(t *testing.T) {
@@ -403,7 +403,7 @@ func TestSuccessLatestTagForBranch(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	version, err := testRepo.sut.LatestTagForBranch(git.Master)
+	version, err := testRepo.sut.LatestTagForBranch(git.DefaultBranch)
 	require.Nil(t, err)
 	require.Equal(t, util.SemverToTagString(version), testRepo.firstTagName)
 }
@@ -482,7 +482,7 @@ func TestSuccessDry(t *testing.T) {
 
 	testRepo.sut.SetDry()
 
-	err := testRepo.sut.Push(git.Master)
+	err := testRepo.sut.Push(git.DefaultBranch)
 	require.Nil(t, err)
 }
 
@@ -495,7 +495,7 @@ func TestSuccessLatestReleaseBranchMergeBaseToLatest(t *testing.T) {
 	require.Equal(t, result.StartSHA(), testRepo.firstCommit)
 	require.Equal(t, result.StartRev(), testRepo.firstTagName)
 	require.Equal(t, result.EndSHA(), testRepo.firstCommit)
-	require.Equal(t, result.EndRev(), git.Master)
+	require.Equal(t, result.EndRev(), git.DefaultBranch)
 }
 
 func TestFailureLatestReleaseBranchMergeBaseToLatestNoLatestTag(t *testing.T) {
@@ -536,11 +536,11 @@ func TestFailureLatestNonPatchFinalToMinor(t *testing.T) {
 	require.Equal(t, git.DiscoverResult{}, result)
 }
 
-func TestTagsForBranchMaster(t *testing.T) {
+func TestTagsForBranchMain(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	result, err := testRepo.sut.TagsForBranch(git.Master)
+	result, err := testRepo.sut.TagsForBranch(git.DefaultBranch)
 	require.Nil(t, err)
 	require.Equal(t, result, []string{testRepo.firstTagName})
 }
@@ -582,7 +582,7 @@ func TestCheckoutSuccess(t *testing.T) {
 	require.True(t, res.Success())
 	require.Contains(t, res.Output(), filepath.Base(testRepo.testFileName))
 
-	err = testRepo.sut.Checkout(git.Master, testRepo.testFileName)
+	err = testRepo.sut.Checkout(git.DefaultBranch, testRepo.testFileName)
 	require.Nil(t, err)
 
 	res, err = command.NewWithWorkDir(
@@ -655,14 +655,14 @@ func TestCurrentBranchDefault(t *testing.T) {
 	require.Equal(t, testRepo.branchName, branch)
 }
 
-func TestCurrentBranchMaster(t *testing.T) {
+func TestCurrentBranchMain(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
-	require.Nil(t, testRepo.sut.Checkout(git.Master))
+	require.Nil(t, testRepo.sut.Checkout(git.DefaultBranch))
 
 	branch, err := testRepo.sut.CurrentBranch()
 	require.Nil(t, err)
-	require.Equal(t, git.Master, branch)
+	require.Equal(t, git.DefaultBranch, branch)
 }
 
 func TestRmSuccessForce(t *testing.T) {
@@ -781,11 +781,11 @@ func TestAddRemoteFailureAlreadyExisting(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestPushToRemoteSuccessRemoteMaster(t *testing.T) {
+func TestPushToRemoteSuccessRemoteMain(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.PushToRemote(git.DefaultRemote, git.Remotify(git.Master))
+	err := testRepo.sut.PushToRemote(git.DefaultRemote, git.Remotify(git.DefaultBranch))
 	require.Nil(t, err)
 }
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -193,7 +193,7 @@ func TestGetRepoURLSuccess(t *testing.T) {
 
 func TestRemotify(t *testing.T) {
 	testcases := []struct{ provided, expected string }{
-		{provided: git.Master, expected: git.DefaultRemote + "/" + git.Master},
+		{provided: git.DefaultBranch, expected: git.DefaultRemote + "/" + git.DefaultBranch},
 		{provided: "origin/ref", expected: "origin/ref"},
 		{provided: "base/another_ref", expected: "base/another_ref"},
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -300,9 +300,9 @@ type TagsPerBranch map[string]string
 // parameter here.
 //
 // Releases are associated in the following way:
-// - x.y.0-alpha.z releases are only associated with the master branch
+// - x.y.0-alpha.z releases are only associated with the main branch
 // - x.y.0-beta.z releases are only associated with their release-x.y branch
-// - x.y.0 final releases are associated with the master and the release-x.y branch
+// - x.y.0 final releases are associated with the main branch and the release-x.y branch
 func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 	// List tags for all pages
 	allTags := []*github.RepositoryTag{}
@@ -326,9 +326,9 @@ func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 	for _, t := range allTags {
 		tag := t.GetName()
 
-		// alpha and beta releases are only available on the master branch
+		// alpha and beta releases are only available on the main branch
 		if strings.Contains(tag, "beta") || strings.Contains(tag, "alpha") {
-			releases.addIfNotExisting(git.Master, tag)
+			releases.addIfNotExisting(git.DefaultBranch, tag)
 			continue
 		}
 
@@ -340,9 +340,9 @@ func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 			continue
 		}
 
-		// Latest vx.x.0 release are on both master and release branch
+		// Latest vx.x.0 release are on both main and release branch
 		if len(semverTag.Pre) == 0 {
-			releases.addIfNotExisting(git.Master, tag)
+			releases.addIfNotExisting(git.DefaultBranch, tag)
 		}
 
 		branch := fmt.Sprintf("release-%d.%d", semverTag.Major, semverTag.Minor)

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -68,7 +68,7 @@ func TestLatestGitHubTagsPerBranchSuccessAlphaAfterMinor(t *testing.T) {
 	// Then
 	require.Nil(t, err)
 	require.Len(t, res, 2)
-	require.Equal(t, tag1, res[git.Master])
+	require.Equal(t, tag1, res[git.DefaultBranch])
 	require.Equal(t, tag2, res["release-1.18"])
 }
 
@@ -92,7 +92,7 @@ func TestLatestGitHubTagsPerBranchMultiplePages(t *testing.T) {
 	// Then
 	require.Nil(t, err)
 	require.Len(t, res, 2)
-	require.Equal(t, tag1, res[git.Master])
+	require.Equal(t, tag1, res[git.DefaultBranch])
 	require.Equal(t, tag2, res["release-1.18"])
 }
 
@@ -126,7 +126,7 @@ func TestLatestGitHubTagsPerBranchSuccessMultipleForSameBranch(t *testing.T) {
 	// Then
 	require.Nil(t, err)
 	require.Len(t, res, 4)
-	require.Equal(t, tag1, res[git.Master])
+	require.Equal(t, tag1, res[git.DefaultBranch])
 	require.Empty(t, res["release-1.18"])
 	require.Empty(t, res["release-1.17"])
 	require.Equal(t, tag5, res["release-1.16"])
@@ -155,7 +155,7 @@ func TestLatestGitHubTagsPerBranchSuccessPatchReleases(t *testing.T) {
 	// Then
 	require.Nil(t, err)
 	require.Len(t, res, 4)
-	require.Equal(t, tag1, res[git.Master])
+	require.Equal(t, tag1, res[git.DefaultBranch])
 	require.Equal(t, tag1, res["release-1.17"])
 	require.Equal(t, tag2, res["release-1.16"])
 	require.Equal(t, tag3, res["release-1.15"])
@@ -281,7 +281,7 @@ func TestCreatePullRequest(t *testing.T) {
 	client.CreatePullRequestReturns(&gogithub.PullRequest{ID: &fakeID}, nil)
 
 	// When
-	pr, err := sut.CreatePullRequest("kubernetes-fake-org", "kubernetes-fake-repo", "master", "user:head-branch", "PR Title", "PR Body")
+	pr, err := sut.CreatePullRequest("kubernetes-fake-org", "kubernetes-fake-repo", git.DefaultBranch, "user:head-branch", "PR Title", "PR Body")
 
 	// Then
 	require.Nil(t, err)
@@ -391,7 +391,7 @@ func TestListBranches(t *testing.T) {
 	// Given
 	sut, client := newSUT()
 
-	branch0 := "master"
+	branch0 := git.DefaultBranch
 	branch1 := "myfork"
 	branch2 := "feature-branch"
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -35,7 +35,7 @@ import (
 const (
 	// gcbmgr/anago defaults
 	DefaultToolRepo   = "release"
-	DefaultToolBranch = git.Master
+	DefaultToolBranch = git.DefaultBranch
 	DefaultToolOrg    = git.DefaultGithubOrg
 	// TODO(vdf): Need to reference K8s Infra project here
 	DefaultKubernetesStagingProject = "kubernetes-release-test"

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/git"
 )
 
 func TestGetDefaultToolRepoURLSuccess(t *testing.T) {
@@ -87,7 +89,7 @@ func TestGetToolBranchSuccess(t *testing.T) {
 	}{
 		{
 			name:     "default branch",
-			expected: "master",
+			expected: git.DefaultBranch,
 		},
 		{
 			name:     "custom branch",

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -117,7 +117,7 @@ func SetReleaseVersion(
 		version, branch, parentBranch,
 	)
 
-	// if branch == master, version is an alpha or beta
+	// if branch == git.DefaultBranch, version is an alpha or beta
 	// if branch == release, version is a rc
 	// if branch == release+1, version is an alpha
 	versionMatch := regex.ReleaseRegex.FindStringSubmatch(version)
@@ -160,7 +160,7 @@ func SetReleaseVersion(
 	// session/type Other labels such as alpha, beta, and rc are set as needed
 	// Index ordering is important here as it's how they are processed
 	releaseVersions := &Versions{}
-	if parentBranch == git.Master {
+	if parentBranch == git.DefaultBranch {
 		branchMatch := regex.BranchRegex.FindStringSubmatch(branch)
 		if len(branchMatch) < 3 {
 			return nil, errors.Errorf("invalid formatted branch %s", branch)
@@ -231,7 +231,7 @@ func SetReleaseVersion(
 			buildVersion.patch,
 		)
 
-		// Enable building beta releases on the master branch.
+		// Enable building beta releases on the main branch.
 		// If the last build version was an alpha (x.y.z-alpha.N), set the
 		// build
 		// label to 'beta' and release version to x.y.z-beta.0.

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -66,11 +66,11 @@ func TestSetReleaseVersion(t *testing.T) {
 			},
 		},
 		{
-			// new release candidate from master
+			// new release candidate from default branch
 			releaseType:  release.ReleaseTypeRC,
 			version:      "v1.18.0-beta.3.2+3ff09514d162b0",
 			branch:       "release-1.18",
-			parentBranch: git.Master,
+			parentBranch: git.DefaultBranch,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.0-rc.0", res.Prime())
@@ -85,7 +85,7 @@ func TestSetReleaseVersion(t *testing.T) {
 			// new beta from beta
 			releaseType:  release.ReleaseTypeBeta,
 			version:      "v1.18.4-beta.1.2+3ff09514d162b0",
-			branch:       git.Master,
+			branch:       git.DefaultBranch,
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
@@ -101,7 +101,7 @@ func TestSetReleaseVersion(t *testing.T) {
 			// new beta from alpha
 			releaseType:  release.ReleaseTypeBeta,
 			version:      "v1.18.0-alpha.1.2+3ff09514d162b0",
-			branch:       git.Master,
+			branch:       git.DefaultBranch,
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
@@ -117,7 +117,7 @@ func TestSetReleaseVersion(t *testing.T) {
 			// new alpha
 			releaseType:  release.ReleaseTypeAlpha,
 			version:      "v1.18.4-alpha.1.2+3ff09514d162b0",
-			branch:       git.Master,
+			branch:       git.DefaultBranch,
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
@@ -133,7 +133,7 @@ func TestSetReleaseVersion(t *testing.T) {
 			// new alpha after beta
 			releaseType:  release.ReleaseTypeAlpha,
 			version:      "v1.18.4-beta.1.2+3ff09514d162b0",
-			branch:       git.Master,
+			branch:       git.DefaultBranch,
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.NotNil(t, err)
@@ -145,7 +145,7 @@ func TestSetReleaseVersion(t *testing.T) {
 			releaseType:  release.ReleaseTypeOfficial,
 			version:      "",
 			branch:       "wrong",
-			parentBranch: git.Master,
+			parentBranch: git.DefaultBranch,
 			expect: func(res *release.Versions, err error) {
 				require.NotNil(t, err)
 				require.Nil(t, res)

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -62,7 +62,7 @@ const (
 
 	// VersionTypeCILatestCross references the latest CI cross build Kubernetes
 	// version, for example `v1.19.0-alpha.0.721+f8ff8f44206ff4`
-	VersionTypeCILatestCross VersionType = "ci/k8s-master"
+	VersionTypeCILatestCross VersionType = "ci/k8s-" + git.DefaultBranch
 
 	// baseURL is the base URL for every release version retrieval
 	baseURL = "https://dl.k8s.io/"
@@ -105,7 +105,7 @@ func (v *Version) GetKubeVersionForBranch(versionType VersionType, branch string
 	)
 
 	version := ""
-	if branch != git.Master {
+	if branch != git.DefaultBranch {
 		if !git.IsReleaseBranch(branch) {
 			return "", errors.Errorf("%s is not a valid release branch", branch)
 		}

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -52,7 +52,7 @@ func TestBlockingTestsSuccess(t *testing.T) {
 	client.GetURLResponseReturns(string(httpRes), nil)
 
 	// When
-	res, err := sut.BlockingTests(git.Master)
+	res, err := sut.BlockingTests(git.DefaultBranch)
 
 	// Then
 	require.Nil(t, err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We're now mostly referencing a default or main branch as well as a renamed git.DefaultBranch variable.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Not all occurrences could be changed for now. For example the `regex` package cannot include the `git` package because this would cause an import cycle.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `git.Master` global const to `git.DefaultBranch` and `git.DefaultMasterRef` to `git.DefaultRef`
```
