### PR TITLE
Cleanup some CI build logic and add k8s-ci-builder image

### DIFF
--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -117,10 +117,10 @@ func init() {
 		"If set, push docker images to specified registry/project",
 	)
 
-	ciBuildCmd.PersistentFlags().StringVar(
+	ciBuildCmd.PersistentFlags().StringSliceVar(
 		&ciBuildOpts.ExtraVersionMarkers,
 		"extra-version-markers",
-		"",
+		build.DefaultExtraVersionMarkers,
 		"Comma separated list which can be used to upload additional version files to GCS. The path is relative and is append to a GCS path. (--ci only)",
 	)
 

--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -91,13 +91,6 @@ func init() {
 		"Do not update the latest file",
 	)
 
-	ciBuildCmd.PersistentFlags().BoolVar(
-		&ciBuildOpts.PrivateBucket,
-		"private-bucket",
-		false,
-		"Do not mark published bits on GCS as publicly readable",
-	)
-
 	// TODO: Configure a default const here
 	ciBuildCmd.PersistentFlags().StringVar(
 		&ciBuildOpts.Bucket,
@@ -116,6 +109,7 @@ func init() {
 		),
 	)
 
+	// TODO: Switch to "--registry" once CI no longer uses it
 	ciBuildCmd.PersistentFlags().StringVar(
 		&ciBuildOpts.DockerRegistry,
 		"docker-registry",

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -104,6 +104,7 @@ func init() {
 		),
 	)
 
+	// TODO: Switch to "--registry" once CI no longer uses it
 	pushBuildCmd.PersistentFlags().StringVar(
 		&pushBuildOpts.DockerRegistry,
 		"docker-registry",

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -112,10 +112,10 @@ func init() {
 		"If set, push docker images to specified registry/project",
 	)
 
-	pushBuildCmd.PersistentFlags().StringVar(
+	pushBuildCmd.PersistentFlags().StringSliceVar(
 		&pushBuildOpts.ExtraVersionMarkers,
 		"extra-version-markers",
-		"",
+		build.DefaultExtraVersionMarkers,
 		"Comma separated list which can be used to upload additional version files to GCS. The path is relative and is append to a GCS path. (--ci only)",
 	)
 

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION
+ARG KUBE_CROSS_VERSION
+FROM golang:${GO_VERSION} as builder
+
+WORKDIR /go/src/k8s.io/release
+
+COPY ./ ./
+
+RUN ./compile-release-tools
+
+### Production image
+
+FROM gcr.io/k8s-staging-releng/k8s-cloud-builder:${KUBE_CROSS_VERSION}
+
+WORKDIR /
+COPY --from=builder /go/bin/* ./
+
+ENTRYPOINT ["/krel"]

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -28,4 +28,10 @@ FROM gcr.io/k8s-testimages/krte:latest-master
 WORKDIR /
 COPY --from=builder /go/bin/* ./
 
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -q update \
+    && apt-get install -qqy \
+        jq
+
 ENTRYPOINT ["wrapper.sh"]

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG KUBE_CROSS_VERSION
 FROM golang:${GO_VERSION} as builder
 
 WORKDIR /go/src/k8s.io/release
@@ -24,9 +23,9 @@ RUN ./compile-release-tools
 
 ### Production image
 
-FROM gcr.io/k8s-staging-releng/k8s-cloud-builder:${KUBE_CROSS_VERSION}
+FROM gcr.io/k8s-testimages/krte:latest-master
 
 WORKDIR /
 COPY --from=builder /go/bin/* ./
 
-ENTRYPOINT ["/krel"]
+ENTRYPOINT ["wrapper.sh"]

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -1,0 +1,38 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: build
+    dir: images/releng/k8s-ci-builder
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}
+    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:latest-${_CONFIG}
+    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:${_KUBE_CROSS_VERSION}
+    - --build-arg=GO_VERSION=${_GO_VERSION}
+    - --build-arg=KUBE_CROSS_VERSION=${_KUBE_CROSS_VERSION}
+    - -f ./Dockerfile
+    - ../../../.
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _CONFIG: 'cross0.0'
+  _GO_VERSION: '0.0.0'
+  _KUBE_CROSS_VERSION: 'v0.0.0-0'
+
+images:
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:latest-${_CONFIG}'
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_KUBE_CROSS_VERSION}'
+
+tags:
+- 'k8s-ci-builder'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_GO_VERSION}
+- ${_KUBE_CROSS_VERSION}

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,0 +1,5 @@
+variants:
+  cross1.15:
+    CONFIG: 'cross1.15'
+    GO_VERSION: '1.15.3'
+    KUBE_CROSS_VERSION: 'v1.15.3-1'

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var DefaultExtraVersionMarkers = []string{}
+
 // Instance is the main structure for creating and pushing builds.
 type Instance struct {
 	opts *Options
@@ -54,7 +56,7 @@ type Options struct {
 	// Comma separated list which can be used to upload additional version
 	// files to GCS. The path is relative and is append to a GCS path. (--ci
 	// only).
-	ExtraVersionMarkers string
+	ExtraVersionMarkers []string
 
 	// Specify a suffix to append to the upload destination on GCS.
 	GCSSuffix string

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -140,8 +140,6 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 		mode += bi.opts.GCSSuffix
 	}
 
-	bi.opts.Bucket = bucket
-
 	gcsBuildRoot := filepath.Join(bucket, mode, version)
 	kubernetesTar := filepath.Join(gcsBuildRoot, release.KubernetesTar)
 	binPath := filepath.Join(gcsBuildRoot, "bin")

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -34,6 +34,7 @@ import (
 func NewCIInstance(opts *Options) *Instance {
 	instance := NewInstance(opts)
 	instance.opts.CI = true
+	instance.setBuildType()
 
 	return instance
 }
@@ -127,20 +128,9 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 		bucket = "kubernetes-release-dev"
 	}
 
-	mode := "ci"
-	if bi.opts.CI {
-		mode = "ci"
-	}
+	gcsDest := bi.getGCSBuildPath(version)
 
-	if bi.opts.Fast {
-		mode += "/fast"
-	}
-
-	if bi.opts.GCSSuffix != "" {
-		mode += bi.opts.GCSSuffix
-	}
-
-	gcsBuildRoot := filepath.Join(bucket, mode, version)
+	gcsBuildRoot := filepath.Join(bucket, gcsDest)
 	kubernetesTar := filepath.Join(gcsBuildRoot, release.KubernetesTar)
 	binPath := filepath.Join(gcsBuildRoot, "bin")
 

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -119,17 +119,7 @@ func (bi *Instance) Push() error {
 		return errors.Wrap(err, "push container images")
 	}
 
-	gcsDest := "devel"
-	if bi.opts.CI {
-		gcsDest = "ci"
-	}
-	gcsDest += bi.opts.GCSSuffix
-
-	if bi.opts.Fast {
-		gcsDest = filepath.Join(gcsDest, "fast")
-	}
-	gcsDest = filepath.Join(gcsDest, version)
-	logrus.Infof("GCS destination is %s", gcsDest)
+	gcsDest := bi.getGCSBuildPath(version)
 
 	if err := bi.PushReleaseArtifacts(
 		filepath.Join(bi.opts.BuildDir, release.GCSStagePath, version),
@@ -151,7 +141,7 @@ func (bi *Instance) Push() error {
 	// Publish release to GCS
 	versionMarkers := strings.Split(bi.opts.ExtraVersionMarkers, ",")
 	if err := release.NewPublisher().PublishVersion(
-		gcsDest, version, bi.opts.BuildDir, bi.opts.Bucket, versionMarkers,
+		bi.opts.BuildType, version, bi.opts.BuildDir, bi.opts.Bucket, versionMarkers,
 		bi.opts.PrivateBucket, bi.opts.Fast,
 	); err != nil {
 		return errors.Wrap(err, "publish release")

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -139,9 +139,9 @@ func (bi *Instance) Push() error {
 	}
 
 	// Publish release to GCS
-	versionMarkers := strings.Split(bi.opts.ExtraVersionMarkers, ",")
+	extraVersionMarkers := bi.opts.ExtraVersionMarkers
 	if err := release.NewPublisher().PublishVersion(
-		bi.opts.BuildType, version, bi.opts.BuildDir, bi.opts.Bucket, versionMarkers,
+		bi.opts.BuildType, version, bi.opts.BuildDir, bi.opts.Bucket, extraVersionMarkers,
 		bi.opts.PrivateBucket, bi.opts.Fast,
 	); err != nil {
 		return errors.Wrap(err, "publish release")

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -79,7 +79,7 @@ func (*defaultPublisher) GetURLResponse(url string) (string, error) {
 // was releaselib.sh: release::gcs::publish_version
 func (p *Publisher) PublishVersion(
 	buildType, version, buildDir, bucket string,
-	versionMarkers []string,
+	extraVersionMarkers []string,
 	privateBucket, fast bool,
 ) error {
 	logrus.Info("Publishing version")
@@ -109,42 +109,48 @@ func (p *Publisher) PublishVersion(
 		return errors.Errorf("invalid version %s", version)
 	}
 
-	var publishFiles []string
+	var versionMarkers []string
 	if fast {
-		publishFiles = append([]string{
-			releaseType + "-fast",
-		}, versionMarkers...)
+		versionMarkers = append(
+			versionMarkers,
+			releaseType+"-fast",
+		)
 	} else {
-		publishFiles = append([]string{
+		versionMarkers = append(
+			versionMarkers,
 			releaseType,
 			fmt.Sprintf("%s-%d", releaseType, sv.Major),
 			fmt.Sprintf("%s-%d.%d", releaseType, sv.Major, sv.Minor),
-		}, versionMarkers...)
+		)
 	}
 
-	logrus.Infof("Publish version markers: %v", publishFiles)
+	if len(extraVersionMarkers) > 0 {
+		versionMarkers = append(versionMarkers, extraVersionMarkers...)
+	}
+
+	logrus.Infof("Publish version markers: %v", versionMarkers)
 	logrus.Infof("Publish official pointer text files to bucket %s", bucket)
 
-	for _, file := range publishFiles {
-		publishFile := filepath.Join(buildType, file+".txt")
+	for _, file := range versionMarkers {
+		versionMarker := filepath.Join(buildType, file+".txt")
 		needsUpdate, err := p.VerifyLatestUpdate(
-			publishFile, bucket, version,
+			versionMarker, bucket, version,
 		)
 		if err != nil {
-			return errors.Wrapf(err, "verify latest update for %s", publishFile)
+			return errors.Wrapf(err, "verify latest update for %s", versionMarker)
 		}
 		// If there's a version that's above the one we're trying to release,
 		// don't do anything, and just try the next one.
 		if !needsUpdate {
 			logrus.Infof(
 				"Skipping %s for %s because it does not need to be updated",
-				publishFile, version,
+				versionMarker, version,
 			)
 			continue
 		}
 
 		if err := p.PublishToGcs(
-			publishFile, buildDir, bucket, version, privateBucket,
+			versionMarker, buildDir, bucket, version, privateBucket,
 		); err != nil {
 			return errors.Wrap(err, "publish release to GCS")
 		}

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -101,7 +101,7 @@ func (p *Publisher) PublishVersion(
 	releasePath = gcs.GcsPrefix + filepath.Join(releasePath, version)
 
 	if err := p.client.GSUtil("ls", releasePath); err != nil {
-		return errors.Wrapf(err, "release files dont exist at %s", releasePath)
+		return errors.Wrapf(err, "release files don't exist at %s", releasePath)
 	}
 
 	sv, err := util.TagStringToSemver(version)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Add k8s-ci-builder image to support Kubernetes builds in CI
  Follow-up to https://github.com/kubernetes/release/pull/1698
- k8s-ci-builder: Short-circuit logic building by using krte image 
- pkg/build: Cleanup some CI flags and build requirements
- pkg/build: Don't rewrite bucket in build Instance
- pkg/build: Consolidate build type / directory setting logic
- pkg/build: Properly handle extra version markers

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

I'm still wrestling with the GCB config file, but I was able to push this locally to support testing with https://github.com/kubernetes/test-infra/pull/19887.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add k8s-ci-builder image to support Kubernetes builds in CI
- k8s-ci-builder: Short-circuit logic building by using krte image 
- pkg/build: Cleanup some CI flags and build requirements
- pkg/build: Don't rewrite bucket in build Instance
- pkg/build: Consolidate build type / directory setting logic
- pkg/build: Properly handle extra version markers
```
