### PR TITLE
Fix golangci-lint check and update config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ issues:
 linters:
   disable-all: true
   enable:
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
@@ -24,8 +25,10 @@ linters:
     - gocyclo
     - godox
     - gofmt
+    - goheader
     - goimports
     - golint
+    - gomodguard
     - goprintffuncname
     - gosimple
     - govet
@@ -36,6 +39,7 @@ linters:
     - nakedret
     - prealloc
     - rowserrcheck
+    - sqlclosecheck
     - staticcheck
     - structcheck
     - stylecheck
@@ -45,14 +49,25 @@ linters:
     - unused
     - varcheck
     - whitespace
+    # - exhaustive
+    # - exportloopref
     # - funlen
+    # - gci
     # - gochecknoglobals
     # - gochecknoinits
     # - gocognit
+    # - godot
+    # - goerr113
+    # - gofumpt
     # - gomnd
     # - gosec
     # - lll
+    # - nestif
+    # - nlreturn
+    # - noctx
+    # - nolintlint
     # - scopelint
+    # - testpackage
     # - wsl
 linters-settings:
   godox:

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" // nolint: staticcheck
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/release/pkg/git"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The .golangci.yml now reflects all linters, whereas the lint issue for
the deprecated protobuf package has been disabled. This is reasoned
because testgrid still uses the package and we have no chance to fix it
within this repository.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
