### PR TITLE
Rename SetClient to SetImpl for stage/release impls

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -83,8 +83,8 @@ func NewDefaultRelease(options *ReleaseOptions) *DefaultRelease {
 	return &DefaultRelease{&defaultReleaseImpl{}, options, nil}
 }
 
-// SetClient can be used to set the internal release implementation.
-func (d *DefaultRelease) SetClient(impl releaseImpl) {
+// SetImpl can be used to set the internal release implementation.
+func (d *DefaultRelease) SetImpl(impl releaseImpl) {
 	d.impl = impl
 }
 

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -43,7 +43,7 @@ func TestCheckPrerequisitesRelease(t *testing.T) {
 	opts := anago.DefaultReleaseOptions()
 	sut := anago.NewDefaultRelease(opts)
 	mock := &anagofakes.FakeReleaseImpl{}
-	sut.SetClient(mock)
+	sut.SetImpl(mock)
 	require.Nil(t, sut.CheckPrerequisites())
 }
 
@@ -75,7 +75,7 @@ func TestGenerateReleaseVersionRelease(t *testing.T) {
 
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		err := sut.GenerateReleaseVersion()
 		if tc.shouldError {
@@ -130,7 +130,7 @@ func TestPushArtifacts(t *testing.T) {
 
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		err := sut.PushArtifacts()
 		if tc.shouldError {
@@ -161,7 +161,7 @@ func TestPrepareWorkspaceRelease(t *testing.T) {
 		sut := anago.NewDefaultRelease(opts)
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 		err := sut.PrepareWorkspace()
 		if tc.shouldError {
 			require.NotNil(t, err)

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -85,8 +85,8 @@ func NewDefaultStage(options *StageOptions) *DefaultStage {
 	return &DefaultStage{&defaultStageImpl{}, options, nil}
 }
 
-// SetClient can be used to set the internal stage implementation.
-func (d *DefaultStage) SetClient(impl stageImpl) {
+// SetImpl can be used to set the internal stage implementation.
+func (d *DefaultStage) SetImpl(impl stageImpl) {
 	d.impl = impl
 }
 

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -43,7 +43,7 @@ func TestCheckPrerequisitesStage(t *testing.T) {
 	opts := anago.DefaultStageOptions()
 	sut := anago.NewDefaultStage(opts)
 	mock := &anagofakes.FakeStageImpl{}
-	sut.SetClient(mock)
+	sut.SetImpl(mock)
 	require.Nil(t, sut.CheckPrerequisites())
 }
 
@@ -75,7 +75,7 @@ func TestGenerateReleaseVersionStage(t *testing.T) {
 
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 		err := sut.GenerateReleaseVersion()
 		if tc.shouldError {
 			require.NotNil(t, err)
@@ -110,7 +110,7 @@ func TestPrepareWorkspaceStage(t *testing.T) {
 
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 		err := sut.PrepareWorkspace()
 		if tc.shouldError {
 			require.NotNil(t, err)
@@ -305,7 +305,7 @@ func TestTagRepository(t *testing.T) {
 
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		err = sut.TagRepository()
 		if tc.shouldError {
@@ -341,7 +341,7 @@ func TestBuild(t *testing.T) {
 
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		err := sut.Build()
 		if tc.shouldError {
@@ -376,7 +376,7 @@ func TestGenerateChangelog(t *testing.T) {
 
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		err := sut.GenerateChangelog()
 		if tc.shouldError {
@@ -437,7 +437,7 @@ func TestStageArtifacts(t *testing.T) {
 		sut := anago.NewDefaultStage(opts)
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
-		sut.SetClient(mock)
+		sut.SetImpl(mock)
 
 		sut.SetState(
 			generateTestingStageState(


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
"Client" seems the wrong terminology in that case, because we already
have `…Impl` interfaces as well as structs. This is just a small cleanup
for sake of consistency.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
