### PR TITLE
Remove unreachable code paths in releaselib.sh

### DIFF
--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -829,19 +829,6 @@ release::set_globals () {
   # Default disk requirements per version - Modified in found_staged_location()
   RELEASE_GB="75"
 
-  if ! ((FLAGS_gcb)); then
-    GCP_USER=$($GCLOUD auth list --filter=status:ACTIVE \
-                                 --format="value(account)" 2>/dev/null)
-    if [[ -z "$GCP_USER" ]]; then
-      logecho $FAILED
-      logecho "Unable to set a valid GCP credential!"
-      return 1
-    fi
-
-    # Lowercase GCP user
-    GCP_USER="${GCP_USER,,}"
-  fi
-
   if ((FLAGS_stage)); then
     BUCKET_TYPE="stage"
   else
@@ -856,24 +843,8 @@ release::set_globals () {
 
   if ((FLAGS_nomock)); then
     RELEASE_BUCKET="$PROD_BUCKET"
-  elif ((FLAGS_gcb)); then
-    RELEASE_BUCKET="$TEST_BUCKET"
-
-    # This is passed to logrun() where appropriate when we want to mock
-    # specific activities like pushes
-    LOGRUN_MOCK="-m"
   else
-    # GCS buckets cannot contain @ or "google", so for those users, just use
-    # the "$USER" portion of $GCP_USER
-    RELEASE_BUCKET_USER="$RELEASE_BUCKET-${GCP_USER%%@google.com}"
-    RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/@/-at-}"
-
-    # GCP also doesn't like anything even remotely looking like a domain name
-    # in the bucket name so convert . to -
-    RELEASE_BUCKET_USER="${RELEASE_BUCKET_USER/\./-}"
-    RELEASE_BUCKET="$RELEASE_BUCKET_USER"
-
-    READ_RELEASE_BUCKETS=("$TEST_BUCKET")
+    RELEASE_BUCKET="$TEST_BUCKET"
 
     # This is passed to logrun() where appropriate when we want to mock
     # specific activities like pushes


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Anago is the only executor of `release::set_globals` and sets (for
compatibility reasons) the `FLAGS_gcb` to be always `1`. This means that
we can therefore remove affected code paths inside that function.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
