### PR TITLE
[krel] krel promote-images subcommand

### DIFF
--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/command"
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/github"
+	"k8s.io/release/pkg/util"
+)
+
+const (
+	k8sioRepo             = "k8s.io"
+	k8sioManifestsPath    = "k8s.gcr.io"
+	stagingRepo           = "k8s-staging-kubernetes"
+	promotionBranchSuffix = "-image-promotion"
+)
+
+// promoteCommand is the krel subcommand to promote conainer images
+var imagePromoteCommand = &cobra.Command{
+	Use:   "promote-images",
+	Short: "Starts an image promotion for a tag of kubernetes images",
+	Long: `krel promote
+
+The 'promote' subcommand of krel updates the image promoter manifests
+ans creates a PR in kubernetes/k8s.io`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Run the PR creation function
+		return runPromote(promoteOpts)
+	},
+}
+
+type promoteOptions struct {
+	userFork        string
+	tag             string
+	interactiveMode bool
+}
+
+func (o *promoteOptions) Validate() error {
+	if o.tag == "" {
+		return errors.New("cannot start promotion --tag is required")
+	}
+	if o.userFork == "" {
+		return errors.New("cannot start promotion --fork is required")
+	}
+
+	// Check the fork slug
+	if _, _, err := git.ParseRepoSlug(o.userFork); err != nil {
+		return errors.Wrap(err, "checking user's fork")
+	}
+
+	// Verify we got a valid tag
+	if _, err := util.TagStringToSemver(o.tag); err != nil {
+		return errors.Wrapf(err, "verifying tag: %s", o.tag)
+	}
+
+	// Check that the GitHub token is set
+	token, isset := os.LookupEnv(github.TokenEnvKey)
+	if !isset || token == "" {
+		return errors.New("cannot promote images if GitHub token is not set")
+	}
+	return nil
+}
+
+var promoteOpts = &promoteOptions{}
+
+func init() {
+	imagePromoteCommand.PersistentFlags().StringVarP(
+		&promoteOpts.tag,
+		"tag",
+		"t",
+		"",
+		"version tag of the images we will promote",
+	)
+
+	imagePromoteCommand.PersistentFlags().StringVar(
+		&promoteOpts.userFork,
+		"fork",
+		"",
+		"the user's fork of kubernetes/k8s.io",
+	)
+
+	imagePromoteCommand.PersistentFlags().BoolVarP(
+		&promoteOpts.interactiveMode,
+		"interactive",
+		"i",
+		false,
+		"interactive mode, asks before every step",
+	)
+
+	for _, flagName := range []string{"tag", "fork"} {
+		if err := imagePromoteCommand.MarkPersistentFlagRequired(flagName); err != nil {
+			logrus.Error(errors.Wrapf(err, "marking tag %s as required", flagName))
+		}
+	}
+
+	rootCmd.AddCommand(imagePromoteCommand)
+}
+
+func runPromote(opts *promoteOptions) error {
+	// Validate options
+	branchname := opts.tag + promotionBranchSuffix
+
+	// Check the cmd line opts
+	if err := opts.Validate(); err != nil {
+		return errors.Wrap(err, "checking command line options")
+	}
+
+	// Get the github org and repo from the fork slug
+	userForkOrg, userForkRepo, err := git.ParseRepoSlug(opts.userFork)
+	if err != nil {
+		return errors.Wrap(err, "parsing user's fork")
+	}
+	if userForkRepo == "" {
+		userForkRepo = k8sioRepo
+	}
+
+	// Check Environment
+	gh := github.New()
+
+	// Check for the cip-mm binary
+	cipmm, err := exec.LookPath("cip-mm")
+	if err != nil {
+		return errors.Wrap(err, "while looking for cip-mm in your path")
+	}
+
+	// Verify the repository is a fork of k8s.io
+	if err = verifyFork(
+		branchname, userForkOrg, userForkRepo, git.DefaultGithubOrg, k8sioRepo,
+	); err != nil {
+		return errors.Wrapf(err, "while checking fork of %s/%s ", git.DefaultGithubOrg, k8sioRepo)
+	}
+
+	// Clone k8s.io
+	repo, err := prepareFork(branchname, git.DefaultGithubOrg, k8sioRepo, userForkOrg, userForkRepo)
+	if err != nil {
+		return errors.Wrap(err, "while preparing k/k8s.io fork")
+	}
+
+	defer func() {
+		if mustRun(opts, "Clean fork directory?") {
+			err = repo.Cleanup()
+		} else {
+			logrus.Infof("All modified files will be left untouched in %s", repo.Dir())
+		}
+	}()
+
+	// Run cip-mm
+	if mustRun(opts, "Run cip-mm?") {
+		if err := command.New(
+			cipmm,
+			fmt.Sprintf("--base_dir=%s", filepath.Join(repo.Dir(), k8sioManifestsPath)),
+			fmt.Sprintf("--staging_repo=gcr.io/%s", stagingRepo),
+			fmt.Sprintf("--filter_tag=%s", opts.tag),
+		).RunSuccess(); err != nil {
+			return errors.Wrap(err, "running cip-mm install in kubernetes-sigs/release-notes")
+		}
+	}
+
+	// TODO: Either remove mock images or we fix them at the origin
+
+	// TODO: verify that the manifest was actually modified
+
+	// add the modified manifest to staging
+	logrus.Debugf("Adding %s to staging area", filepath.Join(k8sioManifestsPath, "images", stagingRepo, "images.yaml"))
+	if err := repo.Add(filepath.Join(k8sioManifestsPath, "images", stagingRepo, "images.yaml")); err != nil {
+		return errors.Wrap(err, "adding image manifest to staging area")
+	}
+
+	commitMessage := fmt.Sprintf("releng: Image promotion for %s", opts.tag)
+
+	// Commit files
+	logrus.Debug("Creating commit")
+	if err := repo.UserCommit(commitMessage); err != nil {
+		return errors.Wrapf(err, "Error creating commit in %s/%s", git.DefaultGithubOrg, k8sioRepo)
+	}
+
+	// Push to fork
+	if mustRun(opts, "Push changes to user's fork?") {
+		logrus.Infof("Pushing manifest changes to %s/%s", userForkOrg, userForkRepo)
+		if err := repo.PushToRemote(userForkName, branchname); err != nil {
+			return errors.Wrapf(err, "pushing %s to %s/%s", userForkName, userForkOrg, userForkRepo)
+		}
+	}
+
+	prBody := fmt.Sprintf("Image promotion for Kubernetes %s\n", opts.tag)
+	prBody += "This is an automated PR generated from `krel The Kubernetes Release Toolbox`\n\n"
+
+	// Create the Pull Request
+	if mustRun(opts, "Create pull request?") {
+		pr, err := gh.CreatePullRequest(
+			git.DefaultGithubOrg, k8sioRepo, git.DefaultBranch,
+			fmt.Sprintf("%s:%s", userForkOrg, branchname),
+			commitMessage, prBody,
+		)
+
+		if err != nil {
+			return errors.Wrap(err, "creating the pull request in k/k8s.io")
+		}
+		logrus.Infof(
+			"Successfully created PR: %s%s/%s/pull/%d",
+			github.GitHubURL, git.DefaultGithubOrg, k8sioRepo, pr.GetNumber(),
+		)
+	}
+
+	// Success!
+	return nil
+}
+
+// mustRun avoids running when a users chooses n in interactive mode
+func mustRun(opts *promoteOptions, question string) bool {
+	if !opts.interactiveMode {
+		return true
+	}
+	_, success, err := util.Ask(fmt.Sprintf("%s (Y/n)", question), "y:Y:yes|n:N:no|y", 10)
+	if err != nil {
+		logrus.Error(err)
+		if err.(util.UserInputError).IsCtrlC() {
+			os.Exit(1)
+		}
+		return false
+	}
+	if success {
+		return true
+	}
+	return false
+}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -27,12 +27,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/tarfile"
 	"github.com/containers/image/v5/manifest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -94,6 +96,12 @@ const (
 	// ProductionBucketURL is the url for the ProductionBucket
 	ProductionBucketURL = "https://dl.k8s.io"
 )
