### PR TITLE
deps: Update to cip/pkg@v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/klog/v2 v2.3.0
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
-	sigs.k8s.io/k8s-container-image-promoter/pkg v0.2.0
+	sigs.k8s.io/k8s-container-image-promoter/pkg v0.3.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1157,8 +1157,8 @@ mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZI
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/k8s-container-image-promoter/pkg v0.2.0 h1:1SqM91UeaRF0vosgmPvOpmJEEcJWN058ukBj1UaDPqE=
-sigs.k8s.io/k8s-container-image-promoter/pkg v0.2.0/go.mod h1:VwNhFxiQ/DVB+sNIkxjhgrGR/DsoyPVRlSq8vAugolg=
+sigs.k8s.io/k8s-container-image-promoter/pkg v0.3.0 h1:Nn+Z9Nx3nPCKamKUsOn0eU/DREKOVxabp5JuuFZUMos=
+sigs.k8s.io/k8s-container-image-promoter/pkg v0.3.0/go.mod h1:0K5/ru06s20K65STf8IFXrnB1ggYPSGoQc95zcj8HLE=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:

Update to [cip/pkg@v0.3.0](https://github.com/kubernetes-sigs/k8s-container-image-promoter/releases/tag/pkg%2Fv0.3.0), which was cut following the promo tools cleanup/migration in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/273 and https://github.com/kubernetes/release/pull/1652.

/assign @listx @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
deps: Update to cip/pkg@v0.3.0
```
