### PR TITLE
Adding setcap image so that capabilities can be applied to

### DIFF
--- a/images/build/setcap/Dockerfile
+++ b/images/build/setcap/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+
+FROM ${BASEIMAGE}
+
+RUN apt-get update && apt-get -y --no-install-recommends install libcap2-bin

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -1,0 +1,80 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY:	build push all all-build all-push-images all-push push-manifest
+
+REGISTRY?="gcr.io/k8s-staging-build-image"
+IMAGE=$(REGISTRY)/setcap
+
+TAG ?= $(shell git describe --tags --always --dirty)
+IMAGE_VERSION ?= buster-v1.4.0
+CONFIG ?= buster
+DEBIAN_BASE_VERSION ?= buster-v1.4.0
+
+ARCH?=amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+
+BASE_REGISTRY?=k8s.gcr.io/build-image
+BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
+
+# Build args
+QEMUVERSION=5.2.0-2
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+build:
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
+	docker buildx version
+	BUILDER=$(shell docker buildx create --use)
+endif
+	docker buildx build \
+		--pull \
+		--load \
+		--platform linux/$(ARCH) \
+		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
+		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
+		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
+		--build-arg=BASEIMAGE=$(BASEIMAGE) \
+		.
+ifneq ($(ARCH),amd64)
+	docker buildx rm $$BUILDER
+endif
+
+push: build
+	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)
+	docker push $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG)
+	docker push $(IMAGE)-$(ARCH):latest-$(CONFIG)
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
+
+all-push: all-push-images push-manifest
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${arch}:${IMAGE_VERSION}; done
+	docker manifest push --purge ${IMAGE}:${IMAGE_VERSION}
+
+all: all-push
+

--- a/images/build/setcap/README.md
+++ b/images/build/setcap/README.md
@@ -1,0 +1,19 @@
+setcap
+This image is based on debian-base and installs the libcap2-bin package. The
+main use of this image is to apply `CAP_NET_BIND_SERVICE` to the kube-apiserver
+binary so that it can a bind to ports less than 1024 and still be run as non
+root.
+
+This image is compiled for multiple architectures.
+
+How to release
+If you're editing the Dockerfile or some other thing, please bump the TAG in the Makefile.
+
+Build and  push images for all the architectures
+$ make all-push
+# ---> staging-k8s.gcr.io/setcap-amd64:TAG
+# ---> staging-k8s.gcr.io/setcap-arm:TAG
+# ---> staging-k8s.gcr.io/setcap-arm64:TAG
+# ---> staging-k8s.gcr.io/setcap-ppc64le:TAG
+# ---> staging-k8s.gcr.io/setcap-s390x:TAG
+If you don't want to push the images, run `make sub-build-{target_arch}`  or `make all-build` instead

--- a/images/build/setcap/cloudbuild.yaml
+++ b/images/build/setcap/cloudbuild.yaml
@@ -1,0 +1,45 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
+    entrypoint: bash
+    dir: ./images/build/setcap
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - REGISTRY=gcr.io/$PROJECT_ID
+      - IMAGE=gcr.io/$PROJECT_ID/setcap
+      - TAG=$_GIT_TAG
+      - PULL_BASE_REF=$_PULL_BASE_REF
+      - IMAGE_VERSION=$_IMAGE_VERSION
+      - CONFIG=$_CONFIG
+      - DEBIAN_BASE_VERSION=$_DEBIAN_BASE_VERSION
+      - HOME=/root  # for docker buildx
+    args:
+    - -c
+    - |
+      gcloud auth configure-docker && \
+      make all-push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _IMAGE_VERSION: 'v0.0.0'
+  _CONFIG: 'codename'
+  _DEBIAN_BASE_VERSION: 'v0.0.0'
+
+tags:
+- 'setcap'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_IMAGE_VERSION}
+- ${_CONFIG}
+- ${_DEBIAN_BASE_VERSION}
+
+images:
+  - 'gcr.io/$PROJECT_ID/setcap-amd64:$_IMAGE_VERSION'
+  - 'gcr.io/$PROJECT_ID/setcap-amd64:$_GIT_TAG-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/setcap-amd64:latest-$_CONFIG'

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -1,0 +1,5 @@
+variants:
+  buster:
+    CONFIG: 'buster'
+    IMAGE_VERSION: 'buster-v1.4.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.4.0'


### PR DESCRIPTION
kubernetes binaries.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR creates an image based on debian-base with libcap2-bin installed so that we can apply capabilities to k8s binaries like kube-apiserver. This will allow kube-apiserver to bind to port lower than 1024 without requiring it to run as root.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
For reference please see: https://github.com/kubernetes/kubernetes/pull/96134
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a new setcap image, that can be used to apply capabilities to the k8s binaries when we build the server-images.
```
