### PR TITLE
Increase Go Tests timeout to 30min

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -16,8 +16,8 @@
 
 set -euo pipefail
 
-# Default timeout is 900s
-TEST_TIMEOUT=900
+# Default timeout is 1800s
+TEST_TIMEOUT=1800
 
 for arg in "$@"
 do


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR increases the go tests timeout to 30 min

#### Which issue(s) this PR fixes:

ref: https://github.com/kubernetes/release/pull/1538#issuecomment-695045725

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
