### PR TITLE
Make krel stage/release parentBranch a bool

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -92,9 +92,6 @@ func (o *Options) Validate() (*State, error) {
 		return nil, errors.Errorf("invalid release branch: %s", o.ReleaseBranch)
 	}
 
-	// TODO: Adjust this value once SetBuildCandidate is done
-	state.parentBranch = ""
-
 	semverBuildVersion, err := util.TagStringToSemver(o.BuildVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid build version: %s", o.BuildVersion)
@@ -133,10 +130,10 @@ type State struct {
 	// The release versions generated after GenerateReleaseVersion()
 	versions *release.Versions
 
-	// TODO: the parent branch has to be returned by the SetBuildCandidate
-	// method. It should be empty (releases cut from master) or
-	// git.DefaultBranch / "master" (releases cut from release branches).
-	parentBranch string
+	// TODO: This was the `$PARENT_BRANCH` in `anago`.
+	// Indicates if we're going to create a new release branch.
+	// Has to be set by the SetBuildCandidate method.
+	createReleaseBranch bool
 }
 
 // DefaultState returns a new empty State
@@ -146,8 +143,8 @@ func DefaultState() *State {
 	return &State{}
 }
 
-func (s *State) SetParentBranch(branchName string) {
-	s.parentBranch = branchName
+func (s *State) SetCreateReleaseBranch(createReleaseBranch bool) {
+	s.createReleaseBranch = createReleaseBranch
 }
 
 func (s *State) SetVersions(versions *release.Versions) {

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -33,8 +33,8 @@ var err = errors.New("error")
 var testVersionTag string = "v1.20.0"
 
 type testStateParameters struct {
-	versionsTag  *string
-	parentBranch *string
+	versionsTag         *string
+	createReleaseBranch *bool
 }
 
 func mockGenerateReleaseVersionStage(mock *anagofakes.FakeStageClient) {

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -243,12 +243,8 @@ func (d *DefaultRelease) ValidateOptions() error {
 func (d *DefaultRelease) CheckPrerequisites() error { return nil }
 
 func (d *DefaultRelease) SetBuildCandidate() error {
-	// TODO: the parent branch has to be returned by the SetBuildCandidate
-	// method. It should be empty (releases cut from master) or
-	// git.DefaultBranch / "master" (releases cut from release branches).
-	//
-	// d.state.parentBranch = XXXXX
-	d.state.parentBranch = ""
+	// TODO: finish the implementation
+	// d.state.createReleaseBranch = true
 	return nil
 }
 
@@ -257,7 +253,7 @@ func (d *DefaultRelease) GenerateReleaseVersion() error {
 		d.options.ReleaseType,
 		d.options.BuildVersion,
 		d.options.ReleaseBranch,
-		d.state.parentBranch == git.DefaultBranch,
+		d.state.createReleaseBranch,
 	)
 	if err != nil {
 		return errors.Wrap(err, "generating versions for release")
@@ -354,11 +350,6 @@ func (d *DefaultRelease) PushGitObjects() error {
 	branchList := []string{}
 	if d.options.ReleaseBranch != git.DefaultBranch {
 		branchList = append(branchList, d.options.ReleaseBranch)
-
-		// # Additionally push the parent branch if a branch of branch
-		if d.state.parentBranch != git.DefaultBranch {
-			branchList = append(branchList, d.state.parentBranch)
-		}
 	}
 
 	// Call the release imprementation PushBranches() method


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We only set the `parentBranch` if we're going to create the release
branch. In that case the `parentBranch` would be always
`git.DefaultBranch`, which means we can convert that variable to a `bool`.

The new variable is now called `createReleaseBranch` to clean up its
purpose.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
