### PR TITLE
Remove inferable flags from `krel anago push`

### DIFF
--- a/anago
+++ b/anago
@@ -1285,7 +1285,6 @@ stage_source_tree () {
 PROGSTEP[push_all_artifacts]="PUSH BINARY RELEASE ARTIFACTS"
 push_all_artifacts () {
   local version="${RELEASE_VERSION[$1]}"
-  local build_dir="$BUILD_OUTPUT-$version"
 
   # The full release stage case
   STAGE_FLAG=--release
@@ -1296,14 +1295,10 @@ push_all_artifacts () {
   logrun -v krel anago push \
     $STAGE_FLAG \
     --version "$version" \
-    --build-dir "$build_dir" \
-    --bucket "$RELEASE_BUCKET" \
-    --local-gcs-stage-path "$build_dir/gcs-stage/$version" \
-    --local-release-images-path "$build_dir/release-images" \
-    --gcs-suffix "$BUCKET_TYPE/$JENKINS_BUILD_VERSION/$version" \
-    --container-registry "$KUBE_DOCKER_REGISTRY" \
-    --staged-bucket "$STAGED_BUCKET" \
     --build-version "$JENKINS_BUILD_VERSION" \
+    --build-dir "$BUILD_OUTPUT-$version" \
+    --bucket "$RELEASE_BUCKET" \
+    --container-registry "$KUBE_DOCKER_REGISTRY" \
     || return 1
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Since `krel anago push` is now in place I did a comparison of the flag
values passed to the subcommand. Some of the flags can be inferred by
the `--build-dir`, whereas others are not required at all. With this
patch, we remove the flags

- `--local-gcs-stage-path`
- `--local-release-images-path`
- `--gcs-suffix`
- `--staged-bucket`

and infer their values from the other provided flags.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed unnecessary flags `--local-gcs-stage-path`, `--local-release-images-path`, `--gcs-suffix`, `--staged-bucket` from `krel anago push`
```
