### PR TITLE
[krel] Change --org and --*-repo flags to --fork in release-notes subcmd

### DIFF
--- a/docs/krel/release-notes.md
+++ b/docs/krel/release-notes.md
@@ -38,14 +38,14 @@ Before running `krel release-notes` export your GitHub token to \$GITHUB_TOKEN:
 ### Command line flags
 
 ```
-      --create-draft-pr       update the Release Notes draft and create a PR in k/sig-release
-      --create-website-pr     patch the relnotes.k8s.io sources and generate a PR with the changes
-      --dependencies          add dependency report (default true)
-      --draft-repo string     k/sig-release fork used when creating the draft PR (default "sig-release")
-  -h, --help                  help for release-notes
-      --org string            a Github organization hosting the forks of k/sig-release or ksigs/release-notes
-  -t, --tag string            version tag for the notes
-      --website-repo string   ksigs/release-notes fork used when creating the website PR (default "release-notes")
+      --create-draft-pr     update the Release Notes draft and create a PR in k/sig-release
+      --create-website-pr   patch the relnotes.k8s.io sources and generate a PR with the changes
+      --dependencies        add dependency report (default true)
+      --fix                 fix release notes
+      --fork string         the user's fork in the form org/repo. Used to submit Pull Requests for the website and draft
+  -h, --help                help for release-notes
+  -m, --maps-from strings   specify a location to recursively look for release notes *.y[a]ml file mappings
+  -t, --tag string          version tag for the notes
 ```
 
 ### Examples
@@ -65,15 +65,15 @@ clone k/sig-release, create a branch, write the draft markdown and then push the
 back to your fork in GitHub. Finally __it will create a pull request__ on your behalf.
 
 To update the Release Notes Draft, run `krel release-notes` with `--create-draft-pr` and set 
-`--org` to your GitHub user (the organization that owns your fork o k/sig-release):
+`--fork` to your GitHub user (the organization that owns your fork o k/sig-release):
 
 ```bash
-krel release-notes --create-draft-pr --org=kubefriend --tag v1.19.0-beta.1 
+krel release-notes --create-draft-pr --fork=kubefriend --tag v1.19.0-beta.1 
 ```
 
 The `--tag` flag is optional, it will default to the latest minor version if it is not defined.
 If, for any reason, your fork of k/sig-release is not named _sig-release_ you can set the name
-of your repository with `--draft-repo`.
+of your repository by specifying the full repo slug `--fork=myorg/myrepo`.
 
 #### Update the relnotes.k8s.io website
 
@@ -82,21 +82,22 @@ The subcommand can also generate the notes and modify the necessary files to upd
 [release-notes repo](https://github.com/kubernetes-sigs/release-notes) and add your fork as
 a remote (kubefriend/release-notes). It will then create a feature branch to commit the notes
 up to the tag you have defined and update the website files. If successful, it will push the
-changes to your GitHub repository (defined by the `--org` flag) and create a pull request:
+changes to your GitHub repository (defined by the `--fork` flag) and create a pull request:
 
 ```bash
-krel release-notes --create-website-pr --org=kubefriend --tag v1.19.0-beta.1 
+krel release-notes --create-website-pr --fork=kubefriend --tag v1.19.0-beta.1 
 ```
 
 As with `--create-draft-pr`, `--tag` is optional and will default to the latest release.
-You can override the name of your fork of kubernetes-sigs/release-notes with
-`--org` and `--website-repo`.
+You can override the name of your fork of kubernetes-sigs/release-notes by specifying
+the full repository slug: `--fork=myorg/myreponame`.
 
 ### Usage notes
 
 You can run `--create-draft-pr` and `--create-website-pr` in the same invocation of krel.
-Note that `krel` will use the same GitHub organization (`--org`) to get the forks of
-k-sigs/relese-notes and  k/sig release when doing so.
+Note that `krel` will use the same GitHub organization (`--fork`) to get the forks of
+k-sigs/relese-notes and  k/sig release when doing so. Note that you cannot override the
+name of the repositories when generating both PRs in the same invacation. 
 
 ## Important notes and issues
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -957,3 +957,24 @@ func (r *Repo) IsDirty() (bool, error) {
 	}
 	return !status.IsClean(), nil
 }
