### PR TITLE
Add workspace preparation for `krel stage` 

### DIFF
--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -22,13 +22,87 @@ import (
 )
 
 type FakeStageImpl struct {
+	PrepareWorkspaceStageStub        func(string) error
+	prepareWorkspaceStageMutex       sync.RWMutex
+	prepareWorkspaceStageArgsForCall []struct {
+		arg1 string
+	}
+	prepareWorkspaceStageReturns struct {
+		result1 error
+	}
+	prepareWorkspaceStageReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStage(arg1 string) error {
+	fake.prepareWorkspaceStageMutex.Lock()
+	ret, specificReturn := fake.prepareWorkspaceStageReturnsOnCall[len(fake.prepareWorkspaceStageArgsForCall)]
+	fake.prepareWorkspaceStageArgsForCall = append(fake.prepareWorkspaceStageArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PrepareWorkspaceStageStub
+	fakeReturns := fake.prepareWorkspaceStageReturns
+	fake.recordInvocation("PrepareWorkspaceStage", []interface{}{arg1})
+	fake.prepareWorkspaceStageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStageCallCount() int {
+	fake.prepareWorkspaceStageMutex.RLock()
+	defer fake.prepareWorkspaceStageMutex.RUnlock()
+	return len(fake.prepareWorkspaceStageArgsForCall)
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStageCalls(stub func(string) error) {
+	fake.prepareWorkspaceStageMutex.Lock()
+	defer fake.prepareWorkspaceStageMutex.Unlock()
+	fake.PrepareWorkspaceStageStub = stub
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStageArgsForCall(i int) string {
+	fake.prepareWorkspaceStageMutex.RLock()
+	defer fake.prepareWorkspaceStageMutex.RUnlock()
+	argsForCall := fake.prepareWorkspaceStageArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStageReturns(result1 error) {
+	fake.prepareWorkspaceStageMutex.Lock()
+	defer fake.prepareWorkspaceStageMutex.Unlock()
+	fake.PrepareWorkspaceStageStub = nil
+	fake.prepareWorkspaceStageReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) PrepareWorkspaceStageReturnsOnCall(i int, result1 error) {
+	fake.prepareWorkspaceStageMutex.Lock()
+	defer fake.prepareWorkspaceStageMutex.Unlock()
+	fake.PrepareWorkspaceStageStub = nil
+	if fake.prepareWorkspaceStageReturnsOnCall == nil {
+		fake.prepareWorkspaceStageReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.prepareWorkspaceStageReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.prepareWorkspaceStageMutex.RLock()
+	defer fake.prepareWorkspaceStageMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -105,7 +105,6 @@ func (d *DefaultRelease) PrepareWorkspace() error {
 	); err != nil {
 		return errors.Wrap(err, "prepare workspace")
 	}
-
 	return nil
 }
 

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// nolint: dupl
 package anago_test
 
 import (
@@ -32,7 +33,7 @@ func TestCheckPrerequisitesRelease(t *testing.T) {
 	require.Nil(t, sut.CheckPrerequisites())
 }
 
-func TestPrepareWorkspace(t *testing.T) {
+func TestPrepareWorkspaceRelease(t *testing.T) {
 	for _, tc := range []struct {
 		prepare     func(*anagofakes.FakeReleaseImpl)
 		shouldError bool

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package anago
 
+import (
+	"github.com/pkg/errors"
+
+	"k8s.io/release/pkg/release"
+)
+
 // stageClient is a client for staging releases.
 //counterfeiter:generate . stageClient
 type stageClient interface {
@@ -71,7 +77,13 @@ type defaultStageImpl struct{}
 
 // stageImpl is the implementation of the stage client.
 //counterfeiter:generate . stageImpl
-type stageImpl interface{}
+type stageImpl interface {
+	PrepareWorkspaceStage(directory string) error
+}
+
+func (d *defaultStageImpl) PrepareWorkspaceStage(directory string) error {
+	return release.PrepareWorkspaceStage(directory)
+}
 
 func (d *DefaultStage) ValidateOptions() error {
 	return d.options.Validate()
@@ -81,7 +93,12 @@ func (d *DefaultStage) CheckPrerequisites() error { return nil }
 
 func (d *DefaultStage) SetBuildCandidate() error { return nil }
 
-func (d *DefaultStage) PrepareWorkspace() error { return nil }
+func (d *DefaultStage) PrepareWorkspace() error {
+	if err := d.impl.PrepareWorkspaceStage(gitRoot); err != nil {
+		return errors.Wrap(err, "prepare workspace")
+	}
+	return nil
+}
 
 func (d *DefaultStage) Build() error { return nil }
 

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// nolint: dupl
 package anago_test
 
 import (
@@ -30,4 +31,34 @@ func TestCheckPrerequisitesStage(t *testing.T) {
 	mock := &anagofakes.FakeStageImpl{}
 	sut.SetClient(mock)
 	require.Nil(t, sut.CheckPrerequisites())
+}
+
+func TestPrepareWorkspaceStage(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeStageImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeStageImpl) {},
+			shouldError: false,
+		},
+		{ // PrepareWorkspaceStage fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.PrepareWorkspaceStageReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultStageOptions()
+		sut := anago.NewDefaultStage(opts)
+		mock := &anagofakes.FakeStageImpl{}
+		tc.prepare(mock)
+		sut.SetClient(mock)
+		err := sut.PrepareWorkspace()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This adds the logic for preparing the workspace when running `krel stage`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673
#### Special notes for your reviewer:
Requires https://github.com/kubernetes/release/pull/1687
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `krel stage` workspace preparation step.
```
