### PR TITLE
vulndash: Fixup image building and build v0.2.0 image

### DIFF
--- a/cmd/vulndash/Dockerfile
+++ b/cmd/vulndash/Dockerfile
@@ -16,47 +16,34 @@
 ARG GO_VERSION
 ARG DISTROLESS_IMAGE
 FROM golang:${GO_VERSION} as builder
-WORKDIR /workspace
+
+WORKDIR /go/src/k8s.io/release
 
 # Copy the sources
-COPY ./../../../cmd/vulndash ./
-#COPY ./../../../go.* ./
-RUN go mod init k8s.io/release/cmd/vulndash
+ENV package="./cmd/vulndash"
+COPY ../../go.mod ../../go.sum ./
+COPY ../../pkg ./pkg/
+COPY ../../cmd/vulndash ${package}/
 
-# Allow fallback to 'direct' for GOPROXY
-#
-# The GOPROXY environment variable now supports skipping proxies that return
-# errors. Proxy URLs may now be separated with either commas (,) or pipe
-# characters (|). If a proxy URL is followed by a comma, the go command will
-# only try the next proxy in the list after a 404 or 410 HTTP response. If a
-# proxy URL is followed by a pipe character, the go command will try the next
-# proxy in the list after any error. Note that the default value of GOPROXY
-# remains https://proxy.golang.org,direct, which does not fall back to direct
-# in case of errors.
-#
-# ref: https://golang.org/doc/go1.15#go-command
-ENV GOPROXY="https://proxy.golang.org|direct"
+RUN go mod download
 
 # Build
-ARG package=.
 ARG ARCH
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=${ARCH}
 
-RUN go env
-
-RUN env
-RUN ls -al
-
 RUN go build -ldflags '-s -w -buildid= -extldflags "-static"' \
     -o vulndash ${package}
 
 # Production image
 FROM gcr.io/distroless/${DISTROLESS_IMAGE}:latest
+
 LABEL maintainers="Kubernetes Authors"
-LABEL description="go based runner for distroless scenarios"
+LABEL description="A vulnerability dashboard for GCR container images"
+
 WORKDIR /
-COPY --from=builder /workspace/vulndash .
+COPY --from=builder /go/src/k8s.io/release/vulndash .
+
 ENTRYPOINT ["/vulndash"]

--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 # include the common image-building Makefiles
-include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.artifact-promoter
+#include $(CURDIR)/../../Makefile.common-image
 
 # set default shell
 SHELL=/bin/bash -o pipefail
 
+REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
 IMAGE_VERSION ?= buster-v2.1.0
 CONFIG ?= buster
@@ -67,11 +68,11 @@ container: init-docker-buildx
 			--progress plain \
 			--platform $${platform} \
 			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
-			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG) \
-			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG) \
+			--tag $(IMAGE)-$${platform##*/}:$(TAG) \
+			--tag $(IMAGE)-$${platform##*/}:latest \
 			$(BUILD_ARGS) \
 			-f $(CURDIR)/Dockerfile \
-			../../../.; \
+			../../.; \
 	done
 
 .PHONY: push
@@ -80,8 +81,8 @@ push: container
 	@for platform in $(PLATFORMS); do \
 		echo "Pushing tags for $${platform} platform"; \
 		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
-		docker push $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG); \
-		docker push $(IMAGE)-$${platform##*/}:latest-$(CONFIG); \
+		docker push $(IMAGE)-$${platform##*/}:$(TAG); \
+		docker push $(IMAGE)-$${platform##*/}:latest; \
 	done
 
 .PHONY: manifest
@@ -93,4 +94,4 @@ manifest: push
 # enable buildx
 .PHONY: init-docker-buildx
 init-docker-buildx:
-	./../../../hack/init-buildx.sh
+	./../../hack/init-buildx.sh

--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= buster-v2.1.0
+IMAGE_VERSION ?= v0.2.0
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/cmd/vulndash/cloudbuild.yaml
+++ b/cmd/vulndash/cloudbuild.yaml
@@ -10,7 +10,7 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
     entrypoint: 'bash'
-    dir: ./images/build/vulndash
+    dir: ./cmd/vulndash
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - REGISTRY=gcr.io/$PROJECT_ID
@@ -18,7 +18,6 @@ steps:
     - TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
     - IMAGE_VERSION=$_IMAGE_VERSION
-    - CONFIG=$_CONFIG
     - GO_VERSION=$_GO_VERSION
     - DISTROLESS_IMAGE=$_DISTROLESS_IMAGE
     args:
@@ -32,8 +31,7 @@ substitutions:
   # can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'codename-v0.0.0'
-  _CONFIG: 'codename'
+  _IMAGE_VERSION: 'v0.0.0'
   _GO_VERSION: '0.0.0'
   _DISTROLESS_IMAGE: 'static-debian00'
 
@@ -42,11 +40,10 @@ tags:
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
 - ${_IMAGE_VERSION}
-- ${_CONFIG}
 - ${_GO_VERSION}
 - ${_DISTROLESS_IMAGE}
 
 images:
   - 'gcr.io/$PROJECT_ID/vulndash-amd64:$_IMAGE_VERSION'
-  - 'gcr.io/$PROJECT_ID/vulndash-amd64:$_GIT_TAG-$_CONFIG'
-  - 'gcr.io/$PROJECT_ID/vulndash-amd64:latest-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/vulndash-amd64:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/vulndash-amd64:latest'

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,0 +1,5 @@
+variants:
+  default:
+    IMAGE_VERSION: 'buster-v2.1.0'
+    GO_VERSION: '1.15.3'
+    DISTROLESS_IMAGE: 'static-debian10'

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   default:
-    IMAGE_VERSION: 'buster-v2.1.0'
+    IMAGE_VERSION: 'v0.2.0'
     GO_VERSION: '1.15.3'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -118,6 +118,15 @@ dependencies:
     - path: images/build/debian-iptables/variants.yaml
       match: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
+  # Images: k8s.io/artifact-promoter
+  - name: "k8s.io/artifact-promoter/vulndash"
+    version: v0.2.0
+    refPaths:
+    - path: cmd/vulndash/Makefile
+      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: cmd/vulndash/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
   # Base images
   - name: "k8s.gcr.io/debian-base"
     version: buster-v1.2.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -59,6 +59,10 @@ dependencies:
   - name: "golang"
     version: 1.15.3
     refPaths:
+    - path: cmd/vulndash/Makefile
+      match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: cmd/vulndash/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/cross/Makefile
       match: GO_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/cross/variants.yaml

--- a/images/artifact-promoter/vulndash/OWNERS
+++ b/images/artifact-promoter/vulndash/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - vulndash-approvers
-reviewers:
-  - vulndash-reviewers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to https://github.com/kubernetes/release/pull/1657, which fixes image build bits for `vulndash`.

- vulndash: Fixup image building
- dependencies.yaml: Add vulndash as golang dependent
- vulndash: Build v0.2.0 image

Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/274.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- vulndash: Fixup image building
- vulndash: Build v0.2.0 image
```
