### PR TITLE
Support fast flag in publish

### DIFF
--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -331,7 +331,7 @@ func (p *PushBuild) Push() error {
 	versionMarkers := strings.Split(p.opts.ExtraVersionMarkers, ",")
 	if err := NewPublisher().PublishVersion(
 		gcsDest, latest, buildDir, releaseBucket, versionMarkers,
-		p.opts.PrivateBucket, p.opts.NoMock,
+		p.opts.PrivateBucket, p.opts.NoMock, p.opts.Fast,
 	); err != nil {
 		return errors.Wrap(err, "publish release")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The publishing locations slightly differs when specifying a fast build.
This is now reflected int he publishing behavior as well as an added
test.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `--fast` upload location for `krel push`
```
