### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -64,6 +64,7 @@ aliases:
     - listx
   release-notes-approvers:
     - jeefy
+    - puerco
     - saschagrunert
   release-notes-reviewers:
     - jeefy

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,9 +50,11 @@ aliases:
     - justaugustus
     - saschagrunert
   krel-reviewers:
+    - cpanato
     - hasheddan
     - hoegaarden
     - justaugustus
+    - puerco
     - saschagrunert
   promo-tools-approvers:
     - justaugustus

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -54,6 +54,14 @@ aliases:
     - hoegaarden
     - justaugustus
     - saschagrunert
+  promo-tools-approvers:
+    - justaugustus
+    - justinsb
+    - listx
+  promo-tools-reviewers:
+    - justaugustus
+    - justinsb
+    - listx
   release-notes-approvers:
     - jeefy
     - saschagrunert

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,13 +24,9 @@ aliases:
     - sethmccombs # Release Manager Associate
     - verolop # Release Manager Associate
   build-admins:
-    - aleksandra-malinowska
     - amwat
     - BenTheElder
-    - listx
     - MushuEE
-    - ps882
-    - sumitranr
     - spiffxp
   build-image-approvers:
     - BenTheElder

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,20 +7,23 @@ aliases:
     - saschagrunert
     - tpepper
   release-engineering-approvers:
-    - calebamiles # subproject owner
+    - cpanato # Release Manager
     - dougm # Release Manager
     - feiskyer # Release Manager
+    - hasheddan # Release Manager
     - hoegaarden # Release Manager
     - idealhack # Release Manager
+    - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
     - tpepper # subproject owner / Release Manager
     - xmudrii # Release Manager
   release-engineering-reviewers:
-    - cpanato # Release Manager
-    - hasheddan # Release Manager
+    - gianarb # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate
-    - saschagrunert # Release Manager
+    - mkorbi # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - puerco # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - verolop # Release Manager Associate
   build-admins:

--- a/cmd/kpromo/OWNERS
+++ b/cmd/kpromo/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - promo-tools-approvers
+reviewers:
+  - promo-tools-reviewers

--- a/cmd/promobot-files/OWNERS
+++ b/cmd/promobot-files/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - promo-tools-approvers
+reviewers:
+  - promo-tools-reviewers

--- a/cmd/promobot-generate-manifest/OWNERS
+++ b/cmd/promobot-generate-manifest/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - promo-tools-approvers
+reviewers:
+  - promo-tools-reviewers

--- a/images/build/OWNERS
+++ b/images/build/OWNERS
@@ -4,5 +4,7 @@ options:
   no_parent_owners: true
 approvers:
   - build-image-approvers
+  - release-engineering-approvers
 reviewers:
   - build-image-reviewers
+  - release-engineering-approvers

--- a/images/build/debian-base/OWNERS
+++ b/images/build/debian-base/OWNERS
@@ -2,11 +2,13 @@
 
 reviewers:
   - build-image-reviewers
+  - release-engineering-approvers
   - BenTheElder
   - mkumatag
   - tallclair
 approvers:
   - build-image-approvers
+  - release-engineering-approvers
   - BenTheElder
   - mkumatag
   - tallclair

--- a/images/build/debian-hyperkube-base/OWNERS
+++ b/images/build/debian-hyperkube-base/OWNERS
@@ -1,10 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - build-image-reviewers
+  - release-engineering-approvers
   - BenTheElder
   - mkumatag
   - tallclair
 approvers:
+  - build-image-approvers
+  - release-engineering-approvers
   - BenTheElder
   - mkumatag
   - tallclair

--- a/images/build/debian-iptables/OWNERS
+++ b/images/build/debian-iptables/OWNERS
@@ -2,6 +2,7 @@
 
 reviewers:
   - build-image-reviewers
+  - release-engineering-approvers
   - BenTheElder
   - bowei
   - freehan
@@ -11,6 +12,7 @@ reviewers:
   - tallclair
 approvers:
   - build-image-approvers
+  - release-engineering-approvers
   - BenTheElder
   - bowei
   - freehan

--- a/images/build/go-runner/OWNERS
+++ b/images/build/go-runner/OWNERS
@@ -2,5 +2,7 @@
 
 approvers:
   - build-image-approvers
+  - release-engineering-approvers
 reviewers:
   - build-image-reviewers
+  - release-engineering-approvers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Add reviewers/approvers for promotion tools (@listx, @justaugustus, @justinsb)
- Promote @puerco to release-notes-approvers
- Add @cpanato and @puerco as krel-reviewers
- Prune @kubernetes/build-admins to only include active members
- Update RelEng reviewers/approvers to include current roster
- Add Release Managers as build image reviewers/approvers

/assign @saschagrunert @hasheddan @cpanato @xmudrii 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
