### PR TITLE
Add krel push `Version` option

### DIFF
--- a/pkg/release/push.go
+++ b/pkg/release/push.go
@@ -59,6 +59,10 @@ type PushBuildOptions struct {
 	// Specify a suffix to append to the upload destination on GCS.
 	GCSSuffix string
 
+	// Version to be used. Usually automatically discovered, but it can be
+	// used to overwrite this behavior.
+	Version string
+
 	// Append suffix to version name if set.
 	VersionSuffix string
 
@@ -163,7 +167,7 @@ func (p *PushBuild) Push() error {
 		return errors.Wrap(err, "check release bucket access")
 	}
 
-	if err := p.StageLocalArtifacts(version); err != nil {
+	if err := p.StageLocalArtifacts(); err != nil {
 		return errors.Wrap(err, "staging local artifacts")
 	}
 
@@ -186,7 +190,7 @@ func (p *PushBuild) Push() error {
 		return errors.Wrap(err, "push release artifacts")
 	}
 
-	if err := p.PushContainerImages(version); err != nil {
+	if err := p.PushContainerImages(); err != nil {
 		return errors.Wrap(err, "push container images")
 	}
 
@@ -219,23 +223,26 @@ func (p *PushBuild) findLatestVersion() (latestVersion string, err error) {
 		return "", errors.Wrap(err, "identify if release built with Bazel")
 	}
 
-	if isBazel {
-		logrus.Info("Using Bazel build version")
-		version, err := ReadBazelVersion(dir)
-		if err != nil {
-			return "", errors.Wrap(err, "read Bazel build version")
+	latestVersion = p.opts.Version
+	if p.opts.Version == "" {
+		if isBazel {
+			logrus.Info("Using Bazel build version")
+			version, err := ReadBazelVersion(dir)
+			if err != nil {
+				return "", errors.Wrap(err, "read Bazel build version")
+			}
+			latestVersion = version
+		} else {
+			logrus.Info("Using Dockerized build version")
+			version, err := ReadDockerizedVersion(dir)
+			if err != nil {
+				return "", errors.Wrap(err, "read Dockerized build version")
+			}
+			latestVersion = version
 		}
-		latestVersion = version
-	} else {
-		logrus.Info("Using Dockerized build version")
-		version, err := ReadDockerizedVersion(dir)
-		if err != nil {
-			return "", errors.Wrap(err, "read Dockerized build version")
-		}
-		latestVersion = version
 	}
 
-	logrus.Infof("Found build version: %s", latestVersion)
+	logrus.Infof("Using build version: %s", latestVersion)
 
 	valid, err := IsValidReleaseBuild(latestVersion)
 	if err != nil {
@@ -321,9 +328,9 @@ func (p *PushBuild) CheckReleaseBucket() error {
 
 // StageLocalArtifacts locally stages the release artifacts
 // was releaselib.sh: release::gcs::locally_stage_release_artifacts
-func (p *PushBuild) StageLocalArtifacts(version string) error {
+func (p *PushBuild) StageLocalArtifacts() error {
 	logrus.Info("Staging local artifacts")
-	stageDir := filepath.Join(p.opts.BuildDir, GCSStagePath, version)
+	stageDir := filepath.Join(p.opts.BuildDir, GCSStagePath, p.opts.Version)
 
 	logrus.Infof("Cleaning staging dir %s", stageDir)
 	if err := util.RemoveAndReplaceDir(stageDir); err != nil {
@@ -422,17 +429,17 @@ func (p *PushBuild) PushReleaseArtifacts(srcPath, gcsPath string) error {
 // PushContainerImages will publish container images into the set
 // `DockerRegistry`. It also validates if the remove manifests are correct,
 // which can be turned of by setting `ValidateRemoteImageDigests` to `false`.
-func (p *PushBuild) PushContainerImages(version string) error {
+func (p *PushBuild) PushContainerImages() error {
 	if p.opts.DockerRegistry == "" {
 		logrus.Info("Registry is not set, will not publish container images")
 		return nil
 	}
 
 	images := NewImages()
-	logrus.Infof("Publishing container images for %s", version)
+	logrus.Infof("Publishing container images for %s", p.opts.Version)
 
 	if err := images.Publish(
-		p.opts.DockerRegistry, version, p.opts.BuildDir,
+		p.opts.DockerRegistry, p.opts.Version, p.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "publish container images")
 	}
@@ -443,7 +450,7 @@ func (p *PushBuild) PushContainerImages(version string) error {
 	}
 
 	if err := images.Validate(
-		p.opts.DockerRegistry, version, p.opts.BuildDir,
+		p.opts.DockerRegistry, p.opts.Version, p.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "validate container images")
 	}
@@ -453,17 +460,17 @@ func (p *PushBuild) PushContainerImages(version string) error {
 
 // CopyStagedFromGCS copies artifacts from GCS and between buckets as needed.
 // was: anago:copy_staged_from_gcs
-func (p *PushBuild) CopyStagedFromGCS(version, buildVersion string) error {
+func (p *PushBuild) CopyStagedFromGCS(stagedBucket, buildVersion string) error {
 	logrus.Info("Copy staged release artifacts from GCS")
 
 	copyOpts := gcs.DefaultGCSCopyOptions
 	copyOpts.NoClobber = pointer.BoolPtr(p.opts.AllowDup)
 	copyOpts.AllowMissing = pointer.BoolPtr(false)
 
-	gsStageRoot := filepath.Join(p.opts.Bucket, stagePath, buildVersion, version)
-	gsReleaseRoot := filepath.Join(p.opts.Bucket, "release", version)
+	gsStageRoot := filepath.Join(p.opts.Bucket, stagePath, buildVersion, p.opts.Version)
+	gsReleaseRoot := filepath.Join(p.opts.Bucket, "release", p.opts.Version)
 
-	src := filepath.Join(gsStageRoot, GCSStagePath, version)
+	src := filepath.Join(gsStageRoot, GCSStagePath, p.opts.Version)
 	dst := gsReleaseRoot
 	logrus.Infof("Bucket to bucket copy from %s to %s", src, dst)
 	if err := gcs.CopyBucketToBucket(src, dst, copyOpts); err != nil {
@@ -471,7 +478,7 @@ func (p *PushBuild) CopyStagedFromGCS(version, buildVersion string) error {
 	}
 
 	src = filepath.Join(src, kubernetesTar)
-	dst = filepath.Join(p.opts.BuildDir, GCSStagePath, version, kubernetesTar)
+	dst = filepath.Join(p.opts.BuildDir, GCSStagePath, p.opts.Version, kubernetesTar)
 	logrus.Infof("Copy kubernetes tarball %s to %s", src, dst)
 	if err := gcs.CopyToLocal(src, dst, copyOpts); err != nil {
 		return errors.Wrapf(err, "copy to local")


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
kubetest2 has the use case to overwrite the version, so we now add a new
`Version` option. This also simplifies the code paths used by `krel
anago push`, which also manually sets the target version (which is not
equal to the Jenkins build version).
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/kubetest2/pull/61#discussion_r504953527
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add krel push `Version` option to manually overwrite the build version
```
