### PR TITLE
krel/gcbmgr: add build-at-head flag

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -190,6 +190,18 @@ func (r *Repo) SetInnerRepo(repo Repository) {
 	r.inner = repo
 }
 
+func LSRemoteExec(repoURL string, args ...string) (string, error) {
+	cmdArgs := append([]string{"ls-remote", repoURL}, args...)
+	cmdStatus, err := command.New(
+		gitExecutable, cmdArgs...).
+		RunSilentSuccessOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to execute the ls-remote command")
+	}
+
+	return strings.TrimSpace(cmdStatus.Output()), nil
+}
+
 // CloneOrOpenDefaultGitHubRepoSSH clones the default Kubernetes GitHub
 // repository via SSH if the repoPath is empty, otherwise updates it at the
 // expected repoPath.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Add a new flag to the `krel gcbmgr` called `--build-at-head` when the release managers need to build a release using what is the head of the branch and not by using the version published.

It retrieves the hash in the head of the branch

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/1497


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel/gcbmgr: add build-at-head flag
```

/assign @saschagrunert @justaugustus @hasheddan @xmudrii 