### PR TITLE
Add binary copy function to `krel push`

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -325,8 +325,15 @@ func runPushBuild(opts *pushBuildOptions) error {
 		}
 	}
 
+	// Copy the "naked" binaries to GCS. This is useful for install scripts
+	// that download the binaries directly and don't need tars.
+	if err := release.CopyBinaries(
+		filepath.Join(buildDir, release.ReleaseStagePath),
+	); err != nil {
+		return errors.Wrap(err, "stage binaries")
+	}
+
 	// TODO
-	// Prepare naked binaries
 	// Write checksums
 	// Push Docker images
 	// Push artifacts to release bucket is --ci


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This introduces a new `release.CopyBinaries` API which copies the
binaries from the provided path into the correct destinations.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1459
#### Special notes for your reviewer:
Converted bash parts:
https://github.com/kubernetes/release/blob/1b2fc8b458887834bc6fdde07bf17a3ba9f9cc87/lib/releaselib.sh#L270-L289
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `release.CopyBinaries` to copy built Kubernetes binaries into the pre-defined target directories
```