+
+// ParseRepoSlug parses a repository string and return the organization and repository name/
+func ParseRepoSlug(repoSlug string) (org, repo string, err error) {
+	match, err := regexp.MatchString(`(?i)^[a-z0-9-/]+$`, repoSlug)
+	if err != nil {
+		return "", "", errors.Wrap(err, "checking repository slug")
+	}
+	if !match {
+		return "", "", errors.New("repository slug contains invalid characters")
+	}
+
+	parts := strings.Split(repoSlug, "/")
+	if len(parts) > 2 {
+		return "", "", errors.New("string is not a well formed org/repo slug")
+	}
+	org = parts[0]
+	if len(parts) > 1 {
+		repo = parts[1]
+	}
+	return org, repo, nil
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -235,3 +235,42 @@ func TestIsDirtyMockFailureWorktreeStatus(t *testing.T) {
 	require.NotNil(t, err)
 	require.False(t, dirty)
 }
+
+func TestParseRepoSlug(t *testing.T) {
+	slugTests := []struct {
+		caseName, repoSlug, orgName, repoName string
+		isValid                               bool
+	}{
+		{caseName: "valid slug", repoSlug: "kubernetes/release",
+			orgName: "kubernetes", repoName: "release", isValid: true},
+
+		{caseName: "slug with hyphens", repoSlug: "kubernetes/repo_with_underscores",
+			orgName: "", repoName: "", isValid: false},
+
+		{caseName: "slug with dashes", repoSlug: "kubernetes-sigs/release-notes",
+			orgName: "kubernetes-sigs", repoName: "release-notes", isValid: true},
+
+		{caseName: "slug with uppercase", repoSlug: "GoogleCloudPlatform/compute-image-tools",
+			orgName: "GoogleCloudPlatform", repoName: "compute-image-tools", isValid: true},
+
+		{caseName: "slug with invalid chars", repoSlug: "kubern#etes/not.valid",
+			orgName: "", repoName: "", isValid: false},
+
+		{caseName: "slug with extra slash", repoSlug: "kubernetes/not/valid",
+			orgName: "", repoName: "", isValid: false},
+
+		{caseName: "slug with only org", repoSlug: "kubernetes",
+			orgName: "kubernetes", repoName: "", isValid: true},
+	}
+
+	for _, testCase := range slugTests {
+		org, repo, err := git.ParseRepoSlug(testCase.repoSlug)
+		if testCase.isValid {
+			require.Nil(t, err, testCase.caseName)
+		} else {
+			require.NotNil(t, err, testCase.caseName)
+		}
+		require.Equal(t, testCase.orgName, org, testCase.caseName)
+		require.Equal(t, testCase.repoName, repo, testCase.caseName)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation
/kind api-change

#### What this PR does / why we need it:

This PR changes introduces a new `--fork` flag in `krel release-notes` that replaces the former `--org`, `--draft-repo` and `--website-repo` flags to avoid confusion with how `--org` is used in the rest of the tools. This was formerly discussed [here](https://github.com/kubernetes/release/pull/1495#issuecomment-674172900). 

To accomplish this, a new function `git.ParseRepoSlug()` function and tests are added to the git package.

It also introduces new directory checking logic to fix a bug where the release notes pull request was not generated when the new release-notes working dirs did not exist.

Finally, the krel documentation is updated to reflect the `--fork` changes 

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/release/pull/1495#issuecomment-674172900

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- Add new function `git.ParseRepoSlug()`
- Fix a bug where the draft pull request was not created when the release-notes subdirs did not exist
- New `krel release-notes` flag `--fork` that replaces `--org`, `--draft-repo` and `--website-repo`.
```
