### PR TITLE
images: Build debian-iptables:buster-v1.3.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,6 +84,15 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
+  # iptables
+  - name: "iptables"
+    version: 1.8.5
+    refPaths:
+    - path: images/build/debian-iptables/Makefile
+      match: IPTABLES_VERSION \?= (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+    - path: images/build/debian-iptables/variants.yaml
+      match: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+
   # Base images
   - name: "k8s.gcr.io/debian-base"
     version: buster-v1.2.0
@@ -94,7 +103,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/debian-base: dependents"
-    version: buster-v1.1.4
+    version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -108,7 +117,7 @@ dependencies:
       match: TAG\?=[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables"
-    version: buster-v1.2.0
+    version: buster-v1.3.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.2.0
+IMAGE_VERSION ?= buster-v1.3.0
 CONFIG ?= buster
-DEBIAN_BASE_VERSION ?= buster-v1.1.4
+DEBIAN_BASE_VERSION ?= buster-v1.2.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
@@ -28,6 +28,9 @@ TEMP_DIR:=$(shell mktemp -d)
 
 BASE_REGISTRY?=k8s.gcr.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
+
+# Build args
+IPTABLES_VERSION ?= 1.8.5
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
@@ -48,6 +51,7 @@ endif
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
+		--build-arg=IPTABLES_VERSION=$(IPTABLES_VERSION) \
 		$(TEMP_DIR)/$(CONFIG)
 
 push: build

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -14,10 +14,11 @@
 
 FROM BASEIMAGE
 
-# Install latest iptables package from buster-backports
+# Install specified iptables package from buster-backports
+ARG IPTABLES_VERSION
 RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list; \
     apt-get update; \
-    apt-get -t buster-backports -y --no-install-recommends install iptables
+    apt-get -t buster-backports -y --no-install-recommends install iptables=${IPTABLES_VERSION}*
 
 # Install other dependencies and then clean up apt caches
 RUN clean-install \

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -16,6 +16,7 @@ steps:
       - IMAGE_VERSION=$_IMAGE_VERSION
       - CONFIG=$_CONFIG
       - DEBIAN_BASE_VERSION=$_DEBIAN_BASE_VERSION
+      - IPTABLES_VERSION=$_IPTABLES_VERSION
     args:
       - all-push
 
@@ -27,6 +28,7 @@ substitutions:
   _IMAGE_VERSION: 'v0.0.0'
   _CONFIG: 'codename'
   _DEBIAN_BASE_VERSION: 'v0.0.0'
+  _IPTABLES_VERSION: '0.0.0'
 
 tags:
 - ${_GIT_TAG}
@@ -34,6 +36,7 @@ tags:
 - ${_IMAGE_VERSION}
 - ${_CONFIG}
 - ${_DEBIAN_BASE_VERSION}
+- ${_IPTABLES_VERSION}
 
 images:
   - 'gcr.io/$PROJECT_ID/debian-iptables-amd64:$_IMAGE_VERSION'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,8 +1,9 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.2.0'
-    DEBIAN_BASE_VERSION: 'buster-v1.1.4'
+    IMAGE_VERSION: 'buster-v1.3.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.2.0'
+    IPTABLES_VERSION: '1.8.5'
   stretch:
     CONFIG: 'stretch'
     IMAGE_VERSION: 'stretch-v1.1.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Uses debian-base:buster-v1.2.0
- Updates iptables to 1.8.5

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @hasheddan @cpanato
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Required for updating the debian-iptables images to include iptables 1.8.5+ (ref: kubernetes/kubernetes#94700)
Continuation of https://github.com/kubernetes/release/pull/1537.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build debian-iptables:buster-v1.3.0
  - Uses debian-base:buster-v1.2.0
  - Updates iptables to 1.8.5
```
