### PR TITLE
Remove flaking command sync unit tests

### DIFF
--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -325,49 +324,4 @@ func TestCommandsFailure(t *testing.T) {
 	res, err := New("echo", "1").Add("wrong").Add("echo", "3").Run()
 	require.NotNil(t, err)
 	require.Nil(t, res)
-}
-
-func TestStdOutStdErrSync(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "stderr-stdout-sync-test-")
-	require.Nil(t, err)
-	defer os.RemoveAll(tempDir)
-
-	file := filepath.Join(tempDir, "main.go")
-	require.Nil(t, ioutil.WriteFile(file, []byte(`
-		package main
-
-		import (
-			"fmt"
-			"os"
-			"time"
-		)
-
-		func main() {
-			time.Sleep(1 * time.Second)
-			fmt.Fprintln(os.Stderr, "1")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stdout, "2")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stderr, "3")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stdout, "4")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stdout, "5")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stderr, "6")
-			time.Sleep(10 * time.Millisecond)
-			fmt.Fprintln(os.Stdout, "7")
-		}
-	`), os.FileMode(0o644)))
-
-	f, err := ioutil.TempFile("", "log")
-	require.Nil(t, err)
-	defer os.RemoveAll(f.Name())
-
-	require.Nil(t, New("go", "run", file).AddWriter(f).RunSuccess())
-	require.Nil(t, err)
-
-	outFileContent, err := ioutil.ReadFile(f.Name())
-	require.Nil(t, err)
-	require.Equal(t, "1\n2\n3\n4\n5\n6\n7\n", string(outFileContent))
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Since we split-up the streams for stdout and stderr we cannot guarantee
which writer will be written first. The unit test therefore tends to
flake in certain environments.

A solution around this could be to unify stderr and stdout, but this
would be a breaking API change.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
