### PR TITLE
krel: Properly handle jobs with GCS Suffix set and don't attempt to set ACLs on K8s Infra buckets

### DIFF
--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -190,7 +190,7 @@ func runPushRelease(
 	}
 
 	if err := release.NewPublisher().PublishVersion(
-		"release", opts.Version, opts.BuildDir, opts.Bucket, nil, false, false,
+		"release", opts.Version, opts.BuildDir, opts.Bucket, "", nil, false, false,
 	); err != nil {
 		return errors.Wrap(err, "publish release")
 	}

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -77,16 +77,17 @@ type FakeReleaseImpl struct {
 	prepareWorkspaceReleaseReturnsOnCall map[int]struct {
 		result1 error
 	}
-	PublishVersionStub        func(string, string, string, string, []string, bool, bool) error
+	PublishVersionStub        func(string, string, string, string, string, []string, bool, bool) error
 	publishVersionMutex       sync.RWMutex
 	publishVersionArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 []string
-		arg6 bool
+		arg5 string
+		arg6 []string
 		arg7 bool
+		arg8 bool
 	}
 	publishVersionReturns struct {
 		result1 error
@@ -364,11 +365,11 @@ func (fake *FakeReleaseImpl) PrepareWorkspaceReleaseReturnsOnCall(i int, result1
 	}{result1}
 }
 
