### PR TITLE
pkg/gcp/gcs: Improve GCS path construction/retrieval logic

### DIFF
--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -153,6 +153,7 @@ func init() {
 	)
 
 	// Deprecated flags
+	// nolint: errcheck
 	ciBuildCmd.PersistentFlags().MarkDeprecated(
 		"gcs-suffix",
 		"please use `--gcs-root` if you need to override the default GCS root",
@@ -162,5 +163,7 @@ func init() {
 }
 
 func runCIBuild(opts *build.Options) error {
-	return build.NewCIInstance(opts).Build()
+	opts.CI = true
+
+	return build.NewInstance(opts).Build()
 }

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -120,10 +120,10 @@ func init() {
 	)
 
 	pushBuildCmd.PersistentFlags().StringVar(
-		&pushBuildOpts.GCSSuffix,
-		"gcs-suffix",
+		&ciBuildOpts.GCSRoot,
+		"gcs-root",
 		"",
-		"Specify a suffix to append to the upload destination on GCS",
+		"Specify an alternate GCS path to push artifacts to",
 	)
 
 	pushBuildCmd.PersistentFlags().StringVar(

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -131,6 +131,17 @@ dependencies:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
+  # skopeo
+  - name: "skopeo"
+    version: v1.2.0
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: SKOPEO_VERSION \?= v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+
   # iptables
   - name: "iptables"
     version: 1.8.5

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -118,7 +118,7 @@ type releaseImpl interface {
 	) error
 	ValidateImages(registry, version, buildPath string) error
 	PublishVersion(
-		buildType, version, buildDir, bucket, gcsSuffix string,
+		buildType, version, buildDir, bucket, gcsRoot string,
 		versionMarkers []string,
 		privateBucket, fast bool,
 	) error
@@ -174,13 +174,13 @@ func (d *defaultReleaseImpl) ValidateImages(
 }
 
 func (d *defaultReleaseImpl) PublishVersion(
-	buildType, version, buildDir, bucket, gcsSuffix string,
+	buildType, version, buildDir, bucket, gcsRoot string,
 	versionMarkers []string,
 	privateBucket, fast bool,
 ) error {
 	return release.
 		NewPublisher().
-		PublishVersion("release", version, buildDir, bucket, gcsSuffix, nil, false, false)
+		PublishVersion("release", version, buildDir, bucket, gcsRoot, nil, false, false)
 }
 
 func (d *DefaultRelease) Submit() error {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -34,6 +34,7 @@ type Instance struct {
 func NewInstance(opts *Options) *Instance {
 	instance := &Instance{opts}
 	instance.setBuildType()
+	instance.setGCSRoot()
 
 	return instance
 }
@@ -121,8 +122,7 @@ func (bi *Instance) getGCSBuildPath(version string) (string, error) {
 
 	buildPath, err := gcs.GetReleasePath(
 		bucket,
-		bi.opts.BuildType,
-		bi.opts.GCSSuffix,
+		bi.opts.GCSRoot,
 		version,
 		bi.opts.Fast,
 	)
@@ -141,5 +141,17 @@ func (bi *Instance) setBuildType() {
 
 	bi.opts.BuildType = buildType
 
-	logrus.Infof("Build type is %s", bi.opts.BuildType)
+	logrus.Infof("Build type has been set to %s", bi.opts.BuildType)
+}
+
+func (bi *Instance) setGCSRoot() {
+	if bi.opts.GCSRoot == "" {
+		if bi.opts.GCSSuffix != "" {
+			bi.opts.GCSRoot = bi.opts.BuildType + "-" + bi.opts.GCSSuffix
+		} else {
+			bi.opts.GCSRoot = bi.opts.BuildType
+		}
+	}
+
+	logrus.Infof("GCS root has been set to %s", bi.opts.GCSRoot)
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package build
 
 import (
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/gcp/gcs"
@@ -93,20 +94,25 @@ type Options struct {
 }
 
 // TODO: Refactor so that version is not required as a parameter
-func (bi *Instance) getGCSBuildPath(version string) string {
+func (bi *Instance) getGCSBuildPath(version string) (string, error) {
 	// TODO: Parameterize this? Maybe a setter for defaults?
 	bucket := bi.opts.Bucket
 	if bi.opts.Bucket == "" {
 		bucket = "kubernetes-release-dev"
 	}
 
-	return gcs.GetReleasePath(
+	buildPath, err := gcs.GetReleasePath(
 		bucket,
 		bi.opts.BuildType,
 		bi.opts.GCSSuffix,
 		version,
 		bi.opts.Fast,
 	)
+	if err != nil {
+		return "", errors.Wrap(err, "get GCS release path")
+	}
+
+	return buildPath, nil
 }
 
 func (bi *Instance) setBuildType() {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -48,6 +48,8 @@ type Options struct {
 	BuildDir string
 
 	// Used to make determinations on where to push artifacts
+	// Can be overridden using `GCSRoot`.
+	//
 	// May be one of: 'devel', 'ci', 'release'
 	BuildType string
 
@@ -59,7 +61,23 @@ type Options struct {
 	// only).
 	ExtraVersionMarkers []string
 
-	// Specify a suffix to append to the upload destination on GCS.
+	// The top-level GCS directory builds will be released to.
+	// If specified, it will override BuildType.
+	//
+	// When unset:
+	//   - BuildType: "ci"
+	//   - final path: gs://<bucket>/ci
+	//
+	// When set:
+	//   - BuildType: "ci"
+	//   - GCSRoot: "new-root"
+	//   - final path: gs://<bucket>/new-root
+	//
+	// This option exists to handle the now-deprecated GCSSuffix option, which
+	// was not plumbed through
+	GCSRoot string
+
+	// [DEPRECATED] Specify a suffix to append to the upload destination on GCS.
 	GCSSuffix string
 
 	// Version to be used. Usually automatically discovered, but it can be

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -30,15 +30,6 @@ import (
 	"k8s.io/release/pkg/release"
 )
 
-// NewCIInstance can be used to create a new build `Instance` for use in CI.
-func NewCIInstance(opts *Options) *Instance {
-	instance := NewInstance(opts)
-	instance.opts.CI = true
-	instance.setBuildType()
-
-	return instance
-}
-
 // Build starts a Kubernetes build with the options defined in the build
 // `Instance`.
 func (bi *Instance) Build() error {

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -123,14 +123,20 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 		return false, nil
 	}
 
-	gcsBuildRoot := bi.getGCSBuildPath(bi.opts.Version)
+	gcsBuildRoot, gcsBuildRootErr := bi.getGCSBuildPath(bi.opts.Version)
+	if gcsBuildRootErr != nil {
+		return false, errors.Wrap(gcsBuildRootErr, "get GCS build root")
+	}
 
-	kubernetesTar := filepath.Join(gcsBuildRoot, release.KubernetesTar)
-	binPath := filepath.Join(gcsBuildRoot, "bin")
+	kubernetesTar, kubernetesTarErr := gcs.NormalizeGCSPath(gcsBuildRoot, release.KubernetesTar)
+	if kubernetesTarErr != nil {
+		return false, errors.Wrap(kubernetesTarErr, "get tarball path")
+	}
 
-	gcsBuildRoot = gcs.NormalizeGCSPath(gcsBuildRoot)
-	kubernetesTar = gcs.NormalizeGCSPath(kubernetesTar)
-	binPath = gcs.NormalizeGCSPath(binPath)
+	binPath, binPathErr := gcs.NormalizeGCSPath(gcsBuildRoot, "bin")
+	if binPathErr != nil {
+		return false, errors.Wrap(binPathErr, "get binary path")
+	}
 
 	gcsBuildPaths := []string{
 		gcsBuildRoot,

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -124,7 +124,10 @@ func (bi *Instance) Push() error {
 		return errors.Wrap(err, "push container images")
 	}
 
-	gcsDest := bi.getGCSBuildPath(version)
+	gcsDest, gcsDestErr := bi.getGCSBuildPath(version)
+	if gcsDestErr != nil {
+		return errors.Wrap(gcsDestErr, "get GCS destination")
+	}
 
 	if err := bi.PushReleaseArtifacts(
 		filepath.Join(bi.opts.BuildDir, release.GCSStagePath, version),
@@ -368,7 +371,11 @@ func (bi *Instance) copyStageFiles(stageDir string, files []stageFile) error {
 // PushReleaseArtifacts can be used to push local artifacts from the `srcPath`
 // to the remote `gcsPath`. The Bucket has to be set via the `Bucket` option.
 func (bi *Instance) PushReleaseArtifacts(srcPath, gcsPath string) error {
-	dstPath := gcs.NormalizeGCSPath(filepath.Join(bi.opts.Bucket, gcsPath))
+	dstPath, dstPathErr := gcs.NormalizeGCSPath(bi.opts.Bucket, gcsPath)
+	if dstPathErr != nil {
+		return errors.Wrap(dstPathErr, "normalize GCS destination")
+	}
+
 	logrus.Infof("Pushing release artifacts from %s to %s", srcPath, dstPath)
 
 	return errors.Wrap(
@@ -420,8 +427,16 @@ func (bi *Instance) CopyStagedFromGCS(stagedBucket, buildVersion string) error {
 	gsStageRoot := filepath.Join(bi.opts.Bucket, release.StagePath, buildVersion, bi.opts.Version)
 	src := filepath.Join(gsStageRoot, release.GCSStagePath, bi.opts.Version)
 
-	gcsSrc := gcs.NormalizeGCSPath(src)
-	dst := gcs.NormalizeGCSPath(filepath.Join(bi.opts.Bucket, "release", bi.opts.Version))
+	gcsSrc, gcsSrcErr := gcs.NormalizeGCSPath(src)
+	if gcsSrcErr != nil {
+		return errors.Wrap(gcsSrcErr, "normalize GCS source")
+	}
+
+	dst, dstErr := gcs.NormalizeGCSPath(bi.opts.Bucket, "release", bi.opts.Version)
+	if dstErr != nil {
+		return errors.Wrap(dstErr, "normalize GCS destination")
+	}
+
 	logrus.Infof("Bucket to bucket rsync from %s to %s", gcsSrc, dst)
 	if err := gcs.RsyncRecursive(gcsSrc, dst); err != nil {
 		return errors.Wrap(err, "copy stage to release bucket")

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -153,7 +153,7 @@ func (bi *Instance) Push() error {
 		version,
 		bi.opts.BuildDir,
 		bi.opts.Bucket,
-		bi.opts.GCSSuffix,
+		bi.opts.GCSRoot,
 		extraVersionMarkers,
 		bi.opts.PrivateBucket,
 		bi.opts.Fast,

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -298,6 +298,8 @@ func IsPathNormalized(gcsPath string) bool {
 		errCount++
 	}
 
+	// TODO: Add logic to handle invalid path characters
+
 	if errCount > 0 {
 		return false
 	}

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -308,13 +308,7 @@ func IsPathNormalized(gcsPath string) bool {
 // RsyncRecursive runs `gsutil rsync` in recursive mode. The caller of this
 // function has to ensure that the provided paths are prefixed with gs:// if
 // necessary (see `NormalizeGCSPath()`).
-// TODO: Implementation of `gsutil rsync` should support local directory copies
-//       with `-d`
 func RsyncRecursive(src, dst string) error {
-	if !IsPathNormalized(src) || !IsPathNormalized(dst) {
-		return errors.New("cannot run `gsutil rsync` as one or more paths does not begin with `gs://`")
-	}
-
 	return errors.Wrap(
 		gcp.GSUtil(concurrentFlag, "rsync", recursiveFlag, src, dst),
 		"running gsutil rsync",

--- a/pkg/gcp/gcs/gcs_test.go
+++ b/pkg/gcp/gcs/gcs_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/gcp/gcs"
+)
+
+// TODO: Add production use cases
+func TestGetReleasePath(t *testing.T) {
+	for _, tc := range []struct {
+		bucket, buildType, gcsSuffix, version string
+		expected                              string
+		fast                                  bool
+		shouldError                           bool
+	}{
+		{ // default CI build
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			expected:    "gs://k8s-release-dev/ci",
+			shouldError: false,
+		},
+		{ // fast CI build
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			gcsSuffix:   "",
+			version:     "",
+			fast:        true,
+			expected:    "gs://k8s-release-dev/ci/fast",
+			shouldError: false,
+		},
+		{ // has version
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			gcsSuffix:   "",
+			version:     "42",
+			fast:        true,
+			expected:    "gs://k8s-release-dev/ci/fast/42",
+			shouldError: false,
+		},
+		{ // has GCS suffix
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			gcsSuffix:   "suffix",
+			fast:        true,
+			expected:    "gs://k8s-release-dev/ci-suffix/fast",
+			shouldError: false,
+		},
+	} {
+		actual, err := gcs.GetReleasePath(
+			tc.bucket,
+			tc.buildType,
+			tc.gcsSuffix,
+			tc.version,
+			tc.fast,
+		)
+
+		require.Equal(t, tc.expected, actual)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+// TODO: Add production use cases
+func TestGetMarkerPath(t *testing.T) {
+	for _, tc := range []struct {
+		bucket, buildType, gcsSuffix string
+		expected                     string
+		shouldError                  bool
+	}{
+		{ // default CI build
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			expected:    "gs://k8s-release-dev/ci",
+			shouldError: false,
+		},
+		{ // has GCS suffix
+			bucket:      "k8s-release-dev",
+			buildType:   "ci",
+			gcsSuffix:   "suffix",
+			expected:    "gs://k8s-release-dev/ci-suffix",
+			shouldError: false,
+		},
+	} {
+		actual, err := gcs.GetMarkerPath(
+			tc.bucket,
+			tc.buildType,
+			tc.gcsSuffix,
+		)
+
+		require.Equal(t, tc.expected, actual)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+func TestNormalizeGCSPath(t *testing.T) {
+	for _, tc := range []struct {
+		gcsPathParts []string
+		expected     string
+		shouldError  bool
+	}{
+		{ // empty parts
+			gcsPathParts: []string{},
+			expected:     "",
+			shouldError:  true,
+		},
+		{ // one element, but empty string
+			gcsPathParts: []string{
+				"",
+			},
+			expected:    "",
+			shouldError: true,
+		},
+		{ // multiple elements, all empty strings
+			gcsPathParts: []string{
+				"",
+				"",
+			},
+			expected:    "",
+			shouldError: true,
+		},
+		{ // strip `gs://` properly
+			gcsPathParts: []string{
+				"gs://foo",
+			},
+			expected:    "gs://foo",
+			shouldError: false,
+		},
+		{ // strip `gs:/` properly
+			gcsPathParts: []string{
+				"gs://foo/bar",
+			},
+			expected:    "gs://foo/bar",
+			shouldError: false,
+		},
+		{ // strip `/` properly
+			gcsPathParts: []string{
+				"/foo/bar",
+			},
+			expected:    "gs://foo/bar",
+			shouldError: false,
+		},
+		{ // multiple parts
+			gcsPathParts: []string{
+				"foo",
+				"bar",
+			},
+			expected:    "gs://foo/bar",
+			shouldError: false,
+		},
+		{ // one of the non-zero parts already contains the `gs://` prefix
+			gcsPathParts: []string{
+				"k8s-release-dev",
+				"gs://k8s-release-dev/ci-no-bootstrap/fast/v1.20.0-beta.1.655+d20e3246bade17",
+			},
+			expected:    "",
+			shouldError: true,
+		},
+	} {
+		actual, err := gcs.NormalizeGCSPath(tc.gcsPathParts...)
+
+		require.Equal(t, tc.expected, actual)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+func TestIsPathNormalized(t *testing.T) {
+	for _, tc := range []struct {
+		gcsPath  string
+		expected bool
+	}{
+		{ // GCS path (%s) should be prefixed with `gs://`
+			gcsPath:  "k8s-release-dev/g",
+			expected: false,
+		},
+		{ // filepath.Join() caused an additional `gs:/` to be included in the path
+			gcsPath:  "gs://k8s-release-dev/gs:/k8s-release-dev/ci-no-bootstrap/fast/v1.20.0-beta.1.655+d20e3246bade17",
+			expected: false,
+		},
+		{ // fast CI build
+			gcsPath:  "gs://k8s-release-dev/ci/fast",
+			expected: true,
+		},
+	} {
+		actual := gcs.IsPathNormalized(tc.gcsPath)
+
+		require.Equal(t, tc.expected, actual)
+	}
+}

--- a/pkg/gcp/gcs/gcs_test.go
+++ b/pkg/gcp/gcs/gcs_test.go
@@ -27,21 +27,20 @@ import (
 // TODO: Add production use cases
 func TestGetReleasePath(t *testing.T) {
 	for _, tc := range []struct {
-		bucket, buildType, gcsSuffix, version string
-		expected                              string
-		fast                                  bool
-		shouldError                           bool
+		bucket, gcsRoot, version string
+		expected                 string
+		fast                     bool
+		shouldError              bool
 	}{
 		{ // default CI build
 			bucket:      "k8s-release-dev",
-			buildType:   "ci",
+			gcsRoot:     "ci",
 			expected:    "gs://k8s-release-dev/ci",
 			shouldError: false,
 		},
 		{ // fast CI build
 			bucket:      "k8s-release-dev",
-			buildType:   "ci",
-			gcsSuffix:   "",
+			gcsRoot:     "ci",
 			version:     "",
 			fast:        true,
 			expected:    "gs://k8s-release-dev/ci/fast",
@@ -49,26 +48,16 @@ func TestGetReleasePath(t *testing.T) {
 		},
 		{ // has version
 			bucket:      "k8s-release-dev",
-			buildType:   "ci",
-			gcsSuffix:   "",
+			gcsRoot:     "ci",
 			version:     "42",
 			fast:        true,
 			expected:    "gs://k8s-release-dev/ci/fast/42",
 			shouldError: false,
 		},
-		{ // has GCS suffix
-			bucket:      "k8s-release-dev",
-			buildType:   "ci",
-			gcsSuffix:   "suffix",
-			fast:        true,
-			expected:    "gs://k8s-release-dev/ci-suffix/fast",
-			shouldError: false,
-		},
 	} {
 		actual, err := gcs.GetReleasePath(
 			tc.bucket,
-			tc.buildType,
-			tc.gcsSuffix,
+			tc.gcsRoot,
 			tc.version,
 			tc.fast,
 		)
@@ -86,28 +75,20 @@ func TestGetReleasePath(t *testing.T) {
 // TODO: Add production use cases
 func TestGetMarkerPath(t *testing.T) {
 	for _, tc := range []struct {
-		bucket, buildType, gcsSuffix string
-		expected                     string
-		shouldError                  bool
+		bucket, gcsRoot string
+		expected        string
+		shouldError     bool
 	}{
 		{ // default CI build
 			bucket:      "k8s-release-dev",
-			buildType:   "ci",
+			gcsRoot:     "ci",
 			expected:    "gs://k8s-release-dev/ci",
-			shouldError: false,
-		},
-		{ // has GCS suffix
-			bucket:      "k8s-release-dev",
-			buildType:   "ci",
-			gcsSuffix:   "suffix",
-			expected:    "gs://k8s-release-dev/ci-suffix",
 			shouldError: false,
 		},
 	} {
 		actual, err := gcs.GetMarkerPath(
 			tc.bucket,
-			tc.buildType,
-			tc.gcsSuffix,
+			tc.gcsRoot,
 		)
 
 		require.Equal(t, tc.expected, actual)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -199,7 +199,7 @@ func (p *Publisher) VerifyLatestUpdate(
 		return false, errors.Wrap(publishFileDstErr, "get marker file destination")
 	}
 
-	// TODO: Should we add pkg/gcp/gcs function for `gsutil cat`?
+	// TODO: Should we add a pkg/gcp/gcs function for `gsutil cat`?
 	gcsVersion, err := p.client.GSUtilOutput("cat", publishFileDst)
 	if err != nil {
 		logrus.Infof("%s does not exist but will be created", publishFileDst)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -105,21 +105,28 @@ func (p *Publisher) PublishVersion(
 		return errors.Errorf("invalid version %s", version)
 	}
 
-	markerPath := gcs.GetMarkerPath(
+	markerPath, markerPathErr := gcs.GetMarkerPath(
 		bucket,
 		buildType,
 		gcsSuffix,
 	)
+	if markerPathErr != nil {
+		return errors.Wrap(markerPathErr, "get version marker path")
+	}
 
-	releasePath := gcs.GetReleasePath(
+	releasePath, releasePathErr := gcs.GetReleasePath(
 		bucket,
 		buildType,
 		gcsSuffix,
 		version,
 		fast,
 	)
+	if releasePathErr != nil {
+		return errors.Wrap(releasePathErr, "get release path")
+	}
 
 	// TODO: This should probably be a more thorough check of explicit files
+	// TODO: This should explicitly do a `gsutil ls` via gcs.PathExists
 	if err := p.client.GSUtil("ls", releasePath); err != nil {
 		return errors.Wrapf(err, "release files don't exist at %s", releasePath)
 	}
@@ -147,6 +154,7 @@ func (p *Publisher) PublishVersion(
 	logrus.Infof("Publish official pointer text files to %s", markerPath)
 
 	for _, file := range versionMarkers {
+		// TODO: This should respect the GCS suffix, if specified
 		versionMarker := filepath.Join(buildType, file+".txt")
 		needsUpdate, err := p.VerifyLatestUpdate(
 			versionMarker, markerPath, version,
@@ -154,6 +162,7 @@ func (p *Publisher) PublishVersion(
 		if err != nil {
 			return errors.Wrapf(err, "verify latest update for %s", versionMarker)
 		}
+
 		// If there's a version that's above the one we're trying to release,
 		// don't do anything, and just try the next one.
 		if !needsUpdate {
@@ -186,7 +195,11 @@ func (p *Publisher) VerifyLatestUpdate(
 ) (needsUpdate bool, err error) {
 	logrus.Infof("Testing %s > %s (published)", version, publishFile)
 
-	publishFileDst := gcs.NormalizeGCSPath(filepath.Join(markerPath, publishFile))
+	publishFileDst, publishFileDstErr := gcs.NormalizeGCSPath(markerPath, publishFile)
+	if publishFileDstErr != nil {
+		return false, errors.Wrap(publishFileDstErr, "get marker file destination")
+	}
+
 	gcsVersion, err := p.client.GSUtilOutput("cat", publishFileDst)
 	if err != nil {
 		logrus.Infof("%s does not exist but will be created", publishFileDst)
@@ -225,7 +238,11 @@ func (p *Publisher) PublishToGcs(
 	privateBucket bool,
 ) error {
 	releaseStage := filepath.Join(buildDir, ReleaseStagePath)
-	publishFileDst := gcs.NormalizeGCSPath(filepath.Join(markerPath, publishFile))
+	publishFileDst, publishFileDstErr := gcs.NormalizeGCSPath(markerPath, publishFile)
+	if publishFileDstErr != nil {
+		return errors.Wrap(publishFileDstErr, "get marker file destination")
+	}
+
 	publicLink := fmt.Sprintf("%s/%s", URLPrefixForBucket(markerPath), publishFile)
 	if strings.HasPrefix(markerPath, ProductionBucket) {
 		publicLink = fmt.Sprintf("%s/%s", ProductionBucketURL, publishFile)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -279,7 +279,7 @@ func (p *Publisher) PublishToGcs(
 		// Ref:
 		// - https://cloud.google.com/storage/docs/bucket-policy-only
 		// - https://github.com/kubernetes/release/issues/904
-		if !strings.HasPrefix(markerPath, "k8s-") {
+		if !strings.HasPrefix(markerPath, "gs://k8s-") {
 			aclOutput, err := p.client.GSUtilOutput(
 				"acl", "ch", "-R", "-g", "all:R", publishFileDst,
 			)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -154,8 +154,7 @@ func (p *Publisher) PublishVersion(
 	logrus.Infof("Publish official pointer text files to %s", markerPath)
 
 	for _, file := range versionMarkers {
-		// TODO: This should respect the GCS suffix, if specified
-		versionMarker := filepath.Join(buildType, file+".txt")
+		versionMarker := file + ".txt"
 		needsUpdate, err := p.VerifyLatestUpdate(
 			versionMarker, markerPath, version,
 		)
@@ -200,6 +199,7 @@ func (p *Publisher) VerifyLatestUpdate(
 		return false, errors.Wrap(publishFileDstErr, "get marker file destination")
 	}
 
+	// TODO: Should we add pkg/gcp/gcs function for `gsutil cat`?
 	gcsVersion, err := p.client.GSUtilOutput("cat", publishFileDst)
 	if err != nil {
 		logrus.Infof("%s does not exist but will be created", publishFileDst)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -76,15 +76,14 @@ func (*defaultPublisher) GetURLResponse(url string) (string, error) {
 // version - The version
 // buildDir - build output directory
 // bucket - GCS bucket
-// gcsSuffix - appended to the buildType to construct a new top-level
-//             destination
+// gcsRoot - The top-level GCS directory builds will be released to
 //
 // Expected destination format:
-//   gs://<bucket>/<buildType>[-<gcsSuffix>][/fast]/<version>
+//   gs://<bucket>/<gcsRoot>[/fast]/<version>
 //
 // was releaselib.sh: release::gcs::publish_version
 func (p *Publisher) PublishVersion(
-	buildType, version, buildDir, bucket, gcsSuffix string,
+	buildType, version, buildDir, bucket, gcsRoot string,
 	extraVersionMarkers []string,
 	privateBucket, fast bool,
 ) error {
@@ -107,8 +106,7 @@ func (p *Publisher) PublishVersion(
 
 	markerPath, markerPathErr := gcs.GetMarkerPath(
 		bucket,
-		buildType,
-		gcsSuffix,
+		gcsRoot,
 	)
 	if markerPathErr != nil {
 		return errors.Wrap(markerPathErr, "get version marker path")
@@ -116,8 +114,7 @@ func (p *Publisher) PublishVersion(
 
 	releasePath, releasePathErr := gcs.GetReleasePath(
 		bucket,
-		buildType,
-		gcsSuffix,
+		gcsRoot,
 		version,
 		fast,
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/issues/1711.

- pkg/gcp/gcs: Improve path normalization logic
  
  - Ensure constructed paths are prefixed with `gs://`
  - Use flag vars instead of strings for RsyncRecursive
  - Add isPathNormalized function
  
    Use this function as pre-check for any gsutil/GCS functions that
    manipulate GCS bucket contents.
  
  - Use isPathNormalized in RsyncRecursive and PathExists
  - Clarify when we are constructing a release path or version marker path

- pkg/gcp/gcs: NormalizeGCSPath now handles multiple path elements
  
  This allows any caller to pass an arbitrary GCS path elements without
  having to handle any filepath.Join() logic.
  
  Should handle the following cases:
  - single path element
  - multiple path elements
  - path element already contains `gs://`
  - path element was the result of a filepath.Join() and contains `gs:/`
  - path element contains a leading `/`
  
  Should error if:
  - there were no path elements
  - the only path element is an empty string

- pkg: Update usages of gcs.NormalizeGCSPath()

- pkg/release: Respect the GCS suffix when pushing version markers

- pkg/gcp/gcs: Add a few test cases for GCS paths

- pkg/build: Fixup filepath.Join() bug when pushing release artifacts

- pkg/build: Deprecate the GCSSuffix option and introduce GCSRoot option
  
  Testing with the `--gcs-suffix` flag has been frustrating.
  
  It's possible the original shell library never properly handled this
  option and it was never noticed because the option isn't exercised in
  our releases or CI jobs.
  
  Here we replace its usage with `--gcs-root`.
  
  If specified, it will override BuildType.
  
  When unset:
    - BuildType: "ci"
    - final path: gs://<bucket>/ci
  
  When set:
    - BuildType: "ci"
    - GCSRoot: "new-root"
    - final path: gs://<bucket>/new-root

- pkg/build: Drop references to GCSSuffix

- pkg/gcp/gcs: RsyncRecursive doesn't need to run against normalized paths
  
  `gsutil rsync` doesn't actual require that either of the specified
  directories be GCS paths, so here we remove that requirement.

- pkg/release: Fix prefix check to determine bucket permissions

- dependencies.yaml: Add entry for skopeo

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/gcp/gcs: Improve path normalization logic
  
  - Ensure constructed paths are prefixed with `gs://`
  - Use flag vars instead of strings for RsyncRecursive
  - Add isPathNormalized function
  
    Use this function as pre-check for any gsutil/GCS functions that
    manipulate GCS bucket contents.
  
  - Use isPathNormalized in RsyncRecursive and PathExists
  - Clarify when we are constructing a release path or version marker path

- pkg/gcp/gcs: NormalizeGCSPath now handles multiple path elements
  
  This allows any caller to pass an arbitrary GCS path elements without
  having to handle any filepath.Join() logic.
  
  Should handle the following cases:
  - single path element
  - multiple path elements
  - path element already contains `gs://`
  - path element was the result of a filepath.Join() and contains `gs:/`
  - path element contains a leading `/`
  
  Should error if:
  - there were no path elements
  - the only path element is an empty string

- pkg: Update usages of gcs.NormalizeGCSPath()

- pkg/release: Respect the GCS suffix when pushing version markers

- pkg/gcp/gcs: Add a few test cases for GCS paths

- pkg/build: Fixup filepath.Join() bug when pushing release artifacts

- pkg/build: Deprecate the GCSSuffix option and introduce GCSRoot option
  
  Testing with the `--gcs-suffix` flag has been frustrating.
  
  It's possible the original shell library never properly handled this
  option and it was never noticed because the option isn't exercised in
  our releases or CI jobs.
  
  Here we replace its usage with `--gcs-root`.
  
  If specified, it will override BuildType.
  
  When unset:
    - BuildType: "ci"
    - final path: gs://<bucket>/ci
  
  When set:
    - BuildType: "ci"
    - GCSRoot: "new-root"
    - final path: gs://<bucket>/new-root

- pkg/build: Drop references to GCSSuffix

- pkg/gcp/gcs: RsyncRecursive doesn't need to run against normalized paths
  
  `gsutil rsync` doesn't actual require that either of the specified
  directories be GCS paths, so here we remove that requirement.

- pkg/release: Fix prefix check to determine bucket permissions
```
