### PR TITLE
Support updating the GitHub release page from the announce page

### DIFF
--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package announce
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/github"
+	"k8s.io/release/pkg/util"
+)
+
+// ghPageBody is a generic template to build the GitHub
+// rekease page.
+const ghPageBody = `{{ if .Substitutions.logo }}
+![Logo]({{ .Substitutions.logo }} "Logo")
+{{ end }}
+{{ .Substitutions.intro }}
+{{ if .Substitutions.changelog }}
+See [the CHANGELOG]({{ .Substitutions.changelog }}) for more details.
+{{ end }}
+### Release Assets
+
+{{ range .Assets }}
+<table>
+<tr><td colspan="2">{{ if .name }}<b>{{ .name }}: </b> {{ .filename }}{{else}}<b>{{ .filename }}</b>{{end}}</td><tr>
+<tr><td>SHA256</td><td>{{ .sha256 }}</td></tr>
+<tr><td>SHA512</td><td>{{ .sha512 }}</td></tr>
+</table>
+
+{{end}}
+`
+
+// GitHubPageOptions data for building the release page
+type GitHubPageOptions struct {
+	// ReleaseType indicates if we are dealing with an alpha,
+	// beta, rc or official
+	ReleaseType string
+
+	// AssetFiles is a list of paths of files to be uploaded
+	// as assets of this release
+	AssetFiles []string
+
+	// Tag is the release the github page will be edited
+	Tag string
+
+	// The release can have a name
+	Name string
+
+	// Owner GitHub organization which owns the repository
+	Owner string
+
+	// Name of the repository where we will publish the
+	// release page. The specified tag has to exist there already
+	Repo string
+
+	// Run the whole process in non-mocked mode. Which means that it uses
+	// production remote locations for storing artifacts and modifying git
+	// repositories.
+	NoMock bool
+
+	// Create a draft release
+	Draft bool
+
+	// If the release exists, we do not overwrite the release page
+	// unless specified so.
+	UpdateIfReleaseExists bool
+
+	// We can use a custom page template by spcifiying the path. The
+	// file is a go template file that renders markdown.
+	PageTemplate string
+
+	// We automatizally calculate most values, but more substitutions for
+	// the template can be supplied
+	Substitutions map[string]string
+}
+
+// UpdateGitHubPage updates a github page with data from the release
+func UpdateGitHubPage(opts *GitHubPageOptions) (err error) {
+	token := os.Getenv(github.TokenEnvKey)
+	if token == "" {
+		return errors.New("cannot update release page without a GitHub token")
+	}
+
+	gh := github.New()
+	releaseVerb := "Posting"
+	semver, err := util.TagStringToSemver(opts.Tag)
+	if err != nil {
+		return errors.Wrap(err, "parsing semver from tag")
+	}
+
+	// Determine if this is a prerelase
+	// // [[ "$FLAGS_type" == official ]] && prerelease="false"
+	isPrerelease := false
+	if len(semver.Pre) > 0 {
+		isPrerelease = true
+	}
+
+	// Process the specified assets
+	releaseAssets, err := processAssetFiles(opts.AssetFiles)
+	if err != nil {
+		return errors.Wrap(err, "processing the asset file list")
+	}
+
+	// Check to see that a tag exists.
+	// non-draft release posts to github create a tag.  We don't want to
+	// create any tags on the repo this way. The tag should already exist
+	// as a result of the release process.
+	tagFound, err := gh.TagExists(opts.Owner, opts.Repo, opts.Tag)
+	if err != nil {
+		return errors.Wrap(err, "checking if the tag already exists in GitHub")
+	}
+	if !tagFound {
+		logrus.Warnf("The %s tag doesn't exist yet on GitHub.", opts.Tag)
+		logrus.Warnf("That can't be good.")
+		logrus.Warnf("We certainly cannot publish a release without a tag.")
+		return errors.New("tag not found while trying to publish release page")
+	}
+
+	// Get the release we are looking for
+	releases, err := gh.Releases(opts.Owner, opts.Repo, true)
+	if err != nil {
+		return errors.Wrap(err, "listing the repositories releases")
+	}
+
+	// Does the release exist yet?
+	var releaseID int64 = 0
+	commitish := ""
+	for _, release := range releases {
+		if release.GetTagName() == opts.Tag {
+			releaseID = release.GetID()
+			commitish = release.GetTargetCommitish()
+		}
+	}
+
+	if releaseID != 0 {
+		logrus.Warnf("The %s is already published on github.", opts.Tag)
+		if !opts.UpdateIfReleaseExists {
+			return errors.New("release " + opts.Tag + " already exists. Left intact")
+		}
+		logrus.Infof("Using release id %d to update existing release.", releaseID)
+		releaseVerb = "Updating"
+	}
+
+	// Post release data
+	logrus.Infof("%s the %s release on github...", releaseVerb, opts.Tag)
+
+	// Substitution struct for the template
+	subs := struct {
+		Substitutions map[string]string
+		Assets        []map[string]string
+	}{
+		Substitutions: opts.Substitutions,
+		Assets:        releaseAssets,
+	}
+
+	// Open the template file (if a custom)
+	templateText := ghPageBody
+	if opts.PageTemplate != "" {
+		logrus.Debugf("Using custom page template %s", opts.PageTemplate)
+		templateText = opts.PageTemplate
+	}
+	// Parse the template we will use to build the release page
+	tmpl, err := template.New("GitHubPage").Parse(templateText)
+	if err != nil {
+		return errors.Wrap(err, "parsing github page template")
+	}
+
+	// Run the template to verify the output.
+	output := new(bytes.Buffer)
+	err = tmpl.Execute(output, subs)
+	if err != nil {
+		return errors.Wrap(err, "executing page template")
+	}
+
+	// If we are in mock, we write it to stdout and exit
+	if !opts.NoMock {
+		logrus.Info("Mock mod, outputting the release page")
+		_, err := os.Stdout.Write(output.Bytes())
+		return errors.Wrap(err, "writing github page to stdout")
+	}
+
+	// Call GitHub to set the release page
+	release, err := gh.UpdateReleasePage(
+		opts.Owner, opts.Repo, releaseID,
+		opts.Tag, commitish, opts.Name, output.String(),
+		opts.Draft, isPrerelease,
+	)
+	if err != nil {
+		return errors.Wrap(err, "updating the release on GitHub")
+	}
+
+	// verify the release was created
+	releases, err = gh.Releases(opts.Owner, opts.Repo, true)
+	if err != nil {
+		return errors.Wrap(err, "listing releases in repository")
+	}
+	releaseFound := false
+	for _, testRelease := range releases {
+		if testRelease.GetID() == release.GetID() {
+			releaseFound = true
+			break
+		}
+	}
+	if !releaseFound {
+		return errors.New("release not found, even when call to github was successful")
+	}
+
+	if err := deleteReleaseAssets(gh, opts.Owner, opts.Repo, release.GetID()); err != nil {
+		return errors.Wrap(err, "deleting the existing release assets")
+	}
+
+	// publish binary
+	for _, assetData := range releaseAssets {
+		logrus.Infof("Uploading %s as release asset", assetData["realpath"])
+		asset, err := gh.UploadReleaseAsset(opts.Owner, opts.Repo, release.GetID(), assetData["rawpath"])
+		if err != nil {
+			return errors.Wrapf(err, "uploading %s to the release", assetData["realpath"])
+		}
+		logrus.Info("Successfully uploaded asset #", asset.GetID())
+	}
+	logrus.Infof("Release %s published on GitHub", opts.Tag)
+	return nil
+}
+
+// processAssetFiles reads the command line strings and returns
+// a map holding the needed info from the asset files
+func processAssetFiles(assetFiles []string) (releaseAssets []map[string]string, err error) {
+	// Check all asset files and get their hashes
+	for _, path := range assetFiles {
+		assetData := map[string]string{
+			"rawpath": path,
+			"name":    "",
+		}
+		// Check if asset path has a label
+		if strings.Contains(path, ":") {
+			p := strings.SplitN(path, ":", 2)
+			if len(p) == 2 {
+				path = p[0]
+				assetData["name"] = p[1]
+			}
+		}
+
+		logrus.Debugf("Checking asset file %s", path)
+
+		// Verify path exists
+		if !util.Exists(path) {
+			return nil, errors.New("unable to render release page, asset file does not exist")
+		}
+
+		assetData["realpath"] = path
+		assetData["filename"] = filepath.Base(path)
+
+		fileHashes, err := getFileHashes(path)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting the hashes")
+		}
+
+		assetData["sha512"] = fileHashes["512"]
+		assetData["sha256"] = fileHashes["256"]
+
+		releaseAssets = append(releaseAssets, assetData)
+	}
+	return releaseAssets, nil
+}
+
+func deleteReleaseAssets(gh *github.GitHub, owner, repo string, releaseID int64) error {
+	// If the release already contains assets, delete them to match
+	// the new uploads we are sending
+	currentAssets, err := gh.ListReleaseAssets(owner, repo, releaseID)
+	if err != nil {
+		return errors.Wrap(err, "while checking if the release already has assets")
+	}
+	if len(currentAssets) == 0 {
+		logrus.Info("No assets found in release")
+		return nil
+	}
+
+	logrus.Warnf("Deleting %d release assets to upload the latest files", len(currentAssets))
+	for _, asset := range currentAssets {
+		logrus.Infof("Deleting %s", asset.GetName())
+		if err := gh.DeleteReleaseAsset(owner, repo, asset.GetID()); err != nil {
+			return errors.Wrap(err, "deleting existing release assets")
+		}
+	}
+	return nil
+}
+
+// getFileHashes obtains a file's sha256 and 512
+func getFileHashes(path string) (hashes map[string]string, err error) {
+	// Get the hashes for this asset file
+	f, err := os.Open(path)
+	if err != nil {
+		return hashes, errors.Wrap(err, "opening asset file")
+	}
+	defer f.Close()
+
+	hasher256 := sha256.New()
+	hasher512 := sha512.New()
+
+	// Get the SHA256 of the file
+	if _, err := io.Copy(hasher256, f); err != nil {
+		return hashes, errors.Wrap(err, "calculating the file's sha256")
+	}
+
+	// Get the SHA512 of the file
+	if _, err := io.Copy(hasher512, f); err != nil {
+		return hashes, errors.Wrap(err, "calculating the file's sha512")
+	}
+
+	return map[string]string{
+		"256": fmt.Sprintf("%x", hasher256.Sum(nil)),
+		"512": fmt.Sprintf("%x", hasher512.Sum(nil)),
+	}, nil
+}
+
+// Validate the GitHub page options to ensure they are correct
+func (o *GitHubPageOptions) Validate() error {
+	// TODO: Check that the tag is well formed
+	if o.Tag == "" {
+		return errors.New("cannot update github page without a tag")
+	}
+	if o.Repo == "" {
+		return errors.New("cannot update github page, repository not defined")
+	}
+	if o.Owner == "" {
+		return errors.New("cannot update github page, github organization not defined")
+	}
+
+	return nil
+}
+
+// ParseSubstitutions gets a slice of strings with the substitutions
+// for the template and parses it as Substitutions in the options
+func (o *GitHubPageOptions) ParseSubstitutions(subs []string) error {
+	o.Substitutions = map[string]string{}
+	for _, sString := range subs {
+		p := strings.SplitN(sString, ":", 2)
+		if len(p) != 2 || p[0] == "" {
+			return errors.New("substitution value not well formed: " + sString)
+		}
+		o.Substitutions[p[0]] = p[1]
+	}
+	return nil
+}
+
+// SetRepository takes a repository slug in the form org/repo,
+// paeses it and assigns the values to the options
+func (o *GitHubPageOptions) SetRepository(repoSlug string) error {
+	org, repo, err := git.ParseRepoSlug(repoSlug)
+	if err != nil {
+		return errors.Wrap(err, "parsing repository slug")
+	}
+	o.Owner = org
+	o.Repo = repo
+	return nil
+}
+
+// ReadTemplate reads a custom template from a file and sets
+// the PageTemplate option with its content
+func (o *GitHubPageOptions) ReadTemplate(templatePath string) error {
+	// If path is empty, no custom template will be used
+	if templatePath == "" {
+		o.PageTemplate = ""
+		return nil
+	}
+
+	// Otherwise, read a custom template from a file
+	templateData, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		return errors.Wrap(err, "reading page template text")
+	}
+	logrus.Infof("Using custom template from %s", templatePath)
+	o.PageTemplate = string(templateData)
+	return nil
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -101,6 +101,22 @@ type Client interface {
 	GetRepository(
 		context.Context, string, string,
 	) (*github.Repository, *github.Response, error)
+
+	UpdateReleasePage(
+		context.Context, string, string, int64, *github.RepositoryRelease,
+	) (*github.RepositoryRelease, error)
+
+	UploadReleaseAsset(
+		context.Context, string, string, int64, *github.UploadOptions, *os.File,
+	) (*github.ReleaseAsset, error)
+
+	DeleteReleaseAsset(
+		context.Context, string, string, int64,
+	) error
+
+	ListReleaseAssets(
+		context.Context, string, string, int64,
+	) ([]*github.ReleaseAsset, error)
 }
 
 // New creates a new default GitHub client. Tokens set via the $GITHUB_TOKEN
