### PR TITLE
Add krel anago push-git-objects

### DIFF
--- a/cmd/krel/cmd/anago/push_git_objects.go
+++ b/cmd/krel/cmd/anago/push_git_objects.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anago
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/release"
+)
+
+// pushGitObjectsCmd is the krel push-git-objects subcommand
+var pushGitObjectsCmd = &cobra.Command{
+	Use:   "push-git-objects",
+	Short: "Push branches and tags to the remote github repository",
+	Long: `krel push-git-objects
+
+NOTE: This subcommand is a temporary commando to be invoked from anago.
+
+The purpose of krel push-git-objects is to push branches and tags to the
+git remote repository of kubernetes. 
+`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runPushGitObjects(pushGitObjectsOpts); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+type pushGitObjectsOptions struct {
+	nomock        bool
+	maxRetries    int
+	releaseBranch string
+	parentBranch  string
+	repoPath      string
+	tags          []string
+}
+
+var pushGitObjectsOpts = &pushGitObjectsOptions{}
+
+func init() {
+	pushGitObjectsCmd.PersistentFlags().StringVar(
+		&pushGitObjectsOpts.releaseBranch,
+		"release-branch",
+		"",
+		"branch name to push",
+	)
+
+	pushGitObjectsCmd.PersistentFlags().StringVar(
+		&pushGitObjectsOpts.parentBranch,
+		"parent-branch",
+		"",
+		fmt.Sprintf("parent branch, if different from %s", git.DefaultBranch),
+	)
+
+	pushGitObjectsCmd.PersistentFlags().BoolVar(
+		&pushGitObjectsOpts.nomock,
+		"nomock",
+		false,
+		"nomock flag",
+	)
+
+	pushGitObjectsCmd.PersistentFlags().StringSliceVarP(
+		&pushGitObjectsOpts.tags,
+		"tags",
+		"t",
+		[]string{},
+		"list of tags to push",
+	)
+
+	pushGitObjectsCmd.PersistentFlags().StringVar(
+		&pushGitObjectsOpts.repoPath,
+		"repo",
+		"",
+		"the local path to the repository to be used",
+	)
+
+	pushGitObjectsCmd.PersistentFlags().IntVar(
+		&pushGitObjectsOpts.maxRetries,
+		"max-retries",
+		10,
+		"number of times to retry git operations if a recoverable error occurs",
+	)
+
+	AnagoCmd.AddCommand(pushGitObjectsCmd)
+}
+
+func runPushGitObjects(options *pushGitObjectsOptions) (err error) {
+	if err := options.Validate(); err != nil {
+		return errors.Wrap(err, "validating command line options")
+	}
+	// Create the git pusher object
+	gitPusher, err := release.NewGitPusher(&release.GitObjectPusherOptions{
+		DryRun:     !options.nomock,
+		MaxRetries: options.maxRetries,
+		RepoPath:   options.repoPath,
+	})
+	if err != nil {
+		return errors.Wrap(err, "creating new git pusher object")
+	}
+
+	// # The real deal?
+	nomockLabel := map[bool]string{true: "(nomock)", false: "(mock)"}
+
+	// Tags are a range, push them all:
+	logrus.Infof("Pushing %s %d tags", nomockLabel[options.nomock], len(options.tags))
+	for _, tag := range options.tags {
+		if err := gitPusher.PushTag(tag); err != nil {
+			return err
+		}
+	}
+
+	// if a release branch was specified, push it
+	if options.releaseBranch != "" {
+		logrus.Infof("Pushing %s %s branch:", nomockLabel[options.nomock], options.releaseBranch)
+		if err := gitPusher.PushBranch(options.releaseBranch); err != nil {
+			return errors.Wrapf(err, "pushing branch %s", options.releaseBranch)
+		}
+
+		// # Additionally push the parent branch if a branch of branch
+		if options.parentBranch != "" {
+			logrus.Infof("Pushing %s %s branch: ", nomockLabel[options.nomock], options.parentBranch)
+			if err := gitPusher.PushBranch(options.parentBranch); err != nil {
+				return errors.Wrapf(err, "pushing parent branch %s", options.parentBranch)
+			}
+		}
+	}
+	/*
+	  # For files created on master with new branches and
+	  # for $CHANGELOG_FILEPATH, update the master
+	  gitlib::push_master
+	*/
+	logrus.Info("git objects push complete")
+	return nil
+}
+
+// Validate checks if the passed options are correct
+func (o *pushGitObjectsOptions) Validate() error {
+	if len(o.tags) == 0 && o.releaseBranch == "" {
+		return errors.New("to run push-git-objects, at least a branch or a tag has to be specified")
+	}
+
+	if o.parentBranch != "" && o.releaseBranch == "" {
+		return errors.New("cannot specify a parent branch if no release branch is defined")
+	}
+	return nil
+}

--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/util"
+)
+
+// GitObjectPusher is an object that pushes things to a gitrepo
+type GitObjectPusher struct {
+	repo git.Repo
+	opts *GitObjectPusherOptions
+}
+
+var dryRunLabel = map[bool]string{true: " --dry-run", false: ""}
+
+// GitObjectPusherOptions struct to hold the pusher options
+type GitObjectPusherOptions struct {
+	// Flago simulate pushes, passes --dry-run to git
+	DryRun bool
+
+	// Number of times to retry pushes
+	MaxRetries int
+
+	// Path to the repository
+	RepoPath string
+}
+
+// NewGitPusher returns a new git object pusher
+func NewGitPusher(opts *GitObjectPusherOptions) (*GitObjectPusher, error) {
+	repo, err := git.OpenRepo(opts.RepoPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while opening repository")
+	}
+
+	logrus.Infof("Checkout %s branch to push objects", git.DefaultBranch)
+	if err := repo.Checkout(git.DefaultBranch); err != nil {
+		return nil, errors.Wrapf(err, "checking out %s branch", git.DefaultBranch)
+	}
+
+	// Pass the dry-run flag to the repo
+	if opts.DryRun {
+		logrus.Debug("Setting dry run flag to repository, pushing will be simuluated")
+		repo.SetDry()
+	}
+
+	// Set the number of retries for the git operations:
+	repo.SetMaxRetries(opts.MaxRetries)
+
+	return &GitObjectPusher{
+		repo: *repo,
+		opts: opts,
+	}, nil
+}
+
+// PushBranch pushes a branch to the repository
+//  this function is idempotent.
+func (gp *GitObjectPusher) PushBranch(branchName string) error {
+	// Check if the branch name is correct
+	if err := gp.checkBranchName(branchName); err != nil {
+		return errors.Wrap(err, "checking branch name")
+	}
+
+	// To be able to push a branch the ref has to exist in the local repo:
+	branchExists, err := gp.repo.HasBranch(branchName)
+	if err != nil {
+		return errors.Wrap(err, "checking if branch already exists locally")
+	}
+	if !branchExists {
+		return errors.New(fmt.Sprintf("Unable to push branch %s, it does not exist in the local repo", branchName))
+	}
+
+	// Check if the remote branch exists already:
+	branchExists, err = gp.repo.HasRemoteBranch(branchName)
+	if err != nil {
+		return errors.Wrapf(err, "checking if branch %s exists in remote repository", branchName)
+	}
+
+	// If the branch already exists in the remote repo, we do not do anything
+	if branchExists {
+		logrus.Infof("Branch %s already exists in the default remote. Noop.", branchName)
+		return nil
+	}
+
+	logrus.Infof("Pushing%s %s branch:", dryRunLabel[gp.opts.DryRun], branchName)
+	if err := gp.repo.Push(branchName); err != nil {
+		return errors.Wrapf(err, "pushing branch %s", branchName)
+	}
+	logrus.Infof("Branch %s pushed successfully", branchName)
+	return nil
+}
+
+// PushTag pushes a tag to the master repo
+func (gp *GitObjectPusher) PushTag(newTag string) (err error) {
+	// Verify that the tag is a valid tag
+	if err := gp.checkTagName(newTag); err != nil {
+		return errors.Wrap(err, "parsing version tag")
+	}
+
+	// Check if tag already exists
+	currentTags, err := gp.repo.TagsForBranch(git.DefaultBranch)
+	if err != nil {
+		return errors.Wrap(err, "checking if tag exists")
+	}
+
+	// verify that the tag exists locally before trying to push
+	tagExists := false
+	for _, tag := range currentTags {
+		if tag == newTag {
+			tagExists = true
+			break
+		}
+	}
+	if !tagExists {
+		return errors.Errorf("unable to push tag %s, it does not exist in the repo yet", newTag)
+	}
+
+	// CHeck if tag already exists in the remote repo
+	tagExists, err = gp.repo.HasRemoteTag(newTag)
+	if err != nil {
+		return errors.Wrapf(err, "checking of tag %s exists", newTag)
+	}
+
+	// If the tag already exists in the remote, we return success
+	if tagExists {
+		logrus.Infof("Tag %s already exists in remote. Noop.", newTag)
+		return nil
+	}
+
+	logrus.Infof("Pushing%s tag for version %s", dryRunLabel[gp.opts.DryRun], newTag)
+
+	// Push the new tag, retrying up to opts.MaxRetries times
+	if err := gp.repo.Push(newTag); err != nil {
+		return errors.Wrapf(err, "pushing tag %s", newTag)
+	}
+
+	logrus.Infof("Successfully pushed tag %s", newTag)
+	return nil
+}
+
+// checkTagName verifies that the specified tag name is valid
+func (gp *GitObjectPusher) checkTagName(tagName string) error {
+	_, err := util.TagStringToSemver(tagName)
+	if err != nil {
+		return errors.Wrap(err, "tranforming tag into semver")
+	}
+	return nil
+}
+
+// checkBranchName verifies that the branch name is valid
+func (gp *GitObjectPusher) checkBranchName(branchName string) error {
+	if !strings.HasPrefix(branchName, "release-") {
+		return errors.New("Branch name has to start with release-")
+	}
+	versionTag := strings.TrimPrefix(branchName, "release-")
+	// Add .0 and check is we get a valid semver
+	_, err := semver.Parse(versionTag + ".0")
+	if err != nil {
+		return errors.Wrap(err, "parsing semantic version in branchname")
+	}
+	return nil
+}

