### PR TITLE
Remove double mock generation in krel gcbmgr

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -50,7 +50,6 @@ type GcbmgrOptions struct {
 	Version      Version
 }
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Repository
 type Repository interface {
 	Open() error
@@ -58,7 +57,6 @@ type Repository interface {
 	GetTag() (string, error)
 }
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Version
 type Version interface {
 	GetKubeVersionForBranch(release.VersionType, string) (string, error)

--- a/cmd/krel/main.go
+++ b/cmd/krel/main.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 package main
 
 import "k8s.io/release/cmd/krel/cmd"


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We do not have to specify the go generate twice, because in that case it
will also run twice. Now we move the generation into the main.go (same
package `cmd`) to apply the mock generation to all files in the package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