+
+// ImagePromoterImages abtracts the manifest used by the image promoter
+type ImagePromoterImages []struct {
+	Name string              `json:"name"`
+	DMap map[string][]string `yaml:"dmap,flow"` // eg "sha256:ef9493aff21f7e368fb3968b46ff2542b0f6863a5de2b9bc58d8d151d8b0232c": ["v1.17.12-rc.0"]
+}
 
 // GetDefaultToolRepoURL returns the default HTTPS repo URL for Release Engineering tools.
 // Expected: https://github.com/kubernetes/release
@@ -485,4 +493,87 @@ func fileToHash(fileName string, hasher hash.Hash) (string, error) {
 	}
 
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+// NewImagePromoterManifestFromFile parses an image promoter manifest file
+func NewImagePromoterManifestFromFile(manifestPath string) (imagesList *ImagePromoterImages, err error) {
+	if !util.Exists(manifestPath) {
+		return nil, errors.New("could not find image promoter manifest")
+	}
+	yamlCode, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading yaml code from file")
+	}
+
+	imagesList = &ImagePromoterImages{}
+	if err := imagesList.Parse(yamlCode); err != nil {
+		return nil, errors.Wrap(err, "parsing manifest yaml")
+	}
+
+	return imagesList, nil
+}
+
+// Parse reads yaml code into an ImagePromoterManifest object
+func (imagesList *ImagePromoterImages) Parse(yamlCode []byte) error {
+	if err := yaml.Unmarshal(yamlCode, imagesList); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ToYAML serializes an image list into an YAML file.
+// We serialize the data by hand to emulate the way it's done by the image promoter
+func (imagesList *ImagePromoterImages) ToYAML() ([]byte, error) {
+	// The image promoter code sorts images by:
+	//	  1. Name 2. Digest SHA (asc)  3. Tag
+
+	// First, sort by name (sort #1)
+	sort.Slice(*imagesList, func(i, j int) bool {
+		return (*imagesList)[i].Name < (*imagesList)[j].Name
+	})
+
+	// Let's build the YAML code
+	yamlCode := ""
+	for _, imgData := range *imagesList {
+		// Add the new name key (it is not sorted in the promoter code)
+		yamlCode += fmt.Sprintf("- name: %s\n", imgData.Name)
+		yamlCode += "  dmap:\n"
+
+		// Now, lets sort by the digest sha (sort #2)
+		keys := make([]string, 0, len(imgData.DMap))
+		for k := range imgData.DMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, digestSHA := range keys {
+			// Finally, sort bt tag (sort #3)
+			tags := imgData.DMap[digestSHA]
+			sort.Strings(tags)
+			yamlCode += fmt.Sprintf("    %q: [", digestSHA)
+			for i, tag := range tags {
+				if i > 0 {
+					yamlCode += ","
+				}
+				yamlCode += fmt.Sprintf("%q", tag)
+			}
+			yamlCode += "]\n"
+		}
+	}
+
+	return []byte(yamlCode), nil
+}
+
+// Write writes the promoter image list into an YAML file.
+func (imagesList *ImagePromoterImages) Write(filePath string) error {
+	yamlCode, err := imagesList.ToYAML()
+	if err != nil {
+		return errors.Wrap(err, "while marshalling image list")
+	}
+	// Write the yaml into the specified file
+	if err := ioutil.WriteFile(filePath, yamlCode, os.FileMode(0o644)); err != nil {
+		return errors.Wrap(err, "writing yaml code into file")
+	}
+
+	return nil
 }

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -100,7 +100,7 @@ const (
 // ImagePromoterImages abtracts the manifest used by the image promoter
 type ImagePromoterImages []struct {
 	Name string              `json:"name"`
-	DMap map[string][]string `yaml:"dmap,flow"` // eg "sha256:ef9493aff21f7e368fb3968b46ff2542b0f6863a5de2b9bc58d8d151d8b0232c": ["v1.17.12-rc.0"]
+	DMap map[string][]string `json:"dmap"` // eg "sha256:ef9493aff21f7e368fb3968b46ff2542b0f6863a5de2b9bc58d8d151d8b0232c": ["v1.17.12-rc.0"]
 }
 
 // GetDefaultToolRepoURL returns the default HTTPS repo URL for Release Engineering tools.
@@ -495,8 +495,8 @@ func fileToHash(fileName string, hasher hash.Hash) (string, error) {
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }
 
-// NewImagePromoterManifestFromFile parses an image promoter manifest file
-func NewImagePromoterManifestFromFile(manifestPath string) (imagesList *ImagePromoterImages, err error) {
+// NewPromoterImageListFromFile parses an image promoter manifest file
+func NewPromoterImageListFromFile(manifestPath string) (imagesList *ImagePromoterImages, err error) {
 	if !util.Exists(manifestPath) {
 		return nil, errors.New("could not find image promoter manifest")
 	}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -837,3 +837,138 @@ func TestWriteChecksums(t *testing.T) {
 		cleanup()
 	}
 }
+
+func TestNewPromoterImageListFromFile(t *testing.T) {
+	listYAML := "- name: pause\n"
+	listYAML += "  dmap:\n"
+	listYAML += "    \"sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f\": [\"3.2\"]\n"
+	listYAML += "    \"sha256:a319ac2280eb7e3a59e252e54b76327cb4a33cf8389053b0d78277f22bbca2fa\": [\"3.3\"]\n"
+
+	tempFile, err := ioutil.TempFile(os.TempDir(), "release-test")
+	require.Nil(t, err, "creating temp file")
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write([]byte(listYAML))
+	require.Nil(t, err, "wrinting temporary promoter image list")
+
+	imageList, err := NewPromoterImageListFromFile(tempFile.Name())
+	require.Nil(t, err)
+
+	require.Equal(t, 1, len(*imageList))
+	require.Equal(t, 2, len((*imageList)[0].DMap))
+}
+
+func TestPromoterImageParse(t *testing.T) {
+	listYAML := "- name: kube-apiserver-amd64\n  dmap:\n"
+	listYAML += "    \"sha256:365063a9b0df28cb8b72525138214079085ce8376e47a8654e34d16766c432f9\": [\"v1.18.9-rc.0\"]\n"
+	listYAML += "    \"sha256:3c65dfd9682ca03989ac8ae9db230ea908e2ba00a8db002b33b09ca577f5c05c\": [\"v1.19.2-rc.0\"]\n"
+	listYAML += "    \"sha256:43374266764aee719ce342c3611d34a12c68315a64a4197a2571b7434bb42f82\": [\"v1.19.1\"]\n"
+	listYAML += "    \"sha256:4da7d4a9176971d2af0a5e4bd6f764677648db4ad2814574fbb76962458c7bbb\": [\"v1.19.0-rc.2\"]\n"
+	listYAML += "    \"sha256:4fd1a6d25b5fe5db3647ed1d368c671b618efafb6ddbe06fc64697d2ba271aa9\": [\"v1.18.8\"]\n"
+	listYAML += "    \"sha256:5b6b95cc8c06262719d10149964ca59496b234e28ef3e3fcdf7323f46c83ce04\": [\"v1.19.0-rc.4\"]\n"
+	listYAML += "    \"sha256:6257f45b4908eed0a4b84d8efeaf2751096ce516006daf74690b321b785e6cc4\": [\"v1.19.0\"]\n"
+	listYAML += "- name: pause\n  dmap:\n"
+	listYAML += "    \"sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f\": [\"3.2\"]\n"
+	listYAML += "    \"sha256:a319ac2280eb7e3a59e252e54b76327cb4a33cf8389053b0d78277f22bbca2fa\": [\"3.3\"]\n"
+
+	imageList := &ImagePromoterImages{}
+	err := imageList.Parse([]byte(listYAML))
+	require.Nil(t, err, "parsing image list yaml")
+
+	require.Equal(t, 2, len(*imageList))
+	require.Equal(t, 7, len((*imageList)[0].DMap))
+	require.Equal(t, 2, len((*imageList)[1].DMap))
+	require.Equal(t, "kube-apiserver-amd64", (*imageList)[0].Name)
+	require.Equal(t, "pause", (*imageList)[1].Name)
+	require.Equal(t, "v1.19.0", (*imageList)[0].DMap["sha256:6257f45b4908eed0a4b84d8efeaf2751096ce516006daf74690b321b785e6cc4"][0])
+	require.Equal(t, "3.3", (*imageList)[1].DMap["sha256:a319ac2280eb7e3a59e252e54b76327cb4a33cf8389053b0d78277f22bbca2fa"][0])
+}
+
+func TestPromoterImageToYAML(t *testing.T) {
+	imageList := &ImagePromoterImages{
+		struct {
+			Name string              "json:\"name\""
+			DMap map[string][]string "json:\"dmap\""
+		}{
+			Name: "hyperkube",
+			DMap: map[string][]string{
+				"sha256:54cdd8d3b74f9c577c8bb4f43e50813f0190006e66efe861bd810ee3f5e7cc7d": {"v1.18.8"},
+				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.16.16-rc.0"},
+				"sha256:9f35b65ee834239ffbbd0ddfb54e0317cf99f10a75d8e8af372af45286d069ab": {"v1.17.10"},
+			},
+		},
+		struct {
+			Name string              "json:\"name\""
+			DMap map[string][]string "json:\"dmap\""
+		}{
+			Name: "conformance",
+			DMap: map[string][]string{
+				"sha256:17fcac56c871a58a093ff36915816161b1dbbb9eca0add9c968d9c27c4ba1881": {"v1.19.0"},
+			},
+		},
+		struct {
+			Name string              "json:\"name\""
+			DMap map[string][]string "json:\"dmap\""
+		}{
+			Name: "kube-proxy",
+			DMap: map[string][]string{
+				"sha256:c752ecbd04bc4517168a19323bb60fb45324eee1e480b2b97d3fd6ea0a54f42d": {"v1.18.8", "v1.19.0"},
+			},
+		},
+	}
+
+	// Expected yaml output, must be sorted correctly, according to the image promoter sort order
+	expectedYAML := "- name: conformance\n  dmap:\n"
+	expectedYAML += "    \"sha256:17fcac56c871a58a093ff36915816161b1dbbb9eca0add9c968d9c27c4ba1881\": [\"v1.19.0\"]\n"
+	expectedYAML += "- name: hyperkube\n  dmap:\n"
+	expectedYAML += "    \"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342\": [\"v1.16.16-rc.0\"]\n"
+	expectedYAML += "    \"sha256:54cdd8d3b74f9c577c8bb4f43e50813f0190006e66efe861bd810ee3f5e7cc7d\": [\"v1.18.8\"]\n"
+	expectedYAML += "    \"sha256:9f35b65ee834239ffbbd0ddfb54e0317cf99f10a75d8e8af372af45286d069ab\": [\"v1.17.10\"]\n"
+	expectedYAML += "- name: kube-proxy\n  dmap:\n"
+	expectedYAML += "    \"sha256:c752ecbd04bc4517168a19323bb60fb45324eee1e480b2b97d3fd6ea0a54f42d\": [\"v1.18.8\",\"v1.19.0\"]\n"
+
+	yamlCode, err := imageList.ToYAML()
+	require.Nil(t, err, "serilizing imagelist to yaml")
+	require.Equal(t, expectedYAML, string(yamlCode), "checking promoter image list yaml output")
+}
+
+func TestPromoterImageWrite(t *testing.T) {
+	imageList := &ImagePromoterImages{
+		struct {
+			Name string              "json:\"name\""
+			DMap map[string][]string "json:\"dmap\""
+		}{
+			Name: "kube-controller-manager-s390x",
+			DMap: map[string][]string{
+				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7": {"v1.19.1"},
+			},
+		},
+		struct {
+			Name string              "json:\"name\""
+			DMap map[string][]string "json:\"dmap\""
+		}{
+			Name: "kube-scheduler",
+			DMap: map[string][]string{
+				"sha256:022b81d70447014f63fdc734df48cb9e3a2854c48f65acdca67aac5c1974fc22": {"v1.19.0-rc.2"},
+			},
+		},
+	}
+
+	expectedFile := "- name: kube-controller-manager-s390x\n  dmap:\n"
+	expectedFile += "    \"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7\": [\"v1.19.1\"]\n"
+	expectedFile += "- name: kube-scheduler\n  dmap:\n"
+	expectedFile += "    \"sha256:022b81d70447014f63fdc734df48cb9e3a2854c48f65acdca67aac5c1974fc22\": [\"v1.19.0-rc.2\"]\n"
+
+	tempFile, err := ioutil.TempFile(os.TempDir(), "release-test")
+	require.Nil(t, err, "creating temp file")
+	defer os.Remove(tempFile.Name())
+
+	err = imageList.Write(tempFile.Name())
+	require.Nil(t, err, "writing data to disk")
+
+	// Read back the file to see if it correct
+	fileContents, err := ioutil.ReadFile(tempFile.Name())
+	require.Nil(t, err, "reading temporary file")
+
+	require.Equal(t, expectedFile, string(fileContents))
+}


### PR DESCRIPTION
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

/kind feature

#### What this PR does / why we need it:

This PR adds a new subcommand to krel: `promote-images`. 

When run, `krel promote` takes a tag and runs [cip-mm](https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/cmd/cip-mm) to modify the image promotion manifests.

After writing the new image into the manifest, krel uses a fork of kubernetes/k8s.io`. It will clone it, write the manifests in it, commit and push the changes. Finally it will create a Pull Request with the modified files.

The subcommand has an `--interactive` flag. When set, krel will ask the user to confirm before running every step. 

The command can be run and will not push or create a PR if no changes are made to the current manifest.

As part of this enhancement, a new API has been added to the release package to read and write the image list, iteself part of a thin manifest from the imagee promoter. Tests are included for all the new functions.

```
Usage:
  krel promote-images [flags]

Flags:
      --fork string   the user's fork of kubernetes/k8s.io
  -h, --help          help for promote-images
  -i, --interactive   interactive mode, asks before every step
  -t, --tag string    version tag of the images we will promote
```

#### Which issue(s) this PR fixes:
fixes #1445 

#### Special notes for your reviewer:

This PR depends on #1543 to run

It needs to have `cip-mm` in the path to run.

#### Does this PR introduce a user-facing change?
```release-note
- New `krel promote-images` subcommand to create the image promotion pull requests
- API to read and write image lists in an [image promoter thin-manifest](https://github.com/kubernetes-sigs/k8s-container-image-promoter#thin-manifests-example)
```
