### PR TITLE
Fix version check when publishing version markers

### DIFF
--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -87,9 +87,9 @@ func (p *Publisher) PublishVersion(
 
 	if buildType == "release" {
 		// For release/ targets, type should be 'stable'
-		if !(strings.HasSuffix(version, ReleaseTypeAlpha) ||
-			strings.HasSuffix(version, ReleaseTypeBeta) ||
-			strings.HasSuffix(version, ReleaseTypeRC)) {
+		if !(strings.Contains(version, ReleaseTypeAlpha) ||
+			strings.Contains(version, ReleaseTypeBeta) ||
+			strings.Contains(version, ReleaseTypeRC)) {
 			releaseType = "stable"
 		}
 	}

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -33,7 +33,7 @@ func TestPublishVersion(t *testing.T) {
 		olderTestVersion = "v1.20.0-alpha.0.22+00000000000000"
 	)
 
-	mockVersioMarkers := func(mock *releasefakes.FakePublisherClient) {
+	mockVersionMarkers := func(mock *releasefakes.FakePublisherClient) {
 		mock.GSUtilOutputReturnsOnCall(0, olderTestVersion, nil)
 		mock.GSUtilOutputReturnsOnCall(1, testVersion, nil)
 		mock.GSUtilOutputReturnsOnCall(2, olderTestVersion, nil)
@@ -77,7 +77,7 @@ func TestPublishVersion(t *testing.T) {
 				tempDir, err := ioutil.TempDir("", "publish-version-test-")
 				require.Nil(t, err)
 
-				mockVersioMarkers(mock)
+				mockVersionMarkers(mock)
 				mock.GSUtilOutputReturnsOnCall(5, testVersion, nil)
 
 				return tempDir, func() {
@@ -94,7 +94,7 @@ func TestPublishVersion(t *testing.T) {
 				tempDir, err := ioutil.TempDir("", "publish-version-test-")
 				require.Nil(t, err)
 
-				mockVersioMarkers(mock)
+				mockVersionMarkers(mock)
 				mock.GSUtilOutputReturnsOnCall(5, "", errors.New(""))
 
 				return tempDir, func() {
@@ -111,7 +111,7 @@ func TestPublishVersion(t *testing.T) {
 				tempDir, err := ioutil.TempDir("", "publish-version-test-")
 				require.Nil(t, err)
 
-				mockVersioMarkers(mock)
+				mockVersionMarkers(mock)
 				mock.GSUtilOutputReturnsOnCall(5, "wrong", nil)
 
 				return tempDir, func() {
@@ -128,7 +128,7 @@ func TestPublishVersion(t *testing.T) {
 				tempDir, err := ioutil.TempDir("", "publish-version-test-")
 				require.Nil(t, err)
 
-				mockVersioMarkers(mock)
+				mockVersionMarkers(mock)
 				mock.GetURLResponseReturns(testVersion, nil)
 
 				return tempDir, func() {
@@ -144,8 +144,7 @@ func TestPublishVersion(t *testing.T) {
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
 				tempDir, err := ioutil.TempDir("", "publish-version-test-")
 				require.Nil(t, err)
-
-				mockVersioMarkers(mock)
+				mockVersionMarkers(mock)
 				mock.GetURLResponseReturns("", errors.New(""))
 
 				return tempDir, func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

The check currently only makes sure that the version does not end with
alpha, beta, or rc, when it should be checking that the versions do not
contain alpha, beta, or rc anywhere. This updates to the desired
functionality.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

xref: https://github.com/kubernetes/kubernetes/issues/95536

(won't mark as fixed until after the actual version files are updated in releases tomorrow)

#### Special notes for your reviewer:

Verified this in logs emitted by unit tests.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
/cc @justaugustus @saschagrunert @cpanato @kubernetes/release-engineering 