### PR TITLE
images: Build debian-base:v1.2.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base"
-    version: buster-v1.1.4
+    version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.1.4
+IMAGE_VERSION ?= buster-v1.2.0
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.1.4'
+    IMAGE_VERSION: 'buster-v1.2.0'
   stretch:
     CONFIG: 'stretch'
     IMAGE_VERSION: 'stretch-v1.1.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

New Debian images are available upstream, so this is just a periodic
image update.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Required for updating the debian-iptables images to include iptables 1.8.5+ (ref: https://github.com/kubernetes/kubernetes/issues/94700)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build debian-base:v1.2.0
  
  New Debian images are available upstream, so this is just a periodic
  image update.
```
