### PR TITLE
Revert "Delete BUILD_AT_HEAD key in krel gcbmgr if not set"

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -343,7 +343,7 @@ func SetGCBSubstitutions(o *GcbmgrOptions, toolOrg, toolRepo, toolBranch string)
 		}
 
 		if o.Stage {
-			delete(gcbSubs, "BUILD_AT_HEAD")
+			gcbSubs["BUILD_AT_HEAD"] = ""
 		}
 	}
 

--- a/cmd/krel/cmd/gcbmgr_test.go
+++ b/cmd/krel/cmd/gcbmgr_test.go
@@ -170,6 +170,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.17.0"),
 			},
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -217,6 +218,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.15.0-rc.1"),
 			},
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -240,6 +242,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.15.1"),
 			},
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -266,6 +269,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			toolRepo:   "best-tools",
 			toolBranch: "tool-branch",
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.16",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
@@ -292,6 +296,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			toolRepo:   "best-tools",
 			toolBranch: "tool-branch",
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.19",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
@@ -315,6 +320,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.18.6-rc.0.15+e38139724f8f00"),
 			},
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
@@ -338,6 +344,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				Version:     mockVersion("v1.18.0-beta.4.15+e38139724f8f00"),
 			},
 			expected: map[string]string{
+				"BUILD_AT_HEAD":          "",
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",


### PR DESCRIPTION

#### What type of PR is this?
/kind regression

#### What this PR does / why we need it:
The fix is not appropriate, we have to re-evaluate a solution on macOS.

This reverts commit 02df445008b63b9713cdd7a0239099bbe6edc99e.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

/priority critical-urgent