### PR TITLE
Fix output dir for kubernetes tarball on krel anago push

### DIFF
--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -431,7 +430,6 @@ func (p *PushBuild) CopyStagedFromGCS(stagedBucket, version, buildVersion string
 
 	gsStageRoot := filepath.Join(stagedBucket, "stage", buildVersion, version)
 	gsReleaseRoot := filepath.Join(p.opts.Bucket, "release", version)
-	outDir := fmt.Sprintf("%s-%s", BuildDir, version)
 
 	src := filepath.Join(gsStageRoot, GCSStagePath, version)
 	dst := gsReleaseRoot
@@ -441,14 +439,14 @@ func (p *PushBuild) CopyStagedFromGCS(stagedBucket, version, buildVersion string
 	}
 
 	src = filepath.Join(src, kubernetesTar)
-	dst = filepath.Join(outDir, GCSStagePath, version)
+	dst = filepath.Join(p.opts.BuildDir, GCSStagePath, version, kubernetesTar)
 	logrus.Infof("Copy kubernetes tarball %s to %s", src, dst)
 	if err := gcs.CopyToLocal(src, dst, copyOpts); err != nil {
 		return errors.Wrapf(err, "copy to local")
 	}
 
 	src = filepath.Join(gsStageRoot, ImagesPath)
-	dst = filepath.Join(outDir, ImagesPath)
+	dst = filepath.Join(p.opts.BuildDir, ImagesPath)
 	if err := os.MkdirAll(dst, os.FileMode(0o755)); err != nil {
 		return errors.Wrap(err, "create dst dir")
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The wrong target destination caused that anago was not able to update
the GitHub release page, which should be now fixed.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:

Logs where the issue occurs: https://console.cloud.google.com/cloud-build/builds/c19d48fc-d94f-4906-972c-23073eb42bce?project=kubernetes-release-test
```
Step #2: ================================================================================
Step #2: UPDATE GITHUB RELEASES PAGE  (14/14)
Step #2: ================================================================================
Step #2: 
Step #2: shasum: /workspace/anago-v1.19.3/src/k8s.io/kubernetes/_output-v1.19.3/gcs-stage/v1.19.3/kubernetes.tar.gz: Not a directory
Step #2: shasum: /workspace/anago-v1.19.3/src/k8s.io/kubernetes/_output-v1.19.3/gcs-stage/v1.19.3/kubernetes.tar.gz: Not a directory
Step #2: Mock run - Skipping.  Use --github-release-draft to force.
Step #2: [2020-Oct-09 12:59:26 UTC] update_github_release in 0s
```

Now, after applying this patch: https://console.cloud.google.com/cloud-build/builds/3638be5f-aeb6-43ac-8cae-d8cf7d7089e7?project=kubernetes-release-test

```
Step #2: ================================================================================
Step #2: UPDATE GITHUB RELEASES PAGE  (14/14)
Step #2: ================================================================================
Step #2: 
Step #2: Mock run - Skipping.  Use --github-release-draft to force.
Step #2: [2020-Oct-09 13:47:42 UTC] update_github_release in 0s
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in `krel anago push` where it did download `kubernetes.tar` into the wrong local destination path.
```
