### PR TITLE
Always push remote branch

### DIFF
--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -91,18 +91,6 @@ func (gp *GitObjectPusher) PushBranch(branchName string) error {
 		return errors.New(fmt.Sprintf("Unable to push branch %s, it does not exist in the local repo", branchName))
 	}
 
-	// Check if the remote branch exists already:
-	branchExists, err = gp.repo.HasRemoteBranch(branchName)
-	if err != nil {
-		return errors.Wrapf(err, "checking if branch %s exists in remote repository", branchName)
-	}
-
-	// If the branch already exists in the remote repo, we do not do anything
-	if branchExists {
-		logrus.Infof("Branch %s already exists in the default remote. Noop.", branchName)
-		return nil
-	}
-
 	logrus.Infof("Pushing%s %s branch:", dryRunLabel[gp.opts.DryRun], branchName)
 	if err := gp.repo.Push(branchName); err != nil {
 		return errors.Wrapf(err, "pushing branch %s", branchName)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We always have to push the remote branch to update it containing the
previously created tag.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Referencing discussion: https://kubernetes.slack.com/archives/C2C40FMNF/p1605266214436700
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to always push remote branches when pushing the git objects.
```
