### PR TITLE
Add changelog generation to krel stage

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -193,9 +193,9 @@ func (s *Stage) Run() error {
 		return errors.Wrap(err, "build release")
 	}
 
-	logrus.Info("Generating release notes")
-	if err := s.client.GenerateReleaseNotes(); err != nil {
-		return errors.Wrap(err, "generate release notes")
+	logrus.Info("Generating changelog")
+	if err := s.client.GenerateChangelog(versions.Prime()); err != nil {
+		return errors.Wrap(err, "generate changelog")
 	}
 
 	logrus.Info("Staging artifacts")

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -87,10 +87,10 @@ func TestStage(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // GenerateReleaseNotes fails
+		{ // GenerateChangelog fails
 			prepare: func(mock *anagofakes.FakeStageClient) {
 				mockGenerateReleaseVersionStage(mock)
-				mock.GenerateReleaseNotesReturns(err)
+				mock.GenerateChangelogReturns(err)
 			},
 			shouldError: true,
 		},

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -45,14 +45,15 @@ type FakeStageClient struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GenerateReleaseNotesStub        func() error
-	generateReleaseNotesMutex       sync.RWMutex
-	generateReleaseNotesArgsForCall []struct {
+	GenerateChangelogStub        func(string) error
+	generateChangelogMutex       sync.RWMutex
+	generateChangelogArgsForCall []struct {
+		arg1 string
 	}
-	generateReleaseNotesReturns struct {
+	generateChangelogReturns struct {
 		result1 error
 	}
-	generateReleaseNotesReturnsOnCall map[int]struct {
+	generateChangelogReturnsOnCall map[int]struct {
 		result1 error
 	}
 	GenerateReleaseVersionStub        func(string) (*release.Versions, error)
@@ -243,17 +244,18 @@ func (fake *FakeStageClient) CheckPrerequisitesReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeStageClient) GenerateReleaseNotes() error {
-	fake.generateReleaseNotesMutex.Lock()
-	ret, specificReturn := fake.generateReleaseNotesReturnsOnCall[len(fake.generateReleaseNotesArgsForCall)]
-	fake.generateReleaseNotesArgsForCall = append(fake.generateReleaseNotesArgsForCall, struct {
-	}{})
-	stub := fake.GenerateReleaseNotesStub
-	fakeReturns := fake.generateReleaseNotesReturns
-	fake.recordInvocation("GenerateReleaseNotes", []interface{}{})
-	fake.generateReleaseNotesMutex.Unlock()
+func (fake *FakeStageClient) GenerateChangelog(arg1 string) error {
+	fake.generateChangelogMutex.Lock()
+	ret, specificReturn := fake.generateChangelogReturnsOnCall[len(fake.generateChangelogArgsForCall)]
+	fake.generateChangelogArgsForCall = append(fake.generateChangelogArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GenerateChangelogStub
+	fakeReturns := fake.generateChangelogReturns
+	fake.recordInvocation("GenerateChangelog", []interface{}{arg1})
+	fake.generateChangelogMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -261,37 +263,44 @@ func (fake *FakeStageClient) GenerateReleaseNotes() error {
 	return fakeReturns.result1
 }
 
-func (fake *FakeStageClient) GenerateReleaseNotesCallCount() int {
-	fake.generateReleaseNotesMutex.RLock()
-	defer fake.generateReleaseNotesMutex.RUnlock()
-	return len(fake.generateReleaseNotesArgsForCall)
+func (fake *FakeStageClient) GenerateChangelogCallCount() int {
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
+	return len(fake.generateChangelogArgsForCall)
 }
 
-func (fake *FakeStageClient) GenerateReleaseNotesCalls(stub func() error) {
-	fake.generateReleaseNotesMutex.Lock()
-	defer fake.generateReleaseNotesMutex.Unlock()
-	fake.GenerateReleaseNotesStub = stub
+func (fake *FakeStageClient) GenerateChangelogCalls(stub func(string) error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = stub
 }
 
-func (fake *FakeStageClient) GenerateReleaseNotesReturns(result1 error) {
-	fake.generateReleaseNotesMutex.Lock()
-	defer fake.generateReleaseNotesMutex.Unlock()
-	fake.GenerateReleaseNotesStub = nil
-	fake.generateReleaseNotesReturns = struct {
+func (fake *FakeStageClient) GenerateChangelogArgsForCall(i int) string {
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
+	argsForCall := fake.generateChangelogArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageClient) GenerateChangelogReturns(result1 error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = nil
+	fake.generateChangelogReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeStageClient) GenerateReleaseNotesReturnsOnCall(i int, result1 error) {
-	fake.generateReleaseNotesMutex.Lock()
-	defer fake.generateReleaseNotesMutex.Unlock()
-	fake.GenerateReleaseNotesStub = nil
-	if fake.generateReleaseNotesReturnsOnCall == nil {
-		fake.generateReleaseNotesReturnsOnCall = make(map[int]struct {
+func (fake *FakeStageClient) GenerateChangelogReturnsOnCall(i int, result1 error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = nil
+	if fake.generateChangelogReturnsOnCall == nil {
+		fake.generateChangelogReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.generateReleaseNotesReturnsOnCall[i] = struct {
+	fake.generateChangelogReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -658,8 +667,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.buildMutex.RUnlock()
 	fake.checkPrerequisitesMutex.RLock()
 	defer fake.checkPrerequisitesMutex.RUnlock()
-	fake.generateReleaseNotesMutex.RLock()
-	defer fake.generateReleaseNotesMutex.RUnlock()
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
 	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"k8s.io/release/pkg/build"
+	"k8s.io/release/pkg/changelog"
 	"k8s.io/release/pkg/release"
 )
 
@@ -34,6 +35,17 @@ type FakeStageImpl struct {
 		result1 error
 	}
 	checkReleaseBucketReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GenerateChangelogStub        func(*changelog.Options) error
+	generateChangelogMutex       sync.RWMutex
+	generateChangelogArgsForCall []struct {
+		arg1 *changelog.Options
+	}
+	generateChangelogReturns struct {
+		result1 error
+	}
+	generateChangelogReturnsOnCall map[int]struct {
 		result1 error
 	}
 	GenerateReleaseVersionStub        func(string, string, string, bool) (*release.Versions, error)
@@ -193,6 +205,67 @@ func (fake *FakeStageImpl) CheckReleaseBucketReturnsOnCall(i int, result1 error)
 		})
 	}
 	fake.checkReleaseBucketReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) GenerateChangelog(arg1 *changelog.Options) error {
+	fake.generateChangelogMutex.Lock()
+	ret, specificReturn := fake.generateChangelogReturnsOnCall[len(fake.generateChangelogArgsForCall)]
+	fake.generateChangelogArgsForCall = append(fake.generateChangelogArgsForCall, struct {
+		arg1 *changelog.Options
+	}{arg1})
+	stub := fake.GenerateChangelogStub
+	fakeReturns := fake.generateChangelogReturns
+	fake.recordInvocation("GenerateChangelog", []interface{}{arg1})
+	fake.generateChangelogMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) GenerateChangelogCallCount() int {
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
+	return len(fake.generateChangelogArgsForCall)
+}
+
+func (fake *FakeStageImpl) GenerateChangelogCalls(stub func(*changelog.Options) error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = stub
+}
+
+func (fake *FakeStageImpl) GenerateChangelogArgsForCall(i int) *changelog.Options {
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
+	argsForCall := fake.generateChangelogArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) GenerateChangelogReturns(result1 error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = nil
+	fake.generateChangelogReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) GenerateChangelogReturnsOnCall(i int, result1 error) {
+	fake.generateChangelogMutex.Lock()
+	defer fake.generateChangelogMutex.Unlock()
+	fake.GenerateChangelogStub = nil
+	if fake.generateChangelogReturnsOnCall == nil {
+		fake.generateChangelogReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateChangelogReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -692,6 +765,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.checkReleaseBucketMutex.RLock()
 	defer fake.checkReleaseBucketMutex.RUnlock()
+	fake.generateChangelogMutex.RLock()
+	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
 	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.makeCrossMutex.RLock()

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -127,6 +127,36 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestGenerateChangelog(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeStageImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeStageImpl) {},
+			shouldError: false,
+		},
+		{ // GenerateChangelog fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.GenerateChangelogReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultStageOptions()
+		sut := anago.NewDefaultStage(opts)
+		mock := &anagofakes.FakeStageImpl{}
+		tc.prepare(mock)
+		sut.SetClient(mock)
+		err := sut.GenerateChangelog("")
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
 func TestStageArtifacts(t *testing.T) {
 	for _, tc := range []struct {
 		prepare     func(*anagofakes.FakeStageImpl)


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
`krel stage` will now generate the changelog in the same way anago does.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1673
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added changelog generation to `krel stage`
```
