### PR TITLE
Fix krel stage local source tree archiving

### DIFF
--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -17,6 +17,7 @@ limitations under the License.
 package anago
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -125,8 +126,13 @@ func runPushStage(
 	buildInstance *build.Instance,
 	opts *build.Options,
 ) error {
+	workDir := os.Getenv("GOPATH")
+	if workDir == "" {
+		return errors.New("GOPATH is not set")
+	}
+
 	// Stage the local source tree
-	if err := buildInstance.StageLocalSourceTree(buildVersion); err != nil {
+	if err := buildInstance.StageLocalSourceTree(workDir, buildVersion); err != nil {
 		return errors.Wrap(err, "staging local source tree")
 	}
 

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -120,11 +120,12 @@ type FakeStageImpl struct {
 	stageLocalArtifactsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StageLocalSourceTreeStub        func(*build.Options, string) error
+	StageLocalSourceTreeStub        func(*build.Options, string, string) error
 	stageLocalSourceTreeMutex       sync.RWMutex
 	stageLocalSourceTreeArgsForCall []struct {
 		arg1 *build.Options
 		arg2 string
+		arg3 string
 	}
 	stageLocalSourceTreeReturns struct {
 		result1 error
@@ -636,19 +637,20 @@ func (fake *FakeStageImpl) StageLocalArtifactsReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeStageImpl) StageLocalSourceTree(arg1 *build.Options, arg2 string) error {
+func (fake *FakeStageImpl) StageLocalSourceTree(arg1 *build.Options, arg2 string, arg3 string) error {
 	fake.stageLocalSourceTreeMutex.Lock()
 	ret, specificReturn := fake.stageLocalSourceTreeReturnsOnCall[len(fake.stageLocalSourceTreeArgsForCall)]
 	fake.stageLocalSourceTreeArgsForCall = append(fake.stageLocalSourceTreeArgsForCall, struct {
 		arg1 *build.Options
 		arg2 string
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.StageLocalSourceTreeStub
 	fakeReturns := fake.stageLocalSourceTreeReturns
-	fake.recordInvocation("StageLocalSourceTree", []interface{}{arg1, arg2})
+	fake.recordInvocation("StageLocalSourceTree", []interface{}{arg1, arg2, arg3})
 	fake.stageLocalSourceTreeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -662,17 +664,17 @@ func (fake *FakeStageImpl) StageLocalSourceTreeCallCount() int {
 	return len(fake.stageLocalSourceTreeArgsForCall)
 }
 
-func (fake *FakeStageImpl) StageLocalSourceTreeCalls(stub func(*build.Options, string) error) {
+func (fake *FakeStageImpl) StageLocalSourceTreeCalls(stub func(*build.Options, string, string) error) {
 	fake.stageLocalSourceTreeMutex.Lock()
 	defer fake.stageLocalSourceTreeMutex.Unlock()
 	fake.StageLocalSourceTreeStub = stub
 }
 
-func (fake *FakeStageImpl) StageLocalSourceTreeArgsForCall(i int) (*build.Options, string) {
+func (fake *FakeStageImpl) StageLocalSourceTreeArgsForCall(i int) (*build.Options, string, string) {
 	fake.stageLocalSourceTreeMutex.RLock()
 	defer fake.stageLocalSourceTreeMutex.RUnlock()
 	argsForCall := fake.stageLocalSourceTreeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStageImpl) StageLocalSourceTreeReturns(result1 error) {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -103,7 +103,7 @@ type stageImpl interface {
 	MakeCross(version string) error
 	GenerateChangelog(options *changelog.Options) error
 	StageLocalSourceTree(
-		options *build.Options, buildVersion string,
+		options *build.Options, workDir, buildVersion string,
 	) error
 	StageLocalArtifacts(options *build.Options) error
 	PushReleaseArtifacts(
@@ -161,9 +161,9 @@ func (d *defaultStageImpl) CheckReleaseBucket(
 }
 
 func (d *defaultStageImpl) StageLocalSourceTree(
-	options *build.Options, buildVersion string,
+	options *build.Options, workDir, buildVersion string,
 ) error {
-	return build.NewInstance(options).StageLocalSourceTree(buildVersion)
+	return build.NewInstance(options).StageLocalSourceTree(workDir, buildVersion)
 }
 
 func (d *defaultStageImpl) StageLocalArtifacts(
@@ -269,6 +269,7 @@ func (d *DefaultStage) StageArtifacts(versions []string) error {
 		// Stage the local source tree
 		if err := d.impl.StageLocalSourceTree(
 			pushBuildOptions,
+			workspaceDir,
 			d.options.BuildVersion,
 		); err != nil {
 			return errors.Wrap(err, "staging local source tree")

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -447,14 +447,9 @@ func (bi *Instance) CopyStagedFromGCS(stagedBucket, buildVersion string) error {
 
 // StageLocalSourceTree creates a src.tar.gz from the Kubernetes sources and
 // uploads it to GCS.
-func (bi *Instance) StageLocalSourceTree(buildVersion string) error {
-	workDir := os.Getenv("GOPATH")
-	if workDir == "" {
-		return errors.New("GOPATH is not set")
-	}
-
+func (bi *Instance) StageLocalSourceTree(workDir, buildVersion string) error {
 	tarballPath := filepath.Join(workDir, release.SourcesTar)
-	logrus.Infof("Creating source tree tarball in %s", workDir)
+	logrus.Infof("Creating source tree tarball %s", tarballPath)
 
 	exclude, err := regexp.Compile(fmt.Sprintf(`.*/%s-.*`, release.BuildDir))
 	if err != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The dependency of staging the local source artifacts to `GOPATH` was
pointing to the wrong location when doing the source tree archive.

We fix the issue by not relying on `GOPATH` any more and using the
pre-defined workspace directory as target location.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
