### PR TITLE
Add /hold and mention releng in image promotion PR body

### DIFF
--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -266,6 +266,7 @@ func runPromote(opts *promoteOptions) error {
 
 	prBody := fmt.Sprintf("Image promotion for Kubernetes %s\n", opts.tag)
 	prBody += "This is an automated PR generated from `krel The Kubernetes Release Toolbox`\n\n"
+	prBody += "/hold\ncc: @kubernetes/release-engineering\n"
 
 	// Create the Pull Request
 	if mustRun(opts, "Create pull request?") {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR adds the /hold label and and  @ mentions releng in the image promotion pull request

#### Which issue(s) this PR fixes:

Ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1600790759065100?thread_ts=1600779080.037400&cid=CJH2GBF7Y

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
