### PR TITLE
images: Build debian-iptables:stretch-v1.2.0

### DIFF
--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -6,7 +6,7 @@ variants:
     IPTABLES_VERSION: '1.8.5'
   stretch:
     CONFIG: 'stretch'
-    IMAGE_VERSION: 'stretch-v1.1.0'
+    IMAGE_VERSION: 'stretch-v1.2.0'
     # TODO(debian-base): Need to update to new version format
     #                    ('codename-v0.0.0') on next image bump
     DEBIAN_BASE_VERSION: 'v1.1.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Image build for https://github.com/kubernetes/release/pull/1613.

- images: Build debian-iptables:stretch-v1.2.0
  - Removes `iptables-wrapper`, which was extraneous for the stretch
    variant of this image

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @listx @saschagrunert 
cc: @wespanther 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build debian-iptables:stretch-v1.2.0
  - Removes `iptables-wrapper`, which was extraneous for the stretch
    variant of this image
```
