### PR TITLE
k8s-ci-builder: Clean up image building configs

### DIFF
--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -88,7 +88,7 @@ func init() {
 	)
 
 	pushCmd.PersistentFlags().StringVar(
-		&pushOpts.DockerRegistry,
+		&pushOpts.Registry,
 		"container-registry",
 		"",
 		"Container image registry to be used",
@@ -177,7 +177,7 @@ func runPushRelease(
 	// In an official nomock release, we want to ensure that container images
 	// have been promoted from staging to production, so we do the image
 	// manifest validation against production instead of staging.
-	targetRegistry := opts.DockerRegistry
+	targetRegistry := opts.Registry
 	if targetRegistry == release.GCRIOPathStaging {
 		targetRegistry = release.GCRIOPathProd
 	}

--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -111,8 +111,8 @@ func init() {
 
 	// TODO: Switch to "--registry" once CI no longer uses it
 	ciBuildCmd.PersistentFlags().StringVar(
-		&ciBuildOpts.DockerRegistry,
-		"docker-registry",
+		&ciBuildOpts.Registry,
+		"registry",
 		"",
 		"If set, push docker images to specified registry/project",
 	)

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -106,8 +106,8 @@ func init() {
 
 	// TODO: Switch to "--registry" once CI no longer uses it
 	pushBuildCmd.PersistentFlags().StringVar(
-		&pushBuildOpts.DockerRegistry,
-		"docker-registry",
+		&pushBuildOpts.Registry,
+		"registry",
 		"",
 		"If set, push docker images to specified registry/project",
 	)

--- a/docs/krel/push.md
+++ b/docs/krel/push.md
@@ -5,7 +5,9 @@ Push Kubernetes release artifacts to Google Cloud Storage (GCS)
 - [Summary](#summary)
 - [Installation](#installation)
 - [Usage](#usage)
-- [Important notes](#important-notes)
+  - [Command line flags](#command-line-flags)
+  - [Examples](#examples)
+- [Important Notes](#important-notes)
 
 ## Summary
 
@@ -31,7 +33,7 @@ In `--ci` mode, 'push' runs in mock mode by default. Use `--nomock` to do a real
       --bucket string               Specify an alternate bucket for pushes (normally 'devel' or 'ci') (default "devel")
       --buildDir string             Specify an alternate build directory (defaults to '_output') (default "_output")
       --ci                          Used when called from Jenkins (for ci runs)
-      --docker-registry string      If set, push docker images to specified registry/project
+      --registry string             If set, push docker images to specified registry/project
       --extra-publish-file string   Used when need to upload additional version file to GCS. The path is relative and is append to a GCS path. (--ci only)
       --gcs-suffix string           Specify a suffix to append to the upload destination on GCS
   -h, --help                        help for push

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -35,7 +35,7 @@ FROM debian:buster
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
 # arg that specifies the bazel version to install
-ARG BAZEL_VERSION_ARG=0.23.1
+ARG BAZEL_VERSION
 ARG GO_VERSION
 
 # add envs:
@@ -45,16 +45,16 @@ ARG GO_VERSION
 # - disabling prompts when installing gsutil etc.
 # - hinting that we are in a docker container
 ENV IMAGE=${IMAGE_ARG} \
-    BAZEL_VERSION=${BAZEL_VERSION_ARG} \
+    BAZEL_VERSION=${BAZEL_VERSION} \
     GOPATH=/home/prow/go \
     PATH=/home/prow/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
     CONTAINER=docker
 
 # copy in image utility scripts
-COPY ["wrapper.sh", \
-      "create_bazel_cache_rcs.sh", \
-      "install-bazel.sh", \
+COPY ["images/releng/k8s-ci-builder/wrapper.sh", \
+      "images/releng/k8s-ci-builder/create_bazel_cache_rcs.sh", \
+      "images/releng/k8s-ci-builder/install-bazel.sh", \
       "/usr/local/bin/"]
 
 # Install tools needed to:

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
+ARG OLD_BAZEL_VERSION
 FROM golang:${GO_VERSION} as builder
 
 WORKDIR /go/src/k8s.io/release
@@ -23,15 +24,114 @@ RUN ./compile-release-tools
 
 ### Production image
 
-FROM gcr.io/k8s-testimages/krte:latest-master
+# Includes tools used for building Kubernetes in CI
+#
+# NOTE: we attempt to avoid unnecessary tools and image layers while
+# supporting kubernetes builds, kind installation, etc.
 
+FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old-bazel
+FROM debian:buster
+
+# arg that specifies the image name (for debugging)
+ARG IMAGE_ARG
+# arg that specifies the bazel version to install
+ARG BAZEL_VERSION_ARG=0.23.1
+ARG GO_VERSION
+
+# add envs:
+# - so we can debug with the image name:tag
+# - with the bazel version
+# - adding gsutil etc. to path (where we will install them)
+# - disabling prompts when installing gsutil etc.
+# - hinting that we are in a docker container
+ENV IMAGE=${IMAGE_ARG} \
+    BAZEL_VERSION=${BAZEL_VERSION_ARG} \
+    GOPATH=/home/prow/go \
+    PATH=/home/prow/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
+    CONTAINER=docker
+
+# copy in image utility scripts
+COPY ["wrapper.sh", \
+      "create_bazel_cache_rcs.sh", \
+      "install-bazel.sh", \
+      "/usr/local/bin/"]
+
+# Install tools needed to:
+# - install docker
+# - build kubernetes (dockerized, or with bazel)
+#
+# TODO: the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+RUN echo "Installing Packages ..." \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends \
+            apt-transport-https \
+            build-essential \
+            ca-certificates \
+            curl \
+            file \
+            git \
+            gnupg2 \
+            jq \
+            kmod \
+            lsb-release \
+            mercurial \
+            openssh-client \
+            pkg-config \
+            procps \
+            python \
+            python-dev \
+            python-pip \
+            rsync \
+            software-properties-common \
+            unzip \
+        && rm -rf /var/lib/apt/lists/* \
+    && echo "Installing Go ..." \
+        && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"\
+        && curl -fsSL "https://storage.googleapis.com/golang/${GO_TARBALL}" --output "${GO_TARBALL}" \
+        && tar xzf "${GO_TARBALL}" -C /usr/local \
+        && rm "${GO_TARBALL}"\
+        && mkdir -p "${GOPATH}/bin" \
+    && echo "Installing Bazel ..." \
+        && install-bazel.sh \
+        && echo "Installing gcloud SDK, kubectl ..." \
+        && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz --output google-cloud-sdk.tar.gz \
+        && tar xzf google-cloud-sdk.tar.gz -C / \
+        && rm google-cloud-sdk.tar.gz \
+        && /google-cloud-sdk/install.sh \
+            --disable-installation-options \
+            --bash-completion=false \
+            --path-update=false \
+            --usage-reporting=false \
+        && gcloud components install kubectl \
+        && gcloud components install alpha \
+        && gcloud components install beta \
+    && echo "Installing Docker ..." \
+        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
+        && add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+            $(lsb_release -cs) stable" \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends docker-ce \
+        && rm -rf /var/lib/apt/lists/* \
+        && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && echo "Ensuring Legacy Iptables ..." \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+ARG OLD_BAZEL_VERSION
+COPY --from=old-bazel \
+    /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_BAZEL_VERSION}
+
+# Copy in release tools from kubernetes/release
 WORKDIR /
 COPY --from=builder /go/bin/* ./
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get -q update \
-    && apt-get install -qqy \
-        jq
-
+# entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
 ENTRYPOINT ["wrapper.sh"]
+# volume for docker in docker, use an emptyDir in Prow
+VOLUME ["/var/lib/docker"]

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -25,8 +25,12 @@ TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
 GO_VERSION ?= 1.15.3
+BAZEL_VERSION ?= 3.4.1
+OLD_BAZEL_VERSION ?= 2.2.0
 
-BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION)
+BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
+							--build-arg=BAZEL_VERSION=$(BAZEL_VERSION) \
+							--build-arg=OLD_BAZEL_VERSION=$(OLD_BAZEL_VERSION)
 
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -1,0 +1,60 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set default shell
+SHELL=/bin/bash -o pipefail
+
+REGISTRY ?= gcr.io/k8s-staging-releng
+IMGNAME = k8s-ci-builder
+CONFIG ?= default
+
+IMAGE = $(REGISTRY)/$(IMGNAME)
+
+TAG ?= $(shell git describe --tags --always --dirty)
+
+# Build args
+GO_VERSION ?= 1.15.3
+
+BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION)
+
+# Ensure support for 'docker buildx' and 'docker manifest' commands
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# build with buildx
+# https://github.com/docker/buildx/issues/59
+.PHONY: build
+build: init-docker-buildx
+	echo "Building $(IMGNAME)..."
+	docker buildx build \
+		--load \
+		--progress plain \
+		--platform linux/amd64 \
+		--tag $(IMAGE):$(CONFIG) \
+		--tag $(IMAGE):$(TAG)-$(CONFIG) \
+		--tag $(IMAGE):latest-$(CONFIG) \
+		$(BUILD_ARGS) \
+		-f $(CURDIR)/Dockerfile \
+		../../../.
+
+.PHONY: push
+push: build
+	echo "Pushing $(IMGNAME) tags"
+	docker push $(IMAGE):$(CONFIG)
+	docker push $(IMAGE):$(TAG)-$(CONFIG)
+	docker push $(IMAGE):latest-$(CONFIG)
+
+# enable buildx
+.PHONY: init-docker-buildx
+init-docker-buildx:
+	./../../../hack/init-buildx.sh

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -22,6 +22,8 @@ steps:
     - PULL_BASE_REF=${_PULL_BASE_REF}
     - CONFIG=${_CONFIG}
     - GO_VERSION=${_GO_VERSION}
+    - BAZEL_VERSION=${_BAZEL_VERSION}
+    - OLD_BAZEL_VERSION=${_OLD_BAZEL_VERSION}
     args:
     - '-c'
     - |
@@ -35,6 +37,8 @@ substitutions:
   _PULL_BASE_REF: 'dev'
   _CONFIG: 'config'
   _GO_VERSION: '0.0.0'
+  _BAZEL_VERSION: '0.0.0'
+  _OLD_BAZEL_VERSION: '0.0.0'
 
 tags:
 - 'k8s-ci-builder'

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -1,38 +1,49 @@
-# See https://cloud.google.com/cloud-build/docs/build-config
+# See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md for more details on image pushing process
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
 timeout: 1200s
+
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+
 steps:
-  - name: gcr.io/cloud-builders/docker
-    id: build
-    dir: images/releng/k8s-ci-builder
+  # TODO: Update image version
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+    entrypoint: 'bash'
+    dir: ./images/releng/k8s-ci-builder
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - REGISTRY=gcr.io/$PROJECT_ID
+    - HOME=/root
+    - TAG=${_GIT_TAG}
+    - PULL_BASE_REF=${_PULL_BASE_REF}
+    - CONFIG=${_CONFIG}
+    - GO_VERSION=${_GO_VERSION}
     args:
-    - build
-    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}
-    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:latest-${_CONFIG}
-    - --tag=gcr.io/$PROJECT_ID/k8s-ci-builder:${_KUBE_CROSS_VERSION}
-    - --build-arg=GO_VERSION=${_GO_VERSION}
-    - --build-arg=KUBE_CROSS_VERSION=${_KUBE_CROSS_VERSION}
-    - -f ./Dockerfile
-    - ../../../.
+    - '-c'
+    - |
+      gcloud auth configure-docker \
+      && make push
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _CONFIG: 'cross0.0'
+  _CONFIG: 'config'
   _GO_VERSION: '0.0.0'
-  _KUBE_CROSS_VERSION: 'v0.0.0-0'
-
-images:
-  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
-  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:latest-${_CONFIG}'
-  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_KUBE_CROSS_VERSION}'
 
 tags:
 - 'k8s-ci-builder'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
+- ${_CONFIG}
 - ${_GO_VERSION}
-- ${_KUBE_CROSS_VERSION}
+
+images:
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_CONFIG}'
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
+  - 'gcr.io/$PROJECT_ID/k8s-ci-builder:latest-${_CONFIG}'

--- a/images/releng/k8s-ci-builder/create_bazel_cache_rcs.sh
+++ b/images/releng/k8s-ci-builder/create_bazel_cache_rcs.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CACHE_HOST="bazel-cache.default.svc.cluster.local."
+CACHE_PORT="8080"
+
+# get the installed version of a debian package
+package_to_version () {
+    dpkg-query --showformat='${Version}' --show "$1"
+}
+
+# look up a binary with `command -v $1` and return the debian package it belongs to
+command_to_package () {
+    # NOTE: we resolve symlinks first because debian packages can provide alternatives
+    # by `update-alternatives` in postinit scripts, which updates a common
+    # symlink for a provided file to the backing entry.
+    # https://wiki.debian.org/DebianAlternatives
+    local binary_path
+    binary_path=$(readlink -f "$(which "$1")")
+    # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
+    # where $file-path belongs to $package
+    # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
+    dpkg-query --search "${binary_path}" | cut -d':' -f1
+}
+
+# get the installed package version relating to a binary
+command_to_version () {
+    # skip commands that aren't installed
+    if ! which "$1"; then
+        return
+    fi
+    local package
+    package=$(command_to_package "$1")
+    package_to_version "${package}"
+}
+
+hash_toolchains () {
+    # if $CC is set bazel will use this to detect c/c++ toolchains, otherwise gcc
+    # https://blog.bazel.build/2016/03/31/autoconfiguration.html
+    local cc="${CC:-gcc}"
+    local cc_version
+    cc_version=$(command_to_version "$cc")
+    # NOTE: IIRC some rules call python internally, this can't hurt
+    local python_version
+    python_version=$(command_to_version python)
+    # the rpm packaging rules use rpmbuild
+    local rpmbuild_version
+    rpmbuild_version=$(command_to_version rpmbuild)
+    # combine all tool versions into a hash
+    # NOTE: if we change the set of tools considered we should
+    # consider prepending the hash with a """schema version""" for completeness
+    local tool_versions
+    tool_versions="CC:${cc_version},PY:${python_version},RPM:${rpmbuild_version}"
+    echo "${tool_versions}" | md5sum | cut -d" " -f1
+}
+
+get_workspace () {
+    # get org/repo from prow, otherwise use $PWD
+    if [[ -n "${REPO_NAME}" ]] && [[ -n "${REPO_OWNER}" ]]; then
+        echo "${REPO_OWNER}/${REPO_NAME}"
+    else
+        echo "$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
+    fi
+}
+
+make_bazel_rc () {
+    # this is the default for recent releases but we set it explicitly
+    # since this is the only hash our cache supports
+    echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256"
+    # use remote caching for all the things
+    # Only set this flag for older bazel versions, it is now enabled by 
+    # default and the flag was removed.
+    #
+    # NOTE: This is an exceptional case (version comparison)
+    # shellcheck disable=SC2072
+    # https://github.com/koalaman/shellcheck/wiki/SC2072#exceptions
+    if [[ "${BAZEL_VERSION:-}" < '0.25' ]]; then
+       echo "build --experimental_remote_spawn_cache"
+    fi
+    # don't fail if the cache is unavailable
+    echo "build --remote_local_fallback"
+    # point bazel at our http cache ...
+    # NOTE our caches are versioned by all path segments up until the last two
+    # IE PUT /foo/bar/baz/cas/asdf -> is in cache "/foo/bar/baz"
+    local cache_id
+    cache_id="$(get_workspace),$(hash_toolchains)"
+    local cache_url
+    cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
+    echo "build --remote_http_cache=${cache_url}"
+    # specifically for bazel 0.15.0 we want to set this flag
+    # our docker image now sets BAZEL_VERSION with the bazel version as installed
+    # https://github.com/bazelbuild/bazel/issues/5047#issuecomment-401295174
+    if [[ "${BAZEL_VERSION:-}" = "0.15.0" ]]; then
+        echo "build --remote_max_connections=200"
+    fi
+}
+
+# https://docs.bazel.build/versions/master/user-manual.html#bazelrc
+# bazel will look for two RC files, taking the first option in each set of paths
+# firstly:
+# - The path specified by the --bazelrc=file startup option. If specified, this option must appear before the command name (e.g. build)
+# - A file named .bazelrc in your base workspace directory
+# - A file named .bazelrc in your home directory
+bazel_rc_contents=$(make_bazel_rc)
+echo "create_bazel_cache_rcs.sh: Configuring '${HOME}/.bazelrc' and '/etc/bazel.bazelrc' with"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}" >> "${HOME}/.bazelrc"
+# Aside from the optional configuration file described above, Bazel also looks for a master rc file next to the binary, in the workspace at tools/bazel.rc or system-wide at /etc/bazel.bazelrc.
+# These files are here to support installation-wide options or options shared between users. Reading of this file can be disabled using the --nomaster_bazelrc option.
+echo "${bazel_rc_contents}" >> "/etc/bazel.bazelrc"
+# hopefully no repos create *both* of these ...

--- a/images/releng/k8s-ci-builder/install-bazel.sh
+++ b/images/releng/k8s-ci-builder/install-bazel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script fetches and runs the upstream installer based on BAZEL_VERSION
+# like 0.14.0 or 0.14.0rc1 etc.
+set -o errexit
+set -o nounset
+
+# match BAZEL_VERSION to installer URL
+INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+if [[ "${BAZEL_VERSION}" =~ ([0-9\.]+)(rc[0-9]+) ]]; then
+    DOWNLOAD_URL="https://storage.googleapis.com/bazel/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${INSTALLER}"
+else
+    DOWNLOAD_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}"
+fi
+echo "$DOWNLOAD_URL"
+# get the installer
+curl -L --output "${INSTALLER}" "${DOWNLOAD_URL}" && chmod +x "${INSTALLER}"
+# install to user dir
+"./${INSTALLER}"
+# remove the installer, we no longer need it
+rm "${INSTALLER}"

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -2,24 +2,20 @@ variants:
   default:
     CONFIG: default
     GO_VERSION: '1.15.3'
-    K8S_RELEASE: stable
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
+    BAZEL_VERSION: '3.4.1'
+    OLD_BAZEL_VERSION: '2.2.0'
   '1.19':
     CONFIG: '1.19'
     GO_VERSION: '1.15.3'
-    K8S_RELEASE: latest-1.19
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: '2.2.0'
+    OLD_BAZEL_VERSION: '0.23.2'
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: '1.13.15'
-    K8S_RELEASE: stable-1.18
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: '2.2.0'
+    OLD_BAZEL_VERSION: '0.23.2'
   '1.17':
     CONFIG: '1.17'
     GO_VERSION: '1.13.15'
-    K8S_RELEASE: stable-1.17
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: '2.2.0'
+    OLD_BAZEL_VERSION: '0.23.2'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,5 +1,25 @@
 variants:
-  cross1.15:
-    CONFIG: 'cross1.15'
+  default:
+    CONFIG: default
     GO_VERSION: '1.15.3'
-    KUBE_CROSS_VERSION: 'v1.15.3-1'
+    K8S_RELEASE: stable
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
+  '1.19':
+    CONFIG: '1.19'
+    GO_VERSION: '1.15.3'
+    K8S_RELEASE: latest-1.19
+    BAZEL_VERSION: 2.2.0
+    OLD_BAZEL_VERSION: 0.23.2
+  '1.18':
+    CONFIG: '1.18'
+    GO_VERSION: '1.13.15'
+    K8S_RELEASE: stable-1.18
+    BAZEL_VERSION: 2.2.0
+    OLD_BAZEL_VERSION: 0.23.2
+  '1.17':
+    CONFIG: '1.17'
+    GO_VERSION: '1.13.15'
+    K8S_RELEASE: stable-1.17
+    BAZEL_VERSION: 2.2.0
+    OLD_BAZEL_VERSION: 0.23.2

--- a/images/releng/k8s-ci-builder/wrapper.sh
+++ b/images/releng/k8s-ci-builder/wrapper.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# wrapper.sh handles setting up things before / after the test command $@
+#
+# usage: wrapper.sh my-test-command [my-test-args]
+#
+# Things wrapper.sh handles:
+# - starting / stopping docker-in-docker
+# -- configuring the docker daemon for IPv6
+# - confuring bazel caching
+# - activating GCP service account credentials
+# - ensuring GOPATH/bin is in PATH
+#
+# After handling these things / before cleanup, my-test-command will be invoked,
+# and the exit code of my-test-command will be preserved by wrapper.sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+>&2 echo "wrapper.sh] [INFO] Wrapping Test Command: \`$*\`"
+>&2 echo "wrapper.sh] [INFO] Running in: ${IMAGE}"
+>&2 echo "wrapper.sh] [INFO] See: https://github.com/kubernetes/test-infra/blob/master/images/krte/wrapper.sh"
+printf '%0.s=' {1..80} >&2; echo >&2
+>&2 echo "wrapper.sh] [SETUP] Performing pre-test setup ..."
+
+cleanup(){
+  if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+    >&2 echo "wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ..."
+    docker ps -aq | xargs -r docker rm -f || true
+    service docker stop || true
+    >&2 echo "wrapper.sh] [CLEANUP] Done cleaning up after Docker in Docker."
+  fi
+}
+
+early_exit_handler() {
+  >&2 echo "wrapper.sh] [EARLY EXIT] Interrupted, entering handler ..."
+  if [ -n "${EXIT_VALUE:-}" ]; then
+    >&2 echo "Original exit code was ${EXIT_VALUE}, not preserving due to interrupt signal"
+  fi
+  cleanup
+  >&2 echo "wrapper.sh] [EARLY EXIT] Completed handler ..."
+  exit 1
+}
+
+trap early_exit_handler TERM INT
+
+# Check if the job has opted-in to bazel remote caching and if so generate 
+# .bazelrc entries pointing to the remote cache
+export BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
+if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
+  >&2 echo "wrapper.sh] [SETUP] Bazel remote cache is enabled, generating .bazelrcs ..."
+  /usr/local/bin/create_bazel_cache_rcs.sh
+  >&2 echo "wrapper.sh] [SETUP] Done setting up .bazelrcs"
+fi
+
+# optionally enable ipv6 docker
+export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+  >&2 echo "wrapper.sh] [SETUP] Enabling IPv6 in Docker config ..."
+  # enable ipv6
+  sysctl net.ipv6.conf.all.disable_ipv6=0
+  sysctl net.ipv6.conf.all.forwarding=1
+  # enable ipv6 iptables
+  modprobe -v ip6table_nat
+  >&2 echo "wrapper.sh] [SETUP] Done enabling IPv6 in Docker config."
+fi
+
+# optionally enable iptables-nft
+export DOCKER_IN_DOCKER_NFT_ENABLED=${DOCKER_IN_DOCKER_NFT_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_NFT_ENABLED}" == "true" ]]; then
+  >&2 echo "wrapper.sh] [SETUP] Enabling iptables-nft ..."
+  # enable iptables-nft
+  update-alternatives --set iptables /usr/sbin/iptables-nft
+  update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
+  # enable nft iptables module
+  modprobe -v nf_tables
+  >&2 echo "wrapper.sh] [SETUP] Done enabling iptables-nft by default."
+fi
+
+# Check if the job has opted-in to docker-in-docker
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+  >&2 echo "wrapper.sh] [SETUP] Docker in Docker enabled, initializing ..."
+  # If we have opted in to docker in docker, start the docker daemon,
+  service docker start
+  # the service can be started but the docker socket not ready, wait for ready
+  WAIT_N=0
+  while true; do
+    # docker ps -q should only work if the daemon is ready
+    docker ps -q > /dev/null 2>&1 && break
+    if [[ ${WAIT_N} -lt 5 ]]; then
+      WAIT_N=$((WAIT_N+1))
+      echo "wrapper.sh] [SETUP] Waiting for Docker to be ready, sleeping for ${WAIT_N} seconds ..."
+      sleep ${WAIT_N}
+    else
+      echo "wrapper.sh] [SETUP] Reached maximum attempts, not waiting any longer ..."
+      break
+    fi
+  done
+  echo "wrapper.sh] [SETUP] Done setting up Docker in Docker."
+fi
+
+# add $GOPATH/bin to $PATH
+export GOPATH="${GOPATH:-${HOME}/go}"
+export PATH="${GOPATH}/bin:${PATH}"
+mkdir -p "${GOPATH}/bin"
+
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  >&2 echo "wrapper.sh] activating service account from GOOGLE_APPLICATION_CREDENTIALS ..."
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+if git rev-parse --is-inside-work-tree >/dev/null; then
+  >&2 echo "wrapper.sh] [SETUP] Setting SOURCE_DATE_EPOCH for build reproducibility ..."
+  # Use a reproducible build date based on the most recent git commit timestamp.
+  SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+  export SOURCE_DATE_EPOCH
+  >&2 echo "wrapper.sh] [SETUP] exported SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
+fi
+
+# actually run the user supplied command
+printf '%0.s=' {1..80}; echo
+>&2 echo "wrapper.sh] [TEST] Running Test Command: \`$*\` ..."
+set +o errexit
+"$@"
+EXIT_VALUE=$?
+set -o errexit
+>&2 echo "wrapper.sh] [TEST] Test Command exit code: ${EXIT_VALUE}"
+
+# cleanup
+cleanup
+
+# preserve exit value from user supplied command
+printf '%0.s=' {1..80} >&2; echo >&2
+>&2 echo "wrapper.sh] Exiting ${EXIT_VALUE}"
+exit ${EXIT_VALUE}

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -196,7 +196,7 @@ func (d *DefaultRelease) PushArtifacts(versions []string) error {
 		pushBuildOptions := &build.Options{
 			Bucket:                     bucket,
 			BuildDir:                   buildDir,
-			DockerRegistry:             containerRegistry,
+			Registry:                   containerRegistry,
 			Version:                    version,
 			AllowDup:                   true,
 			ValidateRemoteImageDigests: true,

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -261,7 +261,7 @@ func (d *DefaultStage) StageArtifacts(versions []string) error {
 		pushBuildOptions := &build.Options{
 			Bucket:                     bucket,
 			BuildDir:                   buildDir,
-			DockerRegistry:             containerRegistry,
+			Registry:                   containerRegistry,
 			Version:                    version,
 			AllowDup:                   true,
 			ValidateRemoteImageDigests: true,

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -51,7 +51,7 @@ type Options struct {
 	BuildType string
 
 	// If set, push docker images to specified registry/project.
-	DockerRegistry string
+	Registry string
 
 	// Comma separated list which can be used to upload additional version
 	// files to GCS. The path is relative and is append to a GCS path. (--ci

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -366,10 +366,10 @@ func (bi *Instance) PushReleaseArtifacts(srcPath, gcsPath string) error {
 }
 
 // PushContainerImages will publish container images into the set
-// `DockerRegistry`. It also validates if the remove manifests are correct,
+// `Registry`. It also validates if the remove manifests are correct,
 // which can be turned of by setting `ValidateRemoteImageDigests` to `false`.
 func (bi *Instance) PushContainerImages() error {
-	if bi.opts.DockerRegistry == "" {
+	if bi.opts.Registry == "" {
 		logrus.Info("Registry is not set, will not publish container images")
 		return nil
 	}
@@ -378,7 +378,7 @@ func (bi *Instance) PushContainerImages() error {
 	logrus.Infof("Publishing container images for %s", bi.opts.Version)
 
 	if err := images.Publish(
-		bi.opts.DockerRegistry, bi.opts.Version, bi.opts.BuildDir,
+		bi.opts.Registry, bi.opts.Version, bi.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "publish container images")
 	}
@@ -389,7 +389,7 @@ func (bi *Instance) PushContainerImages() error {
 	}
 
 	if err := images.Validate(
-		bi.opts.DockerRegistry, bi.opts.Version, bi.opts.BuildDir,
+		bi.opts.Registry, bi.opts.Version, bi.opts.BuildDir,
 	); err != nil {
 		return errors.Wrap(err, "validate container images")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1698 and https://github.com/kubernetes/release/pull/1700.

- k8s-ci-builder: Clean up image building configs
- pkg/build: s/DockerRegistry/Registry
- k8s-ci-builder: Copy Dockerfile and utility scripts from krte
- k8s-ci-builder: Update build args/variants to include krte config

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-ci-builder: Clean up image building configs
- pkg/build: s/DockerRegistry/Registry
- k8s-ci-builder: Copy Dockerfile and utility scripts from krte
- k8s-ci-builder: Update build args/variants to include krte config
```
