### PR TITLE
Release Notes Maps tests and other fixes

### DIFF
--- a/pkg/notes/maps/testdata/fullmap.yaml
+++ b/pkg/notes/maps/testdata/fullmap.yaml
@@ -1,9 +1,9 @@
 ---
 pr: 123
 commit: 1a89038915fe77d73bf7c9cfa8f2ce123a464c82
-release-note:  
-  text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-  author: kubernetes-ci-robot
+releasenote:  
+  author: "kubernetes-ci-robot"
+  text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
   areas:
     - testarea
   kinds:
@@ -28,12 +28,12 @@ datafields:
     - 9875
 ---
 pr: 123
-release-note:
+releasenote:
   author: kubernetes-ci-robot
 ---
 pr: 123
 datafields:
-  classifier-score:
+  classifierscore:
     # Hypothetical ML score
     qa-score: 0.35635 # ← would need to fix this one
     suggested-kinds:

--- a/pkg/notes/maps/testdata/unit/maps.yaml
+++ b/pkg/notes/maps/testdata/unit/maps.yaml
@@ -1,0 +1,50 @@
+---
+pr: 95000
+releasenote:
+  action_required: false
+datafields:
+  testcase:
+    property: "ActionRequired"
+    expected: false
+    name: "Setting ActionRequired to false"
+---
+pr: 95000
+releasenote:
+  text: "This test string has been modified"
+datafields:
+  testcase:
+    property: "Text"
+    expected: "This test string has been modified"
+    name: "Modifying release note text"
+---
+pr: 95000
+releasenote:
+  author: "product-security-committee"
+datafields:
+  testcase:
+    property: "Author"
+    expected: "product-security-committee"
+    name: "Modifying release note author"
+---
+pr: 95000
+releasenote:
+  feature: false
+datafields:
+  testcase:
+    property: "Feature"
+    expected: false
+    name: "Modifying feature flag to false"
+---
+## Areas
+pr: 95000
+releasenote:
+  areas:
+  - kubectl
+  - apiserver
+datafields:
+  testcase:
+    property: "Areas"
+    expected:
+    - kubectl
+    - apiserver
+    name: "Modifying release note areas"

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -61,9 +61,9 @@ func ParseReleaseNotesMap(mapPath string) (*[]ReleaseNotesMap, error) {
 	}
 
 	decoder := yaml.NewDecoder(yamlReader)
-	noteMap := ReleaseNotesMap{}
 
 	for {
+		noteMap := ReleaseNotesMap{}
 		if err := decoder.Decode(&noteMap); err == io.EOF {
 			break
 		} else if err != nil {

--- a/pkg/notes/notes_map_test.go
+++ b/pkg/notes/notes_map_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProviderFromInitString(t *testing.T) {
+	testCases := []struct {
+		initString   string
+		returnsError bool
+	}{
+		{initString: "maps/testdata/unit/", returnsError: false},
+		{initString: "/this/shoud/not/really.exist/as/a/d33rect0ree", returnsError: true},
+		{initString: "gs://bucket-name/map/path/", returnsError: true},
+		{initString: "github://kubernetes/sig-release/maps", returnsError: true},
+	}
+	for _, testCase := range testCases {
+		provider, err := NewProviderFromInitString(testCase.initString)
+		if !testCase.returnsError {
+			require.Nil(t, err)
+			require.NotNil(t, provider)
+		} else {
+			require.NotNil(t, err)
+		}
+	}
+}
+
+func TestParseReleaseNotesMap(t *testing.T) {
+	maps, err := ParseReleaseNotesMap("maps/testdata/unit/maps.yaml")
+	require.Nil(t, err)
+	require.GreaterOrEqual(t, 5, len(*maps))
+
+	maps, err = ParseReleaseNotesMap("maps/testdata/fullmap.yaml")
+	require.Nil(t, err)
+	require.GreaterOrEqual(t, 4, len(*maps))
+}
+
+func TestGetMapsForPR(t *testing.T) {
+	provider, err := NewProviderFromInitString("maps/testdata")
+	require.Nil(t, err)
+
+	maps, err := provider.GetMapsForPR(95000)
+	require.Nil(t, err)
+	require.GreaterOrEqual(t, 5, len(maps))
+
+	maps, err = provider.GetMapsForPR(123)
+	require.Nil(t, err)
+	require.GreaterOrEqual(t, 4, len(maps))
+}
+
+func TestReleaseNotesMapIntegrity(t *testing.T) {
+	maps, err := ParseReleaseNotesMap("maps/testdata/fullmap.yaml")
+	require.Nil(t, err)
+	require.GreaterOrEqual(t, len(*maps), 1)
+
+	// The first map in the test file contains a full map
+	testMap := (*maps)[0]
+
+	// Map metadata
+	require.Equal(t, 123, testMap.PR)
+	require.Equal(t, "1a89038915fe77d73bf7c9cfa8f2ce123a464c82", testMap.Commit)
+
+	// Map release note elements. All are defined, so none should be nil
+	require.NotNil(t, testMap.ReleaseNote.Text)
+	require.Equal(t, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", *testMap.ReleaseNote.Text)
+
+	require.NotNil(t, *testMap.ReleaseNote.Author)
+	require.Equal(t, "kubernetes-ci-robot", *testMap.ReleaseNote.Author)
+
+	require.NotNil(t, *testMap.ReleaseNote.Areas)
+	require.ElementsMatch(t, []string{"testarea"}, *testMap.ReleaseNote.Areas)
+
+	require.NotNil(t, *testMap.ReleaseNote.Kinds)
+	require.ElementsMatch(t, []string{"documentation"}, *testMap.ReleaseNote.Kinds)
+
+	require.NotNil(t, *testMap.ReleaseNote.SIGs)
+	require.ElementsMatch(t, []string{"api-machinery"}, *testMap.ReleaseNote.SIGs)
+
+	require.NotNil(t, *testMap.ReleaseNote.Feature)
+	require.Equal(t, true, *testMap.ReleaseNote.Feature)
+
+	require.NotNil(t, *testMap.ReleaseNote.ActionRequired)
+	require.Equal(t, false, *testMap.ReleaseNote.ActionRequired)
+}


### PR DESCRIPTION
#### What type of PR is this?

After we finally got the release notes maps merged, tests for the new code were missing. This main purpose of this PR is to add a bunch of tests related to the map files to notes.go and notes_map.go.

In addition, this PR includes three other changes:

- It cleans up the data structure of the release notes maps returned by a map provider. The previous structure was a legacy from an ancient iteration of the code and has been replaced by a simpler []string slice.
- It fixes a bug where a provider would ignore all but the last map file when more that one map was found.
- Fixes the test data files as they were also out of date. 

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Until now, the release notes maps feature did not have any tests. This PR adds the first set of tests to the code to ensure proper reading, parsing and applying of the maps.

#### Which issue(s) this PR fixes:

None, but it addresses problems found by the release notes team in https://github.com/kubernetes/sig-release/pull/1305

#### Special notes for your reviewer:

The `ApplyMap()` test leverages the release notes map datafield to define its own testcases.

#### Does this PR introduce a user-facing change?

```release-note
- Add first batch of tests to ensure proper reading, parsing and applying of the maps.
- Fix a bug where all but the last map file would be ignored by a `mapProvider` when multiple maps for a PR were found
```
