### PR TITLE
Add --fast support for krel push

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -59,6 +59,7 @@ type pushBuildOptions struct {
 	ci                  bool
 	noUpdateLatest      bool
 	privateBucket       bool
+	fast                bool
 }
 
 var pushBuildOpts = &pushBuildOptions{}
@@ -207,6 +208,12 @@ func init() {
 		"",
 		"Append suffix to version name if set",
 	)
+	pushBuildCmd.PersistentFlags().BoolVar(
+		&pushBuildOpts.fast,
+		"fast",
+		false,
+		"Specifies a fast build (linux amd64 only)",
+	)
 
 	rootCmd.AddCommand(pushBuildCmd)
 }
@@ -337,6 +344,10 @@ func runPushBuild(opts *pushBuildOptions) error {
 		gcsDest = "ci"
 	}
 	gcsDest += opts.gcsSuffix
+
+	if opts.fast {
+		gcsDest = filepath.Join(gcsDest, "fast")
+	}
 	logrus.Infof("GCS destination is %s", gcsDest)
 
 	copyOpts := gcs.DefaultGCSCopyOptions


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This adds the support for the `--fast` flag to krel push.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Requires #1574 
Refers to #1459 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--fast` flag to `krel push`
```
