### PR TITLE
Enhance the detection logic for host iptables mode

### DIFF
--- a/images/build/debian-iptables/buster/iptables-wrapper
+++ b/images/build/debian-iptables/buster/iptables-wrapper
@@ -26,10 +26,10 @@ set -e
 # legacy iptables was empty / mostly empty.
 
 # Below chains are created by kubelet: valid for now - k8s 1.19
-chains_created_by_kubelet="KUBE-MARK-DROP|KUBE-MARK-MASQ|KUBE-POSTROUTING"
+chains_created_by_kubelet=":KUBE-MARK-DROP|:KUBE-MARK-MASQ|:KUBE-POSTROUTING"
 
-kubelet_nft_chains=$( (iptables-nft -t nat -nL || true; ip6tables-nft -t nat -nL|| true) 2>/dev/null | grep Chain | grep -E ${chains_created_by_kubelet} | wc -l)
-kubelet_legacy_chains=$( (iptables-legacy -t nat -nL || true; ip6tables-legacy -t nat -nL|| true) 2>/dev/null | grep Chain | grep -E ${chains_created_by_kubelet} | wc -l)
+kubelet_nft_chains=$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep -E ${chains_created_by_kubelet} | wc -l)
+kubelet_legacy_chains=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E ${chains_created_by_kubelet} | wc -l)
 
 if [ "${kubelet_nft_chains}" -gt "${kubelet_legacy_chains}" ]; then
     mode=nft

--- a/images/build/debian-iptables/buster/iptables-wrapper
+++ b/images/build/debian-iptables/buster/iptables-wrapper
@@ -25,15 +25,25 @@ set -e
 # avoid hitting that timeout, we only bother to even check nft if
 # legacy iptables was empty / mostly empty.
 
-num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
-if [ "${num_legacy_lines}" -ge 10 ]; then
-    mode=legacy
+# Below chains are created by kubelet: valid for now - k8s 1.19
+chains_created_by_kubelet="KUBE-MARK-DROP|KUBE-MARK-MASQ|KUBE-POSTROUTING"
+
+kubelet_nft_chains=$( (iptables-nft -t nat -nL || true; ip6tables-nft -t nat -nL|| true) 2>/dev/null | grep Chain | grep -E ${chains_created_by_kubelet} | wc -l)
+kubelet_legacy_chains=$( (iptables-legacy -t nat -nL || true; ip6tables-legacy -t nat -nL|| true) 2>/dev/null | grep Chain | grep -E ${chains_created_by_kubelet} | wc -l)
+
+if [ "${kubelet_nft_chains}" -gt "${kubelet_legacy_chains}" ]; then
+    mode=nft
 else
-    num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
-    if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
-	mode=legacy
+    num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "${num_legacy_lines}" -ge 10 ]; then
+        mode=legacy
     else
-	mode=nft
+        num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
     fi
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:


-->
/kind feature

#### What this PR does / why we need it:
As we know,  kube-proxy should ensure its iptables running in the same mode with the one in host OS.
But the current login (the `iptables-wrapper` ) sometimes does not work well. For example, we saw /issues/80462 couple of times on Oracle Linux 8.
I couldn't reveal the root cause at that time, But obviously the `iptables-wrapper` does not work out at the beginning. Maybe there's some other iptables rules exist before kube-proxy runs. 
And when `iptables-wrapper` didn't work out at the very beginning, then the kube-proxy rules will be created in legacy mode, then even kube-proxy reboots, the legacy-rules counter will always greater than the nft-rules. the wrapper script will be always miss-leaded(always run in legacy mode).

moreover , as state in the original code `This assumes that some non-containerized process (eg # kubelet) has already created some iptables rules.`. So my fix just make this assumption more *explicit* : by reading the kubelet code, those chains -- `KUBE-MARK-DROP | KUBE-MARK-MASQ | KUBE-POSTROUTING` are created when kubelet runs. So I put a new logic at the top of the wrapper.

last but not least, actually, there's a chance for `wrapper` to be failing: assuming we run kube-proxy pod right after kubelet service starts. There will be seconds for kubelet to walk thru the code until creating those chains, between this small time window, the kube-proxy may already be mis-lead. This failing case also apply for the original logic of wrapper.


And another solution is not "Auto-Detection" , but "Specific the mode" , to provide information manually:
```
if [ "${IPTABLE_MODE}" != "" ]; then
        mode=${IPTABLE_MODE}
else ..... # following are the original logic
```
But it requires kube-proxy to add *env variable* in diff environment, not quite user friendly.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/80462


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
