### PR TITLE
images: Update to go1.15.3

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,6 +70,14 @@ dependencies:
     - path: images/releng/ci/cloudbuild.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
+  - name: "k8s.gcr.io/go-runner"
+    version: buster-v2.1.0
+    refPaths:
+    - path: images/build/go-runner/Makefile
+      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: images/build/go-runner/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
   - name: "k8s.gcr.io/kube-cross"
     version: v1.15.3-1
     refPaths:
@@ -142,11 +150,3 @@ dependencies:
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-
-  - name: "k8s.gcr.io/go-runner"
-    version: buster-v2.0.2
-    refPaths:
-    - path: images/build/go-runner/Makefile
-      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-    - path: images/build/go-runner/variants.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15.2
+    version: 1.15.3
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -71,7 +71,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "k8s.gcr.io/kube-cross"
-    version: v1.15.2-1
+    version: v1.15.3-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.15.2-1
+IMAGE_VERSION ?= v1.15.3-1
 CONFIG ?= go1.15
 
 # Build args
-GO_VERSION?=1.15.2
+GO_VERSION?=1.15.3
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.2'
-    IMAGE_VERSION: 'v1.15.2-canary-1'
+    GO_VERSION: '1.15.3'
+    IMAGE_VERSION: 'v1.15.3-canary-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.2'
-    IMAGE_VERSION: 'v1.15.2-1'
+    GO_VERSION: '1.15.3'
+    IMAGE_VERSION: 'v1.15.3-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -23,7 +23,10 @@ CONFIG ?= buster
 GO_VERSION ?= 1.15.3
 DISTROLESS_IMAGE ?= static-debian10
 
-PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x
+# TODO: Re-enable linux/ppc64le builds once upstream distroless builds are fixed
+#       ref: https://github.com/GoogleContainerTools/distroless/pull/622
+#PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x
+PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/s390x
 
 HOST_GOOS ?= $(shell go env GOOS)
 HOST_GOARCH ?= $(shell go env GOARCH)

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.0.2
+IMAGE_VERSION ?= buster-v2.1.0
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.15.2
+GO_VERSION ?= 1.15.3
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.0.2'
-    GO_VERSION: '1.15.2'
+    IMAGE_VERSION: 'buster-v2.1.0'
+    GO_VERSION: '1.15.3'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -23,7 +23,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _GO_VERSION: '1.15.2'
+  _GO_VERSION: '1.15.3'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:latest'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- dependencies.yaml: Require go1.15.3
- images: Build releng-ci with go1.15.3
- images: Build kube-cross:v1.15.3-1 and v1.15.3-canary-1
  - Now built with go1.15.3
- images: Build go-runner:buster-v2.1.0
  - Now built with go1.15.3

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold for some build testing

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build releng-ci with go1.15.3
- images: Build kube-cross:v1.15.3-1 and v1.15.3-canary-1
  - Now built with go1.15.3
- images: Build go-runner:buster-v2.1.0
  - Now built with go1.15.3
```
