### PR TITLE
Push gcs-stage and release-images via `krel anago push`

### DIFF
--- a/anago
+++ b/anago
@@ -1332,25 +1332,17 @@ push_all_artifacts () {
   local version="${RELEASE_VERSION[$label]}"
   local jbv="$JENKINS_BUILD_VERSION"
 
-  if [[ -z "$STAGED_LOCATION" ]]; then
-    # Locally Stage the release artifacts in build directory (gcs-stage)
-    logrun -v krel anago push \
-      --version "$version" --build-dir "$BUILD_OUTPUT-$version" \
-      || return 1
-  fi
-
   # The full release stage case
   if ((FLAGS_stage)); then
-    # Push gcs-stage to GCS
-    common::runstep release::gcs::push_release_artifacts \
-     $BUILD_OUTPUT-$version/gcs-stage/$version \
-     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$jbv/$version/gcs-stage/$version \
+    # Locally Stage the release artifacts in build directory (gcs-stage)
+    logrun -v krel anago push \
+      --version "$version" \
+      --build-dir "$BUILD_OUTPUT-$version" \
+      --bucket "$RELEASE_BUCKET" \
+      --local-gcs-stage-path "$BUILD_OUTPUT-$version/gcs-stage/$version" \
+      --local-release-images-path "$BUILD_OUTPUT-${RELEASE_VERSION[$label]}/release-images" \
+      --gcs-suffix "$BUCKET_TYPE/$jbv/$version" \
       || return 1
-
-    # Push docker release-images to GCS
-    common::runstep release::gcs::push_release_artifacts \
-     $BUILD_OUTPUT-${RELEASE_VERSION[$label]}/release-images \
-     gs://$RELEASE_BUCKET/$BUCKET_TYPE/$jbv/$version/release-images || return 1
 
     common::runstep release::docker::release \
       $KUBE_DOCKER_REGISTRY $version $BUILD_OUTPUT-$version || return 1

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -106,9 +106,8 @@ func bucketCopy(src, dst string, opts *Options) error {
 
 	args = append(args, src, dst)
 
-	cpErr := command.Execute(gcp.GSUtilExecutable, args...)
-	if cpErr != nil {
-		return errors.Wrap(cpErr, "gcs copy")
+	if err := command.Execute(gcp.GSUtilExecutable, args...); err != nil {
+		return errors.Wrap(err, "gcs copy")
 	}
 
 	return nil


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now go one step further and also push the release images as well as the locally staged sources to GCS from a new `release.PushReleaseArtifacts` API.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `release.PushReleaseArtifacts` API which is now used in anago to push artifacts to GCS
```
