### PR TITLE
gcp/build: output the command that will send to gcp cloudbuild

### DIFF
--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -242,6 +242,7 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 		cmd.AddWriter(f)
 	}
 
+	logrus.Infof("cloudbuild command to send to gcp: %s", cmd.String())
 	if err := cmd.RunSuccess(); err != nil {
 		return errors.Wrapf(err, "error running %s", cmd.String())
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

add log information of the cloudbuild that will run, useful for checking the parameters when something bad happens

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @saschagrunert 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcp/build: output the command that will send to gcp cloudbuild
```