@@ -277,6 +293,57 @@ func (g *githubClient) GetRepository(
 	}
 
 	return pr, resp, nil
+}
+
+func (g *githubClient) UpdateReleasePage(
+	ctx context.Context, owner, repo string, releaseID int64,
+	releaseData *github.RepositoryRelease,
+) (release *github.RepositoryRelease, err error) {
+	// If release is 0, we create a new Release
+	if releaseID == 0 {
+		release, _, err = g.Repositories.CreateRelease(ctx, owner, repo, releaseData)
+	} else {
+		release, _, err = g.Repositories.EditRelease(ctx, owner, repo, releaseID, releaseData)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "updating release pagin in github")
+	}
+
+	return release, nil
+}
+
+func (g *githubClient) UploadReleaseAsset(
+	ctx context.Context, owner, repo string, releaseID int64, opts *github.UploadOptions, file *os.File,
+) (release *github.ReleaseAsset, err error) {
+	logrus.Infof("Uploading %s to release %d", opts.Name, releaseID)
+	asset, _, err := g.Repositories.UploadReleaseAsset(
+		ctx, owner, repo, releaseID, opts, file,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "while uploading asset file")
+	}
+
+	return asset, nil
+}
+
+func (g *githubClient) DeleteReleaseAsset(
+	ctx context.Context, owner string, repo string, assetID int64) error {
+	_, err := g.Repositories.DeleteReleaseAsset(ctx, owner, repo, assetID)
+	if err != nil {
+		return errors.Wrapf(err, "deleting asset %d", assetID)
+	}
+	return nil
+}
+
+func (g *githubClient) ListReleaseAssets(
+	ctx context.Context, owner, repo string, releaseID int64,
+) ([]*github.ReleaseAsset, error) {
+	assets, _, err := g.Repositories.ListReleaseAssets(ctx, owner, repo, releaseID, &github.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting release assets from GitHub")
+	}
+	return assets, nil
 }
 
 // SetClient can be used to manually set the internal GitHub client
