### PR TITLE
[WIP] gcb: Add hack to rewrite version markers

### DIFF
--- a/fix-version-marker.sh
+++ b/fix-version-marker.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+new_version="v1.19.2"
+fix_version_file="fix_version.txt"
+gcs_bucket="gs://kubernetes-release/release"
+
+markers_to_fix=(
+  "stable"
+  "stable-1"
+)
+
+markers_to_remove=(
+  "stable-1.20"
+)
+
+echo "Writing ${new_version} to ${fix_version_file}..."
+echo "${new_version}" > "${fix_version_file}"
+
+for marker in "${markers_to_fix[@]}"; do
+  echo "Updating $marker to $new_version..."
+  gsutil cp "${fix_version_file}" "$gcs_bucket/$marker.txt"
+done
+
+for marker in "${markers_to_remove[@]}"; do
+  echo "Removing $marker marker..."
+  gsutil rm "$gcs_bucket/$marker.txt"
+done

--- a/gcb/fix/cloudbuild.yaml
+++ b/gcb/fix/cloudbuild.yaml
@@ -1,0 +1,51 @@
+timeout: 14400s
+
+steps:
+- name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "--branch=${_TOOL_BRANCH}"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: k8s.gcr.io/build-image/kube-cross:v1.15.2-1
+  dir: "go/src/k8s.io/release"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - "GO111MODULE=on"
+  - "GOPROXY=https://proxy.golang.org"
+  - "GOSUMDB=sum.golang.org"
+  args:
+  - "./compile-release-tools"
+
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.15.2-1
+  dir: "go/src/k8s.io/release"
+  env:
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_BRANCH=${_TOOL_BRANCH}"
+  args:
+  - "./fix-version-marker.sh"
+
+tags:
+- ${_GCP_USER_TAG}
+- ${_RELEASE_BRANCH}
+- ${_BUILD_POINT}
+- ${_NOMOCK_TAG}
+- FIX
+- ${_GIT_TAG}
+- ${_TYPE_TAG}
+- ${_MAJOR_VERSION_TAG}
+- ${_MINOR_VERSION_TAG}
+- ${_PATCH_VERSION_TAG}
+- ${_KUBERNETES_VERSION_TAG}
+
+options:
+  machineType: N1_HIGHCPU_32
+  substitution_option: ALLOW_LOOSE
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Reported in https://github.com/kubernetes/kubernetes/issues/95536  / https://kubernetes.slack.com/archives/C2C40FMNF/p1602638351297900, our `stable` version markers are currently pointing to v1.20 pre-release versions, instead of v1.19.2.

This is an emergency script (with many of the values hardcoded) to overwrite the production version markers.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

This is the hastily-written bash version of one of the potential "emergency commands" I was referencing in https://github.com/kubernetes/release/issues/1494.
I can take a crack at converting this to go when I have some time.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcb: Add hack to rewrite version markers
```
