### PR TITLE
Determine correct changelog branch for krel stage

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -194,7 +194,9 @@ func (s *Stage) Run() error {
 	}
 
 	logrus.Info("Generating changelog")
-	if err := s.client.GenerateChangelog(versions.Prime()); err != nil {
+	if err := s.client.GenerateChangelog(
+		versions.Prime(), parentBranch,
+	); err != nil {
 		return errors.Wrap(err, "generate changelog")
 	}
 

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -45,10 +45,11 @@ type FakeStageClient struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GenerateChangelogStub        func(string) error
+	GenerateChangelogStub        func(string, string) error
 	generateChangelogMutex       sync.RWMutex
 	generateChangelogArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	generateChangelogReturns struct {
 		result1 error
@@ -244,18 +245,19 @@ func (fake *FakeStageClient) CheckPrerequisitesReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeStageClient) GenerateChangelog(arg1 string) error {
+func (fake *FakeStageClient) GenerateChangelog(arg1 string, arg2 string) error {
 	fake.generateChangelogMutex.Lock()
 	ret, specificReturn := fake.generateChangelogReturnsOnCall[len(fake.generateChangelogArgsForCall)]
 	fake.generateChangelogArgsForCall = append(fake.generateChangelogArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.GenerateChangelogStub
 	fakeReturns := fake.generateChangelogReturns
-	fake.recordInvocation("GenerateChangelog", []interface{}{arg1})
+	fake.recordInvocation("GenerateChangelog", []interface{}{arg1, arg2})
 	fake.generateChangelogMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -269,17 +271,17 @@ func (fake *FakeStageClient) GenerateChangelogCallCount() int {
 	return len(fake.generateChangelogArgsForCall)
 }
 
-func (fake *FakeStageClient) GenerateChangelogCalls(stub func(string) error) {
+func (fake *FakeStageClient) GenerateChangelogCalls(stub func(string, string) error) {
 	fake.generateChangelogMutex.Lock()
 	defer fake.generateChangelogMutex.Unlock()
 	fake.GenerateChangelogStub = stub
 }
 
-func (fake *FakeStageClient) GenerateChangelogArgsForCall(i int) string {
+func (fake *FakeStageClient) GenerateChangelogArgsForCall(i int) (string, string) {
 	fake.generateChangelogMutex.RLock()
 	defer fake.generateChangelogMutex.RUnlock()
 	argsForCall := fake.generateChangelogArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeStageClient) GenerateChangelogReturns(result1 error) {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -66,7 +66,7 @@ type stageClient interface {
 
 	// GenerateChangelog builds the CHANGELOG-x.y.md file and commits it
 	// into the local repository.
-	GenerateChangelog(version string) error
+	GenerateChangelog(version, parentBranch string) error
 
 	// StageArtifacts copies the build artifacts to a Google Cloud Bucket.
 	StageArtifacts(versions []string) error
@@ -230,11 +230,15 @@ func (d *DefaultStage) Build(versions []string) error {
 	return nil
 }
 
-func (d *DefaultStage) GenerateChangelog(version string) error {
+func (d *DefaultStage) GenerateChangelog(version, parentBranch string) error {
+	branch := d.options.ReleaseBranch
+	if parentBranch != "" {
+		branch = parentBranch
+	}
 	return d.impl.GenerateChangelog(&changelog.Options{
 		RepoPath:     gitRoot,
 		Tag:          version,
-		Branch:       d.options.ReleaseBranch,
+		Branch:       branch,
 		Bucket:       d.options.Bucket(),
 		HTMLFile:     filepath.Join(workspaceDir, "src/release-notes.html"),
 		Dependencies: true,

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -148,7 +148,7 @@ func TestGenerateChangelog(t *testing.T) {
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetClient(mock)
-		err := sut.GenerateChangelog("")
+		err := sut.GenerateChangelog("", "")
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In `anago` we run `krel changelog` with the following branch flag:

```
--branch="${PARENT_BRANCH:-$RELEASE_BRANCH}" \
```

This means we have to do the same in `krel stage`, too. If a
`PARENT_BRANCH` is set, then we choose it over the `RELEASE_BRANCH`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
