### PR TITLE
vulndash: Add page size when listing vulnerabilities more logs and build v0.3.0 image

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.2.1
+IMAGE_VERSION ?= v0.3.0
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/cmd/vulndash/cmd/root.go
+++ b/cmd/vulndash/cmd/root.go
@@ -48,6 +48,7 @@ type options struct {
 	project           string
 	bucket            string
 	dashboardFilePath string
+	pageSize          int32
 	logLevel          string
 }
 
@@ -57,6 +58,7 @@ var (
 	projectFlag           = "project"
 	bucketFlag            = "bucket"
 	dashboardFilePathFlag = "dashboard-file-path"
+	pageSizeFlag          = "page-size"
 
 	// requiredFlags only if the config flag is not set
 	requiredFlags = []string{
@@ -102,6 +104,13 @@ func init() {
 		"info",
 		"the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'",
 	)
+
+	rootCmd.PersistentFlags().Int32Var(
+		&opts.pageSize,
+		pageSizeFlag,
+		200,
+		"the page size when getting the list of vulnerabilities",
+	)
 }
 
 func initLogging(*cobra.Command, []string) error {
@@ -132,6 +141,7 @@ func run(opts *options) error {
 		opts.dashboardFilePath,
 		opts.project,
 		opts.bucket,
+		opts.pageSize,
 	)
 	if updateErr != nil {
 		return errors.Wrap(updateErr, "updating vulnerability dashboard")

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   default:
-    IMAGE_VERSION: 'v0.2.1'
+    IMAGE_VERSION: 'v0.3.0'
     GO_VERSION: '1.15.3'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -120,7 +120,7 @@ dependencies:
 
   # Images: k8s.io/artifact-promoter
   - name: "k8s.io/artifact-promoter/vulndash"
-    version: v0.2.1
+    version: v0.3.0
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)


### PR DESCRIPTION
### What type of PR is this?
/kind feature
/kind design


#### What this PR does / why we need it:
The current execution log just sends start and finish messages, sometimes is missing more information where the service is. Adding more logs to make it easier to see what is going on and troubleshoot if need.

Also, add an option to set the page size when listing the vulnerabilities, the default value for the API call is 20, with that it takes too much time to get all info needed.

Add the flag to default to 200, some local tests:

With the page size 20 (default for the API call if you not set) and the new logs took `1:27 minutes`

```shell
$ time vulndash --project=k8s-staging-artifact-promoter --bucket=test-carlos-dash --dashboard-file-path=cmd/vulndash/ --log-level debug --page-size 20
DEBU Setting commands globally into verbose mode
DEBU Using log level "debug"                       file="cmd/root.go:117"
INFO Updating the vulnerability dashboard...       file="cmd/root.go:138"
INFO opening cmd/vulndash/dashboard.html           file="adapter/adapter.go:175"
INFO parsing cmd/vulndash/dashboard.html           file="adapter/adapter.go:181"
INFO uploading cmd/vulndash/dashboard.html to gcs  file="adapter/adapter.go:187"
INFO uploading updated dashboard.js to gcs         file="adapter/adapter.go:194"
INFO checking all vulnerabilities for k8s-staging-artifact-promoter  file="adapter/adapter.go:201"
INFO listing the vulnerabilities...                file="adapter/adapter.go:90"
INFO done listing the vulnerabilities              file="adapter/adapter.go:103"
INFO parsing the vulnerabilities for k8s-staging-artifact-promoter  file="adapter/adapter.go:207"
INFO writing the vulnerabilities for k8s-staging-artifact-promoter in the file cmd/vulndash/dashboard.json  file="adapter/adapter.go:215"
INFO uploading updated cmd/vulndash/dashboard.json to gcs  file="adapter/adapter.go:222"
INFO Finished vulnerability dashboard updates      file="cmd/root.go:150"
vulndash --project=k8s-staging-artifact-promoter --bucket=test-carlos-dash     2.13s user 1.55s system 4% cpu 1:27.00 total
```

With 200 as the page size, it took `19.231 seconds`

```shell
$ time vulndash --project=k8s-staging-artifact-promoter --bucket=test-carlos-dash --dashboard-file-path=cmd/vulndash/ --log-level debug
DEBU Setting commands globally into verbose mode
DEBU Using log level "debug"                       file="cmd/root.go:117"
INFO Updating the vulnerability dashboard...       file="cmd/root.go:138"
INFO opening cmd/vulndash/dashboard.html           file="adapter/adapter.go:177"
INFO parsing cmd/vulndash/dashboard.html           file="adapter/adapter.go:183"
INFO uploading cmd/vulndash/dashboard.html to gcs  file="adapter/adapter.go:189"
INFO uploading updated dashboard.js to gcs         file="adapter/adapter.go:196"
INFO checking all vulnerabilities for k8s-staging-artifact-promoter  file="adapter/adapter.go:203"
INFO listing the vulnerabilities, will take a while...  file="adapter/adapter.go:90"
INFO done listing the vulnerabilities              file="adapter/adapter.go:105"
INFO parsing the vulnerabilities for k8s-staging-artifact-promoter  file="adapter/adapter.go:209"
INFO writing the vulnerabilities for k8s-staging-artifact-promoter in the file cmd/vulndash/dashboard.json  file="adapter/adapter.go:217"
INFO uploading updated cmd/vulndash/dashboard.json to gcs  file="adapter/adapter.go:224"
INFO Finished vulnerability dashboard updates      file="cmd/root.go:150"
vulndash --project=k8s-staging-artifact-promoter --bucket=test-carlos-dash     1.02s user 0.71s system 8% cpu 19.231 total
```

did not add more because looks like it consume more memory and cpu

#### Which issue(s) this PR fixes:

None


/assing @justaugustus 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
vulndash: Add page size when listing vulnerabilities more logs and build v0.3.0 image
```
