### PR TITLE
Fix incorrect label ID for alpha and beta releases

### DIFF
--- a/cmd/krel/cmd/set_release_version_test.go
+++ b/cmd/krel/cmd/set_release_version_test.go
@@ -87,9 +87,9 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 			shouldErr: false,
 			expected: `declare -Ag RELEASE_VERSION
 declare -ag ORDERED_RELEASE_KEYS
-RELEASE_VERSION[alpha]="v1.20.0-alpha.0"
+RELEASE_VERSION[alpha]="v1.20.0-alpha.1"
 ORDERED_RELEASE_KEYS+=("alpha")
-export RELEASE_VERSION_PRIME=v1.20.0-alpha.0
+export RELEASE_VERSION_PRIME=v1.20.0-alpha.1
 `,
 		},
 		{

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -136,13 +136,13 @@ func SetReleaseVersion(
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing build patch version to int")
 	}
-	var labelID *int
+	var labelIDPtr *int
 	if versionMatch[5] != "" {
 		parsedLabelID, err := strconv.Atoi(versionMatch[5])
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing build label ID to int")
 		}
-		labelID = &parsedLabelID
+		labelIDPtr = &parsedLabelID
 	}
 	buildVersion := struct {
 		major, minor, patch int
@@ -153,7 +153,12 @@ func SetReleaseVersion(
 		minor:   buildMinor,
 		patch:   buildPatch,
 		label:   versionMatch[4], // -alpha, -beta, -rc
-		labelID: labelID,
+		labelID: labelIDPtr,
+	}
+
+	labelID := 1
+	if labelIDPtr != nil {
+		labelID = *buildVersion.labelID + 1
 	}
 
 	// releaseVersions.prime is the default release version for this
@@ -201,11 +206,6 @@ func SetReleaseVersion(
 		}
 		releaseVersions.prime += fmt.Sprintf(".%d", patch)
 
-		labelID := 1
-		if buildVersion.labelID != nil {
-			labelID = *buildVersion.labelID + 1
-		}
-
 		if releaseType == ReleaseTypeOfficial {
 			releaseVersions.official = releaseVersions.prime
 			// Only primary branches get rc releases
@@ -244,7 +244,7 @@ func SetReleaseVersion(
 			releaseVersions.beta += fmt.Sprintf("%s.0", buildVersion.label)
 		} else {
 			releaseVersions.beta += fmt.Sprintf(
-				"%s.%d", buildVersion.label, *labelID,
+				"%s.%d", buildVersion.label, labelID,
 			)
 		}
 
@@ -270,7 +270,7 @@ func SetReleaseVersion(
 			buildVersion.minor,
 			buildVersion.patch,
 			buildVersion.label,
-			*labelID,
+			labelID,
 		)
 		releaseVersions.prime = releaseVersions.alpha
 	}

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -89,10 +89,10 @@ func TestSetReleaseVersion(t *testing.T) {
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
-				require.Equal(t, "v1.18.4-beta.1", res.Prime())
+				require.Equal(t, "v1.18.4-beta.2", res.Prime())
 				require.Empty(t, res.Official())
 				require.Empty(t, res.RC())
-				require.Equal(t, "v1.18.4-beta.1", res.Beta())
+				require.Equal(t, "v1.18.4-beta.2", res.Beta())
 				require.Empty(t, res.Alpha())
 				require.Len(t, res.Slice(), 1)
 			},
@@ -121,11 +121,27 @@ func TestSetReleaseVersion(t *testing.T) {
 			parentBranch: "",
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
-				require.Equal(t, "v1.18.4-alpha.1", res.Prime())
+				require.Equal(t, "v1.18.4-alpha.2", res.Prime())
 				require.Empty(t, res.Official())
 				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
-				require.Equal(t, "v1.18.4-alpha.1", res.Alpha())
+				require.Equal(t, "v1.18.4-alpha.2", res.Alpha())
+				require.Len(t, res.Slice(), 1)
+			},
+		},
+		{
+			// new alpha
+			releaseType:  release.ReleaseTypeAlpha,
+			version:      "v1.20.0-alpha.2.1273+4e9bdd481e2400",
+			branch:       git.DefaultBranch,
+			parentBranch: "",
+			expect: func(res *release.Versions, err error) {
+				require.Nil(t, err)
+				require.Equal(t, "v1.20.0-alpha.3", res.Prime())
+				require.Empty(t, res.Official())
+				require.Empty(t, res.RC())
+				require.Empty(t, res.Beta())
+				require.Equal(t, "v1.20.0-alpha.3", res.Alpha())
 				require.Len(t, res.Slice(), 1)
 			},
 		},


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The label ID modification part should be at the global scope of the
function to correctly increment it. Another unit tests covers this issue
now as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
