### PR TITLE
images: Build debian-hyperbase-base:buster-v1.2.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -111,7 +111,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/debian-hyperkube-base"
-    version: buster-v1.1.4
+    version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: TAG\?=[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -125,10 +125,10 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: 12.1.2
+    version: buster-v1.3.0
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
-      match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/go-runner"
     version: buster-v2.0.2

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -19,16 +19,12 @@
 
 REGISTRY?=gcr.io/k8s-staging-build-image
 IMAGE?=$(REGISTRY)/debian-hyperkube-base
-# TODO(debian-base): Need to update to new version format ('codename-v0.0.0')
-#                    on next image bump
-TAG?=buster-v1.1.4
+TAG?=buster-v1.2.0
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 BASE_REGISTRY?=k8s.gcr.io/build-image
-# TODO(debian-base): Need to update to new version format ('codename-v0.0.0')
-#                    on next image bump
-BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):v12.1.2
+BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):buster-v1.3.0
 CNI_VERSION?=v0.8.7
 
 TEMP_DIR:=$(shell mktemp -d)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Uses debian-iptables:buster-v1.3.0

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build debian-hyperbase-base:buster-v1.2.0
  - Uses debian-iptables:buster-v1.3.0
```
