### PR TITLE
vulndash: set Default page size and small test refactor

### DIFF
--- a/pkg/vulndash/adapter/adapter.go
+++ b/pkg/vulndash/adapter/adapter.go
@@ -36,6 +36,10 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 )
 
+// DefaultPageSize to be used in the vulnerabilities list to set how many items
+// will be retrieved in each request
+const DefaultPageSize = 200
+
 func uploadFile(directory, filename, bucket string) error {
 	const timeout = 60
 	ctx := context.Background()
@@ -81,6 +85,9 @@ func GetAllVulnerabilities(
 	}
 	defer client.Close()
 
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
 	req := &grafeaspb.ListOccurrencesRequest{
 		Parent:   fmt.Sprintf("projects/%s", projectID),
 		Filter:   fmt.Sprintf("kind = %q", "VULNERABILITY"),

--- a/pkg/vulndash/adapter/adapter_test.go
+++ b/pkg/vulndash/adapter/adapter_test.go
@@ -17,38 +17,12 @@ limitations under the License.
 package adapter_test
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	adapter "k8s.io/release/pkg/vulndash/adapter"
 )
-
-func checkEqual(got, expected interface{}) error {
-	if !reflect.DeepEqual(got, expected) {
-		return fmt.Errorf(
-			`<<<<<<< got (type %T)
-%v
-=======
-%v
->>>>>>> expected (type %T)`,
-			got,
-			got,
-			expected,
-			expected)
-	}
-	return nil
-}
-
-func checkError(t *testing.T, err error, msg string) {
-	if err != nil {
-		fmt.Printf("\n%v", msg)
-		fmt.Println(err)
-		fmt.Println()
-		t.Fail()
-	}
-}
 
 func TestGenerateVulnerabilityBreakdown(t *testing.T) {
 	tests := []struct {
@@ -248,7 +222,6 @@ func TestGenerateVulnerabilityBreakdown(t *testing.T) {
 
 	for _, test := range tests {
 		testBreakdown := adapter.GenerateVulnerabilityBreakdown(test.vulnerabilities)
-		err := checkEqual(testBreakdown, test.expected)
-		checkError(t, err, fmt.Sprintf("checkError: test: %v (GenerateDashboardJSON)\n", test.name))
+		require.Equal(t, testBreakdown, test.expected)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- Set a default page size when calling the vulnerabilities list API, per request: https://github.com/kubernetes/release/pull/1667#discussion_r515569617

- Also a small test refactor to use the testify lib

/assign @justaugustus 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
vulndash: set Default page size and small test refactor
```
