### PR TITLE
Correctly commit relnotes with only one file changed

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -500,7 +500,7 @@ func createDraftPR(tag string) (err error) {
 			if err != nil {
 				return errors.Wrapf(err, "checking for %s files in %s", dirData.Ext, dirData.Path)
 			}
-			if len(matches) > 1 {
+			if len(matches) > 0 {
 				if err := sigReleaseRepo.Add(filepath.Join(dirData.Path, "*"+dirData.Ext)); err != nil {
 					return errors.Wrapf(err, "adding %s to staging area", dirData.Name)
 				}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes a bug that would prevent release notes map and session files to be added and committed when only one file was present in the working directories.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>