### PR TITLE
Use semver for release version generation

### DIFF
--- a/pkg/release/regex/regex.go
+++ b/pkg/release/regex/regex.go
@@ -21,11 +21,7 @@ import (
 )
 
 const (
-	branchRegexStr  = `master|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$`
-	releaseRegexStr = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
+	branchRegexStr = `master|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$`
 )
 
-var (
-	BranchRegex  = regexp.MustCompile(branchRegexStr)
-	ReleaseRegex = regexp.MustCompile(releaseRegexStr)
-)
+var BranchRegex = regexp.MustCompile(branchRegexStr)

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/release/pkg/release"
 )
 
-func TestSetReleaseVersion(t *testing.T) {
+func TestGenerateReleaseVersion(t *testing.T) {
 	for _, tc := range []struct {
 		releaseType      string
 		version          string


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This simplifies the release version generation by using the `semver`
package instead of regular expressions.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
pkg/release: Use semver for release version generation
```
