### PR TITLE
Move krel `--cleanup` and `--repo-path` flags into subcommands

### DIFF
--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -61,7 +63,6 @@ the golang based 'release-notes' tool:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		changelogOptions.RepoPath = rootOpts.repoPath
 		return changelog.New(changelogOptions).Run()
 	},
 }
@@ -69,6 +70,7 @@ the golang based 'release-notes' tool:
 var changelogOptions = &changelog.Options{}
 
 func init() {
+	changelogCmd.PersistentFlags().StringVar(&changelogOptions.RepoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
 	changelogCmd.PersistentFlags().StringVar(&changelogOptions.Bucket, "bucket", "kubernetes-release", "Specify gs bucket to point to in generated notes")
 	changelogCmd.PersistentFlags().StringVar(&changelogOptions.Tag, "tag", "", "The version tag of the release, for example v1.17.0-rc.1")
 	changelogCmd.PersistentFlags().StringVar(&changelogOptions.Branch, "branch", "", "The branch to be used. Will be automatically inherited by the tag if not set.")

--- a/cmd/krel/cmd/ff_test.go
+++ b/cmd/krel/cmd/ff_test.go
@@ -28,6 +28,7 @@ func (s *sut) getFfOptions() *ffOptions {
 	return &ffOptions{
 		mainRef:        git.Remotify(git.DefaultBranch),
 		nonInteractive: true,
+		repoPath:       s.repo.Dir(),
 	}
 }
 

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -17,9 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -49,8 +46,6 @@ clarifies its purpose.`,
 
 type rootOptions struct {
 	nomock   bool
-	cleanup  bool
-	repoPath string
 	logLevel string
 }
 
@@ -66,8 +61,6 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.nomock, "nomock", false, "nomock flag")
-	rootCmd.PersistentFlags().BoolVar(&rootOpts.cleanup, "cleanup", false, "cleanup flag")
-	rootCmd.PersistentFlags().StringVar(&rootOpts.repoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'")
 
 	rootCmd.AddCommand(anago.AnagoCmd)

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -130,8 +130,6 @@ func (s *sut) lastCommit(t *testing.T, branch string) string {
 func (s *sut) getRootOptions() *rootOptions {
 	return &rootOptions{
 		nomock:   false,
-		cleanup:  false,
-		repoPath: s.repo.Dir(),
 		logLevel: "debug",
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We do not use those flags at all on some subcommands, so we now define
them where they're actually needed. This also helps in removing some
`rootOpts` to `subcommandOpts` conversions.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
