### PR TITLE
Split HasRemoteBranch() return values to bool+error

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -95,8 +95,12 @@ func runFf(opts *ffOptions, rootOpts *rootOptions) error {
 	}
 
 	logrus.Info("Checking if branch is available on the default remote")
-	if err := repo.HasRemoteBranch(branch); err != nil {
-		return err
+	branchExists, err := repo.HasRemoteBranch(branch)
+	if err != nil {
+		return errors.Wrap(err, "checking if branch exists on the default remote")
+	}
+	if !branchExists {
+		return errors.New("branch does not exist on the default remote")
 	}
 
 	if rootOpts.cleanup {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -474,30 +474,31 @@ func (r *Repo) releaseBranchOrMainRef(major, minor uint64) (sha, rev string, err
 
 // HasRemoteBranch takes a branch string and verifies that it exists
 // on the default remote
-func (r *Repo) HasRemoteBranch(branch string) error {
+func (r *Repo) HasRemoteBranch(branch string) (branchExists bool, err error) {
 	logrus.Infof("Verifying %s branch exists on the remote", branch)
 
 	remote, err := r.inner.Remote(DefaultRemote)
 	if err != nil {
-		return err
+		return branchExists, err
 	}
 
 	// We can then use every Remote functions to retrieve wanted information
 	refs, err := remote.List(&git.ListOptions{})
 	if err != nil {
 		logrus.Warn("Could not list references on the remote repository.")
-		return err
+		return branchExists, err
 	}
 
 	for _, ref := range refs {
 		if ref.Name().IsBranch() {
 			if ref.Name().Short() == branch {
 				logrus.Infof("Found branch %s", ref.Name().Short())
-				return nil
+				return true, nil
 			}
 		}
 	}
-	return errors.Errorf("branch %v not found", branch)
+	logrus.Infof("Branch %v not found", branch)
+	return false, nil
 }
 
 // Checkout can be used to checkout any revision inside the repository

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -274,16 +274,22 @@ func TestSuccessHasRemoteBranch(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	require.Nil(t, testRepo.sut.HasRemoteBranch(testRepo.branchName))
-	require.Nil(t, testRepo.sut.HasRemoteBranch(git.DefaultBranch))
+	for _, repo := range []string{testRepo.branchName, git.DefaultBranch} {
+		branchExists, err := testRepo.sut.HasRemoteBranch(repo)
+		require.Nil(t, err)
+		require.Equal(t, true, branchExists)
+	}
 }
 
 func TestFailureHasRemoteBranch(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.HasRemoteBranch("wrong")
-	require.NotNil(t, err)
+	// TODO: Let's simulate an actual git/network failure
+
+	branchExists, err := testRepo.sut.HasRemoteBranch("wrong")
+	require.Equal(t, false, branchExists)
+	require.Nil(t, err)
 }
 
 func TestSuccessHead(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Currently, checking for a branch using the function `git.HasRemoteBranch() ` returns either an error or nil.

This output is difficult to differentiate programmatically to check if an actual error occurred or the the branch simply does not exist. This PR separates the output to return a bool that indicates if the branch exists and an error which can be queried to see if an error happened while checking the remote repository.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

In addition to modifying the git package, the integration tests have been updated and the `krel ff` subcommand is fixed to used the new output (currently the only code using the function).

#### Does this PR introduce a user-facing change?
```release-note
Modify `git.HasRemoteBranch()` to split output into a bool and error.
```
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>