### PR TITLE
Add release version and artifacts push to krel stage/release

### DIFF
--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -19,6 +19,8 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/release"
 )
 
 type FakeReleaseClient struct {
@@ -52,6 +54,19 @@ type FakeReleaseClient struct {
 	createAnnouncementReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GenerateReleaseVersionStub        func(string) (*release.Versions, error)
+	generateReleaseVersionMutex       sync.RWMutex
+	generateReleaseVersionArgsForCall []struct {
+		arg1 string
+	}
+	generateReleaseVersionReturns struct {
+		result1 *release.Versions
+		result2 error
+	}
+	generateReleaseVersionReturnsOnCall map[int]struct {
+		result1 *release.Versions
+		result2 error
+	}
 	PrepareWorkspaceStub        func() error
 	prepareWorkspaceMutex       sync.RWMutex
 	prepareWorkspaceArgsForCall []struct {
@@ -62,9 +77,10 @@ type FakeReleaseClient struct {
 	prepareWorkspaceReturnsOnCall map[int]struct {
 		result1 error
 	}
-	PushArtifactsStub        func() error
+	PushArtifactsStub        func([]string) error
 	pushArtifactsMutex       sync.RWMutex
 	pushArtifactsArgsForCall []struct {
+		arg1 []string
 	}
 	pushArtifactsReturns struct {
 		result1 error
@@ -265,6 +281,70 @@ func (fake *FakeReleaseClient) CreateAnnouncementReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
+func (fake *FakeReleaseClient) GenerateReleaseVersion(arg1 string) (*release.Versions, error) {
+	fake.generateReleaseVersionMutex.Lock()
+	ret, specificReturn := fake.generateReleaseVersionReturnsOnCall[len(fake.generateReleaseVersionArgsForCall)]
+	fake.generateReleaseVersionArgsForCall = append(fake.generateReleaseVersionArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GenerateReleaseVersionStub
+	fakeReturns := fake.generateReleaseVersionReturns
+	fake.recordInvocation("GenerateReleaseVersion", []interface{}{arg1})
+	fake.generateReleaseVersionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeReleaseClient) GenerateReleaseVersionCallCount() int {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	return len(fake.generateReleaseVersionArgsForCall)
+}
+
+func (fake *FakeReleaseClient) GenerateReleaseVersionCalls(stub func(string) (*release.Versions, error)) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = stub
+}
+
+func (fake *FakeReleaseClient) GenerateReleaseVersionArgsForCall(i int) string {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	argsForCall := fake.generateReleaseVersionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeReleaseClient) GenerateReleaseVersionReturns(result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	fake.generateReleaseVersionReturns = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeReleaseClient) GenerateReleaseVersionReturnsOnCall(i int, result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	if fake.generateReleaseVersionReturnsOnCall == nil {
+		fake.generateReleaseVersionReturnsOnCall = make(map[int]struct {
+			result1 *release.Versions
+			result2 error
+		})
+	}
+	fake.generateReleaseVersionReturnsOnCall[i] = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeReleaseClient) PrepareWorkspace() error {
 	fake.prepareWorkspaceMutex.Lock()
 	ret, specificReturn := fake.prepareWorkspaceReturnsOnCall[len(fake.prepareWorkspaceArgsForCall)]
@@ -318,17 +398,23 @@ func (fake *FakeReleaseClient) PrepareWorkspaceReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeReleaseClient) PushArtifacts() error {
+func (fake *FakeReleaseClient) PushArtifacts(arg1 []string) error {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
 	fake.pushArtifactsMutex.Lock()
 	ret, specificReturn := fake.pushArtifactsReturnsOnCall[len(fake.pushArtifactsArgsForCall)]
 	fake.pushArtifactsArgsForCall = append(fake.pushArtifactsArgsForCall, struct {
-	}{})
+		arg1 []string
+	}{arg1Copy})
 	stub := fake.PushArtifactsStub
 	fakeReturns := fake.pushArtifactsReturns
-	fake.recordInvocation("PushArtifacts", []interface{}{})
+	fake.recordInvocation("PushArtifacts", []interface{}{arg1Copy})
 	fake.pushArtifactsMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -342,10 +428,17 @@ func (fake *FakeReleaseClient) PushArtifactsCallCount() int {
 	return len(fake.pushArtifactsArgsForCall)
 }
 
-func (fake *FakeReleaseClient) PushArtifactsCalls(stub func() error) {
+func (fake *FakeReleaseClient) PushArtifactsCalls(stub func([]string) error) {
 	fake.pushArtifactsMutex.Lock()
 	defer fake.pushArtifactsMutex.Unlock()
 	fake.PushArtifactsStub = stub
+}
+
+func (fake *FakeReleaseClient) PushArtifactsArgsForCall(i int) []string {
+	fake.pushArtifactsMutex.RLock()
+	defer fake.pushArtifactsMutex.RUnlock()
+	argsForCall := fake.pushArtifactsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeReleaseClient) PushArtifactsReturns(result1 error) {
@@ -539,6 +632,8 @@ func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	defer fake.checkPrerequisitesMutex.RUnlock()
 	fake.createAnnouncementMutex.RLock()
 	defer fake.createAnnouncementMutex.RUnlock()
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceMutex.RLock()
 	defer fake.prepareWorkspaceMutex.RUnlock()
 	fake.pushArtifactsMutex.RLock()

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -19,9 +19,52 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/build"
+	"k8s.io/release/pkg/release"
 )
 
 type FakeReleaseImpl struct {
+	CheckReleaseBucketStub        func(*build.Options) error
+	checkReleaseBucketMutex       sync.RWMutex
+	checkReleaseBucketArgsForCall []struct {
+		arg1 *build.Options
+	}
+	checkReleaseBucketReturns struct {
+		result1 error
+	}
+	checkReleaseBucketReturnsOnCall map[int]struct {
+		result1 error
+	}
+	CopyStagedFromGCSStub        func(*build.Options, string, string) error
+	copyStagedFromGCSMutex       sync.RWMutex
+	copyStagedFromGCSArgsForCall []struct {
+		arg1 *build.Options
+		arg2 string
+		arg3 string
+	}
+	copyStagedFromGCSReturns struct {
+		result1 error
+	}
+	copyStagedFromGCSReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GenerateReleaseVersionStub        func(string, string, string, bool) (*release.Versions, error)
+	generateReleaseVersionMutex       sync.RWMutex
+	generateReleaseVersionArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}
+	generateReleaseVersionReturns struct {
+		result1 *release.Versions
+		result2 error
+	}
+	generateReleaseVersionReturnsOnCall map[int]struct {
+		result1 *release.Versions
+		result2 error
+	}
 	PrepareWorkspaceReleaseStub        func(string, string, string) error
 	prepareWorkspaceReleaseMutex       sync.RWMutex
 	prepareWorkspaceReleaseArgsForCall []struct {
@@ -35,8 +78,229 @@ type FakeReleaseImpl struct {
 	prepareWorkspaceReleaseReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PublishVersionStub        func(string, string, string, string, []string, bool, bool) error
+	publishVersionMutex       sync.RWMutex
+	publishVersionArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 []string
+		arg6 bool
+		arg7 bool
+	}
+	publishVersionReturns struct {
+		result1 error
+	}
+	publishVersionReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ValidateImagesStub        func(string, string, string) error
+	validateImagesMutex       sync.RWMutex
+	validateImagesArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	validateImagesReturns struct {
+		result1 error
+	}
+	validateImagesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucket(arg1 *build.Options) error {
+	fake.checkReleaseBucketMutex.Lock()
+	ret, specificReturn := fake.checkReleaseBucketReturnsOnCall[len(fake.checkReleaseBucketArgsForCall)]
+	fake.checkReleaseBucketArgsForCall = append(fake.checkReleaseBucketArgsForCall, struct {
+		arg1 *build.Options
+	}{arg1})
+	stub := fake.CheckReleaseBucketStub
+	fakeReturns := fake.checkReleaseBucketReturns
+	fake.recordInvocation("CheckReleaseBucket", []interface{}{arg1})
+	fake.checkReleaseBucketMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucketCallCount() int {
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	return len(fake.checkReleaseBucketArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucketCalls(stub func(*build.Options) error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = stub
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucketArgsForCall(i int) *build.Options {
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	argsForCall := fake.checkReleaseBucketArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucketReturns(result1 error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = nil
+	fake.checkReleaseBucketReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) CheckReleaseBucketReturnsOnCall(i int, result1 error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = nil
+	if fake.checkReleaseBucketReturnsOnCall == nil {
+		fake.checkReleaseBucketReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkReleaseBucketReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCS(arg1 *build.Options, arg2 string, arg3 string) error {
+	fake.copyStagedFromGCSMutex.Lock()
+	ret, specificReturn := fake.copyStagedFromGCSReturnsOnCall[len(fake.copyStagedFromGCSArgsForCall)]
+	fake.copyStagedFromGCSArgsForCall = append(fake.copyStagedFromGCSArgsForCall, struct {
+		arg1 *build.Options
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.CopyStagedFromGCSStub
+	fakeReturns := fake.copyStagedFromGCSReturns
+	fake.recordInvocation("CopyStagedFromGCS", []interface{}{arg1, arg2, arg3})
+	fake.copyStagedFromGCSMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCSCallCount() int {
+	fake.copyStagedFromGCSMutex.RLock()
+	defer fake.copyStagedFromGCSMutex.RUnlock()
+	return len(fake.copyStagedFromGCSArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCSCalls(stub func(*build.Options, string, string) error) {
+	fake.copyStagedFromGCSMutex.Lock()
+	defer fake.copyStagedFromGCSMutex.Unlock()
+	fake.CopyStagedFromGCSStub = stub
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCSArgsForCall(i int) (*build.Options, string, string) {
+	fake.copyStagedFromGCSMutex.RLock()
+	defer fake.copyStagedFromGCSMutex.RUnlock()
+	argsForCall := fake.copyStagedFromGCSArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCSReturns(result1 error) {
+	fake.copyStagedFromGCSMutex.Lock()
+	defer fake.copyStagedFromGCSMutex.Unlock()
+	fake.CopyStagedFromGCSStub = nil
+	fake.copyStagedFromGCSReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) CopyStagedFromGCSReturnsOnCall(i int, result1 error) {
+	fake.copyStagedFromGCSMutex.Lock()
+	defer fake.copyStagedFromGCSMutex.Unlock()
+	fake.CopyStagedFromGCSStub = nil
+	if fake.copyStagedFromGCSReturnsOnCall == nil {
+		fake.copyStagedFromGCSReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.copyStagedFromGCSReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersion(arg1 string, arg2 string, arg3 string, arg4 bool) (*release.Versions, error) {
+	fake.generateReleaseVersionMutex.Lock()
+	ret, specificReturn := fake.generateReleaseVersionReturnsOnCall[len(fake.generateReleaseVersionArgsForCall)]
+	fake.generateReleaseVersionArgsForCall = append(fake.generateReleaseVersionArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.GenerateReleaseVersionStub
+	fakeReturns := fake.generateReleaseVersionReturns
+	fake.recordInvocation("GenerateReleaseVersion", []interface{}{arg1, arg2, arg3, arg4})
+	fake.generateReleaseVersionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersionCallCount() int {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	return len(fake.generateReleaseVersionArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersionCalls(stub func(string, string, string, bool) (*release.Versions, error)) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = stub
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersionArgsForCall(i int) (string, string, string, bool) {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	argsForCall := fake.generateReleaseVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersionReturns(result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	fake.generateReleaseVersionReturns = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeReleaseImpl) GenerateReleaseVersionReturnsOnCall(i int, result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	if fake.generateReleaseVersionReturnsOnCall == nil {
+		fake.generateReleaseVersionReturnsOnCall = make(map[int]struct {
+			result1 *release.Versions
+			result2 error
+		})
+	}
+	fake.generateReleaseVersionReturnsOnCall[i] = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeReleaseImpl) PrepareWorkspaceRelease(arg1 string, arg2 string, arg3 string) error {
@@ -102,11 +366,156 @@ func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseReturnsOnCall(i int, result1
 	}{result1}
 }
 
+func (fake *FakeReleaseImpl) PublishVersion(arg1 string, arg2 string, arg3 string, arg4 string, arg5 []string, arg6 bool, arg7 bool) error {
+	var arg5Copy []string
+	if arg5 != nil {
+		arg5Copy = make([]string, len(arg5))
+		copy(arg5Copy, arg5)
+	}
+	fake.publishVersionMutex.Lock()
+	ret, specificReturn := fake.publishVersionReturnsOnCall[len(fake.publishVersionArgsForCall)]
+	fake.publishVersionArgsForCall = append(fake.publishVersionArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 []string
+		arg6 bool
+		arg7 bool
+	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+	stub := fake.PublishVersionStub
+	fakeReturns := fake.publishVersionReturns
+	fake.recordInvocation("PublishVersion", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+	fake.publishVersionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) PublishVersionCallCount() int {
+	fake.publishVersionMutex.RLock()
+	defer fake.publishVersionMutex.RUnlock()
+	return len(fake.publishVersionArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) PublishVersionCalls(stub func(string, string, string, string, []string, bool, bool) error) {
+	fake.publishVersionMutex.Lock()
+	defer fake.publishVersionMutex.Unlock()
+	fake.PublishVersionStub = stub
+}
+
+func (fake *FakeReleaseImpl) PublishVersionArgsForCall(i int) (string, string, string, string, []string, bool, bool) {
+	fake.publishVersionMutex.RLock()
+	defer fake.publishVersionMutex.RUnlock()
+	argsForCall := fake.publishVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+}
+
+func (fake *FakeReleaseImpl) PublishVersionReturns(result1 error) {
+	fake.publishVersionMutex.Lock()
+	defer fake.publishVersionMutex.Unlock()
+	fake.PublishVersionStub = nil
+	fake.publishVersionReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) PublishVersionReturnsOnCall(i int, result1 error) {
+	fake.publishVersionMutex.Lock()
+	defer fake.publishVersionMutex.Unlock()
+	fake.PublishVersionStub = nil
+	if fake.publishVersionReturnsOnCall == nil {
+		fake.publishVersionReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.publishVersionReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) ValidateImages(arg1 string, arg2 string, arg3 string) error {
+	fake.validateImagesMutex.Lock()
+	ret, specificReturn := fake.validateImagesReturnsOnCall[len(fake.validateImagesArgsForCall)]
+	fake.validateImagesArgsForCall = append(fake.validateImagesArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ValidateImagesStub
+	fakeReturns := fake.validateImagesReturns
+	fake.recordInvocation("ValidateImages", []interface{}{arg1, arg2, arg3})
+	fake.validateImagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) ValidateImagesCallCount() int {
+	fake.validateImagesMutex.RLock()
+	defer fake.validateImagesMutex.RUnlock()
+	return len(fake.validateImagesArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) ValidateImagesCalls(stub func(string, string, string) error) {
+	fake.validateImagesMutex.Lock()
+	defer fake.validateImagesMutex.Unlock()
+	fake.ValidateImagesStub = stub
+}
+
+func (fake *FakeReleaseImpl) ValidateImagesArgsForCall(i int) (string, string, string) {
+	fake.validateImagesMutex.RLock()
+	defer fake.validateImagesMutex.RUnlock()
+	argsForCall := fake.validateImagesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeReleaseImpl) ValidateImagesReturns(result1 error) {
+	fake.validateImagesMutex.Lock()
+	defer fake.validateImagesMutex.Unlock()
+	fake.ValidateImagesStub = nil
+	fake.validateImagesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) ValidateImagesReturnsOnCall(i int, result1 error) {
+	fake.validateImagesMutex.Lock()
+	defer fake.validateImagesMutex.Unlock()
+	fake.ValidateImagesStub = nil
+	if fake.validateImagesReturnsOnCall == nil {
+		fake.validateImagesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateImagesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeReleaseImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	fake.copyStagedFromGCSMutex.RLock()
+	defer fake.copyStagedFromGCSMutex.RUnlock()
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceReleaseMutex.RLock()
 	defer fake.prepareWorkspaceReleaseMutex.RUnlock()
+	fake.publishVersionMutex.RLock()
+	defer fake.publishVersionMutex.RUnlock()
+	fake.validateImagesMutex.RLock()
+	defer fake.validateImagesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -19,6 +19,8 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/release"
 )
 
 type FakeStageClient struct {
@@ -52,6 +54,19 @@ type FakeStageClient struct {
 	generateReleaseNotesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GenerateReleaseVersionStub        func(string) (*release.Versions, error)
+	generateReleaseVersionMutex       sync.RWMutex
+	generateReleaseVersionArgsForCall []struct {
+		arg1 string
+	}
+	generateReleaseVersionReturns struct {
+		result1 *release.Versions
+		result2 error
+	}
+	generateReleaseVersionReturnsOnCall map[int]struct {
+		result1 *release.Versions
+		result2 error
+	}
 	PrepareWorkspaceStub        func() error
 	prepareWorkspaceMutex       sync.RWMutex
 	prepareWorkspaceArgsForCall []struct {
@@ -72,9 +87,10 @@ type FakeStageClient struct {
 	setBuildCandidateReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StageArtifactsStub        func() error
+	StageArtifactsStub        func([]string) error
 	stageArtifactsMutex       sync.RWMutex
 	stageArtifactsArgsForCall []struct {
+		arg1 []string
 	}
 	stageArtifactsReturns struct {
 		result1 error
@@ -255,6 +271,70 @@ func (fake *FakeStageClient) GenerateReleaseNotesReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
+func (fake *FakeStageClient) GenerateReleaseVersion(arg1 string) (*release.Versions, error) {
+	fake.generateReleaseVersionMutex.Lock()
+	ret, specificReturn := fake.generateReleaseVersionReturnsOnCall[len(fake.generateReleaseVersionArgsForCall)]
+	fake.generateReleaseVersionArgsForCall = append(fake.generateReleaseVersionArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GenerateReleaseVersionStub
+	fakeReturns := fake.generateReleaseVersionReturns
+	fake.recordInvocation("GenerateReleaseVersion", []interface{}{arg1})
+	fake.generateReleaseVersionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageClient) GenerateReleaseVersionCallCount() int {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	return len(fake.generateReleaseVersionArgsForCall)
+}
+
+func (fake *FakeStageClient) GenerateReleaseVersionCalls(stub func(string) (*release.Versions, error)) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = stub
+}
+
+func (fake *FakeStageClient) GenerateReleaseVersionArgsForCall(i int) string {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	argsForCall := fake.generateReleaseVersionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageClient) GenerateReleaseVersionReturns(result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	fake.generateReleaseVersionReturns = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageClient) GenerateReleaseVersionReturnsOnCall(i int, result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	if fake.generateReleaseVersionReturnsOnCall == nil {
+		fake.generateReleaseVersionReturnsOnCall = make(map[int]struct {
+			result1 *release.Versions
+			result2 error
+		})
+	}
+	fake.generateReleaseVersionReturnsOnCall[i] = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeStageClient) PrepareWorkspace() error {
 	fake.prepareWorkspaceMutex.Lock()
 	ret, specificReturn := fake.prepareWorkspaceReturnsOnCall[len(fake.prepareWorkspaceArgsForCall)]
@@ -361,17 +441,23 @@ func (fake *FakeStageClient) SetBuildCandidateReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeStageClient) StageArtifacts() error {
+func (fake *FakeStageClient) StageArtifacts(arg1 []string) error {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
 	fake.stageArtifactsMutex.Lock()
 	ret, specificReturn := fake.stageArtifactsReturnsOnCall[len(fake.stageArtifactsArgsForCall)]
 	fake.stageArtifactsArgsForCall = append(fake.stageArtifactsArgsForCall, struct {
-	}{})
+		arg1 []string
+	}{arg1Copy})
 	stub := fake.StageArtifactsStub
 	fakeReturns := fake.stageArtifactsReturns
-	fake.recordInvocation("StageArtifacts", []interface{}{})
+	fake.recordInvocation("StageArtifacts", []interface{}{arg1Copy})
 	fake.stageArtifactsMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -385,10 +471,17 @@ func (fake *FakeStageClient) StageArtifactsCallCount() int {
 	return len(fake.stageArtifactsArgsForCall)
 }
 
-func (fake *FakeStageClient) StageArtifactsCalls(stub func() error) {
+func (fake *FakeStageClient) StageArtifactsCalls(stub func([]string) error) {
 	fake.stageArtifactsMutex.Lock()
 	defer fake.stageArtifactsMutex.Unlock()
 	fake.StageArtifactsStub = stub
+}
+
+func (fake *FakeStageClient) StageArtifactsArgsForCall(i int) []string {
+	fake.stageArtifactsMutex.RLock()
+	defer fake.stageArtifactsMutex.RUnlock()
+	argsForCall := fake.stageArtifactsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStageClient) StageArtifactsReturns(result1 error) {
@@ -476,6 +569,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.checkPrerequisitesMutex.RUnlock()
 	fake.generateReleaseNotesMutex.RLock()
 	defer fake.generateReleaseNotesMutex.RUnlock()
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceMutex.RLock()
 	defer fake.prepareWorkspaceMutex.RUnlock()
 	fake.setBuildCandidateMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -19,9 +19,39 @@ package anagofakes
 
 import (
 	"sync"
+
+	"k8s.io/release/pkg/build"
+	"k8s.io/release/pkg/release"
 )
 
 type FakeStageImpl struct {
+	CheckReleaseBucketStub        func(*build.Options) error
+	checkReleaseBucketMutex       sync.RWMutex
+	checkReleaseBucketArgsForCall []struct {
+		arg1 *build.Options
+	}
+	checkReleaseBucketReturns struct {
+		result1 error
+	}
+	checkReleaseBucketReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GenerateReleaseVersionStub        func(string, string, string, bool) (*release.Versions, error)
+	generateReleaseVersionMutex       sync.RWMutex
+	generateReleaseVersionArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}
+	generateReleaseVersionReturns struct {
+		result1 *release.Versions
+		result2 error
+	}
+	generateReleaseVersionReturnsOnCall map[int]struct {
+		result1 *release.Versions
+		result2 error
+	}
 	PrepareWorkspaceStageStub        func(string) error
 	prepareWorkspaceStageMutex       sync.RWMutex
 	prepareWorkspaceStageArgsForCall []struct {
@@ -33,8 +63,183 @@ type FakeStageImpl struct {
 	prepareWorkspaceStageReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PushContainerImagesStub        func(*build.Options) error
+	pushContainerImagesMutex       sync.RWMutex
+	pushContainerImagesArgsForCall []struct {
+		arg1 *build.Options
+	}
+	pushContainerImagesReturns struct {
+		result1 error
+	}
+	pushContainerImagesReturnsOnCall map[int]struct {
+		result1 error
+	}
+	PushReleaseArtifactsStub        func(*build.Options, string, string) error
+	pushReleaseArtifactsMutex       sync.RWMutex
+	pushReleaseArtifactsArgsForCall []struct {
+		arg1 *build.Options
+		arg2 string
+		arg3 string
+	}
+	pushReleaseArtifactsReturns struct {
+		result1 error
+	}
+	pushReleaseArtifactsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	StageLocalArtifactsStub        func(*build.Options) error
+	stageLocalArtifactsMutex       sync.RWMutex
+	stageLocalArtifactsArgsForCall []struct {
+		arg1 *build.Options
+	}
+	stageLocalArtifactsReturns struct {
+		result1 error
+	}
+	stageLocalArtifactsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	StageLocalSourceTreeStub        func(*build.Options, string) error
+	stageLocalSourceTreeMutex       sync.RWMutex
+	stageLocalSourceTreeArgsForCall []struct {
+		arg1 *build.Options
+		arg2 string
+	}
+	stageLocalSourceTreeReturns struct {
+		result1 error
+	}
+	stageLocalSourceTreeReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucket(arg1 *build.Options) error {
+	fake.checkReleaseBucketMutex.Lock()
+	ret, specificReturn := fake.checkReleaseBucketReturnsOnCall[len(fake.checkReleaseBucketArgsForCall)]
+	fake.checkReleaseBucketArgsForCall = append(fake.checkReleaseBucketArgsForCall, struct {
+		arg1 *build.Options
+	}{arg1})
+	stub := fake.CheckReleaseBucketStub
+	fakeReturns := fake.checkReleaseBucketReturns
+	fake.recordInvocation("CheckReleaseBucket", []interface{}{arg1})
+	fake.checkReleaseBucketMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucketCallCount() int {
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	return len(fake.checkReleaseBucketArgsForCall)
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucketCalls(stub func(*build.Options) error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = stub
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucketArgsForCall(i int) *build.Options {
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	argsForCall := fake.checkReleaseBucketArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucketReturns(result1 error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = nil
+	fake.checkReleaseBucketReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) CheckReleaseBucketReturnsOnCall(i int, result1 error) {
+	fake.checkReleaseBucketMutex.Lock()
+	defer fake.checkReleaseBucketMutex.Unlock()
+	fake.CheckReleaseBucketStub = nil
+	if fake.checkReleaseBucketReturnsOnCall == nil {
+		fake.checkReleaseBucketReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkReleaseBucketReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersion(arg1 string, arg2 string, arg3 string, arg4 bool) (*release.Versions, error) {
+	fake.generateReleaseVersionMutex.Lock()
+	ret, specificReturn := fake.generateReleaseVersionReturnsOnCall[len(fake.generateReleaseVersionArgsForCall)]
+	fake.generateReleaseVersionArgsForCall = append(fake.generateReleaseVersionArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.GenerateReleaseVersionStub
+	fakeReturns := fake.generateReleaseVersionReturns
+	fake.recordInvocation("GenerateReleaseVersion", []interface{}{arg1, arg2, arg3, arg4})
+	fake.generateReleaseVersionMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersionCallCount() int {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	return len(fake.generateReleaseVersionArgsForCall)
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersionCalls(stub func(string, string, string, bool) (*release.Versions, error)) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = stub
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersionArgsForCall(i int) (string, string, string, bool) {
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
+	argsForCall := fake.generateReleaseVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersionReturns(result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	fake.generateReleaseVersionReturns = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GenerateReleaseVersionReturnsOnCall(i int, result1 *release.Versions, result2 error) {
+	fake.generateReleaseVersionMutex.Lock()
+	defer fake.generateReleaseVersionMutex.Unlock()
+	fake.GenerateReleaseVersionStub = nil
+	if fake.generateReleaseVersionReturnsOnCall == nil {
+		fake.generateReleaseVersionReturnsOnCall = make(map[int]struct {
+			result1 *release.Versions
+			result2 error
+		})
+	}
+	fake.generateReleaseVersionReturnsOnCall[i] = struct {
+		result1 *release.Versions
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeStageImpl) PrepareWorkspaceStage(arg1 string) error {
@@ -98,11 +303,270 @@ func (fake *FakeStageImpl) PrepareWorkspaceStageReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
+func (fake *FakeStageImpl) PushContainerImages(arg1 *build.Options) error {
+	fake.pushContainerImagesMutex.Lock()
+	ret, specificReturn := fake.pushContainerImagesReturnsOnCall[len(fake.pushContainerImagesArgsForCall)]
+	fake.pushContainerImagesArgsForCall = append(fake.pushContainerImagesArgsForCall, struct {
+		arg1 *build.Options
+	}{arg1})
+	stub := fake.PushContainerImagesStub
+	fakeReturns := fake.pushContainerImagesReturns
+	fake.recordInvocation("PushContainerImages", []interface{}{arg1})
+	fake.pushContainerImagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) PushContainerImagesCallCount() int {
+	fake.pushContainerImagesMutex.RLock()
+	defer fake.pushContainerImagesMutex.RUnlock()
+	return len(fake.pushContainerImagesArgsForCall)
+}
+
+func (fake *FakeStageImpl) PushContainerImagesCalls(stub func(*build.Options) error) {
+	fake.pushContainerImagesMutex.Lock()
+	defer fake.pushContainerImagesMutex.Unlock()
+	fake.PushContainerImagesStub = stub
+}
+
+func (fake *FakeStageImpl) PushContainerImagesArgsForCall(i int) *build.Options {
+	fake.pushContainerImagesMutex.RLock()
+	defer fake.pushContainerImagesMutex.RUnlock()
+	argsForCall := fake.pushContainerImagesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) PushContainerImagesReturns(result1 error) {
+	fake.pushContainerImagesMutex.Lock()
+	defer fake.pushContainerImagesMutex.Unlock()
+	fake.PushContainerImagesStub = nil
+	fake.pushContainerImagesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) PushContainerImagesReturnsOnCall(i int, result1 error) {
+	fake.pushContainerImagesMutex.Lock()
+	defer fake.pushContainerImagesMutex.Unlock()
+	fake.PushContainerImagesStub = nil
+	if fake.pushContainerImagesReturnsOnCall == nil {
+		fake.pushContainerImagesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pushContainerImagesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifacts(arg1 *build.Options, arg2 string, arg3 string) error {
+	fake.pushReleaseArtifactsMutex.Lock()
+	ret, specificReturn := fake.pushReleaseArtifactsReturnsOnCall[len(fake.pushReleaseArtifactsArgsForCall)]
+	fake.pushReleaseArtifactsArgsForCall = append(fake.pushReleaseArtifactsArgsForCall, struct {
+		arg1 *build.Options
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.PushReleaseArtifactsStub
+	fakeReturns := fake.pushReleaseArtifactsReturns
+	fake.recordInvocation("PushReleaseArtifacts", []interface{}{arg1, arg2, arg3})
+	fake.pushReleaseArtifactsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifactsCallCount() int {
+	fake.pushReleaseArtifactsMutex.RLock()
+	defer fake.pushReleaseArtifactsMutex.RUnlock()
+	return len(fake.pushReleaseArtifactsArgsForCall)
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifactsCalls(stub func(*build.Options, string, string) error) {
+	fake.pushReleaseArtifactsMutex.Lock()
+	defer fake.pushReleaseArtifactsMutex.Unlock()
+	fake.PushReleaseArtifactsStub = stub
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifactsArgsForCall(i int) (*build.Options, string, string) {
+	fake.pushReleaseArtifactsMutex.RLock()
+	defer fake.pushReleaseArtifactsMutex.RUnlock()
+	argsForCall := fake.pushReleaseArtifactsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifactsReturns(result1 error) {
+	fake.pushReleaseArtifactsMutex.Lock()
+	defer fake.pushReleaseArtifactsMutex.Unlock()
+	fake.PushReleaseArtifactsStub = nil
+	fake.pushReleaseArtifactsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) PushReleaseArtifactsReturnsOnCall(i int, result1 error) {
+	fake.pushReleaseArtifactsMutex.Lock()
+	defer fake.pushReleaseArtifactsMutex.Unlock()
+	fake.PushReleaseArtifactsStub = nil
+	if fake.pushReleaseArtifactsReturnsOnCall == nil {
+		fake.pushReleaseArtifactsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pushReleaseArtifactsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) StageLocalArtifacts(arg1 *build.Options) error {
+	fake.stageLocalArtifactsMutex.Lock()
+	ret, specificReturn := fake.stageLocalArtifactsReturnsOnCall[len(fake.stageLocalArtifactsArgsForCall)]
+	fake.stageLocalArtifactsArgsForCall = append(fake.stageLocalArtifactsArgsForCall, struct {
+		arg1 *build.Options
+	}{arg1})
+	stub := fake.StageLocalArtifactsStub
+	fakeReturns := fake.stageLocalArtifactsReturns
+	fake.recordInvocation("StageLocalArtifacts", []interface{}{arg1})
+	fake.stageLocalArtifactsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) StageLocalArtifactsCallCount() int {
+	fake.stageLocalArtifactsMutex.RLock()
+	defer fake.stageLocalArtifactsMutex.RUnlock()
+	return len(fake.stageLocalArtifactsArgsForCall)
+}
+
+func (fake *FakeStageImpl) StageLocalArtifactsCalls(stub func(*build.Options) error) {
+	fake.stageLocalArtifactsMutex.Lock()
+	defer fake.stageLocalArtifactsMutex.Unlock()
+	fake.StageLocalArtifactsStub = stub
+}
+
+func (fake *FakeStageImpl) StageLocalArtifactsArgsForCall(i int) *build.Options {
+	fake.stageLocalArtifactsMutex.RLock()
+	defer fake.stageLocalArtifactsMutex.RUnlock()
+	argsForCall := fake.stageLocalArtifactsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) StageLocalArtifactsReturns(result1 error) {
+	fake.stageLocalArtifactsMutex.Lock()
+	defer fake.stageLocalArtifactsMutex.Unlock()
+	fake.StageLocalArtifactsStub = nil
+	fake.stageLocalArtifactsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) StageLocalArtifactsReturnsOnCall(i int, result1 error) {
+	fake.stageLocalArtifactsMutex.Lock()
+	defer fake.stageLocalArtifactsMutex.Unlock()
+	fake.StageLocalArtifactsStub = nil
+	if fake.stageLocalArtifactsReturnsOnCall == nil {
+		fake.stageLocalArtifactsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.stageLocalArtifactsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTree(arg1 *build.Options, arg2 string) error {
+	fake.stageLocalSourceTreeMutex.Lock()
+	ret, specificReturn := fake.stageLocalSourceTreeReturnsOnCall[len(fake.stageLocalSourceTreeArgsForCall)]
+	fake.stageLocalSourceTreeArgsForCall = append(fake.stageLocalSourceTreeArgsForCall, struct {
+		arg1 *build.Options
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.StageLocalSourceTreeStub
+	fakeReturns := fake.stageLocalSourceTreeReturns
+	fake.recordInvocation("StageLocalSourceTree", []interface{}{arg1, arg2})
+	fake.stageLocalSourceTreeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTreeCallCount() int {
+	fake.stageLocalSourceTreeMutex.RLock()
+	defer fake.stageLocalSourceTreeMutex.RUnlock()
+	return len(fake.stageLocalSourceTreeArgsForCall)
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTreeCalls(stub func(*build.Options, string) error) {
+	fake.stageLocalSourceTreeMutex.Lock()
+	defer fake.stageLocalSourceTreeMutex.Unlock()
+	fake.StageLocalSourceTreeStub = stub
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTreeArgsForCall(i int) (*build.Options, string) {
+	fake.stageLocalSourceTreeMutex.RLock()
+	defer fake.stageLocalSourceTreeMutex.RUnlock()
+	argsForCall := fake.stageLocalSourceTreeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTreeReturns(result1 error) {
+	fake.stageLocalSourceTreeMutex.Lock()
+	defer fake.stageLocalSourceTreeMutex.Unlock()
+	fake.StageLocalSourceTreeStub = nil
+	fake.stageLocalSourceTreeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) StageLocalSourceTreeReturnsOnCall(i int, result1 error) {
+	fake.stageLocalSourceTreeMutex.Lock()
+	defer fake.stageLocalSourceTreeMutex.Unlock()
+	fake.StageLocalSourceTreeStub = nil
+	if fake.stageLocalSourceTreeReturnsOnCall == nil {
+		fake.stageLocalSourceTreeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.stageLocalSourceTreeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkReleaseBucketMutex.RLock()
+	defer fake.checkReleaseBucketMutex.RUnlock()
+	fake.generateReleaseVersionMutex.RLock()
+	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceStageMutex.RLock()
 	defer fake.prepareWorkspaceStageMutex.RUnlock()
+	fake.pushContainerImagesMutex.RLock()
+	defer fake.pushContainerImagesMutex.RUnlock()
+	fake.pushReleaseArtifactsMutex.RLock()
+	defer fake.pushReleaseArtifactsMutex.RUnlock()
+	fake.stageLocalArtifactsMutex.RLock()
+	defer fake.stageLocalArtifactsMutex.RUnlock()
+	fake.stageLocalSourceTreeMutex.RLock()
+	defer fake.stageLocalSourceTreeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/release/pkg/anago"
 	"k8s.io/release/pkg/anago/anagofakes"
+	"k8s.io/release/pkg/git"
 )
 
 func TestCheckPrerequisitesRelease(t *testing.T) {
@@ -31,6 +32,87 @@ func TestCheckPrerequisitesRelease(t *testing.T) {
 	mock := &anagofakes.FakeReleaseImpl{}
 	sut.SetClient(mock)
 	require.Nil(t, sut.CheckPrerequisites())
+}
+
+func TestGenerateReleaseVersionRelease(t *testing.T) {
+	for _, tc := range []struct {
+		parentBranch string
+		prepare      func(*anagofakes.FakeReleaseImpl)
+		shouldError  bool
+	}{
+		{ // success
+			parentBranch: git.DefaultBranch,
+			prepare:      func(*anagofakes.FakeReleaseImpl) {},
+			shouldError:  false,
+		},
+		{ // PrepareWorkspaceRelease fails
+			parentBranch: git.DefaultBranch,
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.GenerateReleaseVersionReturns(nil, err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultReleaseOptions()
+		sut := anago.NewDefaultRelease(opts)
+		mock := &anagofakes.FakeReleaseImpl{}
+		tc.prepare(mock)
+		sut.SetClient(mock)
+		_, err := sut.GenerateReleaseVersion(tc.parentBranch)
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+func TestPushArtifacts(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeReleaseImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeReleaseImpl) {},
+			shouldError: false,
+		},
+		{ // CheckReleaseBucket fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.CheckReleaseBucketReturns(err)
+			},
+			shouldError: true,
+		},
+		{ // CopyStagedFromGCSReturns fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.CopyStagedFromGCSReturns(err)
+			},
+			shouldError: true,
+		},
+		{ // ValidateImages fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.ValidateImagesReturns(err)
+			},
+			shouldError: true,
+		},
+		{ // PusblishVersion fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.PublishVersionReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultReleaseOptions()
+		sut := anago.NewDefaultRelease(opts)
+		mock := &anagofakes.FakeReleaseImpl{}
+		tc.prepare(mock)
+		sut.SetClient(mock)
+		err := sut.PushArtifacts([]string{"v1.20.0"})
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
 }
 
 func TestPrepareWorkspaceRelease(t *testing.T) {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -17,8 +17,14 @@ limitations under the License.
 package anago
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+	"path/filepath"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/build"
+	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/release"
 )
 
@@ -39,6 +45,9 @@ type stageClient interface {
 	// available) and build version for this release.
 	SetBuildCandidate() error
 
+	// GenerateReleaseVersion discovers the next versions to be released.
+	GenerateReleaseVersion(parentBranch string) (*release.Versions, error)
+
 	// PrepareWorkspace verifies that the working directory is in the desired
 	// state. This means that the build directory is cleaned up and the checked
 	// out repository is in a clean state.
@@ -53,7 +62,7 @@ type stageClient interface {
 	GenerateReleaseNotes() error
 
 	// StageArtifacts copies the build artifacts to a Google Cloud Bucket.
-	StageArtifacts() error
+	StageArtifacts(versions []string) error
 }
 
 // DefaultStage is the default staging implementation used in production.
@@ -79,10 +88,60 @@ type defaultStageImpl struct{}
 //counterfeiter:generate . stageImpl
 type stageImpl interface {
 	PrepareWorkspaceStage(directory string) error
+	GenerateReleaseVersion(
+		releaseType, version, branch string, branchFromMaster bool,
+	) (*release.Versions, error)
+	CheckReleaseBucket(options *build.Options) error
+	StageLocalSourceTree(
+		options *build.Options, buildVersion string,
+	) error
+	StageLocalArtifacts(options *build.Options) error
+	PushReleaseArtifacts(
+		options *build.Options, srcPath, gcsPath string,
+	) error
+	PushContainerImages(options *build.Options) error
+}
+
+func (d *defaultStageImpl) GenerateReleaseVersion(
+	releaseType, version, branch string, branchFromMaster bool,
+) (*release.Versions, error) {
+	return release.GenerateReleaseVersion(
+		releaseType, version, branch, branchFromMaster,
+	)
 }
 
 func (d *defaultStageImpl) PrepareWorkspaceStage(directory string) error {
 	return release.PrepareWorkspaceStage(directory)
+}
+
+func (d *defaultStageImpl) CheckReleaseBucket(
+	options *build.Options,
+) error {
+	return build.NewInstance(options).CheckReleaseBucket()
+}
+
+func (d *defaultStageImpl) StageLocalSourceTree(
+	options *build.Options, buildVersion string,
+) error {
+	return build.NewInstance(options).StageLocalSourceTree(buildVersion)
+}
+
+func (d *defaultStageImpl) StageLocalArtifacts(
+	options *build.Options,
+) error {
+	return build.NewInstance(options).StageLocalArtifacts()
+}
+
+func (d *defaultStageImpl) PushReleaseArtifacts(
+	options *build.Options, srcPath, gcsPath string,
+) error {
+	return build.NewInstance(options).PushReleaseArtifacts(srcPath, gcsPath)
+}
+
+func (d *defaultStageImpl) PushContainerImages(
+	options *build.Options,
+) error {
+	return build.NewInstance(options).PushContainerImages()
 }
 
 func (d *DefaultStage) ValidateOptions() error {
@@ -92,6 +151,17 @@ func (d *DefaultStage) ValidateOptions() error {
 func (d *DefaultStage) CheckPrerequisites() error { return nil }
 
 func (d *DefaultStage) SetBuildCandidate() error { return nil }
+
+func (d *DefaultStage) GenerateReleaseVersion(
+	parentBranch string,
+) (*release.Versions, error) {
+	return d.impl.GenerateReleaseVersion(
+		d.options.ReleaseType,
+		d.options.BuildVersion,
+		d.options.ReleaseBranch,
+		parentBranch == git.DefaultBranch,
+	)
+}
 
 func (d *DefaultStage) PrepareWorkspace() error {
 	if err := d.impl.PrepareWorkspaceStage(gitRoot); err != nil {
@@ -104,4 +174,62 @@ func (d *DefaultStage) Build() error { return nil }
 
 func (d *DefaultStage) GenerateReleaseNotes() error { return nil }
 
-func (d *DefaultStage) StageArtifacts() error { return nil }
+func (d *DefaultStage) StageArtifacts(versions []string) error {
+	for _, version := range versions {
+		logrus.Infof("Staging artifacts for version %s", version)
+		buildDir := filepath.Join(
+			gitRoot, fmt.Sprintf("%s-%s", release.BuildDir, version),
+		)
+		bucket := d.options.Bucket()
+		containerRegistry := d.options.ContainerRegistry()
+		pushBuildOptions := &build.Options{
+			Bucket:                     bucket,
+			BuildDir:                   buildDir,
+			DockerRegistry:             containerRegistry,
+			Version:                    version,
+			AllowDup:                   true,
+			ValidateRemoteImageDigests: true,
+		}
+		if err := d.impl.CheckReleaseBucket(pushBuildOptions); err != nil {
+			return errors.Wrap(err, "check release bucket access")
+		}
+
+		// Stage the local source tree
+		if err := d.impl.StageLocalSourceTree(
+			pushBuildOptions,
+			d.options.BuildVersion,
+		); err != nil {
+			return errors.Wrap(err, "staging local source tree")
+		}
+
+		// Stage local artifacts and write checksums
+		if err := d.impl.StageLocalArtifacts(pushBuildOptions); err != nil {
+			return errors.Wrap(err, "staging local artifacts")
+		}
+		gcsPath := filepath.Join("stage", d.options.BuildVersion, version)
+
+		// Push gcs-stage to GCS
+		if err := d.impl.PushReleaseArtifacts(
+			pushBuildOptions,
+			filepath.Join(buildDir, release.GCSStagePath, version),
+			filepath.Join(gcsPath, release.GCSStagePath, version),
+		); err != nil {
+			return errors.Wrap(err, "pushing release artifacts")
+		}
+
+		// Push container release-images to GCS
+		if err := d.impl.PushReleaseArtifacts(
+			pushBuildOptions,
+			filepath.Join(buildDir, release.ImagesPath),
+			filepath.Join(gcsPath, release.ImagesPath),
+		); err != nil {
+			return errors.Wrap(err, "pushing release artifacts")
+		}
+
+		// Push container images into registry
+		if err := d.impl.PushContainerImages(pushBuildOptions); err != nil {
+			return errors.Wrap(err, "pushing container images")
+		}
+	}
+	return nil
+}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -107,6 +107,9 @@ const (
 	// Staging registry root URL
 	GCRIOPathStaging = "gcr.io/k8s-staging-kubernetes"
 
+	// Mock staging registry root URL
+	GCRIOPathMock = GCRIOPathStaging + "/mock"
+
 	// BuildDir is the default build output directory.
 	BuildDir = "_output"
 

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -89,6 +89,23 @@ func (r *Versions) String() string {
 	return sb.String()
 }
 
+// Ordered returns a list of ordered release versions.
+func (r *Versions) Ordered() (versions []string) {
+	if r.Official() != "" {
+		versions = append(versions, r.Official())
+	}
+	if r.RC() != "" {
+		versions = append(versions, r.RC())
+	}
+	if r.Beta() != "" {
+		versions = append(versions, r.Beta())
+	}
+	if r.Alpha() != "" {
+		versions = append(versions, r.Alpha())
+	}
+	return versions
+}
+
 // GenerateReleaseVersion returns the next build versions for the provided parameters
 func GenerateReleaseVersion(
 	releaseType, version, branch string, branchFromMaster bool,

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -46,6 +46,10 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.5-rc.0", res.RC())
 				require.Empty(t, res.Beta())
 				require.Empty(t, res.Alpha())
+				require.Equal(t,
+					[]string{"v1.18.4", "v1.18.5-rc.0"},
+					res.Ordered(),
+				)
 			},
 		},
 		{
@@ -61,6 +65,7 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.4-rc.1", res.RC())
 				require.Empty(t, res.Beta())
 				require.Empty(t, res.Alpha())
+				require.Equal(t, []string{"v1.18.4-rc.1"}, res.Ordered())
 			},
 		},
 		{
@@ -76,6 +81,10 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Equal(t, "v1.18.0-rc.0", res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.19.0-alpha.0", res.Alpha())
+				require.Equal(t,
+					[]string{"v1.18.0-rc.0", "v1.19.0-alpha.0"},
+					res.Ordered(),
+				)
 			},
 		},
 		{
@@ -91,6 +100,7 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Equal(t, "v1.18.4-beta.2", res.Beta())
 				require.Empty(t, res.Alpha())
+				require.Equal(t, []string{"v1.18.4-beta.2"}, res.Ordered())
 			},
 		},
 		{
@@ -106,6 +116,7 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Equal(t, "v1.18.0-beta.0", res.Beta())
 				require.Empty(t, res.Alpha())
+				require.Equal(t, []string{"v1.18.0-beta.0"}, res.Ordered())
 			},
 		},
 		{
@@ -121,6 +132,7 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.18.4-alpha.2", res.Alpha())
+				require.Equal(t, []string{"v1.18.4-alpha.2"}, res.Ordered())
 			},
 		},
 		{
@@ -136,6 +148,7 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
 				require.Equal(t, "v1.20.0-alpha.3", res.Alpha())
+				require.Equal(t, []string{"v1.20.0-alpha.3"}, res.Ordered())
 			},
 		},
 		{


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add the artifacts pushing and generation of the release version
to `krel stage/release`. This does right now not work for releases where
we create a release branch, because this variable will be set by
`SetBuildCandidate`, which is not implemented yet.

It does also not work stage, because the release build is not
implemented there.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1673
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added artifact pushing and release version generation to `krel stage/release`
```
