### PR TITLE
krel/cloudbuild: defautl disk size request to 500Gb

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -271,7 +271,6 @@ func RunGcbmgr(opts *GcbmgrOptions) error {
 		jobType = "stage"
 	case opts.Release:
 		jobType = "release"
-		buildOpts.DiskSize = "100"
 	default:
 		return listJobs(buildOpts.Project, opts.LastJobs)
 	}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -54,7 +54,7 @@ const (
 	// TODO(vdf): Need to reference K8s Infra project here
 	DefaultKubernetesStagingProject = "kubernetes-release-test"
 	DefaultRelengStagingProject     = "k8s-staging-releng"
-	DefaultDiskSize                 = "300"
+	DefaultDiskSize                 = "500"
 	BucketPrefix                    = "kubernetes-release-"
 
 	versionReleaseRE   = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When running the release step we saw this error

```
Step #2: Checking for at least 150 GB on /workspace: FAILED
Step #2: AVAILABLE SPACE: 102
Step #2: THRESHOLD: 150
Step #2: [2020-Nov-11 10:08:35 UTC] common::disk_space_check in 0s
Step #2: FAILED in common::disk_space_check.
Step #2: 
Step #2: RELEASE INCOMPLETE! Exiting...
Step #2: 
```

defining the disk request to run the cloudbuild job

/cc @saschagrunert @kubernetes/release-engineering 


#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
cloudbuild: define disk request size to the gcp cloudbuild
```
