### PR TITLE
[WIP] Add a glibc-containing variant of go-runner

### DIFF
--- a/images/build/go-runner-glibc/BUILD.bazel
+++ b/images/build/go-runner-glibc/BUILD.bazel
@@ -1,0 +1,14 @@
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/images/build/go-runner-glibc/OWNERS
+++ b/images/build/go-runner-glibc/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - build-image-approvers
+reviewers:
+  - build-image-reviewers

--- a/images/build/go-runner-glibc/cloudbuild.yaml
+++ b/images/build/go-runner-glibc/cloudbuild.yaml
@@ -1,0 +1,55 @@
+# See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md for more details on image pushing process
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+    entrypoint: 'bash'
+    dir: ./images/build/go-runner
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - REGISTRY=gcr.io/$PROJECT_ID
+    - HOME=/root
+    - TAG=$_GIT_TAG
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    - IMGNAME=go-runner-glibc
+    - IMAGE_VERSION=$_IMAGE_VERSION
+    - CONFIG=$_CONFIG
+    - GO_VERSION=$_GO_VERSION
+    - DISTROLESS_IMAGE=$_DISTROLESS_IMAGE
+    # `distroless/base` only supports linux/amd64, currently.
+    - PLATFORMS=linux/amd64
+    args:
+    - '-c'
+    - |
+      gcloud auth configure-docker \
+      && make manifest
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _IMAGE_VERSION: 'codename-v0.0.0'
+  _CONFIG: 'codename'
+  _GO_VERSION: '1.15.2'
+  _DISTROLESS_IMAGE: 'base-debian10'
+
+tags:
+- 'go-runner-glibc'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_IMAGE_VERSION}
+- ${_CONFIG}
+- ${_GO_VERSION}
+- ${_DISTROLESS_IMAGE}
+
+images:
+  - 'gcr.io/$PROJECT_ID/go-runner-glibc-amd64:$_IMAGE_VERSION'
+  - 'gcr.io/$PROJECT_ID/go-runner-glibc-amd64:$_GIT_TAG-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/go-runner-glibc-amd64:latest-$_CONFIG'

--- a/images/build/go-runner-glibc/variants.yaml
+++ b/images/build/go-runner-glibc/variants.yaml
@@ -1,0 +1,6 @@
+variants:
+  buster:
+    CONFIG: 'buster'
+    IMAGE_VERSION: 'buster-v2.0.2'
+    GO_VERSION: '1.15.2'
+    DISTROLESS_IMAGE: 'base-debian10'


### PR DESCRIPTION
Build a glibc-containing variant to GCB's variants.yaml. This allows for dynamically-linked workloads to work in the context of a `go-runner` image.

Documentation on the differences between `distroless/static` and `distroless/base`: https://github.com/GoogleContainerTools/distroless/tree/master/base

/kind feature

```release-note
NONE
```
