### PR TITLE
Reduce verbosity of GSUtil commands

### DIFF
--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -153,8 +153,7 @@ func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
 	u := uuid.New()
 	uploaded := fmt.Sprintf("%s/%s.tgz", targetBucket, u.String())
 	logrus.Infof("Uploading %s to %s...", name, uploaded)
-	cpErr := command.Execute(
-		gcp.GSUtilExecutable,
+	cpErr := gcp.GSUtil(
 		"cp",
 		name,
 		uploaded,

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -18,12 +18,13 @@ package gcp
 
 import (
 	"github.com/pkg/errors"
+
 	"k8s.io/release/pkg/command"
 )
 
 const (
 	GCloudExecutable = "gcloud"
-	GSUtilExecutable = "gsutil"
+	gSUtilExecutable = "gsutil"
 	TarExecutable    = "tar"
 )
 
@@ -32,7 +33,7 @@ const (
 func PreCheck() error {
 	for _, e := range []string{
 		GCloudExecutable,
-		GSUtilExecutable,
+		gSUtilExecutable,
 		TarExecutable,
 	} {
 		if !command.Available(e) {
@@ -47,14 +48,14 @@ func PreCheck() error {
 
 // GSUtil can be used to run a gsutil command
 func GSUtil(args ...string) error {
-	return command.Execute(GSUtilExecutable, args...)
+	return command.New(gSUtilExecutable, args...).RunSilentSuccess()
 }
 
 // GSUtilOutput can be used to run a gsutil command while capturing its output
 func GSUtilOutput(args ...string) (string, error) {
-	stream, err := command.New(GSUtilExecutable, args...).RunSilentSuccessOutput()
+	stream, err := command.New(gSUtilExecutable, args...).RunSilentSuccessOutput()
 	if err != nil {
-		return "", errors.Wrapf(err, "executing %s", GSUtilExecutable)
+		return "", errors.Wrapf(err, "executing %s", gSUtilExecutable)
 	}
 	return stream.OutputTrimNL(), nil
 }

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/gcp"
 	"k8s.io/utils/pointer"
 )
@@ -112,7 +111,7 @@ func bucketCopy(src, dst string, opts *Options) error {
 
 	args = append(args, src, dst)
 
-	if err := command.Execute(gcp.GSUtilExecutable, args...); err != nil {
+	if err := gcp.GSUtil(args...); err != nil {
 		return errors.Wrap(err, "gcs copy")
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
The commands are spamming the build logs and we already have logrus
in place to show us relevant information. We now make the
`gcp.GSUtil*()` functions less verbose and also make the
`gSUtilExecutable` const private the stick users to this function.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed `gcp.GSUtilExecutable` to be private. Please use the `gcp.GSUtil()` function instead.
```
