### PR TITLE
Add and integrate `krel anago push`

### DIFF
--- a/anago
+++ b/anago
@@ -1334,8 +1334,9 @@ push_all_artifacts () {
 
   if [[ -z "$STAGED_LOCATION" ]]; then
     # Locally Stage the release artifacts in build directory (gcs-stage)
-    common::runstep release::gcs::locally_stage_release_artifacts \
-     $version $BUILD_OUTPUT-$version || return 1
+    logrun -v krel anago push \
+      --version "$version" --build-dir "$BUILD_OUTPUT-$version" \
+      || return 1
   fi
 
   # The full release stage case

--- a/cmd/krel/cmd/anago/anago.go
+++ b/cmd/krel/cmd/anago/anago.go
@@ -82,14 +82,6 @@ func init() {
 		release.DefaultBaseDir,
 		"",
 	)
-
-	for _, f := range []string{
-		"release-type",
-	} {
-		if err := AnagoCmd.MarkPersistentFlagRequired(f); err != nil {
-			logrus.Fatalf("Unable to set %q flag as required: %v", f, err)
-		}
-	}
 }
 
 // runAnago is the function invoked by 'krel anago', responsible for submitting release jobs to GCB

--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anago
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/release"
+)
+
+// pushCmd represents the subcommand for `krel anago push`
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push release artifacts into the Google Cloud",
+	Long: `krel anago push
+
+This subcommand can be used to push the release artifacts to the Google Cloud. 
+It's only indented to be used from anago, which means the command might be
+removed in future releases again when anago goes end of life.
+`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.Wrap(runPush(pushOpts, version), "run krel anago push")
+	},
+}
+
+var (
+	pushOpts = &release.PushBuildOptions{}
+	version  string
+)
+
+func init() {
+	pushCmd.PersistentFlags().StringVar(
+		&version,
+		"version",
+		"",
+		"version to be used",
+	)
+
+	pushCmd.PersistentFlags().StringVar(
+		&pushOpts.BuildDir,
+		"build-dir",
+		"",
+		"build artifact directory of the release",
+	)
+
+	AnagoCmd.AddCommand(pushCmd)
+}
+
+func runPush(opts *release.PushBuildOptions, version string) error {
+	return release.NewPushBuild(opts).StageLocalArtifacts(version)
+}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -589,17 +589,9 @@ func TestGetOCIManifest(t *testing.T) {
 }
 
 func TestCopyBinaries(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.Nil(t, err)
-
-	testDir, err := ioutil.TempDir("", "test-copy-binaries-")
-	require.Nil(t, err)
-	require.Nil(t, os.Chdir(testDir))
-	defer os.RemoveAll(testDir)
-
 	for _, tc := range []struct {
 		prepare  func() (rootPath string, cleanup func())
-		validate func(error)
+		validate func(error, string)
 	}{
 		{ // success client
 			prepare: func() (string, func()) {
@@ -607,9 +599,9 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				binDir := filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				)
-				require.Nil(t, os.MkdirAll(binDir, os.FileMode(0o644)))
+				require.Nil(t, os.MkdirAll(binDir, os.FileMode(0o755)))
 
 				for _, f := range []string{"1", "2", "3"} {
 					_, err = os.Create(filepath.Join(binDir, f))
@@ -620,10 +612,10 @@ func TestCopyBinaries(t *testing.T) {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) {
+			validate: func(err error, testDir string) {
 				require.Nil(t, err)
 
-				binDir := filepath.Join(testDir, "bin/linux")
+				binDir := filepath.Join(testDir, "bin/linux/amd64")
 				require.FileExists(t, filepath.Join(binDir, "1"))
 				require.FileExists(t, filepath.Join(binDir, "2"))
 				require.FileExists(t, filepath.Join(binDir, "3"))
@@ -638,7 +630,7 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				), os.FileMode(0o755)))
 
 				_, err = os.Create(filepath.Join(tempDir, "client/some-file"))
@@ -648,7 +640,7 @@ func TestCopyBinaries(t *testing.T) {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) { require.Nil(t, err) },
+			validate: func(err error, _ string) { require.Nil(t, err) },
 		},
 		{ // success server
 			prepare: func() (string, func()) {
@@ -656,17 +648,17 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				), os.FileMode(0o755)))
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "server/linux/kubernetes/server/bin",
+					tempDir, "server/linux-amd64/kubernetes/server/bin",
 				), os.FileMode(0o755)))
 
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) { require.Nil(t, err) },
+			validate: func(err error, _ string) { require.Nil(t, err) },
 		},
 		{ // success node
 			prepare: func() (string, func()) {
@@ -674,17 +666,17 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				), os.FileMode(0o755)))
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "node/linux/kubernetes/node/bin",
+					tempDir, "node/linux-amd64/kubernetes/node/bin",
 				), os.FileMode(0o755)))
 
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) { require.Nil(t, err) },
+			validate: func(err error, _ string) { require.Nil(t, err) },
 		},
 		{ // failure wrong server dir
 			prepare: func() (string, func()) {
@@ -692,17 +684,17 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				), os.FileMode(0o755)))
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "server/linux/kubernetes/wrong/bin",
+					tempDir, "server/linux-amd64/kubernetes/wrong/bin",
 				), os.FileMode(0o755)))
 
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) { require.NotNil(t, err) },
+			validate: func(err error, _ string) { require.NotNil(t, err) },
 		},
 		{ // failure wrong node dir
 			prepare: func() (string, func()) {
@@ -710,35 +702,34 @@ func TestCopyBinaries(t *testing.T) {
 				require.Nil(t, err)
 
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "client/linux/kubernetes/client/bin",
+					tempDir, "client/linux-amd64/kubernetes/client/bin",
 				), os.FileMode(0o755)))
 				require.Nil(t, os.MkdirAll(filepath.Join(
-					tempDir, "node/linux/kubernetes/wrong/bin",
+					tempDir, "node/linux-amd64/kubernetes/wrong/bin",
 				), os.FileMode(0o755)))
 
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
 				}
 			},
-			validate: func(err error) { require.NotNil(t, err) },
+			validate: func(err error, _ string) { require.NotNil(t, err) },
 		},
 		{ // empty dirs should error
 			prepare:  func() (string, func()) { return "", func() {} },
-			validate: func(err error) { require.NotNil(t, err) },
+			validate: func(err error, _ string) { require.NotNil(t, err) },
 		},
 	} {
 		// Given
 		rootPath, cleanup := tc.prepare()
+		stageDir := filepath.Join(rootPath, "stage")
 
 		// When
-		err := CopyBinaries(rootPath)
+		err := CopyBinaries(rootPath, stageDir)
 
 		// Then
-		tc.validate(err)
+		tc.validate(err, stageDir)
 		cleanup()
 	}
-
-	require.Nil(t, os.Chdir(cwd))
 }
 
 func TestWriteChecksums(t *testing.T) {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Target of this subcommand is to completely replace the push logic in
anago. For now we only stage the local artifacts with it to verify that
everything works as intended.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Requires #1596 
/hold
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `krel anago push` subcommand for publishing anago stage and release artifacts.
```
