### PR TITLE
deps: Add dependency versions check via zeitgeist and update repo-infra to v0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,26 +33,26 @@ verify-published-rpms: ## Ensure rpms have been published
 
 ##@ Verify
 
-.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-shellcheck
+.PHONY: verify verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint verify-shellcheck
 
 # TODO: Uncomment verify-shellcheck once we finish shellchecking the repo.
 #       ref: https://github.com/kubernetes/release/issues/726
-verify: verify-golangci-lint verify-boilerplate verify-go-mod verify-dependencies #verify-shellcheck ## Runs verification scripts to ensure correct execution
-
-verify-shellcheck: ## Runs shellcheck
-	./hack/verify-shellcheck.sh
-
-verify-golangci-lint: ## Runs all golang linters
-	./hack/verify-golangci-lint.sh
-
-verify-go-mod: ## Runs the go module linter
-	./hack/verify-go-mod.sh
+verify: verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint #verify-shellcheck ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh
 
 verify-dependencies: ## Runs zeitgeist to verify dependency versions
 	./hack/verify-dependencies.sh
+
+verify-go-mod: ## Runs the go module linter
+	./hack/verify-go-mod.sh
+
+verify-golangci-lint: ## Runs all golang linters
+	./hack/verify-golangci-lint.sh
+
+verify-shellcheck: ## Runs shellcheck
+	./hack/verify-shellcheck.sh
 
 ##@ Tests
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ verify-published-rpms: ## Ensure rpms have been published
 
 ##@ Verify
 
-.PHONY: verify verify-shellcheck verify-golangci-lint verify-boilerplate
+.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-shellcheck
 
 # TODO: Uncomment verify-shellcheck once we finish shellchecking the repo.
 #       ref: https://github.com/kubernetes/release/issues/726
-verify: verify-golangci-lint verify-go-mod verify-boilerplate #verify-shellcheck ## Runs verification scripts to ensure correct execution
+verify: verify-golangci-lint verify-boilerplate verify-go-mod verify-dependencies #verify-shellcheck ## Runs verification scripts to ensure correct execution
 
 verify-shellcheck: ## Runs shellcheck
 	./hack/verify-shellcheck.sh
@@ -50,6 +50,9 @@ verify-go-mod: ## Runs the go module linter
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh
+
+verify-dependencies: ## Runs zeitgeist to verify dependency versions
+	./hack/verify-dependencies.sh
 
 ##@ Tests
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ verify-published-rpms: ## Ensure rpms have been published
 
 # TODO: Uncomment verify-shellcheck once we finish shellchecking the repo.
 #       ref: https://github.com/kubernetes/release/issues/726
-verify: verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint #verify-shellcheck ## Runs verification scripts to ensure correct execution
+verify: release-tools verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint #verify-shellcheck ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -92,7 +92,11 @@ main() {
 
   if [ $# -gt 0 ]; then
     for tool in "$@"; do
-      compile_with_flags "${tool}"
+      if [[ ${tool} =~ github.com\/ ]]; then
+        compile "${tool}"
+      else
+        compile_with_flags "${tool}"
+      fi
     done
   else
     for tool in "${RELEASE_TOOLS[@]}"; do

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # repo infra
   - name: "repo-infra"
-    version: 0.0.11
+    version: 0.1.1
     refPaths:
     - path: hack/verify-boilerplate.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,6 +6,13 @@ dependencies:
     - path: hack/verify-boilerplate.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
+  # zeitgeist
+  - name: "zeitgeist"
+    version: 0.0.17
+    refPaths:
+    - path: hack/verify-dependencies.sh
+      match: VERSION=(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+
   # CNI plugins
   - name: "CNI plugins"
     version: 0.8.7

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: 0.0.11
     refPaths:
     - path: hack/verify-boilerplate.sh
-      match: VERSION\?=v\d+\.\d+.\d+
+      match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
   # CNI plugins
   - name: "CNI plugins"
@@ -83,6 +83,13 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
+  # golangci-lint
+  - name: "golangci-lint"
+    version: 1.31.0
+    refPaths:
+    - path: hack/verify-golangci-lint.sh
+      match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+
   # iptables
   - name: "iptables"
     version: 1.8.5
@@ -136,10 +143,3 @@ dependencies:
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-
-  # golangci-lint
-  - name: "golangci-lint"
-    version: 1.31.0
-    refPaths:
-    - path: hack/verify-golangci-lint.sh
-      match: VERSION\?=v\d+\.\d+.\d+

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v0.0.11
+VERSION=v0.1.1
 URL_BASE=https://raw.githubusercontent.com/kubernetes/repo-infra
 URL=$URL_BASE/$VERSION/hack/verify_boilerplate.py
 BIN_DIR=bin

--- a/hack/verify-dependencies.sh
+++ b/hack/verify-dependencies.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION=0.0.17
+OS="$(uname -s)"
+OS="${OS,,}"
+URL_BASE=https://github.com/kubernetes-sigs/zeitgeist/releases/download
+FILENAME="zeitgeist_${VERSION}_${OS}_amd64.tar.gz"
+URL="${URL_BASE}/v${VERSION}/${FILENAME}"
+
+mkdir -p ./bin ./zeitgeist
+PATH=$PATH:bin
+
+if ! command -v zeitgeist; then
+  curl -sfL "${URL}" -o "${FILENAME}"
+  tar -xzf "${FILENAME}" -C zeitgeist
+  mv ./zeitgeist/zeitgeist ./bin
+  rm -rf ./zeitgeist "${FILENAME}"
+fi
+
+zeitgeist validate


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- dependencies.yaml: Fixup regexes for repo-infra and golangci-lint
- deps: Update repo-infra to v0.1.1
- compile-release-tools: Allow external tools to be compiled
- deps: Add dependency versions check via zeitgeist
- Makefile: Reorder verify targets to allow faster targets to run first

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- deps: Update repo-infra to v0.1.1
- deps: Add dependency versions check via zeitgeist
```
