### PR TITLE
Take `NoUpdateLatest` into account for krel push

### DIFF
--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -192,6 +192,11 @@ func (p *PushBuild) Push() error {
 		return nil
 	}
 
+	if p.opts.NoUpdateLatest {
+		logrus.Info("Not updating version markers")
+		return nil
+	}
+
 	// Publish release to GCS
 	versionMarkers := strings.Split(p.opts.ExtraVersionMarkers, ",")
 	if err := NewPublisher().PublishVersion(


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If the flag is given, we should not try to update the version markers.
This is now applied with this patch.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where it tried to update the version markers on `krel push` if `--noupdatelatest` is provided.
```
