### PR TITLE
images: Build kube-cross:v1.15.2-1 and go-runner:buster-v2.0.2 (using go1.15.2)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -53,7 +53,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15.1
+    version: 1.15.2
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -65,7 +65,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "k8s.gcr.io/kube-cross"
-    version: v1.15.1-2
+    version: v1.15.2-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
@@ -122,7 +122,7 @@ dependencies:
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):v\d+\.\d+\.\d+
 
   - name: "k8s.gcr.io/go-runner"
-    version: buster-v2.0.1
+    version: buster-v2.0.2
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.15.1-2
+IMAGE_VERSION ?= v1.15.2-1
 CONFIG ?= go1.15
 
 # Build args
-GO_VERSION?=1.15.1
+GO_VERSION?=1.15.2
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.1'
-    IMAGE_VERSION: 'v1.15.1-canary-2'
+    GO_VERSION: '1.15.2'
+    IMAGE_VERSION: 'v1.15.2-canary-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.1'
-    IMAGE_VERSION: 'v1.15.1-2'
+    GO_VERSION: '1.15.2'
+    IMAGE_VERSION: 'v1.15.2-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.0.1
+IMAGE_VERSION ?= buster-v2.0.2
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.15.1
+GO_VERSION ?= 1.15.2
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.0.1'
-    GO_VERSION: '1.15.1'
+    IMAGE_VERSION: 'buster-v2.0.2'
+    GO_VERSION: '1.15.2'
     DISTROLESS_IMAGE: 'static-debian10'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- images: Build kube-cross v1.15.2-1 and v1.15.2-canary-1
- images: Build go-runner:buster-v2.0.2 (using go1.15.2)

/assign @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering 

Tracking issue: https://github.com/kubernetes/release/issues/1517

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold still waiting for the upstream images to be available: https://github.com/docker-library/golang
Filed an issue about some of the docker-library/golang image builds being stuck: https://github.com/docker-library/golang/issues/342

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build kube-cross v1.15.2-1 and v1.15.2-canary-1
- images: Build go-runner:buster-v2.0.2 (using go1.15.2)
```
