### PR TITLE
Allow submitting jobs via krel stage/release

### DIFF
--- a/gcb/release-krel/cloudbuild.yaml
+++ b/gcb/release-krel/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
   args:
   - "bin/krel"
   - "release"
+  - "--submit=false"
   - "${_NOMOCK}"
   - "--log-level=${_LOG_LEVEL}"
   - "--type=${_TYPE}"

--- a/gcb/stage-krel/cloudbuild.yaml
+++ b/gcb/stage-krel/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
   args:
   - "bin/krel"
   - "stage"
+  - "--submit=false"
   - "${_NOMOCK}"
   - "--log-level=${_LOG_LEVEL}"
   - "--type=${_TYPE}"

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -207,6 +207,15 @@ func (s *Stage) SetClient(client stageClient) {
 	s.client = client
 }
 
+// Submit can be used to submit a staging Google Cloud Build (GCB) job.
+func (s *Stage) Submit() error {
+	logrus.Info("Submitting stage GCB job")
+	if err := s.client.Submit(); err != nil {
+		return errors.Wrap(err, "submit stage job")
+	}
+	return nil
+}
+
 // Run for the `Stage` struct prepares a release and puts the results on a
 // staging bucket.
 // nolint:dupl
@@ -313,6 +322,15 @@ func NewRelease(options *ReleaseOptions) *Release {
 // SetClient can be used to set the internal stage client.
 func (r *Release) SetClient(client releaseClient) {
 	r.client = client
+}
+
+// Submit can be used to submit a releasing Google Cloud Build (GCB) job.
+func (r *Release) Submit() error {
+	logrus.Info("Submitting release GCB job")
+	if err := r.client.Submit(); err != nil {
+		return errors.Wrap(err, "submit release job")
+	}
+	return nil
 }
 
 // Run for for `Release` struct finishes a previously staged release.

--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -102,6 +102,16 @@ type FakeReleaseClient struct {
 	setBuildCandidateReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SubmitStub        func() error
+	submitMutex       sync.RWMutex
+	submitArgsForCall []struct {
+	}
+	submitReturns struct {
+		result1 error
+	}
+	submitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ValidateOptionsStub        func() error
 	validateOptionsMutex       sync.RWMutex
 	validateOptionsArgsForCall []struct {
@@ -540,6 +550,59 @@ func (fake *FakeReleaseClient) SetBuildCandidateReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
+func (fake *FakeReleaseClient) Submit() error {
+	fake.submitMutex.Lock()
+	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
+	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
+	}{})
+	stub := fake.SubmitStub
+	fakeReturns := fake.submitReturns
+	fake.recordInvocation("Submit", []interface{}{})
+	fake.submitMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseClient) SubmitCallCount() int {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	return len(fake.submitArgsForCall)
+}
+
+func (fake *FakeReleaseClient) SubmitCalls(stub func() error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = stub
+}
+
+func (fake *FakeReleaseClient) SubmitReturns(result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	fake.submitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseClient) SubmitReturnsOnCall(i int, result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	if fake.submitReturnsOnCall == nil {
+		fake.submitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.submitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeReleaseClient) ValidateOptions() error {
 	fake.validateOptionsMutex.Lock()
 	ret, specificReturn := fake.validateOptionsReturnsOnCall[len(fake.validateOptionsArgsForCall)]
@@ -612,6 +675,8 @@ func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	defer fake.pushGitObjectsMutex.RUnlock()
 	fake.setBuildCandidateMutex.RLock()
 	defer fake.setBuildCandidateMutex.RUnlock()
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
 	fake.validateOptionsMutex.RLock()
 	defer fake.validateOptionsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"k8s.io/release/pkg/build"
+	"k8s.io/release/pkg/gcp/gcb"
 	"k8s.io/release/pkg/release"
 )
 
@@ -93,6 +94,17 @@ type FakeReleaseImpl struct {
 		result1 error
 	}
 	publishVersionReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SubmitStub        func(*gcb.Options) error
+	submitMutex       sync.RWMutex
+	submitArgsForCall []struct {
+		arg1 *gcb.Options
+	}
+	submitReturns struct {
+		result1 error
+	}
+	submitReturnsOnCall map[int]struct {
 		result1 error
 	}
 	ValidateImagesStub        func(string, string, string) error
@@ -438,6 +450,67 @@ func (fake *FakeReleaseImpl) PublishVersionReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeReleaseImpl) Submit(arg1 *gcb.Options) error {
+	fake.submitMutex.Lock()
+	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
+	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
+		arg1 *gcb.Options
+	}{arg1})
+	stub := fake.SubmitStub
+	fakeReturns := fake.submitReturns
+	fake.recordInvocation("Submit", []interface{}{arg1})
+	fake.submitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseImpl) SubmitCallCount() int {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	return len(fake.submitArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) SubmitCalls(stub func(*gcb.Options) error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = stub
+}
+
+func (fake *FakeReleaseImpl) SubmitArgsForCall(i int) *gcb.Options {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	argsForCall := fake.submitArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeReleaseImpl) SubmitReturns(result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	fake.submitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseImpl) SubmitReturnsOnCall(i int, result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	if fake.submitReturnsOnCall == nil {
+		fake.submitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.submitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeReleaseImpl) ValidateImages(arg1 string, arg2 string, arg3 string) error {
 	fake.validateImagesMutex.Lock()
 	ret, specificReturn := fake.validateImagesReturnsOnCall[len(fake.validateImagesArgsForCall)]
@@ -514,6 +587,8 @@ func (fake *FakeReleaseImpl) Invocations() map[string][][]interface{} {
 	defer fake.prepareWorkspaceReleaseMutex.RUnlock()
 	fake.publishVersionMutex.RLock()
 	defer fake.publishVersionMutex.RUnlock()
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
 	fake.validateImagesMutex.RLock()
 	defer fake.validateImagesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -92,6 +92,16 @@ type FakeStageClient struct {
 	stageArtifactsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SubmitStub        func() error
+	submitMutex       sync.RWMutex
+	submitArgsForCall []struct {
+	}
+	submitReturns struct {
+		result1 error
+	}
+	submitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	TagRepositoryStub        func() error
 	tagRepositoryMutex       sync.RWMutex
 	tagRepositoryArgsForCall []struct {
@@ -487,6 +497,59 @@ func (fake *FakeStageClient) StageArtifactsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeStageClient) Submit() error {
+	fake.submitMutex.Lock()
+	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
+	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
+	}{})
+	stub := fake.SubmitStub
+	fakeReturns := fake.submitReturns
+	fake.recordInvocation("Submit", []interface{}{})
+	fake.submitMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageClient) SubmitCallCount() int {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	return len(fake.submitArgsForCall)
+}
+
+func (fake *FakeStageClient) SubmitCalls(stub func() error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = stub
+}
+
+func (fake *FakeStageClient) SubmitReturns(result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	fake.submitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) SubmitReturnsOnCall(i int, result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	if fake.submitReturnsOnCall == nil {
+		fake.submitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.submitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageClient) TagRepository() error {
 	fake.tagRepositoryMutex.Lock()
 	ret, specificReturn := fake.tagRepositoryReturnsOnCall[len(fake.tagRepositoryArgsForCall)]
@@ -610,6 +673,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.setBuildCandidateMutex.RUnlock()
 	fake.stageArtifactsMutex.RLock()
 	defer fake.stageArtifactsMutex.RUnlock()
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
 	fake.tagRepositoryMutex.RLock()
 	defer fake.tagRepositoryMutex.RUnlock()
 	fake.validateOptionsMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/release/pkg/build"
 	"k8s.io/release/pkg/changelog"
+	"k8s.io/release/pkg/gcp/gcb"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/release"
 )
@@ -221,6 +222,17 @@ type FakeStageImpl struct {
 		result1 error
 	}
 	stageLocalSourceTreeReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SubmitStub        func(*gcb.Options) error
+	submitMutex       sync.RWMutex
+	submitArgsForCall []struct {
+		arg1 *gcb.Options
+	}
+	submitReturns struct {
+		result1 error
+	}
+	submitReturnsOnCall map[int]struct {
 		result1 error
 	}
 	TagStub        func(*git.Repo, string, string) error
@@ -1227,6 +1239,67 @@ func (fake *FakeStageImpl) StageLocalSourceTreeReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
+func (fake *FakeStageImpl) Submit(arg1 *gcb.Options) error {
+	fake.submitMutex.Lock()
+	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
+	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
+		arg1 *gcb.Options
+	}{arg1})
+	stub := fake.SubmitStub
+	fakeReturns := fake.submitReturns
+	fake.recordInvocation("Submit", []interface{}{arg1})
+	fake.submitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) SubmitCallCount() int {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	return len(fake.submitArgsForCall)
+}
+
+func (fake *FakeStageImpl) SubmitCalls(stub func(*gcb.Options) error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = stub
+}
+
+func (fake *FakeStageImpl) SubmitArgsForCall(i int) *gcb.Options {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	argsForCall := fake.submitArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) SubmitReturns(result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	fake.submitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) SubmitReturnsOnCall(i int, result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	if fake.submitReturnsOnCall == nil {
+		fake.submitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.submitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageImpl) Tag(arg1 *git.Repo, arg2 string, arg3 string) error {
 	fake.tagMutex.Lock()
 	ret, specificReturn := fake.tagReturnsOnCall[len(fake.tagArgsForCall)]
@@ -1325,6 +1398,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.stageLocalArtifactsMutex.RUnlock()
 	fake.stageLocalSourceTreeMutex.RLock()
 	defer fake.stageLocalSourceTreeMutex.RUnlock()
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
 	fake.tagMutex.RLock()
 	defer fake.tagMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -170,3 +170,33 @@ func TestPrepareWorkspaceRelease(t *testing.T) {
 		}
 	}
 }
+
+func TestSubmitReleaseImpl(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeReleaseImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeReleaseImpl) {},
+			shouldError: false,
+		},
+		{ // Submit fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.SubmitReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultReleaseOptions()
+		sut := anago.NewDefaultRelease(opts)
+		mock := &anagofakes.FakeReleaseImpl{}
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+		err := sut.Submit()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -453,3 +453,33 @@ func TestStageArtifacts(t *testing.T) {
 		}
 	}
 }
