### PR TITLE
Delete BUILD_AT_HEAD key in krel gcbmgr if not set

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -343,7 +343,7 @@ func SetGCBSubstitutions(o *GcbmgrOptions, toolOrg, toolRepo, toolBranch string)
 		}
 
 		if o.Stage {
-			gcbSubs["BUILD_AT_HEAD"] = ""
+			delete(gcbSubs, "BUILD_AT_HEAD")
 		}
 	}
 

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -170,7 +170,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.17.0"),
 			},
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -218,7 +217,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.15.0-rc.1"),
 			},
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -242,7 +240,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.15.1"),
 			},
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -269,7 +266,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			toolRepo:   "best-tools",
 			toolBranch: "tool-branch",
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.16",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
@@ -296,7 +292,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			toolRepo:   "best-tools",
 			toolBranch: "tool-branch",
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.19",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
@@ -320,7 +315,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.18.6-rc.0.15+e38139724f8f00"),
 			},
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -344,7 +338,6 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.18.0-beta.4.15+e38139724f8f00"),
 			},
 			expected: map[string]string{
-				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Delete BUILD_AT_HEAD key in krel gcbmgr if not set

Before this patch we set the GCB substitution to `""`, which caused a failure like:

 ```
RROR: (gcloud.builds.submit) INVALID_ARGUMENT: generic::invalid_argument: key in the template "_BUILD_AT_HEAD" is not matched in the substitution data;
```

We now delete the key in the map if no build version is provided. The issue was only reproducible on macOS, not on Linux.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold
for review from @cpanato 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `krel gcbmgr --stage` execution to not set the `BUILD_AT_HEAD` GCB substitution to `""`
```
