### PR TITLE
Split Go test suite unit and integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,15 @@ verify-shellcheck: ## Runs shellcheck
 ##@ Tests
 
 .PHONY: test
-test: test-go test-sh ## Runs unit tests to ensure correct execution
+test: test-go-unit test-sh ## Runs unit tests to ensure correct execution
 
-.PHONY: test-go
-test-go: ## Runs all golang tests
+.PHONY: test-go-unit
+test-go-unit: ## Runs golang unit tests
 	./hack/test-go.sh
+
+.PHONY: test-go-integration
+test-go-integration: ## Runs golang integration tests
+	./hack/test-go-integration.sh
 
 .PHONY: test-sh
 test-sh: ## Runs all shellscript tests
@@ -130,7 +134,8 @@ update-deps-go: ## Update all golang dependencies for this repo
 	go get -u -t ./...
 	go mod tidy
 	go mod verify
-	$(MAKE) test-go
+	$(MAKE) test-go-unit
+	./hack/update-all.sh
 
 ##@ Helpers
 

--- a/hack/test-go-integration.sh
+++ b/hack/test-go-integration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 set -euo pipefail
 
-# Default timeout is 1800s
-TEST_TIMEOUT=1800
+# Default timeout is 900s
+TEST_TIMEOUT=900
 
 for arg in "$@"
 do
@@ -36,5 +36,5 @@ done
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./... | grep -v k8s.io/release/cmd)
+GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out ./cmd/...
 go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The current `make test` target timeouts often in CI and sig-release decided to split it up to integration and unit tests.

This PR reshape `make` targets and it creates a new `make test-go-unit` that runs the unit tests. It runs as part of the old `make test` target.

There is a new target called `make test-go-integration` that runs the `./cmd` tests only. Those tests do not run as part of `make test`

#### Which issue(s) this PR fixes:

Fixes #1556 

#### Which issue(s) this PR fixes:

```release-note
- Fixes #1556 introducing a new make target called test-go-integration
```