### PR TITLE
Add configurable timeout to test-go.sh

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -16,8 +16,25 @@
 
 set -euo pipefail
 
+# Default timeout is 900s
+TEST_TIMEOUT=900
+
+for arg in "$@"
+do
+    case $arg in
+        -t=*|--timeout=*)
+        TEST_TIMEOUT="${arg#*=}"
+        shift
+        ;;
+        -t|--timeout)
+        TEST_TIMEOUT="$2"
+        shift
+        shift
+    esac
+done
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-GO111MODULE=on go test -v -count=1 -cover -coverprofile coverage.out ./...
+GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out ./...
 go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds a configurable timeout to `test-go.sh` via a `-t|--timeout` flag. It also adds a new default timeout setr to 900 seconds

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

Add configurable timeout to test-go.sh with a new `-t|--timeout` flag

```
