### PR TITLE
Add generic krel stage/release options

### DIFF
--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -19,6 +19,8 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/anago"
 )
 
 type FakeReleaseClient struct {
@@ -90,6 +92,17 @@ type FakeReleaseClient struct {
 		result1 error
 	}
 	setBuildCandidateReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ValidateOptionsStub        func(*anago.ReleaseOptions) error
+	validateOptionsMutex       sync.RWMutex
+	validateOptionsArgsForCall []struct {
+		arg1 *anago.ReleaseOptions
+	}
+	validateOptionsReturns struct {
+		result1 error
+	}
+	validateOptionsReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -467,6 +480,67 @@ func (fake *FakeReleaseClient) SetBuildCandidateReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
+func (fake *FakeReleaseClient) ValidateOptions(arg1 *anago.ReleaseOptions) error {
+	fake.validateOptionsMutex.Lock()
+	ret, specificReturn := fake.validateOptionsReturnsOnCall[len(fake.validateOptionsArgsForCall)]
+	fake.validateOptionsArgsForCall = append(fake.validateOptionsArgsForCall, struct {
+		arg1 *anago.ReleaseOptions
+	}{arg1})
+	stub := fake.ValidateOptionsStub
+	fakeReturns := fake.validateOptionsReturns
+	fake.recordInvocation("ValidateOptions", []interface{}{arg1})
+	fake.validateOptionsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseClient) ValidateOptionsCallCount() int {
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
+	return len(fake.validateOptionsArgsForCall)
+}
+
+func (fake *FakeReleaseClient) ValidateOptionsCalls(stub func(*anago.ReleaseOptions) error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = stub
+}
+
+func (fake *FakeReleaseClient) ValidateOptionsArgsForCall(i int) *anago.ReleaseOptions {
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
+	argsForCall := fake.validateOptionsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeReleaseClient) ValidateOptionsReturns(result1 error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = nil
+	fake.validateOptionsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseClient) ValidateOptionsReturnsOnCall(i int, result1 error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = nil
+	if fake.validateOptionsReturnsOnCall == nil {
+		fake.validateOptionsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateOptionsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -484,6 +558,8 @@ func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	defer fake.pushGitObjectsMutex.RUnlock()
 	fake.setBuildCandidateMutex.RLock()
 	defer fake.setBuildCandidateMutex.RUnlock()
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -19,6 +19,8 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/anago"
 )
 
 type FakeStageClient struct {
@@ -80,6 +82,17 @@ type FakeStageClient struct {
 		result1 error
 	}
 	stageArtifactsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ValidateOptionsStub        func(*anago.StageOptions) error
+	validateOptionsMutex       sync.RWMutex
+	validateOptionsArgsForCall []struct {
+		arg1 *anago.StageOptions
+	}
+	validateOptionsReturns struct {
+		result1 error
+	}
+	validateOptionsReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -404,6 +417,67 @@ func (fake *FakeStageClient) StageArtifactsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeStageClient) ValidateOptions(arg1 *anago.StageOptions) error {
+	fake.validateOptionsMutex.Lock()
+	ret, specificReturn := fake.validateOptionsReturnsOnCall[len(fake.validateOptionsArgsForCall)]
+	fake.validateOptionsArgsForCall = append(fake.validateOptionsArgsForCall, struct {
+		arg1 *anago.StageOptions
+	}{arg1})
+	stub := fake.ValidateOptionsStub
+	fakeReturns := fake.validateOptionsReturns
+	fake.recordInvocation("ValidateOptions", []interface{}{arg1})
+	fake.validateOptionsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageClient) ValidateOptionsCallCount() int {
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
+	return len(fake.validateOptionsArgsForCall)
+}
+
+func (fake *FakeStageClient) ValidateOptionsCalls(stub func(*anago.StageOptions) error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = stub
+}
+
+func (fake *FakeStageClient) ValidateOptionsArgsForCall(i int) *anago.StageOptions {
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
+	argsForCall := fake.validateOptionsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageClient) ValidateOptionsReturns(result1 error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = nil
+	fake.validateOptionsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) ValidateOptionsReturnsOnCall(i int, result1 error) {
+	fake.validateOptionsMutex.Lock()
+	defer fake.validateOptionsMutex.Unlock()
+	fake.ValidateOptionsStub = nil
+	if fake.validateOptionsReturnsOnCall == nil {
+		fake.validateOptionsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateOptionsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -419,6 +493,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.setBuildCandidateMutex.RUnlock()
 	fake.stageArtifactsMutex.RLock()
 	defer fake.stageArtifactsMutex.RUnlock()
+	fake.validateOptionsMutex.RLock()
+	defer fake.validateOptionsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -19,6 +19,9 @@ package anago
 // releaseClient is a client for release a previously staged release.
 //counterfeiter:generate . releaseClient
 type releaseClient interface {
+	// Validate if the provided `ReleaseOptions` are correctly set.
+	ValidateOptions(*ReleaseOptions) error
+
 	// CheckPrerequisites verifies that a valid GITHUB_TOKEN environment
 	// variable is set. It also checks for the existence and version of
 	// required packages and if the correct Google Cloud project is set. A
@@ -73,6 +76,10 @@ type defaultReleaseImpl struct{}
 // releaseImpl is the implementation of the release client.
 //counterfeiter:generate . releaseImpl
 type releaseImpl interface{}
+
+func (d *DefaultRelease) ValidateOptions(options *ReleaseOptions) error {
+	return options.Validate()
+}
 
 func (d *DefaultRelease) CheckPrerequisites() error { return nil }
 

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -19,6 +19,9 @@ package anago
 // stageClient is a client for staging releases.
 //counterfeiter:generate . stageClient
 type stageClient interface {
+	// Validate if the provided `ReleaseOptions` are correctly set.
+	ValidateOptions(*StageOptions) error
+
 	// CheckPrerequisites verifies that a valid GITHUB_TOKEN environment
 	// variable is set. It also checks for the existence and version of
 	// required packages and if the correct Google Cloud project is set. A
@@ -68,6 +71,10 @@ type defaultStageImpl struct{}
 // stageImpl is the implementation of the stage client.
 //counterfeiter:generate . stageImpl
 type stageImpl interface{}
+
+func (d *DefaultStage) ValidateOptions(options *StageOptions) error {
+	return options.Validate()
+}
 
 func (d *DefaultStage) CheckPrerequisites() error { return nil }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add a generic `Options` type to `krel stage` and `krel release`.
These options have strong defaults, documentation as well as are being
validated upon running `stage/release`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1673
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added krel stage/release shared CLI parameters
```
