### PR TITLE
Move anago 'stage source tree' step into 'krel anago push'

### DIFF
--- a/anago
+++ b/anago
@@ -1262,23 +1262,6 @@ archive_release () {
 }
 
 ##############################################################################
-# Stages the completed tar'd up source tree archive on GCS for later use
-# returns 1 on failure
-PROGSTEP[stage_source_tree]="STAGE SOURCE TREE"
-stage_source_tree () {
-  local jbv="$JENKINS_BUILD_VERSION"
-
-  logecho -n "Tar up staged source tree: "
-  logrun -s tar cvfz $WORKDIR/src.tar.gz --exclude="_output-*" -C $WORKDIR src \
-   || return 1
-  logecho -n "Archive fully staged source tree on GCS: "
-  logrun -s $GSUTIL -m cp $WORKDIR/src.tar.gz \
-            gs://$RELEASE_BUCKET/$BUCKET_TYPE/$jbv/src.tar.gz || return 1
-  # Clean up
-  logrun rm -f $WORKDIR/src.tar.gz || return 1
-}
-
-##############################################################################
 # Pushes all binary and pointer artifacts up to GCS and GCR
 # @param label - the label index for the version being pushed
 # returns 1 on failure
@@ -1351,9 +1334,7 @@ if ((FLAGS_buildonly)); then
 elif ! ((FLAGS_prebuild)); then
   common::stepindex "make_cross"
   common::stepindex "build_tree" "generate_release_notes"
-  if ((FLAGS_stage)); then
-    common::stepindex "stage_source_tree"
-  else
+  if ! ((FLAGS_stage)); then
     common::stepindex "push_git_objects"
   fi
   common::stepindex "push_all_artifacts"
@@ -1558,10 +1539,6 @@ else
        common::check_state -a $entry
      fi
   done
-fi
-
-if ((FLAGS_stage)); then
-  common::run_stateful stage_source_tree
 fi
 
 # Push for each release version of this session

--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -125,6 +125,11 @@ func runPushStage(
 	opts *release.PushBuildOptions,
 	version string,
 ) error {
+	// Stage the local source tree
+	if err := pushBuild.StageLocalSourceTree(buildVersion); err != nil {
+		return errors.Wrap(err, "staging local source tree")
+	}
+
 	// Stage local artifacts and write checksums
 	if err := pushBuild.StageLocalArtifacts(version); err != nil {
 		return errors.Wrap(err, "staging local artifacts")
@@ -160,9 +165,7 @@ func runPushRelease(
 	opts *release.PushBuildOptions,
 	version string,
 ) error {
-	if err := pushBuild.CopyStagedFromGCS(
-		opts.Bucket, version, buildVersion,
-	); err != nil {
+	if err := pushBuild.CopyStagedFromGCS(version, buildVersion); err != nil {
 		return errors.Wrap(err, "copy staged from GCS")
 	}
 

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,6 +56,13 @@ func TestCompress(t *testing.T) {
 		))
 	}
 
+	logrus.SetLevel(logrus.DebugLevel)
+
+	require.Nil(t, os.Symlink(
+		filepath.Join(baseTmpDir, "1.txt"),
+		filepath.Join(subTmpDir, "link"),
+	))
+
 	excludes := []*regexp.Regexp{
 		regexp.MustCompile(".md"),
 		regexp.MustCompile("5"),
@@ -64,7 +72,7 @@ func TestCompress(t *testing.T) {
 	require.Nil(t, Compress(tarFilePath, baseTmpDir, excludes...))
 	require.FileExists(t, tarFilePath)
 
-	res := []string{"1.txt", "2.bin", "sub/4.txt"}
+	res := []string{"1.txt", "2.bin", "sub/4.txt", "sub/link"}
 	require.Nil(t, iterateTarball(
 		tarFilePath, func(_ *tar.Reader, header *tar.Header) bool {
 			require.Equal(t, res[0], header.Name)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This way we can move the logic closer together while removing some lines
of bash from anago.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Manual testing:
- :heavy_check_mark: Stage: https://console.cloud.google.com/cloud-build/builds/afb080c8-ec5f-4d39-afa7-984db41416c0?project=kubernetes-release-test
- :heavy_check_mark: Release: https://console.cloud.google.com/cloud-build/builds/290b394c-c6f9-407e-90b4-f2f7111bcb89?project=648026197307

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Migrated the "stage source tree" step from anago to `krel anago push`
```
