### PR TITLE
testgrid: check if need to upload the images

### DIFF
--- a/testgridshot
+++ b/testgridshot
@@ -102,8 +102,7 @@ get_tests_by_status() {
   local board
   local summary
 
-  for board in "$@"
-  do
+  for board in "$@"; do
     summary="$( curl_with_retry --retry 0 "${TESTGRID}/${board}/summary" 2>/dev/null )" || {
       log "Could not get summary for board '${board}'"
       return 1
@@ -174,8 +173,7 @@ get_header_stub() {
 
   echo "Boards checked for $(comma_sep "${STATES}"):"
 
-  for board in "$@"
-  do
+  for board in "$@"; do
     printf -- '- [%s](%s)\n' "$board" "${TESTGRID}/${board}"
   done
 }
@@ -197,8 +195,7 @@ usage() {
 }
 
 wait_for_all() {
-  for pid in "$@"
-  do
+  for pid in "$@"; do
     wait "$pid"
   done
 }
@@ -212,8 +209,7 @@ shoot() {
   local pids=()
   local comment
 
-  if [ -n "$LOCAL_IMG_DIR" ] && [ -e "$LOCAL_IMG_DIR" ]
-  then
+  if [ -n "$LOCAL_IMG_DIR" ] && [ -e "$LOCAL_IMG_DIR" ]; then
     log "Directory '${LOCAL_IMG_DIR}' must be empty"
     return 1
   fi
@@ -234,12 +230,10 @@ shoot() {
 
   get_header_stub "$target_release" "${boards[@]}" > "$( get_issue_stub_name "${tmp_dir}" "${idx}" )"
 
-  for s in ${STATES}
-  do
+  for s in ${STATES}; do
     raw_tests="$( get_tests_by_status "$s" "${boards[@]}" )"
     mapfile -t tests <<< "$raw_tests"
-    for t in "${tests[@]}"
-    do
+    for t in "${tests[@]}"; do
       [ -n "${t}" ] || continue
 
       idx=$(( idx + 1 ))
@@ -290,14 +284,17 @@ shoot() {
 
   comment="$( combine_issue_stubs "${tmp_dir}" | tee "${tmp_dir}/issue_comment.txt" )"
 
-  if [ -n "$LOCAL_IMG_DIR" ]
-  then
+  if [ -n "$LOCAL_IMG_DIR" ]; then
     log "Skipping upload, moving results to '$LOCAL_IMG_DIR'"
     mv "${tmp_dir}" "${LOCAL_IMG_DIR}"
   else
-    log "Starting upload to '$BUCKET'"
-    upload_and_publish_images "$img_dir" "$img_bucket_dir"
-    log "Upload finished successfully"
+    if [ ! "$(ls -A $img_dir)" ]; then
+      log "$img_dir is empty! Skipping upload."
+    else
+      log "Starting upload to '$BUCKET'"
+      upload_and_publish_images "$img_dir" "$img_bucket_dir"
+      log "Upload finished successfully"
+    fi
   fi
 
   echo


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When the testgrid reports no failing or flaky jobs there is no image to screenshot and in sequence no image to upload to the GS bucket and then the `./testgridshot` fails in the upload step.

for example The current release-1.19 (at 09.09.2020 11:50 AM CEST) have no failing tests, and if we run the tesgridshot command we get:

```shell
$ ./testgridshot 1.19
2020-09-09 09:50:54+0000 Starting upload to 'k8s-staging-releng'
CommandException: No URLs matched. Do the files you're operating on exist?
```

This PR fixes this issue by checking if there are images to be uploaded to the bucket.

After the fix:

```shell
$ ./testgridshot 1.19
2020-09-09 09:50:25+0000 /tmp/tmp.Xrrl1DEY8Z/images is empty! Skipping upload.

<!-- ----[ issue comment ]---- -->
### Testgrid dashboards for 1.19
Boards checked for FAILING:
- [sig-release-1.19-blocking](https://testgrid.k8s.io/sig-release-1.19-blocking)
- [sig-release-1.19-informing](https://testgrid.k8s.io/sig-release-1.19-informing)

**NO FAILING TESTS**
<!-- ----[ issue comment ]---- -->
```


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/cc @saschagrunert 
