### PR TITLE
Use gsutil rsync to copy artifacts

### DIFF
--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -141,7 +141,8 @@ func runPushStage(
 
 	// Push container release-images to GCS
 	if err := pushBuild.PushReleaseArtifacts(
-		filepath.Join(opts.BuildDir, release.ImagesPath), gcsPath,
+		filepath.Join(opts.BuildDir, release.ImagesPath),
+		filepath.Join(gcsPath, release.ImagesPath),
 	); err != nil {
 		return errors.Wrap(err, "pushing release artifacts")
 	}

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -61,7 +61,7 @@ var DefaultGCSCopyOptions = &Options{
 // CopyToGCS copies a local directory to the specified GCS path
 func CopyToGCS(src, gcsPath string, opts *Options) error {
 	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
-	gcsPath = normalizeGCSPath(gcsPath)
+	gcsPath = NormalizeGCSPath(gcsPath)
 
 	_, err := os.Stat(src)
 	if err != nil {
@@ -81,7 +81,7 @@ func CopyToGCS(src, gcsPath string, opts *Options) error {
 // CopyToLocal copies a GCS path to the specified local directory
 func CopyToLocal(gcsPath, dst string, opts *Options) error {
 	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
-	gcsPath = normalizeGCSPath(gcsPath)
+	gcsPath = NormalizeGCSPath(gcsPath)
 
 	return bucketCopy(gcsPath, dst, opts)
 }
@@ -89,7 +89,7 @@ func CopyToLocal(gcsPath, dst string, opts *Options) error {
 // CopyBucketToBucket copies between two GCS paths.
 func CopyBucketToBucket(src, dst string, opts *Options) error {
 	logrus.Infof("Copying %s to %s", src, dst)
-	return bucketCopy(normalizeGCSPath(src), normalizeGCSPath(dst), opts)
+	return bucketCopy(NormalizeGCSPath(src), NormalizeGCSPath(dst), opts)
 }
 
 func bucketCopy(src, dst string, opts *Options) error {
@@ -119,7 +119,9 @@ func bucketCopy(src, dst string, opts *Options) error {
 	return nil
 }
 
-func normalizeGCSPath(gcsPath string) string {
+// NormalizeGCSPath takes a gcs path and ensures that the `GcsPrefix` is
+// prepended to it.
+func NormalizeGCSPath(gcsPath string) string {
 	gcsPath = strings.TrimPrefix(gcsPath, GcsPrefix)
 	gcsPath = GcsPrefix + gcsPath
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
This allows us to make the staging process idempotent and restart it if
any of the artifacts failed copying.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Testing stage and release logs are looking good:
- https://console.cloud.google.com/cloud-build/builds/067c934f-c055-439c-a088-537c155b0b75?project=kubernetes-release-test
- https://console.cloud.google.com/cloud-build/builds/dbb5518b-4d2e-4331-a3af-c9afa20bd9f9?project=kubernetes-release-test
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
