### PR TITLE
Add `tar` package

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -41,6 +41,7 @@ import (
 
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/http"
+	"k8s.io/release/pkg/tar"
 	"k8s.io/release/pkg/util"
 )
 
@@ -170,7 +171,7 @@ func ReadBazelVersion(workDir string) (string, error) {
 // ReadDockerizedVersion reads the version from a Dockerized Kubernetes build.
 func ReadDockerizedVersion(workDir string) (string, error) {
 	dockerTarball := filepath.Join(workDir, BuildDir, ReleaseTarsPath, kubernetesTar)
-	reader, err := util.ReadFileFromGzippedTar(
+	reader, err := tar.ReadFileFromGzippedTar(
 		dockerTarball, filepath.Join("kubernetes", "version"),
 	)
 	if err != nil {

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tar
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Compress the provided  `tarContentsPath` into the `tarFilePath` while
+// excluding the `exclude` regular expression patterns.
+func Compress(tarFilePath, tarContentsPath string, excludes ...*regexp.Regexp) error {
+	tarFile, err := os.Create(tarFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "create tar file %q", tarFilePath)
+	}
+	defer tarFile.Close()
+
+	gzipWriter := gzip.NewWriter(tarFile)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if err := filepath.Walk(tarContentsPath, func(filePath string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fileInfo.IsDir() || filePath == tarFilePath {
+			return nil
+		}
+
+		for _, re := range excludes {
+			if re != nil && re.MatchString(filePath) {
+				return nil
+			}
+		}
+
+		header, err := tar.FileInfoHeader(fileInfo, filePath)
+		if err != nil {
+			return errors.Wrapf(err, "create file info header for %q", filePath)
+		}
+		// Make the path inside the tar relative to the archive path if
+		// necessary.
+		header.Name = strings.TrimLeft(
+			strings.TrimPrefix(filePath, filepath.Dir(tarFilePath)),
+			string(filepath.Separator),
+		)
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return errors.Wrap(err, "writing tar header")
+		}
+
+		file, err := os.Open(filePath)
+		if err != nil {
+			return errors.Wrapf(err, "open file %q", filePath)
+		}
+
+		if _, err := io.Copy(tarWriter, file); err != nil {
+			return errors.Wrap(err, "writing file to tar writer")
+		}
+
+		file.Close()
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walking tree in %q", tarContentsPath)
+	}
+
+	return nil
+}
+
+// ReadFileFromGzippedTar opens a tarball and reads contents of a file inside.
+func ReadFileFromGzippedTar(
+	tarPath, filePath string,
+) (res io.Reader, err error) {
+	if err := iterateTarball(
+		tarPath,
+		func(reader *tar.Reader, header *tar.Header) (stop bool) {
+			if header.Name == filePath {
+				res = reader
+				return true
+			}
+			return false
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, errors.Errorf(
+			"unable to find file %q in tarball %q", tarPath, filePath,
+		)
+	}
+
+	return res, nil
+}
+
+// iterateTarball can be used to iterate over the contents of a tarball by
+// calling the callback for each entry.
+func iterateTarball(
+	tarPath string,
+	callback func(*tar.Reader, *tar.Header) (stop bool),
+) error {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return errors.Wrapf(err, "opening tar file %q", tarPath)
+	}
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return errors.Wrapf(err, "creating gzip reader for file %q", tarPath)
+	}
+	tarReader := tar.NewReader(gzipReader)
+
+	for {
+		tarHeader, err := tarReader.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+
+		if callback(tarReader, tarHeader) {
+			// User wants to stop
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tar
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompress(t *testing.T) {
+	baseTmpDir, err := ioutil.TempDir("", "compress-")
+	require.Nil(t, err)
+	defer os.RemoveAll(baseTmpDir)
+
+	for _, fileName := range []string{
+		"1.txt", "2.bin", "3.md",
+	} {
+		require.Nil(t, ioutil.WriteFile(
+			filepath.Join(baseTmpDir, fileName),
+			[]byte{1, 2, 3},
+			os.FileMode(0o644),
+		))
+	}
+
+	subTmpDir := filepath.Join(baseTmpDir, "sub")
+	require.Nil(t, os.MkdirAll(subTmpDir, os.FileMode(0o755)))
+
+	for _, fileName := range []string{
+		"4.txt", "5.bin", "6.md",
+	} {
+		require.Nil(t, ioutil.WriteFile(
+			filepath.Join(subTmpDir, fileName),
+			[]byte{4, 5, 6},
+			os.FileMode(0o644),
+		))
+	}
+
+	excludes := []*regexp.Regexp{
+		regexp.MustCompile(".md"),
+		regexp.MustCompile("5"),
+	}
+
+	tarFilePath := filepath.Join(baseTmpDir, "res.tar.gz")
+	require.Nil(t, Compress(tarFilePath, baseTmpDir, excludes...))
+	require.FileExists(t, tarFilePath)
+
+	res := []string{"1.txt", "2.bin", "sub/4.txt"}
+	require.Nil(t, iterateTarball(
+		tarFilePath, func(_ *tar.Reader, header *tar.Header) bool {
+			require.Equal(t, res[0], header.Name)
+			res = res[1:]
+			return false
+		}),
+	)
+}
+
+func TestReadFileFromGzippedTar(t *testing.T) {
+	baseTmpDir, err := ioutil.TempDir("", "tar-read-file-")
+	require.Nil(t, err)
+	defer os.RemoveAll(baseTmpDir)
+
+	const (
+		testFilePath     = "test.txt"
+		testFileContents = "test-file-contents"
+	)
+	testTarPath := filepath.Join(baseTmpDir, "test.tar.gz")
+
+	require.Nil(t, ioutil.WriteFile(
+		filepath.Join(baseTmpDir, testFilePath),
+		[]byte(testFileContents),
+		os.FileMode(0o644),
+	))
+	require.Nil(t, Compress(testTarPath, baseTmpDir, nil))
+
+	type args struct {
+		tarPath  string
+		filePath string
+	}
+	type want struct {
+		fileContents string
+		shouldErr    bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"FoundFileInTar": {
+			args: args{
+				tarPath:  testTarPath,
+				filePath: testFilePath,
+			},
+			want: want{fileContents: testFileContents},
+		},
+		"FileNotInTar": {
+			args: args{
+				tarPath:  testTarPath,
+				filePath: "badfile.txt",
+			},
+			want: want{shouldErr: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r, err := ReadFileFromGzippedTar(tc.args.tarPath, tc.args.filePath)
+			if tc.want.shouldErr {
+				require.Nil(t, r)
+				require.NotNil(t, err)
+			} else {
+				file, err := ioutil.ReadAll(r)
+				require.Nil(t, err)
+				require.Equal(t, tc.want.fileContents, string(file))
+			}
+		})
+	}
+}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -17,9 +17,7 @@ limitations under the License.
 package util
 
 import (
-	"archive/tar"
 	"bufio"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -366,33 +364,6 @@ func FakeGOPATH(srcDir string) (string, error) {
 	}
 
 	return gitRoot, nil
-}
-
-// ReadFileFromGzippedTar opens a tarball and reads contents of a file inside.
-func ReadFileFromGzippedTar(tarPath, filePath string) (io.Reader, error) {
-	file, err := os.Open(tarPath)
-	if err != nil {
-		return nil, err
-	}
-
-	archive, err := gzip.NewReader(file)
-	if err != nil {
-		return nil, err
-	}
-	tr := tar.NewReader(archive)
-
-	for {
-		h, err := tr.Next()
-		if err == io.EOF {
-			break // End of archive
-		}
-
-		if h.Name == filePath {
-			return tr, nil
-		}
-	}
-
-	return nil, errors.New("unable to find file in tarball")
 }
 
 // MoreRecent determines if file at path a was modified more recently than file


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The new tar package now contains the previously existing
`ReadFileFromGzippedTar` from the `common` package as well as a new
`Compress` API for compressing tarballs. This new function automatically
strips the prefix-path (`tar -C` option) and allows excluding regular
expression patterns (`tar --exclude` flag).


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Required for https://github.com/kubernetes/release/pull/1661
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `tar` package which now contains the `ReadFileFromGzippedTar()` as well as the `Compress()` API.
```
