### PR TITLE
Remove `nomock` option from krel push

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -28,14 +28,10 @@ const description = `
 Used for pushing developer builds and Jenkins' continuous builds.
 
 Developer pushes simply run as they do pushing to devel/ on GCS.
-In --ci mode, 'push' runs in mock mode by default. Use --nomock to do
-a real push.
 
-push                       - Do a developer push
-push --nomock --ci
-                           - Do a (non-mocked) CI push
-push --bucket=kubernetes-release-$USER
-                           - Do a developer push to kubernetes-release-$USER`
+krel push                                   - Do a developer push
+krel push --ci                              - Do a CI push
+krel push --bucket=kubernetes-release-$USER - Do a developer push to kubernetes-release-$USER`
 
 var pushBuildOpts = &release.PushBuildOptions{}
 
@@ -135,6 +131,5 @@ func init() {
 }
 
 func runPushBuild(opts *release.PushBuildOptions) error {
-	opts.NoMock = rootOpts.nomock
 	return release.NewPushBuild(opts).Push()
 }

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -80,7 +80,7 @@ func (*defaultPublisher) GetURLResponse(url string) (string, error) {
 func (p *Publisher) PublishVersion(
 	buildType, version, buildDir, bucket string,
 	versionMarkers []string,
-	noMock, privateBucket, fast bool,
+	privateBucket, fast bool,
 ) error {
 	releaseType := "latest"
 
@@ -143,7 +143,7 @@ func (p *Publisher) PublishVersion(
 		}
 
 		if err := p.PublishToGcs(
-			publishFile, buildDir, bucket, version, noMock, privateBucket,
+			publishFile, buildDir, bucket, version, privateBucket,
 		); err != nil {
 			return errors.Wrap(err, "publish release to GCS")
 		}
@@ -200,7 +200,7 @@ func (p *Publisher) VerifyLatestUpdate(
 // was releaselib.sh: release::gcs::publish
 func (p *Publisher) PublishToGcs(
 	publishFile, buildDir, bucket, version string,
-	noMock, privateBucket bool,
+	privateBucket bool,
 ) error {
 	releaseStage := filepath.Join(buildDir, ReleaseStagePath)
 	publishFileDst := gcs.GcsPrefix + filepath.Join(bucket, publishFile)
@@ -233,7 +233,7 @@ func (p *Publisher) PublishToGcs(
 	}
 
 	var content string
-	if noMock && !privateBucket {
+	if !privateBucket {
 		// New Kubernetes infra buckets, like k8s-staging-kubernetes, have a
 		// bucket-only ACL policy set, which means attempting to set the ACL on
 		// an object will fail. We should skip this ACL change in those

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -191,7 +191,7 @@ func TestPublishVersion(t *testing.T) {
 
 		err := sut.PublishVersion(
 			"release", tc.version, buildDir, tc.bucket,
-			nil, true, tc.privateBucket, tc.fast,
+			nil, tc.privateBucket, tc.fast,
 		)
 		if tc.shouldError {
 			require.NotNil(t, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The implicit user bucket handling when specifying `mock` seems
misleading and we should let the user specify a user bucket via the
`--bucket` option. Therefore I see no reason for taking a `--nomock`
flag into consideration.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `nomock` option from `krel push`
```
