### PR TITLE
Integrate workspace preparation into `krel release`

### DIFF
--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -19,8 +19,6 @@ package anagofakes
 
 import (
 	"sync"
-
-	"k8s.io/release/pkg/anago"
 )
 
 type FakeReleaseClient struct {
@@ -94,10 +92,9 @@ type FakeReleaseClient struct {
 	setBuildCandidateReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ValidateOptionsStub        func(*anago.ReleaseOptions) error
+	ValidateOptionsStub        func() error
 	validateOptionsMutex       sync.RWMutex
 	validateOptionsArgsForCall []struct {
-		arg1 *anago.ReleaseOptions
 	}
 	validateOptionsReturns struct {
 		result1 error
@@ -480,18 +477,17 @@ func (fake *FakeReleaseClient) SetBuildCandidateReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
-func (fake *FakeReleaseClient) ValidateOptions(arg1 *anago.ReleaseOptions) error {
+func (fake *FakeReleaseClient) ValidateOptions() error {
 	fake.validateOptionsMutex.Lock()
 	ret, specificReturn := fake.validateOptionsReturnsOnCall[len(fake.validateOptionsArgsForCall)]
 	fake.validateOptionsArgsForCall = append(fake.validateOptionsArgsForCall, struct {
-		arg1 *anago.ReleaseOptions
-	}{arg1})
+	}{})
 	stub := fake.ValidateOptionsStub
 	fakeReturns := fake.validateOptionsReturns
-	fake.recordInvocation("ValidateOptions", []interface{}{arg1})
+	fake.recordInvocation("ValidateOptions", []interface{}{})
 	fake.validateOptionsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
@@ -505,17 +501,10 @@ func (fake *FakeReleaseClient) ValidateOptionsCallCount() int {
 	return len(fake.validateOptionsArgsForCall)
 }
 
-func (fake *FakeReleaseClient) ValidateOptionsCalls(stub func(*anago.ReleaseOptions) error) {
+func (fake *FakeReleaseClient) ValidateOptionsCalls(stub func() error) {
 	fake.validateOptionsMutex.Lock()
 	defer fake.validateOptionsMutex.Unlock()
 	fake.ValidateOptionsStub = stub
-}
-
-func (fake *FakeReleaseClient) ValidateOptionsArgsForCall(i int) *anago.ReleaseOptions {
-	fake.validateOptionsMutex.RLock()
-	defer fake.validateOptionsMutex.RUnlock()
-	argsForCall := fake.validateOptionsArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeReleaseClient) ValidateOptionsReturns(result1 error) {

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -22,13 +22,156 @@ import (
 )
 
 type FakeReleaseImpl struct {
+	InitWorkspaceStub        func() error
+	initWorkspaceMutex       sync.RWMutex
+	initWorkspaceArgsForCall []struct {
+	}
+	initWorkspaceReturns struct {
+		result1 error
+	}
+	initWorkspaceReturnsOnCall map[int]struct {
+		result1 error
+	}
+	PrepareWorkspaceReleaseStub        func(string, string, string) error
+	prepareWorkspaceReleaseMutex       sync.RWMutex
+	prepareWorkspaceReleaseArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	prepareWorkspaceReleaseReturns struct {
+		result1 error
+	}
+	prepareWorkspaceReleaseReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeReleaseImpl) InitWorkspace() error {
+	fake.initWorkspaceMutex.Lock()
+	ret, specificReturn := fake.initWorkspaceReturnsOnCall[len(fake.initWorkspaceArgsForCall)]
+	fake.initWorkspaceArgsForCall = append(fake.initWorkspaceArgsForCall, struct {
+	}{})
+	stub := fake.InitWorkspaceStub
+	fakeReturns := fake.initWorkspaceReturns
+	fake.recordInvocation("InitWorkspace", []interface{}{})
+	fake.initWorkspaceMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) InitWorkspaceCallCount() int {
+	fake.initWorkspaceMutex.RLock()
+	defer fake.initWorkspaceMutex.RUnlock()
+	return len(fake.initWorkspaceArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) InitWorkspaceCalls(stub func() error) {
+	fake.initWorkspaceMutex.Lock()
+	defer fake.initWorkspaceMutex.Unlock()
+	fake.InitWorkspaceStub = stub
+}
+
+func (fake *FakeReleaseImpl) InitWorkspaceReturns(result1 error) {
+	fake.initWorkspaceMutex.Lock()
+	defer fake.initWorkspaceMutex.Unlock()
+	fake.InitWorkspaceStub = nil
+	fake.initWorkspaceReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) InitWorkspaceReturnsOnCall(i int, result1 error) {
+	fake.initWorkspaceMutex.Lock()
+	defer fake.initWorkspaceMutex.Unlock()
+	fake.InitWorkspaceStub = nil
+	if fake.initWorkspaceReturnsOnCall == nil {
+		fake.initWorkspaceReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.initWorkspaceReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceRelease(arg1 string, arg2 string, arg3 string) error {
+	fake.prepareWorkspaceReleaseMutex.Lock()
+	ret, specificReturn := fake.prepareWorkspaceReleaseReturnsOnCall[len(fake.prepareWorkspaceReleaseArgsForCall)]
+	fake.prepareWorkspaceReleaseArgsForCall = append(fake.prepareWorkspaceReleaseArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.PrepareWorkspaceReleaseStub
+	fakeReturns := fake.prepareWorkspaceReleaseReturns
+	fake.recordInvocation("PrepareWorkspaceRelease", []interface{}{arg1, arg2, arg3})
+	fake.prepareWorkspaceReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseCallCount() int {
+	fake.prepareWorkspaceReleaseMutex.RLock()
+	defer fake.prepareWorkspaceReleaseMutex.RUnlock()
+	return len(fake.prepareWorkspaceReleaseArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseCalls(stub func(string, string, string) error) {
+	fake.prepareWorkspaceReleaseMutex.Lock()
+	defer fake.prepareWorkspaceReleaseMutex.Unlock()
+	fake.PrepareWorkspaceReleaseStub = stub
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseArgsForCall(i int) (string, string, string) {
+	fake.prepareWorkspaceReleaseMutex.RLock()
+	defer fake.prepareWorkspaceReleaseMutex.RUnlock()
+	argsForCall := fake.prepareWorkspaceReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseReturns(result1 error) {
+	fake.prepareWorkspaceReleaseMutex.Lock()
+	defer fake.prepareWorkspaceReleaseMutex.Unlock()
+	fake.PrepareWorkspaceReleaseStub = nil
+	fake.prepareWorkspaceReleaseReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseReturnsOnCall(i int, result1 error) {
+	fake.prepareWorkspaceReleaseMutex.Lock()
+	defer fake.prepareWorkspaceReleaseMutex.Unlock()
+	fake.PrepareWorkspaceReleaseStub = nil
+	if fake.prepareWorkspaceReleaseReturnsOnCall == nil {
+		fake.prepareWorkspaceReleaseReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.prepareWorkspaceReleaseReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeReleaseImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.initWorkspaceMutex.RLock()
+	defer fake.initWorkspaceMutex.RUnlock()
+	fake.prepareWorkspaceReleaseMutex.RLock()
+	defer fake.prepareWorkspaceReleaseMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -19,8 +19,6 @@ package anagofakes
 
 import (
 	"sync"
-
-	"k8s.io/release/pkg/anago"
 )
 
 type FakeStageClient struct {
@@ -84,10 +82,9 @@ type FakeStageClient struct {
 	stageArtifactsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ValidateOptionsStub        func(*anago.StageOptions) error
+	ValidateOptionsStub        func() error
 	validateOptionsMutex       sync.RWMutex
 	validateOptionsArgsForCall []struct {
-		arg1 *anago.StageOptions
 	}
 	validateOptionsReturns struct {
 		result1 error
@@ -417,18 +414,17 @@ func (fake *FakeStageClient) StageArtifactsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeStageClient) ValidateOptions(arg1 *anago.StageOptions) error {
+func (fake *FakeStageClient) ValidateOptions() error {
 	fake.validateOptionsMutex.Lock()
 	ret, specificReturn := fake.validateOptionsReturnsOnCall[len(fake.validateOptionsArgsForCall)]
 	fake.validateOptionsArgsForCall = append(fake.validateOptionsArgsForCall, struct {
-		arg1 *anago.StageOptions
-	}{arg1})
+	}{})
 	stub := fake.ValidateOptionsStub
 	fakeReturns := fake.validateOptionsReturns
-	fake.recordInvocation("ValidateOptions", []interface{}{arg1})
+	fake.recordInvocation("ValidateOptions", []interface{}{})
 	fake.validateOptionsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
@@ -442,17 +438,10 @@ func (fake *FakeStageClient) ValidateOptionsCallCount() int {
 	return len(fake.validateOptionsArgsForCall)
 }
 
-func (fake *FakeStageClient) ValidateOptionsCalls(stub func(*anago.StageOptions) error) {
+func (fake *FakeStageClient) ValidateOptionsCalls(stub func() error) {
 	fake.validateOptionsMutex.Lock()
 	defer fake.validateOptionsMutex.Unlock()
 	fake.ValidateOptionsStub = stub
-}
-
-func (fake *FakeStageClient) ValidateOptionsArgsForCall(i int) *anago.StageOptions {
-	fake.validateOptionsMutex.RLock()
-	defer fake.validateOptionsMutex.RUnlock()
-	argsForCall := fake.validateOptionsArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeStageClient) ValidateOptionsReturns(result1 error) {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -20,7 +20,7 @@ package anago
 //counterfeiter:generate . stageClient
 type stageClient interface {
 	// Validate if the provided `ReleaseOptions` are correctly set.
-	ValidateOptions(*StageOptions) error
+	ValidateOptions() error
 
 	// CheckPrerequisites verifies that a valid GITHUB_TOKEN environment
 	// variable is set. It also checks for the existence and version of
@@ -52,12 +52,13 @@ type stageClient interface {
 
 // DefaultStage is the default staging implementation used in production.
 type DefaultStage struct {
-	impl stageImpl
+	impl    stageImpl
+	options *StageOptions
 }
 
 // NewDefaultStage creates a new defaultStage instance.
-func NewDefaultStage() *DefaultStage {
-	return &DefaultStage{&defaultStageImpl{}}
+func NewDefaultStage(options *StageOptions) *DefaultStage {
+	return &DefaultStage{&defaultStageImpl{}, options}
 }
 
 // SetClient can be used to set the internal stage implementation.
@@ -72,8 +73,8 @@ type defaultStageImpl struct{}
 //counterfeiter:generate . stageImpl
 type stageImpl interface{}
 
-func (d *DefaultStage) ValidateOptions(options *StageOptions) error {
-	return options.Validate()
+func (d *DefaultStage) ValidateOptions() error {
+	return d.options.Validate()
 }
 
 func (d *DefaultStage) CheckPrerequisites() error { return nil }

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestCheckPrerequisitesStage(t *testing.T) {
-	sut := anago.NewDefaultStage()
+	opts := anago.DefaultStageOptions()
+	sut := anago.NewDefaultStage(opts)
 	mock := &anagofakes.FakeStageImpl{}
 	sut.SetClient(mock)
 	require.Nil(t, sut.CheckPrerequisites())

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -90,6 +90,9 @@ const (
 	// WindowsLocalPath is the directory where Windows GCE scripts are created.
 	WindowsLocalPath = ReleaseStagePath + "/full/kubernetes/cluster/gce/windows"
 
+	// TestBucket is the default bucket for mocked Kubernetes releases
+	TestBucket = "kubernetes-release-gcb"
+
 	// ProductionBucket is the default bucket for Kubernetes releases
 	ProductionBucket = "kubernetes-release"
 

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -38,6 +38,8 @@ import (
 func PrepareWorkspaceStage(directory string) error {
 	logrus.Infof("Preparing workspace for staging in %s", directory)
 	parent := filepath.Dir(directory)
+
+	// TODO: remove this if anago does not exist any more
 	if err := util.RemoveAndReplaceDir(parent); err != nil {
 		return errors.Wrapf(err, "ensuring repository parent %s", parent)
 	}
@@ -71,6 +73,8 @@ func PrepareWorkspaceStage(directory string) error {
 // the staged sources on the provided bucket.
 func PrepareWorkspaceRelease(directory, buildVersion, bucket string) error {
 	logrus.Infof("Preparing workspace for release in %s", directory)
+
+	// TODO: remove this if anago does not exist any more
 	if err := os.RemoveAll(directory); err != nil {
 		return errors.Wrap(err, "removing workspace directory")
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now integrate the workspace preparation into krel release. For that
we add a new `Options` API `Bucket()`, which can be used to retrieve the
right target bucket based on the value of `NoMock`. We also move the
options into the stage/release implementations to be able to access them.

Mocks and tests have been updated as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1673
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added workspace preparation to `krel release`.
```
