### PR TITLE
images: Build releng-ci:v0.1.1 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -127,6 +127,13 @@ dependencies:
     - path: cmd/vulndash/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
+  # Images: k8s.io/releng
+  - name: "k8s.io/releng/releng-ci"
+    version: v0.1.1
+    refPaths:
+    - path: images/releng/ci/cloudbuild.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
   # Base images
   - name: "k8s.gcr.io/debian-base"
     version: buster-v1.2.0

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
     args:
       - build
       - --tag=gcr.io/$PROJECT_ID/releng-ci:$_GIT_TAG
+      - --tag=gcr.io/$PROJECT_ID/releng-ci:$_IMAGE_VERSION
       - --tag=gcr.io/$PROJECT_ID/releng-ci:latest
       - --build-arg=GO_VERSION=${_GO_VERSION}
       - .
@@ -23,9 +24,11 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
+  _IMAGE_VERSION: 'v0.1.1'
   _GO_VERSION: '1.15.3'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
+  - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'
   - 'gcr.io/$PROJECT_ID/releng-ci:latest'
 
 tags:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

No changes to the Dockerfile; just adding a version to the image so that
we can target it for promotion.

I'm going to promote this and use it as the image for the GCR prod backup jobs

https://github.com/kubernetes/test-infra/blob/bb494c0354bb60e0fd769a9f3f4c8cbc61e11a89/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml#L84-L86

ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
images: Build releng-ci:v0.1.1 image
```
