### PR TITLE
Rename GCB `Run()` method to `Submit()`

### DIFF
--- a/cmd/krel/cmd/gcbmgr.go
+++ b/cmd/krel/cmd/gcbmgr.go
@@ -39,7 +39,7 @@ var gcbmgrCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		gcbmgrOpts.NoMock = rootOpts.nomock
 		gcbmgrOpts.LogLevel = rootOpts.logLevel
-		return gcb.New(gcbmgrOpts).Run()
+		return gcb.New(gcbmgrOpts).Submit()
 	},
 }
 

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -135,10 +135,10 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-// Run is the function responsible for submitting release jobs to GCB.
-func (g *GCB) Run() error {
+// Submit is the main method responsible for submitting release jobs to GCB.
+func (g *GCB) Submit() error {
 	if err := g.options.Validate(); err != nil {
-		return errors.Wrap(err, "validating gcb options")
+		return errors.Wrap(err, "validating GCB options")
 	}
 
 	toolOrg := release.GetToolOrg()
@@ -157,7 +157,7 @@ func (g *GCB) Run() error {
 		return errors.Wrap(err, "verifying repository state")
 	}
 
-	logrus.Infof("Running gcb with the following options: %+v", g.options)
+	logrus.Infof("Running GCB with the following options: %+v", g.options)
 
 	g.options.NoSource = true
 	g.options.DiskSize = release.DefaultDiskSize

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -43,7 +43,7 @@ func mockVersion(version string) gcb.Version {
 	return mock
 }
 
-func TestRunList(t *testing.T) {
+func TestSubmitList(t *testing.T) {
 	testcases := []struct {
 		name         string
 		gcbOpts      *gcb.Options
@@ -92,7 +92,7 @@ func TestRunList(t *testing.T) {
 		sut.SetRepoClient(tc.repoMock)
 		sut.SetVersionClient(tc.versionMock)
 		sut.SetListJobsClient(tc.listJobsMock)
-		err := sut.Run()
+		err := sut.Submit()
 
 		if tc.expectedErr {
 			require.NotNil(t, err)
@@ -102,7 +102,7 @@ func TestRunList(t *testing.T) {
 	}
 }
 
-func TestRunGcbFailure(t *testing.T) {
+func TestSubmitGcbFailure(t *testing.T) {
 	testcases := []struct {
 		name        string
 		gcbOpts     *gcb.Options
@@ -136,7 +136,7 @@ func TestRunGcbFailure(t *testing.T) {
 		sut := gcb.New(tc.gcbOpts)
 		sut.SetRepoClient(tc.repoMock)
 		sut.SetVersionClient(tc.versionMock)
-		err := sut.Run()
+		err := sut.Submit()
 		require.Error(t, err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We now name the main GCB method `Submit()` to make its intention more clear. This also fixes the logging (`gcb` -> `GCB`) within the package.

#### Which issue(s) this PR fixes:
Follow up of https://github.com/kubernetes/release/pull/1723#pullrequestreview-528433422
#### Special notes for your reviewer:
I think we may consider moving the `gcb` package to another location, because this is a more special implementation than the `pkg/gcp/build` package. Any thoughts on that?
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