@@ -499,6 +566,62 @@ func (g *GitHub) downloadAssetsParallel(assets []github.ReleaseAsset, owner, rep
 	return finalErr
 }
 
+// UploadReleaseAsset uploads a file onto the release assets
+func (g *GitHub) UploadReleaseAsset(
+	owner, repo string, releaseID int64, fileName string,
+) (*github.ReleaseAsset, error) {
+	fileLabel := ""
+	// We can get a label for the asset by appeding it to the path with a colon
+	if strings.Contains(fileName, ":") {
+		p := strings.SplitN(fileName, ":", 2)
+		if len(p) == 2 {
+			fileName = p[0]
+			fileLabel = p[1]
+		}
+	}
+
+	// Check the file exists
+	if !util.Exists(fileName) {
+		return nil, errors.New("unable to upload asset, file not found")
+	}
+
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening the asset file for reading")
+	}
+
+	// Only the first 512 bytes are used to sniff the content type.
+	buffer := make([]byte, 512)
+
+	_, err = f.Read(buffer)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading file to determine mimetype")
+	}
+	// Reset the pointer to reuse the filehandle
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "rewinding the asset filepointer")
+	}
+
+	contentType := http.DetectContentType(buffer)
+	logrus.Infof("Asset filetype will be %s", contentType)
+
+	uopts := &github.UploadOptions{
+		Name:      filepath.Base(fileName),
+		Label:     fileLabel,
+		MediaType: contentType,
+	}
+
+	asset, err := g.Client().UploadReleaseAsset(
+		context.Background(), owner, repo, releaseID, uopts, f,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "uploading asset file to release")
+	}
+
+	return asset, nil
+}
+
 // CreatePullRequest Creates a new pull request in owner/repo:baseBranch to merge changes from headBranchName
 // which is a string containing a branch in the same repository or a user:branch pair
 func (g *GitHub) CreatePullRequest(
@@ -579,5 +702,74 @@ func (g *GitHub) BranchExists(
 	}
 
 	logrus.Debugf("Repository %s/%s does not have a branch named %s", owner, repo, branchname)
+	return false, nil
+}
+
+// UpdateReleasePage updates a release page in GitHub
+func (g *GitHub) UpdateReleasePage(
+	owner, repo string,
+	releaseID int64,
+	tag, commitish, name, body string,
+	isDraft, isPrerelease bool,
+) (release *github.RepositoryRelease, err error) {
+	logrus.Infof("Updating release page for %s", tag)
+
+	// Create the options for the
+	releaseData := &github.RepositoryRelease{
+		TagName:         &tag,
+		TargetCommitish: &commitish,
+		Name:            &name,
+		Body:            &body,
+		Draft:           &isDraft,
+		Prerelease:      &isPrerelease,
+	}
+
+	// Call the client
+	release, err = g.Client().UpdateReleasePage(
+		context.Background(), owner, repo, releaseID, releaseData,
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "updating the release page")
+	}
+
+	return release, nil
+}
+
+// DeleteReleaseAsset deletes an asset from a release
+func (g *GitHub) DeleteReleaseAsset(owner, repo string, assetID int64) error {
+	return errors.Wrap(g.Client().DeleteReleaseAsset(
+		context.Background(), owner, repo, assetID,
+	), "deleting asset from release")
+}
+
+// ListReleaseAssets gets the assets uploaded to a GitHub release
+func (g *GitHub) ListReleaseAssets(
+	owner, repo string, releaseID int64) ([]*github.ReleaseAsset, error) {
+	// Get the assets from the client
+	assets, err := g.Client().ListReleaseAssets(
+		context.Background(), owner, repo, releaseID,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting release assets")
+	}
+	return assets, nil
+}
+
+// TagExists returns true is a specified tag exists in the repo
+func (g *GitHub) TagExists(owner, repo, tag string) (exists bool, err error) {
+	tags, _, err := g.Client().ListTags(
+		context.Background(), owner, repo, &github.ListOptions{},
+	)
+	if err != nil {
+		return exists, errors.Wrap(err, "listing repository tags")
+	}
+
+	// List all tags and check if it exists
+	for _, testTag := range tags {
+		if testTag.GetName() == tag {
+			return true, nil
+		}
+	}
 	return false, nil
 }

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -20,6 +20,7 @@ package githubfakes
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 
 	githuba "github.com/google/go-github/v29/github"
