### PR TITLE
Migrate gitlib::push_master to golang

### DIFF
--- a/anago
+++ b/anago
@@ -584,10 +584,6 @@ push_git_objects () {
     --parent-branch="${PARENT_BRANCH}" \
     --repo="$TREE_ROOT" \
     --tags="${tags_flag}" || return 1
-
-  # For files created on master with new branches and
-  # for $CHANGELOG_FILEPATH, update the master
-  gitlib::push_master
 }
 
 ###############################################################################

--- a/cmd/krel/cmd/anago/push_git_objects.go
+++ b/cmd/krel/cmd/anago/push_git_objects.go
@@ -147,11 +147,13 @@ func runPushGitObjects(options *pushGitObjectsOptions) (err error) {
 			}
 		}
 	}
-	/*
-	  # For files created on master with new branches and
-	  # for $CHANGELOG_FILEPATH, update the master
-	  gitlib::push_master
-	*/
+
+	// For files created on master with new branches and
+	// for $CHANGELOG_FILEPATH, update the master
+	if err := gitPusher.PushMain(); err != nil {
+		return errors.Wrap(err, "pushing changes in main branch")
+	}
+
 	logrus.Info("git objects push complete")
 	return nil
 }

--- a/lib/gitlib.sh
+++ b/lib/gitlib.sh
@@ -214,24 +214,6 @@ gitlib::branch_exists () {
    refs/heads/$branch &>/dev/null
 }
 
-##############################################################################
-# Fetch, rebase and push master.
-gitlib::push_master () {
-  local dryrun_flag=" --dry-run"
-  ((FLAGS_nomock)) && dryrun_flag=""
-
-  logecho -n "Checkout master branch to push objects: "
-  logrun -s git checkout master || return 1
-  logrun -v git status -s || return 1
-  logrun -v git show || return 1
-
-  logecho -n "Rebase master branch: "
-  logrun -v git fetch origin || return 1
-  logrun -s -v git rebase origin/master || return 1
-  logecho -n "Pushing$dryrun_flag master branch: "
-  logrun -s git push$dryrun_flag origin master || return 1
-}
-
 # Set up git config for GCB
 if ((FLAGS_gcb)); then
   gitlib::git_config_for_gcb || common::exit "Exiting..."


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR removes the `gitlib::push_master` and the call to it from `anago` and implements the same functions in go. The PR is split in three parts:

1. Four new functions are added to the git package:
    - `git.Fetch()` to fetch objects from a remote repository
    - `git.ShowLastCommit()` returns the last commit data from the log
    - `git.Rebase()` reabases to the specified branch
    - Finally, `git.Status()` returns a go-git status object with the current repo state
  Tests are included for each of these new functions

2. A new function has been added to the git pusher object: `PushMain()`. This function replaces `gitlib::push_master` by outputting some info, fetching, rebasing the main branch and finally pushing to the remote repo.
3. The third commit removes the bash code from anago and gitlib.sh

#### Which issue(s) this PR fixes:
Related to #1673

#### Special notes for your reviewer:

A test run of the code would be greatly appreciated !

#### Does this PR introduce a user-facing change?

```release-note
- The git package now has four new functions: `git.Status()`, `git.Fetch()`, `git.ShowLastCommit()` and `git.Rebase()`
- `krel anago ` now has a new flag `--push-main` that pushes changes made to the main branch
```
