### PR TITLE
Fix $CHANGELOG_PATH for krel announce

### DIFF
--- a/anago
+++ b/anago
@@ -845,8 +845,7 @@ announce () {
   local nomock_flag=""
   local pubotRc=0
   local pubotIssue=''
-  local changelog_path="${CHANGELOG_FILEPATH}/${CHANGELOG_FILE}"
-
+  
   logecho "Creating k8s ${RELEASE_VERSION_PRIME} announcement in ${WORKDIR} ..."
 
   if [[ "$arg" == "--branch" ]]; then
@@ -866,7 +865,7 @@ announce () {
     fi
   else
     logrun -v krel announce build release \
-    --changelog-file-path "$changelog_path" \
+    --changelog-file-path "${CHANGELOG_FILEPATH}" \
     --tag ${RELEASE_VERSION_PRIME} \
     --changelog-html-file ${RELEASE_NOTES_HTML} \
     --workdir ${WORKDIR} \


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

A contributor reported that amid the rush of the last patch releases, the release announcement email went out with the wrong URL in the changelog link.  

The wrong link was:  https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.18.md/CHANGELOG-1.18.md and was due to a bad assignment to `$changelog_path` in `announce () `. This caused `krel announce` to get the wrong flag:
```
Step #2: anago::announce(): krel announce build release 
   --changelog-file-path CHANGELOG/CHANGELOG-1.18.md/CHANGELOG-1.18.md
   --tag v1.18.9 --changelog-html-file /workspace/anago-v1.18.9/src/release-notes.html
   --workdir /workspace/anago-v1.18.9
```

This PR cancels that assignment and passes `$CHANGELOG_FILEPATH` directly to krel

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

The correct assignment of `$CHANGELOG_FILEPATH` as directory + filename already happens in line 1484 of anago:

https://github.com/kubernetes/release/blob/5d10c22483ed81094171f3f6eabff7c661087f69/anago#L1484

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
