### PR TITLE
Add `RsyncRecursive()` API to gcs package

### DIFF
--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -127,3 +127,13 @@ func NormalizeGCSPath(gcsPath string) string {
 
 	return gcsPath
 }
+
+// RsyncRecursive runs `gsutil rsync` in recursive mode. The caller of this
+// function has to ensure that the provided paths are prefixed with gs:// if
+// necessary (see `NormalizeGCSPath()`).
+func RsyncRecursive(src, dst string) error {
+	return errors.Wrap(
+		gcp.GSUtil("-m", "rsync", "-r", src, dst),
+		"running gsutil rsync",
+	)
+}

--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp"
 	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/util"
 	"k8s.io/utils/pointer"
@@ -381,8 +380,7 @@ func (p *PushBuild) PushReleaseArtifacts(srcPath, gcsPath string) error {
 	logrus.Infof("Pushing release artifacts from %s to %s", srcPath, dstPath)
 
 	return errors.Wrap(
-		gcp.GSUtil("-m", "rsync", "-r", srcPath, dstPath),
-		"copy artifacts to GCS",
+		gcs.RsyncRecursive(srcPath, dstPath), "rsync artifacts to GCS",
 	)
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows us to re-use the rsync functionality in other packages.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Follow-up of https://github.com/kubernetes/release/pull/1626
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added  `RsyncRecursive()` API to gcs package to run `gsutil rsync`
```