--- a/pkg/release/push_git_objects_test.go
+++ b/pkg/release/push_git_objects_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckBranchName(t *testing.T) {
+	ghp, err := NewGitPusher(&GitObjectPusherOptions{})
+	require.Nil(t, err)
+
+	sampleBaranches := []struct {
+		branchName string
+		valid      bool
+	}{
+		{"release-1.20", true},     // Valid name
+		{"release-chorizo", false}, // Invalid, not a semver
+		{"1.20", false},            // Invalid, has to start with release
+	}
+	for _, testCase := range sampleBaranches {
+		if testCase.valid {
+			require.Nil(t, ghp.checkBranchName(testCase.branchName))
+		} else {
+			require.NotNil(t, ghp.checkBranchName(testCase.branchName))
+		}
+	}
+}
+
+func TestCheckTagName(t *testing.T) {
+	ghp, err := NewGitPusher(&GitObjectPusherOptions{})
+	require.Nil(t, err)
+
+	sampleTags := []struct {
+		tagName string
+		valid   bool
+	}{
+		{"v1.20.0-alpha.2", true}, // Valid
+		{"myTag", false},          // Invalid, not a semver
+		{"1.20", false},           // Invalid, incomplete
+	}
+	for _, testCase := range sampleTags {
+		if testCase.valid {
+			require.Nil(t, ghp.checkTagName(testCase.tagName))
+		} else {
+			require.NotNil(t, ghp.checkTagName(testCase.tagName))
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This introduces a new subcommand `krel anago push-git-objects` to push tags and branches to a repository remote.

The subcommand is an interface that talks to a new object `release.GitObjectPusher()` that lays the foundation for building amore robust interface to pushing tags and branches to a git repo.

This subcommand is designed to be called from anago, it offers the following command line interfaces:

```
$ krel anago push-git-objects --help
[...]
  -h, --help                    help for push-git-objects
      --max-retries int         number of times to retry git operations if a recoverable error occurs (default 10)
      --parent-branch string    parent branch, if different from master
      --release-branch string   branch name to push
  -t, --tags strings            list of tags to push
  -y, --yes                     say yes to prompts without asking the user

```
The internal pusher object does not (yet) offer the full testing and scenario handling but does improve over the anago bash implementation in two main ways:

1. Retries when git fails due to network errors
2. Runs are idempotent as the pusher object verifies if the tags and branches already exist before attempting to modify the remote repo. 

#### Which issue(s) this PR fixes:
Fixes #1446 

#### Special notes for your reviewer:

Depends on #1621 ~#1620~ and  #1625 to run

#### Does this PR introduce a user-facing change?
```release-note
- New `release.GitObjectPusher` object to handle pushes to remote git repos 
- New `krel anago push-git-objects` subcommand that pushes branches and tags to a repository remote
```
