### PR TITLE
Add git.Tags() API

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -833,6 +833,19 @@ func (r *Repo) TagsForBranch(branch string) (res []string, err error) {
 	return strings.Fields(status.Output()), nil
 }
 
+// Tags returns a list of tags for the repository.
+func (r *Repo) Tags() (res []string, err error) {
+	tags, err := r.inner.Tags()
+	if err != nil {
+		return nil, errors.Wrap(err, "get tags")
+	}
+	_ = tags.ForEach(func(t *plumbing.Reference) error { // nolint: errcheck
+		res = append(res, t.Name().Short())
+		return nil
+	})
+	return res, nil
+}
+
 // Add adds a file to the staging area of the repo
 func (r *Repo) Add(filename string) error {
 	return errors.Wrapf(

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -892,3 +892,15 @@ func TestSetURLFailureRemoteDoesNotExists(t *testing.T) {
 
 	require.NotNil(t, testRepo.sut.SetURL("some-remote", ""))
 }
+
+func TestAllTags(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	tags, err := testRepo.sut.Tags()
+	require.Nil(t, err)
+	require.Len(t, tags, 3)
+	require.Equal(t, testRepo.secondTagName, tags[0])
+	require.Equal(t, testRepo.firstTagName, tags[1])
+	require.Equal(t, testRepo.thirdTagName, tags[2])
+}

--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -119,7 +119,7 @@ func (gp *GitObjectPusher) PushTag(newTag string) (err error) {
 	}
 
 	// Check if tag already exists
-	currentTags, err := gp.repo.TagsForBranch(git.DefaultBranch)
+	currentTags, err := gp.repo.Tags()
 	if err != nil {
 		return errors.Wrap(err, "checking if tag exists")
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature
/kind regression

#### What this PR does / why we need it:
This API is required for pushing the git tags, which tries to validate
existing tags before pushing. The API takes all branches into account,
which is required for pushing tags from release branches.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `git.Tags()` API which is now used for validation of available tags on `krel anago push-git-objects`
```
