### PR TITLE
debian-iptables: Install ebtables from buster-backports

### DIFF
--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -37,6 +37,7 @@ substitutions:
   _ETCD_VERSION: 'v0.0.0'
 
 tags:
+- 'kube-cross'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 - ${_CONFIG}

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -28,6 +28,7 @@ substitutions:
   _CONFIG: 'codename'
 
 tags:
+- 'debian-base'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 - ${_IMAGE_VERSION}

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -13,3 +13,6 @@ steps:
       - IMAGE=gcr.io/$PROJECT_ID/debian-hyperkube-base
     args:
       - all-push
+
+tags:
+- 'debian-hyperkube-base'

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -14,16 +14,17 @@
 
 FROM BASEIMAGE
 
-# Install specified iptables package from buster-backports
+# Install iptables and ebtables packages from buster-backports
 ARG IPTABLES_VERSION
-RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list; \
-    apt-get update; \
-    apt-get -t buster-backports -y --no-install-recommends install iptables=${IPTABLES_VERSION}*
+RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get -t buster-backports -y --no-install-recommends install \
+        iptables=${IPTABLES_VERSION}* \
+        ebtables
 
 # Install other dependencies and then clean up apt caches
 RUN clean-install \
     conntrack \
-    ebtables \
     ipset \
     kmod \
     netbase

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -31,6 +31,7 @@ substitutions:
   _IPTABLES_VERSION: '0.0.0'
 
 tags:
+- 'debian-iptables'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 - ${_IMAGE_VERSION}

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -38,6 +38,7 @@ substitutions:
   _DISTROLESS_IMAGE: 'static-debian00'
 
 tags:
+- 'go-runner'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 - ${_IMAGE_VERSION}

--- a/images/k8s-cloud-builder/cloudbuild.yaml
+++ b/images/k8s-cloud-builder/cloudbuild.yaml
@@ -31,3 +31,6 @@ images:
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}'
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:latest-${_CONFIG}'
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}'
+
+tags:
+- 'k8s-cloud-builder'

--- a/images/releng-ci-bazel/cloudbuild.yaml
+++ b/images/releng-ci-bazel/cloudbuild.yaml
@@ -23,3 +23,6 @@ substitutions:
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci-bazel:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/releng-ci-bazel:latest'
+
+tags:
+- 'releng-ci-bazel'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dependency

#### What this PR does / why we need it:

- debian-iptables: Install ebtables from buster-backports

  Resolves the build failure in https://console.cloud.google.com/cloud-build/builds/d42f0b9a-c4bb-47ab-b218-f8ad17feb7e3?project=k8s-staging-build-image:

  ```console
  Some packages could not be installed. This may mean that you have
  requested an impossible situation or if you are using the unstable
  distribution that some required packages have not yet been created
  or been moved out of Incoming.
  The following information may help to resolve the situation:

  The following packages have unmet dependencies:
  netbase : Breaks: ebtables (< 2.0.11-2) but 2.0.10.4+snapshot20181205-3
            is to be installed
  E: Error, pkgProblemResolver::Resolve generated breaks, this may be
    caused by held packages.

  ebtables:
    Installed: (none)
    Candidate: 2.0.10.4+snapshot20181205-3
    Version table:
      2.0.11-4~bpo10+1 100
          100 http://deb.debian.org/debian buster-backports/main amd64
              Packages
      2.0.10.4+snapshot20181205-3 500
          500 http://deb.debian.org/debian buster/main amd64 Packages
  ```

- images: Add image name tags to image-building GCB configs
  
  Now that we're producing images on a regular basis, this will be helpful
  to surface details about which GCB jobs are related to which images.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian-iptables: Install ebtables from buster-backports

  Resolves the build failure in which we've requested an impossible package
  dependency resolution:

  The following packages have unmet dependencies:
  netbase : Breaks: ebtables (< 2.0.11-2) but 2.0.10.4+snapshot20181205-3
            is to be installed
  E: Error, pkgProblemResolver::Resolve generated breaks, this may be
    caused by held packages.

  ebtables:
    Installed: (none)
    Candidate: 2.0.10.4+snapshot20181205-3
    Version table:
      2.0.11-4~bpo10+1 100
          100 http://deb.debian.org/debian buster-backports/main amd64
              Packages
      2.0.10.4+snapshot20181205-3 500
          500 http://deb.debian.org/debian buster/main amd64 Packages

- images: Add image name tags to image-building GCB configs
  
  Now that we're producing images on a regular basis, this will be helpful
  to surface details about which GCB jobs are related to which images.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>
```
