### PR TITLE
Fix GCP double copy

### DIFF
--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -407,12 +407,12 @@ func (bi *Instance) CopyStagedFromGCS(stagedBucket, buildVersion string) error {
 	copyOpts.AllowMissing = pointer.BoolPtr(false)
 
 	gsStageRoot := filepath.Join(bi.opts.Bucket, release.StagePath, buildVersion, bi.opts.Version)
-	gsReleaseRoot := filepath.Join(bi.opts.Bucket, "release", bi.opts.Version)
-
 	src := filepath.Join(gsStageRoot, release.GCSStagePath, bi.opts.Version)
-	dst := gsReleaseRoot
-	logrus.Infof("Bucket to bucket copy from %s to %s", src, dst)
-	if err := gcs.CopyBucketToBucket(src, dst, copyOpts); err != nil {
+
+	gcsSrc := gcs.NormalizeGCSPath(src)
+	dst := gcs.NormalizeGCSPath(filepath.Join(bi.opts.Bucket, "release", bi.opts.Version))
+	logrus.Infof("Bucket to bucket rsync from %s to %s", gcsSrc, dst)
+	if err := gcs.RsyncRecursive(gcsSrc, dst); err != nil {
 		return errors.Wrap(err, "copy stage to release bucket")
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
`gsutil cp` will re-use the directory if it already exists on the remote
location. This means if we copy multiple times, we might create nested
structures which is not intended at all. To avoid that, we now use the
new `rsync` API.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/1724
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed release artifact nested structure when running `krel release` multiple times.
```
