### PR TITLE
Check release buckets in krel anago push

### DIFF
--- a/anago
+++ b/anago
@@ -358,11 +358,6 @@ check_prerequisites () {
   fi
   logecho -r "$OK"
 
-  # Verify write access to $WRITE_RELEASE_BUCKETS
-  for rb in ${WRITE_RELEASE_BUCKETS[*]}; do
-    release::gcs::check_release_bucket $rb || return 1
-  done
-
   logecho -n "Checking the availability of krel: "
   logrun -v -s krel version || return 1
 }

--- a/lib/releaselib.sh
+++ b/lib/releaselib.sh
@@ -45,37 +45,6 @@ readonly CHANGELOG_DIR="CHANGELOG"
 # FUNCTIONS
 ###############################################################################
 
-###############################################################################
-# Check that the GCS bucket exists and is writable.
-#
-# @param bucket - The gs release bucket name
-# @return 1 if bucket does not exist or is not writable.
-release::gcs::check_release_bucket() {
-  local bucket=$1
-  local tempfile=$TMPDIR/$PROG-gcs-write.$$
-
-  if ! $GSUTIL ls "gs://$bucket" >/dev/null 2>&1 ; then
-    logecho "Google Cloud Storage bucket does not exist: $bucket. Create the bucket with this command:"
-    logecho "$GSUTIL mb -p \"$GCLOUD_PROJECT\" \"gs://$bucket\""
-    logecho "If the bucket should be publicly readable, make it so with this command:"
-    logecho "$GSUTIL defacl ch -u AllUsers:R \"gs://$bucket\""
-    logecho "WARNING: This affects all objects uploaded to the bucket!"
-    return 1
-  fi
-
-  logecho -n "Checking write access to bucket $bucket: "
-  if logrun touch $tempfile && \
-     logrun $GSUTIL cp $tempfile gs://$bucket && \
-     logrun $GSUTIL rm gs://$bucket/${tempfile##*/} && \
-     logrun rm -f $tempfile; then
-    logecho $OK
-  else
-    logecho "$FAILED: You do not have access/write permission on $bucket." \
-            "Unable to continue."
-    return 1
-  fi
-}
-
 ##############################################################################
 # Sets major global variables
 # Used only in anago


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This allows us to move `release::gcs::check_release_bucket` into
`push-build.sh` which makes `releaselib.sh` _almost_ empty. The
`push-build.sh` script does not rely on `releaselib.sh` any more, which
further decouples the technical debt from the golang based
implementation.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold
Doing a manual test.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
