### PR TITLE
Migrate image validation to golang

### DIFF
--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -36,8 +36,6 @@ import (
 
 const (
 	k8sioRepo             = "k8s.io"
-	k8sioManifestsPath    = "k8s.gcr.io"
-	stagingRepo           = "k8s-staging-kubernetes"
 	promotionBranchSuffix = "-image-promotion"
 )
 
@@ -173,7 +171,12 @@ func runPromote(opts *promoteOptions) error {
 	}()
 
 	// Path to the promoter image list
-	imagesListPath := filepath.Join(k8sioManifestsPath, "images", stagingRepo, "images.yaml")
+	imagesListPath := filepath.Join(
+		release.GCRIOPathProd,
+		"images",
+		filepath.Base(release.GCRIOPathStaging),
+		"images.yaml",
+	)
 
 	// Read the current manifest to check later if new images come up
 	oldlist := make([]byte, 0)
@@ -189,8 +192,8 @@ func runPromote(opts *promoteOptions) error {
 	if mustRun(opts, "Update the Image Promoter manifest with cip-mm?") {
 		if err := command.New(
 			cipmm,
-			fmt.Sprintf("--base_dir=%s", filepath.Join(repo.Dir(), k8sioManifestsPath)),
-			fmt.Sprintf("--staging_repo=gcr.io/%s", stagingRepo),
+			fmt.Sprintf("--base_dir=%s", filepath.Join(repo.Dir(), release.GCRIOPathProd)),
+			fmt.Sprintf("--staging_repo=%s", release.GCRIOPathStaging),
 			fmt.Sprintf("--filter_tag=%s", opts.tag),
 		).RunSuccess(); err != nil {
 			return errors.Wrap(err, "running cip-mm install in kubernetes-sigs/release-notes")

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -125,6 +125,12 @@ func init() {
 		false,
 		"Specifies a fast build (linux amd64 only)",
 	)
+	pushBuildCmd.PersistentFlags().BoolVar(
+		&pushBuildOpts.ValidateRemoteImageDigests,
+		"validate-images",
+		false,
+		"Validate that the remove image digests exists, needs `skopeo` in `$PATH`",
+	)
 
 	rootCmd.AddCommand(pushBuildCmd)
 }

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -95,6 +95,12 @@ const (
 
 	// ProductionBucketURL is the url for the ProductionBucket
 	ProductionBucketURL = "https://dl.k8s.io"
+
+	// Production registry root URL
+	GCRIOPathProd = "k8s.gcr.io"
+
+	// Staging registry root URL
+	GCRIOPathStaging = "gcr.io/k8s-staging-kubernetes"
 )
 
 // ImagePromoterImages abtracts the manifest used by the image promoter

--- a/pkg/release/releasefakes/fake_command_client.go
+++ b/pkg/release/releasefakes/fake_command_client.go
@@ -34,6 +34,20 @@ type FakeCommandClient struct {
 	executeReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ExecuteOutputStub        func(string, ...string) (string, error)
+	executeOutputMutex       sync.RWMutex
+	executeOutputArgsForCall []struct {
+		arg1 string
+		arg2 []string
+	}
+	executeOutputReturns struct {
+		result1 string
+		result2 error
+	}
+	executeOutputReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	RepoTagFromTarballStub        func(string) (string, error)
 	repoTagFromTarballMutex       sync.RWMutex
 	repoTagFromTarballArgsForCall []struct {
@@ -112,6 +126,70 @@ func (fake *FakeCommandClient) ExecuteReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeCommandClient) ExecuteOutput(arg1 string, arg2 ...string) (string, error) {
+	fake.executeOutputMutex.Lock()
+	ret, specificReturn := fake.executeOutputReturnsOnCall[len(fake.executeOutputArgsForCall)]
+	fake.executeOutputArgsForCall = append(fake.executeOutputArgsForCall, struct {
+		arg1 string
+		arg2 []string
+	}{arg1, arg2})
+	fake.recordInvocation("ExecuteOutput", []interface{}{arg1, arg2})
+	fake.executeOutputMutex.Unlock()
+	if fake.ExecuteOutputStub != nil {
+		return fake.ExecuteOutputStub(arg1, arg2...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.executeOutputReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCommandClient) ExecuteOutputCallCount() int {
+	fake.executeOutputMutex.RLock()
+	defer fake.executeOutputMutex.RUnlock()
+	return len(fake.executeOutputArgsForCall)
+}
+
+func (fake *FakeCommandClient) ExecuteOutputCalls(stub func(string, ...string) (string, error)) {
+	fake.executeOutputMutex.Lock()
+	defer fake.executeOutputMutex.Unlock()
+	fake.ExecuteOutputStub = stub
+}
+
+func (fake *FakeCommandClient) ExecuteOutputArgsForCall(i int) (string, []string) {
+	fake.executeOutputMutex.RLock()
+	defer fake.executeOutputMutex.RUnlock()
+	argsForCall := fake.executeOutputArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeCommandClient) ExecuteOutputReturns(result1 string, result2 error) {
+	fake.executeOutputMutex.Lock()
+	defer fake.executeOutputMutex.Unlock()
+	fake.ExecuteOutputStub = nil
+	fake.executeOutputReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCommandClient) ExecuteOutputReturnsOnCall(i int, result1 string, result2 error) {
+	fake.executeOutputMutex.Lock()
+	defer fake.executeOutputMutex.Unlock()
+	fake.ExecuteOutputStub = nil
+	if fake.executeOutputReturnsOnCall == nil {
+		fake.executeOutputReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.executeOutputReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeCommandClient) RepoTagFromTarball(arg1 string) (string, error) {
 	fake.repoTagFromTarballMutex.Lock()
 	ret, specificReturn := fake.repoTagFromTarballReturnsOnCall[len(fake.repoTagFromTarballArgsForCall)]
@@ -180,6 +258,8 @@ func (fake *FakeCommandClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.executeMutex.RLock()
 	defer fake.executeMutex.RUnlock()
+	fake.executeOutputMutex.RLock()
+	defer fake.executeOutputMutex.RUnlock()
 	fake.repoTagFromTarballMutex.RLock()
 	defer fake.repoTagFromTarballMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The image validation used in anago was added to verify that the remote
manifest exists. This is now part of the golang API and therefore can be
optionally reused in `krel push`. Target is to use this logic later on
to exchange a bunch of bash code in anago.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
cc @puerco 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--validate-images` flag to `krel push` to validate the existence of the remote images (default: `false`)
```
