### PR TITLE
New tool: publish-release utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ across branches.
 - [End User](#end-user)
   - [`release-notes`](#release-notes)
   - [`gcbuilder`](#gcbuilder)
+  - [`publish-release`](#publish-release)
 - [Legacy](#legacy)
   - [`push-build.sh`](#push-buildsh)
 - [Contributing](#contributing)
@@ -121,6 +122,13 @@ substitutions.
 Status: Unused
 
 Details: [Documentation](/cmd/gcbuilder/README.md)
+
+### [`publish-release`](/cmd/publish-release)
+
+A tool to announce software releases. Currently supports updating the
+release page on GitHub based on templates and updating release artifacts.
+
+Details: [Documentation](cmd/publish-release/README.md)
 
 ## Legacy
 

--- a/cmd/publish-release/README.md
+++ b/cmd/publish-release/README.md
@@ -1,0 +1,68 @@
+# publish-release
+
+## A tool to publish releases
+
+`publish-release` is a command to publish and announce software releases. 
+The current implementation implements a subcommand to update a release page
+un GitHub, future plans include incorporating SIG Release's announce email 
+tool in a generic form.
+
+### Update a GitHub release page
+
+This command allows you to update a release page on GitHub. You can define 
+your logo, name of the release, a link to your changelog and an introductory
+text.
+
+You can customize the look of the release page look by using a custom golang
+template with any number of string substitutions.
+
+```
+This command updates the GitHub release page for a given tag. It will
+update the page using a built in template or you can update it using
+a custom template.
+
+Before updating the page, the tag has to exist already on github.
+
+To publish the page, --nomock has to be defined. Otherwise, the rendered
+page will be printed to stdout and the program will exit.
+
+CUSTOM TEMPLATES
+================
+You can define a custom golang template to use in your release page. Your
+template can contain string substitutions and you can define those using 
+the --substitution flag:
+
+  --substitution="releaseTheme:Accentuate the Paw-sitive"
+  --substitution="releaseLogo:accentuate-the-pawsitive.png"
+
+ASSET FILES
+===========
+This command supports uploading release assets to the github page. You
+can add asset files with the --asset flag:
+
+  --asset=_output/kubernetes-1.18.2-2.fc33.x86_64.rpm
+
+You can also specify a label for the assets by appending it with a colon
+to the asset file:
+
+  --asset="_output/kubernetes-1.18.2-2.fc33.x86_64.rpm:RPM Package for amd64"
+
+Usage:
+  release-announce github [flags]
+
+Flags:
+  -a, --asset strings          Path to asset file for the release. Can be specified multiple times.
+      --draft                  Mark the release as a draft in GitHub so you can finish editing and publish it manually.
+  -h, --help                   help for github
+  -n, --name string            name for the release
+      --noupdate               Fail if the release already exists
+  -r, --repo string            repository slug containing the release page
+  -s, --substitution strings   String substitution for the page template
+      --template string        path to a custom page template
+
+Global Flags:
+      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace' (default "info")
+      --nomock             tag for the release to be used
+  -t, --tag string         tag for the release to be used
+
+```

--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/announce"
+)
+
+// releaseNotesCmd represents the subcommand for `krel release-notes`
+var githuPageCmd = &cobra.Command{
+	Use:   "github",
+	Short: "Updates the github page of a release",
+	Long: `publish-release github
+
+This command updates the GitHub release page for a given tag. It will
+update the page using a built in template or you can update it using
+a custom template.
+
+Before updating the page, the tag has to exist already on github.
+
+To publish the page, --nomock has to be defined. Otherwise, the rendered
+page will be printed to stdout and the program will exit.
+
+CUSTOM TEMPLATES
+================
+You can define a custom golang template to use in your release page. Your
+template can contain string substitutions and you can define those using 
+the --substitution flag:
+
+  --substitution="releaseTheme:Accentuate the Paw-sitive"
+  --substitution="releaseLogo:accentuate-the-pawsitive.png"
+
+ASSET FILES
+===========
+This command supports uploading release assets to the github page. You
+can add asset files with the --asset flag:
+
+  --asset=_output/kubernetes-1.18.2-2.fc33.x86_64.rpm
+
+You can also specify a label for the assets by appending it with a colon
+to the asset file:
+
+  --asset="_output/kubernetes-1.18.2-2.fc33.x86_64.rpm:RPM Package for amd64"
+
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Run the PR creation function
+		return runGithubPage(ghPageOpts)
+	},
+}
+
+type githubPageCmdLineOptions struct {
+	noupdate      bool
+	draft         bool
+	name          string
+	repo          string
+	template      string
+	substitutions []string
+	assets        []string
+}
+
+var ghPageOpts = &githubPageCmdLineOptions{}
+
+func init() {
+	githuPageCmd.PersistentFlags().StringVarP(
+		&ghPageOpts.repo,
+		"repo",
+		"r",
+		"",
+		"repository slug containing the release page",
+	)
+	githuPageCmd.PersistentFlags().StringVar(
+		&ghPageOpts.template,
+		"template",
+		"",
+		"path to a custom page template",
+	)
+	githuPageCmd.PersistentFlags().StringVarP(
+		&ghPageOpts.name,
+		"name",
+		"n",
+		"",
+		"name for the release",
+	)
+	githuPageCmd.PersistentFlags().StringSliceVarP(
+		&ghPageOpts.assets,
+		"asset",
+		"a",
+		[]string{},
+		"Path to asset file for the release. Can be specified multiple times.",
+	)
+	githuPageCmd.PersistentFlags().StringSliceVarP(
+		&ghPageOpts.substitutions,
+		"substitution",
+		"s",
+		[]string{},
+		"String substitution for the page template",
+	)
+	githuPageCmd.PersistentFlags().BoolVar(
+		&ghPageOpts.noupdate,
+		"noupdate",
+		false,
+		"Fail if the release already exists",
+	)
+	githuPageCmd.PersistentFlags().BoolVar(
+		&ghPageOpts.draft,
+		"draft",
+		false,
+		"Mark the release as a draft in GitHub so you can finish editing and publish it manually.",
+	)
+	rootCmd.AddCommand(githuPageCmd)
+}
+
+func runGithubPage(opts *githubPageCmdLineOptions) error {
+	// Build the release page options
+	announceOpts := announce.GitHubPageOptions{
+		AssetFiles:            opts.assets,
+		Tag:                   commandLineOpts.tag,
+		NoMock:                commandLineOpts.nomock,
+		UpdateIfReleaseExists: !opts.noupdate,
+		Name:                  opts.name,
+		Draft:                 opts.draft,
+	}
+
+	// Assign the repository data
+	if err := announceOpts.SetRepository(opts.repo); err != nil {
+		return errors.Wrap(err, "assigning the repository slug")
+	}
+
+	// Assign the substitutions
+	if err := announceOpts.ParseSubstitutions(opts.substitutions); err != nil {
+		return errors.Wrap(err, "parsing template substitutions")
+	}
+
+	// Read the csutom template data
+	if err := announceOpts.ReadTemplate(opts.template); err != nil {
+		return errors.Wrap(err, "reading the template file")
+	}
+
+	// Validate the options
+	if err := announceOpts.Validate(); err != nil {
+		return errors.Wrap(err, "validating options")
+	}
+
+	// Run the update process
+	return announce.UpdateGitHubPage(&announceOpts)
+}

--- a/cmd/publish-release/cmd/root.go
+++ b/cmd/publish-release/cmd/root.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/log"
+)
+
+var rootCmd = &cobra.Command{
+	Short: "publish-release → A tool for announcing software releases",
+	Long: `publish-release → A tool for announcing software releases
+
+This tool lets software developers announce new software releases.
+
+`,
+	Use:               "publish-release",
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	PersistentPreRunE: initLogging,
+}
+
+type commandLineOptions struct {
+	nomock   bool
+	logLevel string
+	tag      string
+}
+
+var commandLineOpts = &commandLineOptions{}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(
+		&commandLineOpts.tag,
+		"tag",
+		"t",
+		"",
+		"tag for the release to be used",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&commandLineOpts.nomock,
+		"nomock",
+		false,
+		"run in no mock mode, otherwise only prints to stdout",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&commandLineOpts.logLevel,
+		"log-level",
+		"info",
+		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
+	)
+}
+
+// Execute builds the command
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func initLogging(*cobra.Command, []string) error {
+	return log.SetupGlobalLogger(commandLineOpts.logLevel)
+}

--- a/cmd/publish-release/main.go
+++ b/cmd/publish-release/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"k8s.io/release/cmd/publish-release/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Just as we have seen adoption of the `release-notes` tool in other projects, I propose making available the announcement features of SIG Release in a new tool: `publish-release`.

This first implementation adds a single subcommand to the tool: `publish-release github`. 

This subcommand takes several arguments to update the GitHub release page of a given tag. It implements all of the announcement packages features to create/update the release page. 

An example:
```bash
publish-release github --repo="puerco/testPush" -t=v1.13.0-beta.0 --nomock \
  --asset="kubernetes-1.18.2-2.fc33.x86_64.rpm:K8s RPM for amd64" \
  --asset="kubens_v0.9.0_linux_x86_64.tar.gz" \
  --name="Kubernetes v1.13.0-beta.0" \
  --substitution="intro:This is a special kubernetes release focused on stability and less features." \
  --substitution="logo:https://raw.githubusercontent.com/puerco/lab/master/kubernetes.png"
```

That run uses the generic (included) template to render this release page:
https://github.com/puerco/testPush/releases/tag/v1.13.0-beta.0

This is the current --help output:

```
]$ publish-release github --help

This command updates the GitHub release page for a given tag. It will
update the page using a built in template or you can update it using
a custom template.

Before updating the page, the tag has to exist already on github.

To publish the page, --nomock has to be defined. Otherwise, the rendered
page will be printed to stdout and the program will exit.

CUSTOM TEMPLATES
================
You can define a custom golang template to use in your release page. Your
template can contain string substitutions and you can define those using 
the --substitution flag:

  --substitution="releaseTheme:Accentuate the Paw-sitive"
  --substitution="releaseLogo:accentuate-the-pawsitive.png"

ASSET FILES
===========
This command supports uploading release assets to the github page. You
can add asset files with the --asset flag:

  --asset=_output/kubernetes-1.18.2-2.fc33.x86_64.rpm

You can also specify a label for the assets by appending it with a colon
to the asset file:

  --asset="_output/kubernetes-1.18.2-2.fc33.x86_64.rpm:RPM Package for amd64"

Usage:
  release-announce github [flags]

Flags:
  -a, --asset strings          Path to asset file for the release. Can be specified multiple times.
      --draft                  Mark the release as a draft in GitHub so you can finish editing and publish it manually.
  -h, --help                   help for github
  -n, --name string            name for the release
      --noupdate               Fail if the release already exists
  -r, --repo string            repository slug containing the release page
  -s, --substitution strings   String substitution for the page template
      --template string        path to a custom page template

Global Flags:
      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace' (default "info")
      --nomock             tag for the release to be used
  -t, --tag string         tag for the release to be used

```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Same as in #1704 no test are included as I want to write them once we discuss them

#### Does this PR introduce a user-facing change?
```release-note
- New tool `publish-release` to make available our release announcement tools to other projects.
```
