### PR TITLE
Make default build dir an internal const

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/release/pkg/release"
@@ -86,8 +88,11 @@ func init() {
 	pushBuildCmd.PersistentFlags().StringVar(
 		&pushBuildOpts.BuildDir,
 		"buildDir",
-		"_output",
-		"Specify an alternate build directory (defaults to '_output')",
+		release.BuildDir,
+		fmt.Sprintf(
+			"Specify an alternate build directory (defaults to '%s')",
+			release.BuildDir,
+		),
 	)
 	pushBuildCmd.PersistentFlags().StringVar(
 		&pushBuildOpts.DockerRegistry,

--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -42,7 +42,7 @@ type PushBuildOptions struct {
 	// Specify an alternate bucket for pushes (normally 'devel' or 'ci').
 	Bucket string
 
-	// Specify an alternate build directory (defaults to '_output').
+	// Specify an alternate build directory (defaults to `release.BuildDir`).
 	BuildDir string
 
 	// If set, push docker images to specified registry/project.

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -58,7 +58,7 @@ const (
 	versionReleaseRE  = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
 	versionBuildRE    = `([0-9]{1,})\+([0-9a-f]{5,40})`
 	versionDirtyRE    = `(-dirty)`
-	dockerBuildPath   = "_output/release-tars"
+	dockerBuildPath   = BuildDir + "/release-tars"
 	bazelBuildPath    = "bazel-bin/build/release-tars"
 	bazelVersionPath  = "bazel-bin/version"
 	dockerVersionPath = "kubernetes/version"
@@ -101,6 +101,9 @@ const (
 
 	// Staging registry root URL
 	GCRIOPathStaging = "gcr.io/k8s-staging-kubernetes"
+
+	// BuildDir is the default build output directory.
+	BuildDir = "_output"
 )
 
 // ImagePromoterImages abtracts the manifest used by the image promoter

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -139,13 +139,17 @@ func TestBuiltWithBazel(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	baseDockerFile := filepath.Join(baseTmpDir, "_output/release-tars/kubernetes.tar.gz")
+	baseDockerFile := filepath.Join(
+		baseTmpDir, BuildDir, "release-tars/kubernetes.tar.gz",
+	)
 	require.Nil(t, ioutil.WriteFile(
 		baseDockerFile,
 		[]byte("test"),
 		os.FileMode(0644),
 	))
-	dockerFile := filepath.Join(dockerTmpDir, "_output/release-tars/kubernetes.tar.gz")
+	dockerFile := filepath.Join(
+		dockerTmpDir, BuildDir, "release-tars/kubernetes.tar.gz",
+	)
 	require.Nil(t, ioutil.WriteFile(
 		dockerFile,
 		[]byte("test"),


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
To be able to reference the default `_output` build dir from other
projects we now have them as const value in place. Referencing usages
have been changed accordingly.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `release.BuildDIr`const for referencing the default build directory `_output`
```
