### PR TITLE
Update release confirmation message to show expected yes/no input

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -215,7 +215,7 @@ func RunGcbmgr(opts *GcbmgrOptions) error {
 	if rootOpts.nomock {
 		// TODO: Consider a '--yes' flag so we can mock this
 		_, nomockSubmit, askErr := util.Ask(
-			fmt.Sprintf("Really submit a --nomock release job against the %s branch?", opts.Branch),
+			fmt.Sprintf("Really submit a --nomock release job against the %s branch? (yes/no)", opts.Branch),
 			"yes",
 			3,
 		)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds the expected input `(yes/no)` to the `Really submit a --nomock release job against the %s branch?` message to make it more clear what users should type.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @saschagrunert 