### PR TITLE
pkg/build: Validate images exist before proceeding with CI builds

### DIFF
--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -78,6 +78,10 @@ RUN echo "Installing Packages ..." \
             gnupg2 \
             jq \
             kmod \
+            libassuan-dev \
+            libbtrfs-dev \
+            libdevmapper-dev \
+            libgpgme-dev \
             lsb-release \
             mercurial \
             openssh-client \
@@ -126,6 +130,14 @@ RUN echo "Installing Packages ..." \
 ARG OLD_BAZEL_VERSION
 COPY --from=old-bazel \
     /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_BAZEL_VERSION}
+
+ARG SKOPEO_VERSION
+RUN git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
+RUN cd $GOPATH/src/github.com/containers/skopeo \
+    && git checkout ${SKOPEO_VERSION} \
+    && make bin/skopeo \
+    && cp bin/skopeo /usr/local/bin \
+    && rm -rf $GOPATH/src/github.com/containers/skopeo
 
 # Copy in release tools from kubernetes/release
 WORKDIR /

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -27,10 +27,12 @@ TAG ?= $(shell git describe --tags --always --dirty)
 GO_VERSION ?= 1.15.3
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
+IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
 							--build-arg=BAZEL_VERSION=$(BAZEL_VERSION) \
-							--build-arg=OLD_BAZEL_VERSION=$(OLD_BAZEL_VERSION)
+							--build-arg=OLD_BAZEL_VERSION=$(OLD_BAZEL_VERSION) \
+							--build-arg=IMAGE_ARG=$(IMAGE_ARG)
 
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -28,11 +28,13 @@ GO_VERSION ?= 1.15.3
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
+SKOPEO_VERSION ?= v1.2.0
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
 							--build-arg=BAZEL_VERSION=$(BAZEL_VERSION) \
 							--build-arg=OLD_BAZEL_VERSION=$(OLD_BAZEL_VERSION) \
-							--build-arg=IMAGE_ARG=$(IMAGE_ARG)
+							--build-arg=IMAGE_ARG=$(IMAGE_ARG) \
+							--build-arg=SKOPEO_VERSION=$(SKOPEO_VERSION)
 
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -24,6 +24,7 @@ steps:
     - GO_VERSION=${_GO_VERSION}
     - BAZEL_VERSION=${_BAZEL_VERSION}
     - OLD_BAZEL_VERSION=${_OLD_BAZEL_VERSION}
+    - IMAGE_ARG='gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
     args:
     - '-c'
     - |

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
     - BAZEL_VERSION=${_BAZEL_VERSION}
     - OLD_BAZEL_VERSION=${_OLD_BAZEL_VERSION}
     - IMAGE_ARG='gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
+    - SKOPEO_VERSION=${_SKOPEO_VERSION}
     args:
     - '-c'
     - |
@@ -40,6 +41,7 @@ substitutions:
   _GO_VERSION: '0.0.0'
   _BAZEL_VERSION: '0.0.0'
   _OLD_BAZEL_VERSION: '0.0.0'
+  _SKOPEO_VERSION: 'v0.0.0'
 
 tags:
 - 'k8s-ci-builder'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -4,18 +4,22 @@ variants:
     GO_VERSION: '1.15.3'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
+    SKOPEO_VERSION: 'v1.2.0'
   '1.19':
     CONFIG: '1.19'
     GO_VERSION: '1.15.3'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
+    SKOPEO_VERSION: 'v1.2.0'
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: '1.13.15'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
+    SKOPEO_VERSION: 'v1.2.0'
   '1.17':
     CONFIG: '1.17'
     GO_VERSION: '1.13.15'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
+    SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1710.
Part of https://github.com/kubernetes/release/issues/1711.

- k8s-ci-builder: Pass the image ref as a build arg for debuggability
- pkg/build: Validate images exist before proceeding with CI builds
- k8s-ci-builder: Add skopeo (v1.2.0) to support image validation

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-ci-builder: Pass the image ref as a build arg for debuggability
- pkg/build: Validate images exist before proceeding with CI builds
- k8s-ci-builder: Add skopeo (v1.2.0) to support image validation
```
