### PR TITLE
Pass --log-level via `krel gcbmgr`

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -279,6 +279,7 @@ func RunGcbmgr(opts *GcbmgrOptions) error {
 	// Use dedicated job types for krel-based executions
 	if opts.NoAnago {
 		delete(gcbSubs, "BUILD_AT_HEAD")
+		gcbSubs["LOG_LEVEL"] = rootOpts.logLevel
 		jobType += "-krel"
 	}
 

--- a/gcb/release-krel/cloudbuild.yaml
+++ b/gcb/release-krel/cloudbuild.yaml
@@ -44,6 +44,7 @@ steps:
   - "bin/krel"
   - "release"
   - "${_NOMOCK}"
+  - "--log-level=${_LOG_LEVEL}"
   - "--type=${_TYPE}"
   - "--branch=${_RELEASE_BRANCH}"
   - "--build-version=${_BUILDVERSION}"

--- a/gcb/stage-krel/cloudbuild.yaml
+++ b/gcb/stage-krel/cloudbuild.yaml
@@ -44,6 +44,7 @@ steps:
   - "bin/krel"
   - "stage"
   - "${_NOMOCK}"
+  - "--log-level=${_LOG_LEVEL}"
   - "--type=${_TYPE}"
   - "--branch=${_RELEASE_BRANCH}"
   - "--build-version=${_BUILDVERSION}"


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows us to pass the `krel gcbmgr --log-level` via a GCB
substitution to the `krel stage/release` job. This way we're able to set
the release build process do `debug`, which helps during development and
troubleshooting.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:

##### Example `--log-level=info` (default):
https://console.cloud.google.com/cloud-build/builds/72c14cc0-c63d-467b-9811-be4b3684e0f2?project=kubernetes-release-test

##### Example `--log-level=debug`:
https://console.cloud.google.com/cloud-build/builds/ed4189fd-7179-47f7-ab7d-fb9bc9a88a1e?project=kubernetes-release-test

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `krel gcbmgr --log-level` will now passed to `krel stage/release` and applies in the same way.
```
