### PR TITLE
Rename `SetReleaseVersion` to be `GetBuildVersion`

### DIFF
--- a/anago
+++ b/anago
@@ -1198,7 +1198,7 @@ get_build_candidate () {
 # Also ensures the RELEASE_VERSION_PRIME tag doesn't already exist.
 PROGSTEP[set_release_values]="SET RELEASE VALUES"
 set_release_values () {
-  eval "$(krel anago set-release-version \
+  eval "$(krel anago generate-release-version \
     --release-type "$FLAGS_type" \
     --build-version "${BRANCH_POINT:-$JENKINS_BUILD_VERSION}" \
     --branch "$RELEASE_BRANCH" \

--- a/cmd/krel/cmd/generate_release_version_test.go
+++ b/cmd/krel/cmd/generate_release_version_test.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/release/pkg/release"
 )
 
-func TestRunSetReleaseVersion(t *testing.T) {
+func TestRunGenerateReleaseVersion(t *testing.T) {
 	for _, tc := range []struct {
 		anagoOpts *release.Options
-		opts      *setReleaseVersionOptions
+		opts      *generateReleaseVersionOptions
 		shouldErr bool
 		expected  string
 	}{
@@ -36,7 +36,7 @@ func TestRunSetReleaseVersion(t *testing.T) {
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeOfficial,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       "release-1.19",
 			},
@@ -54,7 +54,7 @@ export RELEASE_VERSION_PRIME=v1.19.1
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeRC,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       "release-1.19",
 			},
@@ -70,7 +70,7 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeAlpha,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.19.1-rc.0.34+5f5b46a6e8ad56",
 				branch:       git.DefaultBranch,
 			},
@@ -80,7 +80,7 @@ export RELEASE_VERSION_PRIME=v1.19.1-rc.1
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeAlpha,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       git.DefaultBranch,
 			},
@@ -96,7 +96,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-alpha.1
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeBeta,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       git.DefaultBranch,
 			},
@@ -112,7 +112,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-beta.0
 			anagoOpts: &release.Options{
 				ReleaseType: release.ReleaseTypeRC,
 			},
-			opts: &setReleaseVersionOptions{
+			opts: &generateReleaseVersionOptions{
 				buildVersion: "v1.20.0-alpha.0.1273+4e9bdd481e2400",
 				branch:       "release-1.20",
 				parentBranch: git.DefaultBranch,
@@ -128,7 +128,7 @@ export RELEASE_VERSION_PRIME=v1.20.0-rc.0
 `,
 		},
 	} {
-		res, err := runSetReleaseVersion(tc.opts, tc.anagoOpts)
+		res, err := runGenerateReleaseVersion(tc.opts, tc.anagoOpts)
 		if tc.shouldErr {
 			require.NotNil(t, err)
 		} else {

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -27,18 +27,18 @@ import (
 
 func TestSetReleaseVersion(t *testing.T) {
 	for _, tc := range []struct {
-		releaseType  string
-		version      string
-		branch       string
-		parentBranch string
-		expect       func(*release.Versions, error)
+		releaseType      string
+		version          string
+		branch           string
+		branchFromMaster bool
+		expect           func(*release.Versions, error)
 	}{
 		{
 			// new final patch release
-			releaseType:  release.ReleaseTypeOfficial,
-			version:      "v1.18.4-rc.0.3+3ff09514d162b0",
-			branch:       "release-1.18",
-			parentBranch: "release-1.18",
+			releaseType:      release.ReleaseTypeOfficial,
+			version:          "v1.18.4-rc.0.3+3ff09514d162b0",
+			branch:           "release-1.18",
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.4", res.Prime())
@@ -46,15 +46,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.5-rc.0", res.RC())
 				require.Empty(t, res.Beta())
 				require.Empty(t, res.Alpha())
-				require.Len(t, res.Slice(), 2)
 			},
 		},
 		{
 			// new release candidate from release branch
-			releaseType:  release.ReleaseTypeRC,
-			version:      "v1.18.4-beta.0.2+3ff09514d162b0",
-			branch:       "release-1.18",
-			parentBranch: "release-1.18",
+			releaseType:      release.ReleaseTypeRC,
+			version:          "v1.18.4-beta.0.2+3ff09514d162b0",
+			branch:           "release-1.18",
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.4-rc.1", res.Prime())
@@ -62,15 +61,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.4-rc.1", res.RC())
 				require.Empty(t, res.Beta())
 				require.Empty(t, res.Alpha())
-				require.Len(t, res.Slice(), 1)
 			},
 		},
 		{
 			// new release candidate from default branch
-			releaseType:  release.ReleaseTypeRC,
-			version:      "v1.18.0-beta.3.2+3ff09514d162b0",
-			branch:       "release-1.18",
-			parentBranch: git.DefaultBranch,
+			releaseType:      release.ReleaseTypeRC,
+			version:          "v1.18.0-beta.3.2+3ff09514d162b0",
+			branch:           "release-1.18",
+			branchFromMaster: true,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.0-rc.0", res.Prime())
@@ -78,15 +76,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.0-rc.0", res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.19.0-alpha.0", res.Alpha())
-				require.Len(t, res.Slice(), 2)
 			},
 		},
 		{
 			// new beta from beta
-			releaseType:  release.ReleaseTypeBeta,
-			version:      "v1.18.4-beta.1.2+3ff09514d162b0",
-			branch:       git.DefaultBranch,
-			parentBranch: "",
+			releaseType:      release.ReleaseTypeBeta,
+			version:          "v1.18.4-beta.1.2+3ff09514d162b0",
+			branch:           git.DefaultBranch,
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.4-beta.2", res.Prime())
@@ -94,15 +91,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Equal(t, "v1.18.4-beta.2", res.Beta())
 				require.Empty(t, res.Alpha())
-				require.Len(t, res.Slice(), 1)
 			},
 		},
 		{
 			// new beta from alpha
-			releaseType:  release.ReleaseTypeBeta,
-			version:      "v1.18.0-alpha.1.2+3ff09514d162b0",
-			branch:       git.DefaultBranch,
-			parentBranch: "",
+			releaseType:      release.ReleaseTypeBeta,
+			version:          "v1.18.0-alpha.1.2+3ff09514d162b0",
+			branch:           git.DefaultBranch,
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.0-beta.0", res.Prime())
@@ -110,15 +106,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Equal(t, "v1.18.0-beta.0", res.Beta())
 				require.Empty(t, res.Alpha())
-				require.Len(t, res.Slice(), 1)
 			},
 		},
 		{
 			// new alpha
-			releaseType:  release.ReleaseTypeAlpha,
-			version:      "v1.18.4-alpha.1.2+3ff09514d162b0",
-			branch:       git.DefaultBranch,
-			parentBranch: "",
+			releaseType:      release.ReleaseTypeAlpha,
+			version:          "v1.18.4-alpha.1.2+3ff09514d162b0",
+			branch:           git.DefaultBranch,
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.4-alpha.2", res.Prime())
@@ -126,15 +121,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.18.4-alpha.2", res.Alpha())
-				require.Len(t, res.Slice(), 1)
 			},
 		},
 		{
 			// new alpha
-			releaseType:  release.ReleaseTypeAlpha,
-			version:      "v1.20.0-alpha.2.1273+4e9bdd481e2400",
-			branch:       git.DefaultBranch,
-			parentBranch: "",
+			releaseType:      release.ReleaseTypeAlpha,
+			version:          "v1.20.0-alpha.2.1273+4e9bdd481e2400",
+			branch:           git.DefaultBranch,
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.20.0-alpha.3", res.Prime())
@@ -142,15 +136,14 @@ func TestSetReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.20.0-alpha.3", res.Alpha())
-				require.Len(t, res.Slice(), 1)
 			},
 		},
 		{
 			// new alpha after beta
-			releaseType:  release.ReleaseTypeAlpha,
-			version:      "v1.18.4-beta.1.2+3ff09514d162b0",
-			branch:       git.DefaultBranch,
-			parentBranch: "",
+			releaseType:      release.ReleaseTypeAlpha,
+			version:          "v1.18.4-beta.1.2+3ff09514d162b0",
+			branch:           git.DefaultBranch,
+			branchFromMaster: false,
 			expect: func(res *release.Versions, err error) {
 				require.NotNil(t, err)
 				require.Nil(t, res)
@@ -158,18 +151,18 @@ func TestSetReleaseVersion(t *testing.T) {
 		},
 		{
 			// invalid branch
-			releaseType:  release.ReleaseTypeOfficial,
-			version:      "",
-			branch:       "wrong",
-			parentBranch: git.DefaultBranch,
+			releaseType:      release.ReleaseTypeOfficial,
+			version:          "",
+			branch:           "wrong",
+			branchFromMaster: true,
 			expect: func(res *release.Versions, err error) {
 				require.NotNil(t, err)
 				require.Nil(t, res)
 			},
 		},
 	} {
-		tc.expect(release.SetReleaseVersion(
-			tc.releaseType, tc.version, tc.branch, tc.parentBranch,
+		tc.expect(release.GenerateReleaseVersion(
+			tc.releaseType, tc.version, tc.branch, tc.branchFromMaster,
 		))
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This should make it's usage intention more clear. The function now also
does not use the `parentBranch` argument any more, but just a bool
indicating if we're going to create a new branch from the master. Some
other refactorings around internal variables have been applied, too.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
