### PR TITLE
Always validate images against the provided registry

### DIFF
--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -173,17 +173,10 @@ func (i *Images) Publish(registry, version, buildPath string) error {
 // registry.
 // was in releaselib.sh: release::docker::validate_remote_manifests
 func (i *Images) Validate(registry, version, buildPath string) error {
-	// In an official release, we want to ensure that container images have
-	// been promoted from staging to production, so we do the image manifest
-	// validation against production instead of staging.
-	targetRegistry := registry
-	if registry == GCRIOPathStaging {
-		targetRegistry = GCRIOPathProd
-	}
-	logrus.Infof("Validating image manifests in %s", targetRegistry)
+	logrus.Infof("Validating image manifests in %s", registry)
 
 	manifestImages, err := i.getManifestImages(
-		targetRegistry, version, buildPath, nil,
+		registry, version, buildPath, nil,
 	)
 	if err != nil {
 		return errors.Wrap(err, "get manifest images")


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The logic to flip the container registry for the image validation was an
artifact from old times, where we had the promotion in a different
place. We can later on decide if we still want to verify the images on
`k8s.gcr.io` in a dedicated verification step on `release`, not on
`stage`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/priority critical-urgent
Required for v1.20.0-alpha.2
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed image verification step to always stick to the provided container registry and not automatically use `k8s.gcr.io`
```
