### PR TITLE
Build images using go1.15.5

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -28,7 +28,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.15.3
+GO_VERSION ?= 1.15.5
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64

--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.3.0
+IMAGE_VERSION ?= v0.3.0-1
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   default:
     IMAGE_VERSION: 'v0.3.0'
-    GO_VERSION: '1.15.3'
+    GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   default:
-    IMAGE_VERSION: 'v0.3.0'
+    IMAGE_VERSION: 'v0.3.0-1'
     GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,6 +81,12 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
+  - name: "gcr.io/k8s-staging-releng/releng-ci"
+    version: v0.1.2
+    refPaths:
+    - path: images/releng/ci/cloudbuild.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
     version: v0.3.0-1
     refPaths:
@@ -133,13 +139,6 @@ dependencies:
       match: IPTABLES_VERSION \?= (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
     - path: images/build/debian-iptables/variants.yaml
       match: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
-
-  # Images: k8s.io/releng
-  - name: "k8s.gcr.io/releng/releng-ci"
-    version: v0.1.1
-    refPaths:
-    - path: images/releng/ci/cloudbuild.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15.3
+    version: 1.15.5
     refPaths:
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -74,7 +74,15 @@ dependencies:
     - path: images/releng/ci/cloudbuild.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  - name: "k8s.gcr.io/go-runner"
+  # TODO(go): Update to 1.15.5 after kubernetes/kubernetes has been updated
+  - name: "golang: after kubernetes/kubernetes update"
+    version: 1.15.3
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  # TODO(go): Bump tag to denote go1.15.5 update
+  - name: "k8s.gcr.io/build-image/go-runner"
     version: buster-v2.1.0
     refPaths:
     - path: images/build/go-runner/Makefile
@@ -82,13 +90,13 @@ dependencies:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
-  - name: "k8s.gcr.io/kube-cross"
-    version: v1.15.3-1
+  - name: "k8s.gcr.io/build-image/kube-cross"
+    version: v1.15.5-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
-  - name: "k8s.gcr.io/kube-cross: config variant"
+  - name: "k8s.gcr.io/build-image/kube-cross: config variant"
     version: go1.15
     refPaths:
     - path: images/build/cross/Makefile
@@ -96,11 +104,21 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: go\d+.\d+
 
-  - name: "k8s.gcr.io/kube-cross: dependents"
+  # TODO(go): Bump tag to denote go1.15.5 update
+  - name: "k8s.gcr.io/build-image/kube-cross: dependents"
     version: v1.15.3-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
+
+  # TODO(go): Bump tag to denote go1.15.5 update
+  - name: "k8s.io/artifact-promoter/vulndash"
+    version: v0.3.0
+    refPaths:
+    - path: cmd/vulndash/Makefile
+      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: cmd/vulndash/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # golangci-lint
   - name: "golangci-lint"
@@ -118,24 +136,15 @@ dependencies:
     - path: images/build/debian-iptables/variants.yaml
       match: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
-  # Images: k8s.io/artifact-promoter
-  - name: "k8s.io/artifact-promoter/vulndash"
-    version: v0.3.0
-    refPaths:
-    - path: cmd/vulndash/Makefile
-      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-    - path: cmd/vulndash/variants.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-
   # Images: k8s.io/releng
-  - name: "k8s.io/releng/releng-ci"
+  - name: "k8s.gcr.io/releng/releng-ci"
     version: v0.1.1
     refPaths:
     - path: images/releng/ci/cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # Base images
-  - name: "k8s.gcr.io/debian-base"
+  - name: "k8s.gcr.io/build-image/debian-base"
     version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-base/Makefile
@@ -143,7 +152,7 @@ dependencies:
     - path: images/build/debian-base/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
-  - name: "k8s.gcr.io/debian-base: dependents"
+  - name: "k8s.gcr.io/build-image/debian-base: dependents"
     version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
@@ -151,13 +160,13 @@ dependencies:
     - path: images/build/debian-iptables/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
-  - name: "k8s.gcr.io/debian-hyperkube-base"
+  - name: "k8s.gcr.io/build-image/debian-hyperkube-base"
     version: buster-v1.2.0
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: TAG\?=[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
-  - name: "k8s.gcr.io/debian-iptables"
+  - name: "k8s.gcr.io/build-image/debian-iptables"
     version: buster-v1.3.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
@@ -165,7 +174,7 @@ dependencies:
     - path: images/build/debian-iptables/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
-  - name: "k8s.gcr.io/debian-iptables: dependents"
+  - name: "k8s.gcr.io/build-image/debian-iptables: dependents"
     version: buster-v1.3.0
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,6 +81,14 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
+  - name: "k8s.gcr.io/artifact-promoter/vulndash"
+    version: v0.3.0-1
+    refPaths:
+    - path: cmd/vulndash/Makefile
+      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
+    - path: cmd/vulndash/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
+
   - name: "k8s.gcr.io/build-image/go-runner"
     version: buster-v2.2.0
     refPaths:
@@ -109,15 +117,6 @@ dependencies:
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
-
-  # TODO(go): Bump tag to denote go1.15.5 update
-  - name: "k8s.io/artifact-promoter/vulndash"
-    version: v0.3.0
-    refPaths:
-    - path: cmd/vulndash/Makefile
-      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-    - path: cmd/vulndash/variants.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # golangci-lint
   - name: "golangci-lint"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,9 +81,8 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # TODO(go): Bump tag to denote go1.15.5 update
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.1.0
+    version: buster-v2.2.0
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.15.3-1
+IMAGE_VERSION ?= v1.15.5-1
 CONFIG ?= go1.15
 
 # Build args
-GO_VERSION?=1.15.3
+GO_VERSION?=1.15.5
 PROTOBUF_VERSION?=3.0.2
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.3'
-    IMAGE_VERSION: 'v1.15.3-canary-1'
+    GO_VERSION: '1.15.5'
+    IMAGE_VERSION: 'v1.15.5-canary-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.3'
-    IMAGE_VERSION: 'v1.15.3-1'
+    GO_VERSION: '1.15.5'
+    IMAGE_VERSION: 'v1.15.5-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -20,7 +20,7 @@ IMAGE_VERSION ?= buster-v2.1.0
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.15.3
+GO_VERSION ?= 1.15.5
 DISTROLESS_IMAGE ?= static-debian10
 
 # TODO: Re-enable linux/ppc64le builds once upstream distroless builds are fixed

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,7 +16,7 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.1.0
+IMAGE_VERSION ?= buster-v2.2.0
 CONFIG ?= buster
 
 # Build args

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -2,5 +2,5 @@ variants:
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v2.1.0'
-    GO_VERSION: '1.15.3'
+    GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.1.0'
+    IMAGE_VERSION: 'buster-v2.2.0'
     GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -24,7 +24,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.1.1'
+  _IMAGE_VERSION: 'v0.1.2'
   _GO_VERSION: '1.15.5'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -25,7 +25,7 @@ substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
   _IMAGE_VERSION: 'v0.1.1'
-  _GO_VERSION: '1.15.3'
+  _GO_VERSION: '1.15.5'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency security

#### What this PR does / why we need it:

Go 1.15.5 (and 1.14.12) security releases are out!
https://groups.google.com/g/golang-nuts/c/c-ssaaS7RMI
(ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1605129514273400)

The following images are now built with go1.15.5:

- kube-cross:v1.15.5-1
- go-runner:buster-v2.2.0
- vulndash:v0.3.0-1
- releng-ci:v0.1.2

Tracking issue: https://github.com/kubernetes/release/issues/1651

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- The following images are now built with go1.15.5:
  - kube-cross:v1.15.5-1
  - go-runner:buster-v2.2.0
  - vulndash:v0.3.0-1
  - releng-ci:v0.1.2
```