@@ -45,6 +46,20 @@ type FakeClient struct {
 	createPullRequestReturnsOnCall map[int]struct {
 		result1 *githuba.PullRequest
 		result2 error
+	}
+	DeleteReleaseAssetStub        func(context.Context, string, string, int64) error
+	deleteReleaseAssetMutex       sync.RWMutex
+	deleteReleaseAssetArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}
+	deleteReleaseAssetReturns struct {
+		result1 error
+	}
+	deleteReleaseAssetReturnsOnCall map[int]struct {
+		result1 error
 	}
 	DownloadReleaseAssetStub        func(context.Context, string, string, int64) (io.ReadCloser, string, error)
 	downloadReleaseAssetMutex       sync.RWMutex
@@ -208,6 +223,22 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	ListReleaseAssetsStub        func(context.Context, string, string, int64) ([]*githuba.ReleaseAsset, error)
+	listReleaseAssetsMutex       sync.RWMutex
+	listReleaseAssetsArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}
+	listReleaseAssetsReturns struct {
+		result1 []*githuba.ReleaseAsset
+		result2 error
+	}
+	listReleaseAssetsReturnsOnCall map[int]struct {
+		result1 []*githuba.ReleaseAsset
+		result2 error
+	}
 	ListReleasesStub        func(context.Context, string, string, *githuba.ListOptions) ([]*githuba.RepositoryRelease, *githuba.Response, error)
 	listReleasesMutex       sync.RWMutex
 	listReleasesArgsForCall []struct {
@@ -244,6 +275,41 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	UpdateReleasePageStub        func(context.Context, string, string, int64, *githuba.RepositoryRelease) (*githuba.RepositoryRelease, error)
+	updateReleasePageMutex       sync.RWMutex
+	updateReleasePageArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+		arg5 *githuba.RepositoryRelease
+	}
+	updateReleasePageReturns struct {
+		result1 *githuba.RepositoryRelease
+		result2 error
+	}
+	updateReleasePageReturnsOnCall map[int]struct {
+		result1 *githuba.RepositoryRelease
+		result2 error
+	}
+	UploadReleaseAssetStub        func(context.Context, string, string, int64, *githuba.UploadOptions, *os.File) (*githuba.ReleaseAsset, error)
+	uploadReleaseAssetMutex       sync.RWMutex
+	uploadReleaseAssetArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+		arg5 *githuba.UploadOptions
+		arg6 *os.File
+	}
+	uploadReleaseAssetReturns struct {
+		result1 *githuba.ReleaseAsset
+		result2 error
+	}
+	uploadReleaseAssetReturnsOnCall map[int]struct {
+		result1 *githuba.ReleaseAsset
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -260,15 +326,16 @@ func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg
 		arg6 string
 		arg7 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	stub := fake.CreatePullRequestStub
+	fakeReturns := fake.createPullRequestReturns
 	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.createPullRequestMutex.Unlock()
-	if fake.CreatePullRequestStub != nil {
-		return fake.CreatePullRequestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createPullRequestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -317,6 +384,70 @@ func (fake *FakeClient) CreatePullRequestReturnsOnCall(i int, result1 *githuba.P
 	}{result1, result2}
 }
 
+func (fake *FakeClient) DeleteReleaseAsset(arg1 context.Context, arg2 string, arg3 string, arg4 int64) error {
+	fake.deleteReleaseAssetMutex.Lock()
+	ret, specificReturn := fake.deleteReleaseAssetReturnsOnCall[len(fake.deleteReleaseAssetArgsForCall)]
+	fake.deleteReleaseAssetArgsForCall = append(fake.deleteReleaseAssetArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.DeleteReleaseAssetStub
+	fakeReturns := fake.deleteReleaseAssetReturns
+	fake.recordInvocation("DeleteReleaseAsset", []interface{}{arg1, arg2, arg3, arg4})
+	fake.deleteReleaseAssetMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeleteReleaseAssetCallCount() int {
+	fake.deleteReleaseAssetMutex.RLock()
+	defer fake.deleteReleaseAssetMutex.RUnlock()
+	return len(fake.deleteReleaseAssetArgsForCall)
+}
+
+func (fake *FakeClient) DeleteReleaseAssetCalls(stub func(context.Context, string, string, int64) error) {
+	fake.deleteReleaseAssetMutex.Lock()
+	defer fake.deleteReleaseAssetMutex.Unlock()
+	fake.DeleteReleaseAssetStub = stub
+}
+
+func (fake *FakeClient) DeleteReleaseAssetArgsForCall(i int) (context.Context, string, string, int64) {
+	fake.deleteReleaseAssetMutex.RLock()
+	defer fake.deleteReleaseAssetMutex.RUnlock()
+	argsForCall := fake.deleteReleaseAssetArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) DeleteReleaseAssetReturns(result1 error) {
+	fake.deleteReleaseAssetMutex.Lock()
+	defer fake.deleteReleaseAssetMutex.Unlock()
+	fake.DeleteReleaseAssetStub = nil
+	fake.deleteReleaseAssetReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteReleaseAssetReturnsOnCall(i int, result1 error) {
+	fake.deleteReleaseAssetMutex.Lock()
+	defer fake.deleteReleaseAssetMutex.Unlock()
+	fake.DeleteReleaseAssetStub = nil
+	if fake.deleteReleaseAssetReturnsOnCall == nil {
+		fake.deleteReleaseAssetReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteReleaseAssetReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeClient) DownloadReleaseAsset(arg1 context.Context, arg2 string, arg3 string, arg4 int64) (io.ReadCloser, string, error) {
 	fake.downloadReleaseAssetMutex.Lock()
 	ret, specificReturn := fake.downloadReleaseAssetReturnsOnCall[len(fake.downloadReleaseAssetArgsForCall)]
@@ -326,15 +457,16 @@ func (fake *FakeClient) DownloadReleaseAsset(arg1 context.Context, arg2 string, 
 		arg3 string
 		arg4 int64
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.DownloadReleaseAssetStub
+	fakeReturns := fake.downloadReleaseAssetReturns
 	fake.recordInvocation("DownloadReleaseAsset", []interface{}{arg1, arg2, arg3, arg4})
 	fake.downloadReleaseAssetMutex.Unlock()
-	if fake.DownloadReleaseAssetStub != nil {
-		return fake.DownloadReleaseAssetStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.downloadReleaseAssetReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -395,15 +527,16 @@ func (fake *FakeClient) GetCommit(arg1 context.Context, arg2 string, arg3 string
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetCommitStub
+	fakeReturns := fake.getCommitReturns
 	fake.recordInvocation("GetCommit", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getCommitMutex.Unlock()
-	if fake.GetCommitStub != nil {
-		return fake.GetCommitStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getCommitReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -464,15 +597,16 @@ func (fake *FakeClient) GetPullRequest(arg1 context.Context, arg2 string, arg3 s
 		arg3 string
 		arg4 int
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetPullRequestStub
+	fakeReturns := fake.getPullRequestReturns
 	fake.recordInvocation("GetPullRequest", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getPullRequestMutex.Unlock()
-	if fake.GetPullRequestStub != nil {
-		return fake.GetPullRequestStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getPullRequestReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -533,15 +667,16 @@ func (fake *FakeClient) GetReleaseByTag(arg1 context.Context, arg2 string, arg3 
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetReleaseByTagStub
+	fakeReturns := fake.getReleaseByTagReturns
 	fake.recordInvocation("GetReleaseByTag", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getReleaseByTagMutex.Unlock()
-	if fake.GetReleaseByTagStub != nil {
-		return fake.GetReleaseByTagStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getReleaseByTagReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -602,15 +737,16 @@ func (fake *FakeClient) GetRepoCommit(arg1 context.Context, arg2 string, arg3 st
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetRepoCommitStub
+	fakeReturns := fake.getRepoCommitReturns
 	fake.recordInvocation("GetRepoCommit", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getRepoCommitMutex.Unlock()
-	if fake.GetRepoCommitStub != nil {
-		return fake.GetRepoCommitStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getRepoCommitReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -670,15 +806,16 @@ func (fake *FakeClient) GetRepository(arg1 context.Context, arg2 string, arg3 st
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.GetRepositoryStub
+	fakeReturns := fake.getRepositoryReturns
 	fake.recordInvocation("GetRepository", []interface{}{arg1, arg2, arg3})
 	fake.getRepositoryMutex.Unlock()
-	if fake.GetRepositoryStub != nil {
-		return fake.GetRepositoryStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getRepositoryReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -739,15 +876,16 @@ func (fake *FakeClient) ListBranches(arg1 context.Context, arg2 string, arg3 str
 		arg3 string
 		arg4 *githuba.BranchListOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListBranchesStub
+	fakeReturns := fake.listBranchesReturns
 	fake.recordInvocation("ListBranches", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listBranchesMutex.Unlock()
-	if fake.ListBranchesStub != nil {
-		return fake.ListBranchesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.listBranchesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -808,15 +946,16 @@ func (fake *FakeClient) ListCommits(arg1 context.Context, arg2 string, arg3 stri
 		arg3 string
 		arg4 *githuba.CommitsListOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListCommitsStub
+	fakeReturns := fake.listCommitsReturns
 	fake.recordInvocation("ListCommits", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listCommitsMutex.Unlock()
-	if fake.ListCommitsStub != nil {
-		return fake.ListCommitsStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.listCommitsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -878,15 +1017,16 @@ func (fake *FakeClient) ListPullRequestsWithCommit(arg1 context.Context, arg2 st
 		arg4 string
 		arg5 *githuba.PullRequestListOptions
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.ListPullRequestsWithCommitStub
+	fakeReturns := fake.listPullRequestsWithCommitReturns
 	fake.recordInvocation("ListPullRequestsWithCommit", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.listPullRequestsWithCommitMutex.Unlock()
-	if fake.ListPullRequestsWithCommitStub != nil {
-		return fake.ListPullRequestsWithCommitStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.listPullRequestsWithCommitReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -938,6 +1078,73 @@ func (fake *FakeClient) ListPullRequestsWithCommitReturnsOnCall(i int, result1 [
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListReleaseAssets(arg1 context.Context, arg2 string, arg3 string, arg4 int64) ([]*githuba.ReleaseAsset, error) {
+	fake.listReleaseAssetsMutex.Lock()
+	ret, specificReturn := fake.listReleaseAssetsReturnsOnCall[len(fake.listReleaseAssetsArgsForCall)]
+	fake.listReleaseAssetsArgsForCall = append(fake.listReleaseAssetsArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListReleaseAssetsStub
+	fakeReturns := fake.listReleaseAssetsReturns
+	fake.recordInvocation("ListReleaseAssets", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listReleaseAssetsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListReleaseAssetsCallCount() int {
+	fake.listReleaseAssetsMutex.RLock()
+	defer fake.listReleaseAssetsMutex.RUnlock()
+	return len(fake.listReleaseAssetsArgsForCall)
+}
+
+func (fake *FakeClient) ListReleaseAssetsCalls(stub func(context.Context, string, string, int64) ([]*githuba.ReleaseAsset, error)) {
+	fake.listReleaseAssetsMutex.Lock()
+	defer fake.listReleaseAssetsMutex.Unlock()
+	fake.ListReleaseAssetsStub = stub
+}
+
+func (fake *FakeClient) ListReleaseAssetsArgsForCall(i int) (context.Context, string, string, int64) {
+	fake.listReleaseAssetsMutex.RLock()
+	defer fake.listReleaseAssetsMutex.RUnlock()
+	argsForCall := fake.listReleaseAssetsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) ListReleaseAssetsReturns(result1 []*githuba.ReleaseAsset, result2 error) {
+	fake.listReleaseAssetsMutex.Lock()
+	defer fake.listReleaseAssetsMutex.Unlock()
+	fake.ListReleaseAssetsStub = nil
+	fake.listReleaseAssetsReturns = struct {
+		result1 []*githuba.ReleaseAsset
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListReleaseAssetsReturnsOnCall(i int, result1 []*githuba.ReleaseAsset, result2 error) {
+	fake.listReleaseAssetsMutex.Lock()
+	defer fake.listReleaseAssetsMutex.Unlock()
+	fake.ListReleaseAssetsStub = nil
+	if fake.listReleaseAssetsReturnsOnCall == nil {
+		fake.listReleaseAssetsReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.ReleaseAsset
+			result2 error
+		})
+	}
+	fake.listReleaseAssetsReturnsOnCall[i] = struct {
+		result1 []*githuba.ReleaseAsset
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListReleases(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.ListOptions) ([]*githuba.RepositoryRelease, *githuba.Response, error) {
 	fake.listReleasesMutex.Lock()
 	ret, specificReturn := fake.listReleasesReturnsOnCall[len(fake.listReleasesArgsForCall)]
@@ -947,15 +1154,16 @@ func (fake *FakeClient) ListReleases(arg1 context.Context, arg2 string, arg3 str
 		arg3 string
 		arg4 *githuba.ListOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListReleasesStub
+	fakeReturns := fake.listReleasesReturns
 	fake.recordInvocation("ListReleases", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listReleasesMutex.Unlock()
-	if fake.ListReleasesStub != nil {
-		return fake.ListReleasesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.listReleasesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1016,15 +1224,16 @@ func (fake *FakeClient) ListTags(arg1 context.Context, arg2 string, arg3 string,
 		arg3 string
 		arg4 *githuba.ListOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListTagsStub
+	fakeReturns := fake.listTagsReturns
 	fake.recordInvocation("ListTags", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listTagsMutex.Unlock()
-	if fake.ListTagsStub != nil {
-		return fake.ListTagsStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.listTagsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1076,11 +1285,150 @@ func (fake *FakeClient) ListTagsReturnsOnCall(i int, result1 []*githuba.Reposito
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) UpdateReleasePage(arg1 context.Context, arg2 string, arg3 string, arg4 int64, arg5 *githuba.RepositoryRelease) (*githuba.RepositoryRelease, error) {
+	fake.updateReleasePageMutex.Lock()
+	ret, specificReturn := fake.updateReleasePageReturnsOnCall[len(fake.updateReleasePageArgsForCall)]
+	fake.updateReleasePageArgsForCall = append(fake.updateReleasePageArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+		arg5 *githuba.RepositoryRelease
+	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.UpdateReleasePageStub
+	fakeReturns := fake.updateReleasePageReturns
+	fake.recordInvocation("UpdateReleasePage", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.updateReleasePageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) UpdateReleasePageCallCount() int {
+	fake.updateReleasePageMutex.RLock()
+	defer fake.updateReleasePageMutex.RUnlock()
+	return len(fake.updateReleasePageArgsForCall)
+}
+
+func (fake *FakeClient) UpdateReleasePageCalls(stub func(context.Context, string, string, int64, *githuba.RepositoryRelease) (*githuba.RepositoryRelease, error)) {
+	fake.updateReleasePageMutex.Lock()
+	defer fake.updateReleasePageMutex.Unlock()
+	fake.UpdateReleasePageStub = stub
+}
+
+func (fake *FakeClient) UpdateReleasePageArgsForCall(i int) (context.Context, string, string, int64, *githuba.RepositoryRelease) {
+	fake.updateReleasePageMutex.RLock()
+	defer fake.updateReleasePageMutex.RUnlock()
+	argsForCall := fake.updateReleasePageArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakeClient) UpdateReleasePageReturns(result1 *githuba.RepositoryRelease, result2 error) {
+	fake.updateReleasePageMutex.Lock()
+	defer fake.updateReleasePageMutex.Unlock()
+	fake.UpdateReleasePageStub = nil
+	fake.updateReleasePageReturns = struct {
+		result1 *githuba.RepositoryRelease
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) UpdateReleasePageReturnsOnCall(i int, result1 *githuba.RepositoryRelease, result2 error) {
+	fake.updateReleasePageMutex.Lock()
+	defer fake.updateReleasePageMutex.Unlock()
+	fake.UpdateReleasePageStub = nil
+	if fake.updateReleasePageReturnsOnCall == nil {
+		fake.updateReleasePageReturnsOnCall = make(map[int]struct {
+			result1 *githuba.RepositoryRelease
+			result2 error
+		})
+	}
+	fake.updateReleasePageReturnsOnCall[i] = struct {
+		result1 *githuba.RepositoryRelease
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) UploadReleaseAsset(arg1 context.Context, arg2 string, arg3 string, arg4 int64, arg5 *githuba.UploadOptions, arg6 *os.File) (*githuba.ReleaseAsset, error) {
+	fake.uploadReleaseAssetMutex.Lock()
+	ret, specificReturn := fake.uploadReleaseAssetReturnsOnCall[len(fake.uploadReleaseAssetArgsForCall)]
+	fake.uploadReleaseAssetArgsForCall = append(fake.uploadReleaseAssetArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int64
+		arg5 *githuba.UploadOptions
+		arg6 *os.File
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.UploadReleaseAssetStub
+	fakeReturns := fake.uploadReleaseAssetReturns
+	fake.recordInvocation("UploadReleaseAsset", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.uploadReleaseAssetMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) UploadReleaseAssetCallCount() int {
+	fake.uploadReleaseAssetMutex.RLock()
+	defer fake.uploadReleaseAssetMutex.RUnlock()
+	return len(fake.uploadReleaseAssetArgsForCall)
+}
+
+func (fake *FakeClient) UploadReleaseAssetCalls(stub func(context.Context, string, string, int64, *githuba.UploadOptions, *os.File) (*githuba.ReleaseAsset, error)) {
+	fake.uploadReleaseAssetMutex.Lock()
+	defer fake.uploadReleaseAssetMutex.Unlock()
+	fake.UploadReleaseAssetStub = stub
+}
+
+func (fake *FakeClient) UploadReleaseAssetArgsForCall(i int) (context.Context, string, string, int64, *githuba.UploadOptions, *os.File) {
+	fake.uploadReleaseAssetMutex.RLock()
+	defer fake.uploadReleaseAssetMutex.RUnlock()
+	argsForCall := fake.uploadReleaseAssetArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+}
+
+func (fake *FakeClient) UploadReleaseAssetReturns(result1 *githuba.ReleaseAsset, result2 error) {
+	fake.uploadReleaseAssetMutex.Lock()
+	defer fake.uploadReleaseAssetMutex.Unlock()
+	fake.UploadReleaseAssetStub = nil
+	fake.uploadReleaseAssetReturns = struct {
+		result1 *githuba.ReleaseAsset
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) UploadReleaseAssetReturnsOnCall(i int, result1 *githuba.ReleaseAsset, result2 error) {
+	fake.uploadReleaseAssetMutex.Lock()
+	defer fake.uploadReleaseAssetMutex.Unlock()
+	fake.UploadReleaseAssetStub = nil
+	if fake.uploadReleaseAssetReturnsOnCall == nil {
+		fake.uploadReleaseAssetReturnsOnCall = make(map[int]struct {
+			result1 *githuba.ReleaseAsset
+			result2 error
+		})
+	}
+	fake.uploadReleaseAssetReturnsOnCall[i] = struct {
+		result1 *githuba.ReleaseAsset
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.createPullRequestMutex.RLock()
 	defer fake.createPullRequestMutex.RUnlock()
+	fake.deleteReleaseAssetMutex.RLock()
+	defer fake.deleteReleaseAssetMutex.RUnlock()
 	fake.downloadReleaseAssetMutex.RLock()
 	defer fake.downloadReleaseAssetMutex.RUnlock()
 	fake.getCommitMutex.RLock()
@@ -1099,10 +1447,16 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listCommitsMutex.RUnlock()
 	fake.listPullRequestsWithCommitMutex.RLock()
 	defer fake.listPullRequestsWithCommitMutex.RUnlock()
+	fake.listReleaseAssetsMutex.RLock()
+	defer fake.listReleaseAssetsMutex.RUnlock()
 	fake.listReleasesMutex.RLock()
 	defer fake.listReleasesMutex.RUnlock()
 	fake.listTagsMutex.RLock()
 	defer fake.listTagsMutex.RUnlock()
+	fake.updateReleasePageMutex.RLock()
+	defer fake.updateReleasePageMutex.RUnlock()
+	fake.uploadReleaseAssetMutex.RLock()
+	defer fake.uploadReleaseAssetMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -44,6 +44,7 @@ const (
 	gitHubAPIGetRepository              gitHubAPI = "GetRepository"
 	gitHubAPIListBranches               gitHubAPI = "ListBranches"
 	gitHubAPIGetReleaseByTag            gitHubAPI = "GetReleaseByTag"
+	gitHubAPIListReleaseAssets          gitHubAPI = "ListReleaseAssets"
 )
 
 type apiRecord struct {
@@ -205,6 +206,41 @@ func (c *githubNotesRecordClient) ListBranches(
 	}
 
 	return branches, resp, nil
+}
+
+// UpdateReleasePage modifies a release, not recorded
+func (c *githubNotesRecordClient) UpdateReleasePage(
+	ctx context.Context, owner, repo string, releaseID int64, releaseData *github.RepositoryRelease,
+) (*github.RepositoryRelease, error) {
+	return &github.RepositoryRelease{}, nil
+}
+
+// UploadReleaseAsset uploads files, not recorded
+func (c *githubNotesRecordClient) UploadReleaseAsset(
+	context.Context, string, string, int64, *github.UploadOptions, *os.File,
+) (*github.ReleaseAsset, error) {
+	return &github.ReleaseAsset{}, nil
+}
+
+// DeleteReleaseAsset removes an asset from a page, note recorded
+func (c *githubNotesRecordClient) DeleteReleaseAsset(
+	ctx context.Context, owner, repo string, assetID int64) error {
+	return nil
+}
+
+func (c *githubNotesRecordClient) ListReleaseAssets(
+	ctx context.Context, owner, repo string, releaseID int64,
+) ([]*github.ReleaseAsset, error) {
+	assets, err := c.client.ListReleaseAssets(ctx, owner, repo, releaseID)
+	if err != nil {
+		return assets, err
+	}
+
+	if err := c.recordAPICall(gitHubAPIListReleaseAssets, assets, nil); err != nil {
+		return nil, err
+	}
+
+	return assets, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -211,4 +212,39 @@ func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error
 
 	c.replayState[api]++
 	return file, nil
+}
+
+// UpdateReleasePage modifies a release, not recorded
+func (c *githubNotesReplayClient) UpdateReleasePage(
+	ctx context.Context, owner, repo string, releaseID int64, releaseData *github.RepositoryRelease,
+) (*github.RepositoryRelease, error) {
+	return &github.RepositoryRelease{}, nil
+}
+
+// UploadReleaseAsset uploads files, not recorded
+func (c *githubNotesReplayClient) UploadReleaseAsset(
+	context.Context, string, string, int64, *github.UploadOptions, *os.File,
+) (*github.ReleaseAsset, error) {
+	return &github.ReleaseAsset{}, nil
+}
+
+// DeleteReleaseAsset removes an asset from a page, note recorded
+func (c *githubNotesReplayClient) DeleteReleaseAsset(
+	ctx context.Context, owner, repo string, assetID int64) error {
+	return nil
+}
+
+func (c *githubNotesReplayClient) ListReleaseAssets(
+	ctx context.Context, owner, repo string, releaseID int64,
+) ([]*github.ReleaseAsset, error) {
+	data, err := c.readRecordedData(gitHubAPIListReleaseAssets)
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*github.ReleaseAsset, 0)
+	record := apiRecord{Result: assets}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, err
+	}
+	return assets, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds new functionality to the announce package to build the GitHub release page and upload it's assets. It also adds the required functions  to the GitHub package. The PR is split in two commits:

- The first one adds the following function to the `github` package, replay/record clientes and I've re-generated the fake client:
  * `UpdateReleasePage()` creates or updates the releases page. It is idempotent.
  * `ListReleaseAssets()`, `DeleteReleaseAsset()` and `UploadReleaseAsset()` handle listing deleting and uploading files to the github release.
- The second commit adds a new file to the announce package: `github_page.go`. This file adds the code to implement the `announce.UpdateGitHubPage()` method which creates or updates the GitHub release page.

All asset files support adding labels and get their SHA[256|512] checksums calculated. These properties are made available to the page template.

The current implementation includes a generic template to build the GitHub page. It is _not_ the page we currently publish when a release is cut. That template will come in the `krel release` integration of this code. The idea is to have a reusable announce code and not to hardcode the k/k release page.


#### Which issue(s) this PR fixes:

Part of #1673

#### Special notes for your reviewer:

I have not included any tests because I'd like to talk a bit what we should test and what's expected of them.

#### Does this PR introduce a user-facing change?

```release-note
- The `announce` package now has the capability to create/update the GitHub page of a release and upload asset files
- New functions added to the github package: `UpdateReleasePage()` as well as `ListReleaseAssets()`, `DeleteReleaseAsset()` and `UploadReleaseAsset()` to work with asset files
```
