### PR TITLE
vulndash: fix dashboard.json file mode and build v0.2.1 image

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.2.0
+IMAGE_VERSION ?= v0.2.1
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   default:
-    IMAGE_VERSION: 'v0.2.0'
+    IMAGE_VERSION: 'v0.2.1'
     GO_VERSION: '1.15.3'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -120,7 +120,7 @@ dependencies:
 
   # Images: k8s.io/artifact-promoter
   - name: "k8s.io/artifact-promoter/vulndash"
-    version: v0.2.0
+    version: v0.2.1
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/pkg/vulndash/adapter/adapter.go
+++ b/pkg/vulndash/adapter/adapter.go
@@ -59,9 +59,11 @@ func uploadFile(directory, filename, bucket string) error {
 	if _, err = io.Copy(wc, f); err != nil {
 		return errors.Errorf("io.Copy: %v", err)
 	}
+
 	if err := wc.Close(); err != nil {
 		return errors.Errorf("Writer.Close: %v", err)
 	}
+
 	return nil
 }
 
@@ -94,6 +96,7 @@ func GetAllVulnerabilities(
 		}
 		occurrenceList = append(occurrenceList, occ)
 	}
+
 	return occurrenceList, err
 }
 
@@ -195,15 +198,17 @@ func UpdateVulnerabilityDashboard(
 	}
 
 	err = ioutil.WriteFile(dashboardPath+"dashboard.json",
-		jsonFile, os.ModeTemporary)
+		jsonFile, 0644)
 	if err != nil {
 		return errors.Errorf("Unable to create temporary local"+
 			"JSON file for the dashboard: %v", err)
 	}
+
 	err = uploadFile(dashboardPath, "dashboard.json", dashboardBucket)
 	if err != nil {
 		return errors.Errorf("Unable to upload latest version of "+
 			"dashboard JSON: %v", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Fix the mode when creating the `dashboard.json` file to update to the GCS bucket

Before we see this error:

`os.Open: open /tmp/dashboard.json: permission denied`

if check the permission in the file you can see

`----------  1 cpanato   4 Oct 29 13:57 dashboard.json`

after the fix and no error and i can see the file in the GCS bucket

`-rw-r--r--  1 cpanato   4 Oct 29 13:59 dashboard.json`

/assign @justaugustus 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- vulndash: fix file mode when creating the dashboard.json
- vulndash: Build v0.2.1 image
```