-func (fake *FakeReleaseImpl) PublishVersion(arg1 string, arg2 string, arg3 string, arg4 string, arg5 []string, arg6 bool, arg7 bool) error {
-	var arg5Copy []string
-	if arg5 != nil {
-		arg5Copy = make([]string, len(arg5))
-		copy(arg5Copy, arg5)
+func (fake *FakeReleaseImpl) PublishVersion(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string, arg6 []string, arg7 bool, arg8 bool) error {
+	var arg6Copy []string
+	if arg6 != nil {
+		arg6Copy = make([]string, len(arg6))
+		copy(arg6Copy, arg6)
 	}
 	fake.publishVersionMutex.Lock()
 	ret, specificReturn := fake.publishVersionReturnsOnCall[len(fake.publishVersionArgsForCall)]
@@ -377,16 +378,17 @@ func (fake *FakeReleaseImpl) PublishVersion(arg1 string, arg2 string, arg3 strin
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 []string
-		arg6 bool
+		arg5 string
+		arg6 []string
 		arg7 bool
-	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+		arg8 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6Copy, arg7, arg8})
 	stub := fake.PublishVersionStub
 	fakeReturns := fake.publishVersionReturns
-	fake.recordInvocation("PublishVersion", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+	fake.recordInvocation("PublishVersion", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6Copy, arg7, arg8})
 	fake.publishVersionMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1
@@ -400,17 +402,17 @@ func (fake *FakeReleaseImpl) PublishVersionCallCount() int {
 	return len(fake.publishVersionArgsForCall)
 }
 
-func (fake *FakeReleaseImpl) PublishVersionCalls(stub func(string, string, string, string, []string, bool, bool) error) {
+func (fake *FakeReleaseImpl) PublishVersionCalls(stub func(string, string, string, string, string, []string, bool, bool) error) {
 	fake.publishVersionMutex.Lock()
 	defer fake.publishVersionMutex.Unlock()
 	fake.PublishVersionStub = stub
 }
 
-func (fake *FakeReleaseImpl) PublishVersionArgsForCall(i int) (string, string, string, string, []string, bool, bool) {
+func (fake *FakeReleaseImpl) PublishVersionArgsForCall(i int) (string, string, string, string, string, []string, bool, bool) {
 	fake.publishVersionMutex.RLock()
 	defer fake.publishVersionMutex.RUnlock()
 	argsForCall := fake.publishVersionArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
 }
 
 func (fake *FakeReleaseImpl) PublishVersionReturns(result1 error) {

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -103,7 +103,7 @@ type releaseImpl interface {
 	) error
 	ValidateImages(registry, version, buildPath string) error
 	PublishVersion(
-		buildType, version, buildDir, bucket string,
+		buildType, version, buildDir, bucket, gcsSuffix string,
 		versionMarkers []string,
 		privateBucket, fast bool,
 	) error
@@ -148,13 +148,13 @@ func (d *defaultReleaseImpl) ValidateImages(
 }
 
 func (d *defaultReleaseImpl) PublishVersion(
-	buildType, version, buildDir, bucket string,
+	buildType, version, buildDir, bucket, gcsSuffix string,
 	versionMarkers []string,
 	privateBucket, fast bool,
 ) error {
 	return release.
 		NewPublisher().
-		PublishVersion("release", version, buildDir, bucket, nil, false, false)
+		PublishVersion("release", version, buildDir, bucket, gcsSuffix, nil, false, false)
 }
 
 func (d *DefaultRelease) ValidateOptions() error {
@@ -228,7 +228,7 @@ func (d *DefaultRelease) PushArtifacts(versions []string) error {
 		}
 
 		if err := d.impl.PublishVersion(
-			"release", version, buildDir, bucket, nil, false, false,
+			"release", version, buildDir, bucket, "", nil, false, false,
 		); err != nil {
 			return errors.Wrap(err, "publish release")
 		}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -17,9 +17,9 @@ limitations under the License.
 package build
 
 import (
-	"path/filepath"
-
 	"github.com/sirupsen/logrus"
+
+	"k8s.io/release/pkg/gcp/gcs"
 )
 
 var DefaultExtraVersionMarkers = []string{}
@@ -92,21 +92,21 @@ type Options struct {
 	ValidateRemoteImageDigests bool
 }
 
-// TODO: Support "release" buildType
+// TODO: Refactor so that version is not required as a parameter
 func (bi *Instance) getGCSBuildPath(version string) string {
-	gcsDest := bi.opts.BuildType
-
-	if bi.opts.GCSSuffix != "" {
-		gcsDest += "-" + bi.opts.GCSSuffix
+	// TODO: Parameterize this? Maybe a setter for defaults?
+	bucket := bi.opts.Bucket
+	if bi.opts.Bucket == "" {
+		bucket = "kubernetes-release-dev"
 	}
 
-	if bi.opts.Fast {
-		gcsDest = filepath.Join(gcsDest, "fast")
-	}
-	gcsDest = filepath.Join(gcsDest, version)
-	logrus.Infof("GCS destination is %s", gcsDest)
-
-	return gcsDest
+	return gcs.GetReleasePath(
+		bucket,
+		bi.opts.BuildType,
+		bi.opts.GCSSuffix,
+		version,
+		bi.opts.Fast,
+	)
 }
 
 func (bi *Instance) setBuildType() {

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -123,14 +123,8 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 		return false, nil
 	}
 
-	bucket := bi.opts.Bucket
-	if bi.opts.Bucket == "" {
-		bucket = "kubernetes-release-dev"
-	}
+	gcsBuildRoot := bi.getGCSBuildPath(bi.opts.Version)
 
-	gcsDest := bi.getGCSBuildPath(version)
-
-	gcsBuildRoot := filepath.Join(bucket, gcsDest)
 	kubernetesTar := filepath.Join(gcsBuildRoot, release.KubernetesTar)
 	binPath := filepath.Join(gcsBuildRoot, "bin")
 

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -105,6 +105,11 @@ func (bi *Instance) Push() error {
 	if err != nil {
 		return errors.Wrap(err, "find latest version")
 	}
+
+	if version == "" {
+		return errors.New("cannot push an empty version")
+	}
+
 	logrus.Infof("Latest version is %s", version)
 
 	if err := bi.CheckReleaseBucket(); err != nil {

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -146,8 +146,14 @@ func (bi *Instance) Push() error {
 	// Publish release to GCS
 	extraVersionMarkers := bi.opts.ExtraVersionMarkers
 	if err := release.NewPublisher().PublishVersion(
-		bi.opts.BuildType, version, bi.opts.BuildDir, bi.opts.Bucket, extraVersionMarkers,
-		bi.opts.PrivateBucket, bi.opts.Fast,
+		bi.opts.BuildType,
+		version,
+		bi.opts.BuildDir,
+		bi.opts.Bucket,
+		bi.opts.GCSSuffix,
+		extraVersionMarkers,
+		bi.opts.PrivateBucket,
+		bi.opts.Fast,
 	); err != nil {
 		return errors.Wrap(err, "publish release")
 	}

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -18,6 +18,7 @@ package gcs
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -116,6 +117,34 @@ func bucketCopy(src, dst string, opts *Options) error {
 	}
 
 	return nil
+}
+
+// GetReleasePath returns a GCS path to retrieve builds from or push builds to
+//
+// Expected destination format:
+//   gs://<bucket>/<buildType>[-<gcsSuffix>][/fast][/<version>]
+// TODO: Support "release" buildType
+func GetReleasePath(
+	bucket, buildType, gcsSuffix, version string,
+	fast bool) string {
+	gcsPath := bucket
+	gcsPath = filepath.Join(gcsPath, buildType)
+
+	if gcsSuffix != "" {
+		gcsPath += "-" + gcsSuffix
+	}
+
+	if fast {
+		gcsPath = filepath.Join(gcsPath, "fast")
+	}
+
+	if version != "" {
+		gcsPath = filepath.Join(gcsPath, version)
+	}
+
+	logrus.Infof("GCS path is %s", gcsPath)
+
+	return gcsPath
 }
 
 // NormalizeGCSPath takes a gcs path and ensures that the `GcsPrefix` is

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -123,9 +123,42 @@ func bucketCopy(src, dst string, opts *Options) error {
 //
 // Expected destination format:
 //   gs://<bucket>/<buildType>[-<gcsSuffix>][/fast][/<version>]
-// TODO: Support "release" buildType
 func GetReleasePath(
 	bucket, buildType, gcsSuffix, version string,
+	fast bool) string {
+	return getPath(
+		bucket,
+		buildType,
+		gcsSuffix,
+		version,
+		"release",
+		fast,
+	)
+}
+
+// GetMarkerPath returns a GCS path where version markers should be stored
+//
+// Expected destination format:
+//   gs://<bucket>/<buildType>[-<gcsSuffix>]
+func GetMarkerPath(
+	bucket, buildType, gcsSuffix string) string {
+	return getPath(
+		bucket,
+		buildType,
+		gcsSuffix,
+		"",
+		"marker",
+		false,
+	)
+}
+
+// GetReleasePath returns a GCS path to retrieve builds from or push builds to
+//
+// Expected destination format:
+//   gs://<bucket>/<buildType>[-<gcsSuffix>][/fast][/<version>]
+// TODO: Support "release" buildType
+func getPath(
+	bucket, buildType, gcsSuffix, version, pathType string,
 	fast bool) string {
 	gcsPath := bucket
 	gcsPath = filepath.Join(gcsPath, buildType)
@@ -134,12 +167,14 @@ func GetReleasePath(
 		gcsPath += "-" + gcsSuffix
 	}
 
-	if fast {
-		gcsPath = filepath.Join(gcsPath, "fast")
-	}
+	if pathType == "release" {
+		if fast {
+			gcsPath = filepath.Join(gcsPath, "fast")
+		}
 
-	if version != "" {
-		gcsPath = filepath.Join(gcsPath, version)
+		if version != "" {
+			gcsPath = filepath.Join(gcsPath, version)
+		}
 	}
 
 	logrus.Infof("GCS path is %s", gcsPath)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -250,7 +250,7 @@ func (p *Publisher) PublishToGcs(
 		// Ref:
 		// - https://cloud.google.com/storage/docs/bucket-policy-only
 		// - https://github.com/kubernetes/release/issues/904
-		if strings.HasPrefix(bucket, "k8s-") {
+		if !strings.HasPrefix(bucket, "k8s-") {
 			aclOutput, err := p.client.GSUtilOutput(
 				"acl", "ch", "-R", "-g", "all:R", publishFileDst,
 			)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -75,10 +75,16 @@ func (*defaultPublisher) GetURLResponse(url string) (string, error) {
 // buildType - One of 'release' or 'ci'
 // version - The version
 // buildDir - build output directory
-// bucket - GS bucket
+// bucket - GCS bucket
+// gcsSuffix - appended to the buildType to construct a new top-level
+//             destination
+//
+// Expected destination format:
+//   gs://<bucket>/<buildType>[-<gcsSuffix>][/fast]/<version>
+//
 // was releaselib.sh: release::gcs::publish_version
 func (p *Publisher) PublishVersion(
-	buildType, version, buildDir, bucket string,
+	buildType, version, buildDir, bucket, gcsSuffix string,
 	extraVersionMarkers []string,
 	privateBucket, fast bool,
 ) error {
@@ -94,19 +100,28 @@ func (p *Publisher) PublishVersion(
 		}
 	}
 
-	releasePath := filepath.Join(bucket, buildType)
-	if fast {
-		releasePath = filepath.Join(releasePath, "fast")
-	}
-	releasePath = gcs.GcsPrefix + filepath.Join(releasePath, version)
-
-	if err := p.client.GSUtil("ls", releasePath); err != nil {
-		return errors.Wrapf(err, "release files don't exist at %s", releasePath)
-	}
-
 	sv, err := util.TagStringToSemver(version)
 	if err != nil {
 		return errors.Errorf("invalid version %s", version)
+	}
+
+	markerPath := gcs.GetMarkerPath(
+		bucket,
+		buildType,
+		gcsSuffix,
+	)
+
+	releasePath := gcs.GetReleasePath(
+		bucket,
+		buildType,
+		gcsSuffix,
+		version,
+		fast,
+	)
+
+	// TODO: This should probably be a more thorough check of explicit files
+	if err := p.client.GSUtil("ls", releasePath); err != nil {
+		return errors.Wrapf(err, "release files don't exist at %s", releasePath)
 	}
 
 	var versionMarkers []string
@@ -129,12 +144,12 @@ func (p *Publisher) PublishVersion(
 	}
 
 	logrus.Infof("Publish version markers: %v", versionMarkers)
-	logrus.Infof("Publish official pointer text files to bucket %s", bucket)
+	logrus.Infof("Publish official pointer text files to %s", markerPath)
 
 	for _, file := range versionMarkers {
 		versionMarker := filepath.Join(buildType, file+".txt")
 		needsUpdate, err := p.VerifyLatestUpdate(
-			versionMarker, bucket, version,
+			versionMarker, markerPath, version,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "verify latest update for %s", versionMarker)
@@ -150,7 +165,7 @@ func (p *Publisher) PublishVersion(
 		}
 
 		if err := p.PublishToGcs(
-			versionMarker, buildDir, bucket, version, privateBucket,
+			versionMarker, buildDir, markerPath, version, privateBucket,
 		); err != nil {
 			return errors.Wrap(err, "publish release to GCS")
 		}
@@ -162,16 +177,16 @@ func (p *Publisher) PublishVersion(
 // VerifyLatestUpdate checks if the new version is greater than the version
 // currently published on GCS. It returns `true` for `needsUpdate` if the remote
 // version does not exist or needs to be updated.
-// publishFile - the GCS location to look in
-// bucket - GS bucket
+// publishFile - the version marker to look for
+// markerPath - the GCS path to search for the version marker in
 // version - release version
 // was releaselib.sh: release::gcs::verify_latest_update
 func (p *Publisher) VerifyLatestUpdate(
-	publishFile, bucket, version string,
+	publishFile, markerPath, version string,
 ) (needsUpdate bool, err error) {
 	logrus.Infof("Testing %s > %s (published)", version, publishFile)
 
-	publishFileDst := gcs.GcsPrefix + filepath.Join(bucket, publishFile)
+	publishFileDst := gcs.NormalizeGCSPath(filepath.Join(markerPath, publishFile))
 	gcsVersion, err := p.client.GSUtilOutput("cat", publishFileDst)
 	if err != nil {
 		logrus.Infof("%s does not exist but will be created", publishFileDst)
@@ -202,17 +217,17 @@ func (p *Publisher) VerifyLatestUpdate(
 // PublishToGcs publishes a release to GCS
 // publishFile - the GCS location to look in
 // buildDir - build output directory
-// bucket - GS bucket
+// markerPath - the GCS path to publish a version marker to
 // version - release version
 // was releaselib.sh: release::gcs::publish
 func (p *Publisher) PublishToGcs(
-	publishFile, buildDir, bucket, version string,
+	publishFile, buildDir, markerPath, version string,
 	privateBucket bool,
 ) error {
 	releaseStage := filepath.Join(buildDir, ReleaseStagePath)
-	publishFileDst := gcs.GcsPrefix + filepath.Join(bucket, publishFile)
-	publicLink := fmt.Sprintf("%s/%s", URLPrefixForBucket(bucket), publishFile)
-	if bucket == ProductionBucket {
+	publishFileDst := gcs.NormalizeGCSPath(filepath.Join(markerPath, publishFile))
+	publicLink := fmt.Sprintf("%s/%s", URLPrefixForBucket(markerPath), publishFile)
+	if strings.HasPrefix(markerPath, ProductionBucket) {
 		publicLink = fmt.Sprintf("%s/%s", ProductionBucketURL, publishFile)
 	}
 
@@ -250,7 +265,7 @@ func (p *Publisher) PublishToGcs(
 		// Ref:
 		// - https://cloud.google.com/storage/docs/bucket-policy-only
 		// - https://github.com/kubernetes/release/issues/904
-		if !strings.HasPrefix(bucket, "k8s-") {
+		if !strings.HasPrefix(markerPath, "k8s-") {
 			aclOutput, err := p.client.GSUtilOutput(
 				"acl", "ch", "-R", "-g", "all:R", publishFileDst,
 			)

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -42,9 +42,10 @@ func TestPublishVersion(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		bucket  string
-		version string
-		prepare func(
+		bucket    string
+		gcsSuffix string
+		version   string
+		prepare   func(
 			*releasefakes.FakePublisherClient,
 		) (buildDir string, cleanup func())
 		privateBucket bool
@@ -189,7 +190,7 @@ func TestPublishVersion(t *testing.T) {
 		buildDir, cleanup := tc.prepare(clientMock)
 
 		err := sut.PublishVersion(
-			"release", tc.version, buildDir, tc.bucket,
+			"release", tc.version, buildDir, tc.bucket, tc.gcsSuffix,
 			nil, tc.privateBucket, tc.fast,
 		)
 		if tc.shouldError {

--- a/pkg/release/releasefakes/fake_command_client.go
+++ b/pkg/release/releasefakes/fake_command_client.go
@@ -72,15 +72,16 @@ func (fake *FakeCommandClient) Execute(arg1 string, arg2 ...string) error {
 		arg1 string
 		arg2 []string
 	}{arg1, arg2})
+	stub := fake.ExecuteStub
+	fakeReturns := fake.executeReturns
 	fake.recordInvocation("Execute", []interface{}{arg1, arg2})
 	fake.executeMutex.Unlock()
-	if fake.ExecuteStub != nil {
-		return fake.ExecuteStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.executeReturns
 	return fakeReturns.result1
 }
 
@@ -133,15 +134,16 @@ func (fake *FakeCommandClient) ExecuteOutput(arg1 string, arg2 ...string) (strin
 		arg1 string
 		arg2 []string
 	}{arg1, arg2})
+	stub := fake.ExecuteOutputStub
+	fakeReturns := fake.executeOutputReturns
 	fake.recordInvocation("ExecuteOutput", []interface{}{arg1, arg2})
 	fake.executeOutputMutex.Unlock()
-	if fake.ExecuteOutputStub != nil {
-		return fake.ExecuteOutputStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.executeOutputReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -196,15 +198,16 @@ func (fake *FakeCommandClient) RepoTagFromTarball(arg1 string) (string, error) {
 	fake.repoTagFromTarballArgsForCall = append(fake.repoTagFromTarballArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RepoTagFromTarballStub
+	fakeReturns := fake.repoTagFromTarballReturns
 	fake.recordInvocation("RepoTagFromTarball", []interface{}{arg1})
 	fake.repoTagFromTarballMutex.Unlock()
-	if fake.RepoTagFromTarballStub != nil {
-		return fake.RepoTagFromTarballStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.repoTagFromTarballReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/release/releasefakes/fake_publisher_client.go
+++ b/pkg/release/releasefakes/fake_publisher_client.go
@@ -69,15 +69,16 @@ func (fake *FakePublisherClient) GSUtil(arg1 ...string) error {
 	fake.gSUtilArgsForCall = append(fake.gSUtilArgsForCall, struct {
 		arg1 []string
 	}{arg1})
+	stub := fake.GSUtilStub
+	fakeReturns := fake.gSUtilReturns
 	fake.recordInvocation("GSUtil", []interface{}{arg1})
 	fake.gSUtilMutex.Unlock()
-	if fake.GSUtilStub != nil {
-		return fake.GSUtilStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.gSUtilReturns
 	return fakeReturns.result1
 }
 
@@ -129,15 +130,16 @@ func (fake *FakePublisherClient) GSUtilOutput(arg1 ...string) (string, error) {
 	fake.gSUtilOutputArgsForCall = append(fake.gSUtilOutputArgsForCall, struct {
 		arg1 []string
 	}{arg1})
+	stub := fake.GSUtilOutputStub
+	fakeReturns := fake.gSUtilOutputReturns
 	fake.recordInvocation("GSUtilOutput", []interface{}{arg1})
 	fake.gSUtilOutputMutex.Unlock()
-	if fake.GSUtilOutputStub != nil {
-		return fake.GSUtilOutputStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.gSUtilOutputReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -192,15 +194,16 @@ func (fake *FakePublisherClient) GetURLResponse(arg1 string) (string, error) {
 	fake.getURLResponseArgsForCall = append(fake.getURLResponseArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetURLResponseStub
+	fakeReturns := fake.getURLResponseReturns
 	fake.recordInvocation("GetURLResponse", []interface{}{arg1})
 	fake.getURLResponseMutex.Unlock()
-	if fake.GetURLResponseStub != nil {
-		return fake.GetURLResponseStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getURLResponseReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/release/releasefakes/fake_repository.go
+++ b/pkg/release/releasefakes/fake_repository.go
@@ -108,15 +108,16 @@ func (fake *FakeRepository) CurrentBranch() (string, error) {
 	ret, specificReturn := fake.currentBranchReturnsOnCall[len(fake.currentBranchArgsForCall)]
 	fake.currentBranchArgsForCall = append(fake.currentBranchArgsForCall, struct {
 	}{})
+	stub := fake.CurrentBranchStub
+	fakeReturns := fake.currentBranchReturns
 	fake.recordInvocation("CurrentBranch", []interface{}{})
 	fake.currentBranchMutex.Unlock()
-	if fake.CurrentBranchStub != nil {
-		return fake.CurrentBranchStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentBranchReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -164,15 +165,16 @@ func (fake *FakeRepository) Describe(arg1 *git.DescribeOptions) (string, error) 
 	fake.describeArgsForCall = append(fake.describeArgsForCall, struct {
 		arg1 *git.DescribeOptions
 	}{arg1})
+	stub := fake.DescribeStub
+	fakeReturns := fake.describeReturns
 	fake.recordInvocation("Describe", []interface{}{arg1})
 	fake.describeMutex.Unlock()
-	if fake.DescribeStub != nil {
-		return fake.DescribeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.describeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -226,15 +228,16 @@ func (fake *FakeRepository) Head() (string, error) {
 	ret, specificReturn := fake.headReturnsOnCall[len(fake.headArgsForCall)]
 	fake.headArgsForCall = append(fake.headArgsForCall, struct {
 	}{})
+	stub := fake.HeadStub
+	fakeReturns := fake.headReturns
 	fake.recordInvocation("Head", []interface{}{})
 	fake.headMutex.Unlock()
-	if fake.HeadStub != nil {
-		return fake.HeadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.headReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -281,15 +284,16 @@ func (fake *FakeRepository) IsDirty() (bool, error) {
 	ret, specificReturn := fake.isDirtyReturnsOnCall[len(fake.isDirtyArgsForCall)]
 	fake.isDirtyArgsForCall = append(fake.isDirtyArgsForCall, struct {
 	}{})
+	stub := fake.IsDirtyStub
+	fakeReturns := fake.isDirtyReturns
 	fake.recordInvocation("IsDirty", []interface{}{})
 	fake.isDirtyMutex.Unlock()
-	if fake.IsDirtyStub != nil {
-		return fake.IsDirtyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isDirtyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -337,15 +341,16 @@ func (fake *FakeRepository) LsRemote(arg1 ...string) (string, error) {
 	fake.lsRemoteArgsForCall = append(fake.lsRemoteArgsForCall, struct {
 		arg1 []string
 	}{arg1})
+	stub := fake.LsRemoteStub
+	fakeReturns := fake.lsRemoteReturns
 	fake.recordInvocation("LsRemote", []interface{}{arg1})
 	fake.lsRemoteMutex.Unlock()
-	if fake.LsRemoteStub != nil {
-		return fake.LsRemoteStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.lsRemoteReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -399,15 +404,16 @@ func (fake *FakeRepository) Remotes() ([]*git.Remote, error) {
 	ret, specificReturn := fake.remotesReturnsOnCall[len(fake.remotesArgsForCall)]
 	fake.remotesArgsForCall = append(fake.remotesArgsForCall, struct {
 	}{})
+	stub := fake.RemotesStub
+	fakeReturns := fake.remotesReturns
 	fake.recordInvocation("Remotes", []interface{}{})
 	fake.remotesMutex.Unlock()
-	if fake.RemotesStub != nil {
-		return fake.RemotesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.remotesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/release/releasefakes/fake_version_client.go
+++ b/pkg/release/releasefakes/fake_version_client.go
@@ -47,15 +47,16 @@ func (fake *FakeVersionClient) GetURLResponse(arg1 string) (string, error) {
 	fake.getURLResponseArgsForCall = append(fake.getURLResponseArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetURLResponseStub
+	fakeReturns := fake.getURLResponseReturns
 	fake.recordInvocation("GetURLResponse", []interface{}{arg1})
 	fake.getURLResponseMutex.Unlock()
-	if fake.GetURLResponseStub != nil {
-		return fake.GetURLResponseStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getURLResponseReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

(Continuation of work on ci-kubernetes-build-no-bootstrap: 
https://github.com/kubernetes/release/issues/1711)

- pkg/release/publish: Don't attempt to set ACLs on K8s Infra buckets
- pkg/gcp/gcs: Add GetReleasePath as a common builder for a GCS path
- pkg/release: Respect a GCS suffix when publishing version markers

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/release/publish: Don't attempt to set ACLs on K8s Infra buckets
- pkg/gcp/gcs: Add GetReleasePath as a common builder for a GCS path
- pkg/release: Respect a GCS suffix when publishing version markers
```
