### PR TITLE
Remove --release-type flag from krel push

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -108,12 +108,6 @@ func init() {
 		"Specify a suffix to append to the upload destination on GCS",
 	)
 	pushBuildCmd.PersistentFlags().StringVar(
-		&pushBuildOpts.ReleaseType,
-		"release-type",
-		"devel",
-		"Specify an alternate bucket for pushes (normally 'devel' or 'ci')",
-	)
-	pushBuildCmd.PersistentFlags().StringVar(
 		&pushBuildOpts.VersionSuffix,
 		"version-suffix",
 		"",

--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -56,9 +56,6 @@ type PushBuildOptions struct {
 	// Specify a suffix to append to the upload destination on GCS.
 	GCSSuffix string
 
-	// Specify an alternate bucket for pushes (normally 'devel' or 'ci').
-	ReleaseType string
-
 	// Append suffix to version name if set.
 	VersionSuffix string
 
@@ -294,7 +291,7 @@ func (p *PushBuild) Push() error {
 	}
 
 	// Publish container images
-	gcsDest := p.opts.ReleaseType
+	gcsDest := "devel"
 	if p.opts.CI {
 		gcsDest = "ci"
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The flag provides information which is already available via the `--ci`
flag. To reduce the simplicity we now have no need to specify the
`--release-type` any more.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `--release-type` flag from `krel push`. Please use `--ci` instead.
```
