### PR TITLE
Add isPushableBranch() function to determine which branches are pushed

### DIFF
--- a/cmd/krel/cmd/anago/push_git_objects_test.go
+++ b/cmd/krel/cmd/anago/push_git_objects_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anago
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/release/pkg/git"
+)
+
+func TestIsPushableBranch(t *testing.T) {
+	// Keeping master here to prvent it from getting pushed in case git.DefaultBranch changes
+	require.False(t, isPushableBranch("master"))
+	require.False(t, isPushableBranch(git.DefaultBranch))
+	require.True(t, isPushableBranch("release-1.20"))
+	require.False(t, isPushableBranch("v1.20.0-release"))
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR splits the logic that decides which branches are pushed into a new function `isPushableBranch()` to add a bit of logic into deciding which branches we consider for pushing. This removes this logic from anago and we now determine which branches are pushed in go.


#### Which issue(s) this PR fixes:
Related to: https://github.com/kubernetes/release/pull/1658

#### Special notes for your reviewer:

Tiny test for the new func is included

#### Does this PR introduce a user-facing change?

```release-note
Add isPushableBranch() function to `krel anago push-git-objects` to determine which branches should be pushed
```