+
+func TestSubmitStageImpl(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeStageImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeStageImpl) {},
+			shouldError: false,
+		},
+		{ // Submit fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.SubmitReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultStageOptions()
+		sut := anago.NewDefaultStage(opts)
+		mock := &anagofakes.FakeStageImpl{}
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+		err := sut.Submit()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -66,6 +66,14 @@ type Options struct {
 	EnvPassthrough string
 }
 
+// NewDefaultOptions returns a new default `*Options` instance.
+func NewDefaultOptions() *Options {
+	return &Options{
+		Project:        release.DefaultKubernetesStagingProject,
+		CloudbuildFile: DefaultCloudbuildFile,
+	}
+}
+
 func PrepareBuilds(o *Options) error {
 	if o.ConfigDir == "" {
 		return errors.New("expected a config directory to be provided")

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -85,6 +85,14 @@ type Options struct {
 	LastJobs     int64
 }
 
+// NewDefaultOptions returns a new default `*Options` instance.
+func NewDefaultOptions() *Options {
+	return &Options{
+		LogLevel: logrus.StandardLogger().GetLevel().String(),
+		Options:  *build.NewDefaultOptions(),
+	}
+}
+
 //counterfeiter:generate . Repository
 type Repository interface {
 	Open() error


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This change allows us to directly use `krel stage/release` for submitting jobs to GCB.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
##### :heavy_check_mark: Stage:
```
> export TOOL_ORG=saschagrunert && \
  export TOOL_BRANCH=krel-submit && \
  go run ./cmd/krel stage --type beta
```
https://console.cloud.google.com/cloud-build/builds/4f32ded1-a13f-469d-a1a9-b5555ceb83f4?project=kubernetes-release-test

##### :heavy_check_mark: Release:
```
> export TOOL_ORG=saschagrunert && \
  export TOOL_BRANCH=krel-submit && \
  go run ./cmd/krel release --type official --branch release-1.19 --build-version v1.19.4-rc.0.51+5f1e5cafd33a88
```
https://console.cloud.google.com/cloud-build/builds/885226c9-4d5f-4e1f-b782-ecb967cb1125?project=kubernetes-release-test
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
