### PR TITLE
Validate promoted container images on nomock release

### DIFF
--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -394,11 +394,10 @@ func (p *PushBuild) PushContainerImages(version string) error {
 	}
 
 	images := NewImages()
-	normalizedVersion := strings.ReplaceAll(version, "+", "_")
-	logrus.Infof("Publishing container images for %s", normalizedVersion)
+	logrus.Infof("Publishing container images for %s", version)
 
 	if err := images.Publish(
-		p.opts.DockerRegistry, normalizedVersion, p.opts.BuildDir,
+		p.opts.DockerRegistry, version, p.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "publish container images")
 	}
@@ -409,7 +408,7 @@ func (p *PushBuild) PushContainerImages(version string) error {
 	}
 
 	if err := images.Validate(
-		p.opts.DockerRegistry, normalizedVersion, p.opts.BuildDir,
+		p.opts.DockerRegistry, version, p.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "validate container images")
 	}
@@ -444,12 +443,11 @@ func (p *PushBuild) CopyStagedFromGCS(stagedBucket, version, buildVersion string
 	}
 
 	src = filepath.Join(gsStageRoot, ImagesPath)
-	dst = filepath.Join(p.opts.BuildDir, ImagesPath)
-	if err := os.MkdirAll(dst, os.FileMode(0o755)); err != nil {
+	if err := os.MkdirAll(p.opts.BuildDir, os.FileMode(0o755)); err != nil {
 		return errors.Wrap(err, "create dst dir")
 	}
-	logrus.Infof("Copy container images %s to %s", src, dst)
-	if err := gcs.CopyToLocal(src, dst, copyOpts); err != nil {
+	logrus.Infof("Copy container images %s to %s", src, p.opts.BuildDir)
+	if err := gcs.CopyToLocal(src, p.opts.BuildDir, copyOpts); err != nil {
 		return errors.Wrapf(err, "copy to local")
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We moved the image validation to `stage` (directly after pushing the
images), which is fine. We now additionally validate on `release`, which
gives us the chance to test if the images have been promoted correctly.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold
If v1.20.0-alpha.2 has been released.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added additional image validation step to `krel anago push --stage` to test for the image promotion.
```
