### PR TITLE
pkg/build: Fully remove GCSSuffix option

### DIFF
--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -130,14 +130,6 @@ func init() {
 		"Specify an alternate GCS path to push artifacts to",
 	)
 
-	// TODO: Fully remove this flag once we stop using it in CI
-	ciBuildCmd.PersistentFlags().StringVar(
-		&ciBuildOpts.GCSSuffix,
-		"gcs-suffix",
-		"",
-		"Specify a suffix to append to the upload destination on GCS",
-	)
-
 	ciBuildCmd.PersistentFlags().StringVar(
 		&ciBuildOpts.VersionSuffix,
 		"version-suffix",
@@ -150,13 +142,6 @@ func init() {
 		"validate-images",
 		false,
 		"Validate that the remove image digests exists, needs `skopeo` in `$PATH`",
-	)
-
-	// Deprecated flags
-	// nolint: errcheck
-	ciBuildCmd.PersistentFlags().MarkDeprecated(
-		"gcs-suffix",
-		"please use `--gcs-root` if you need to override the default GCS root",
 	)
 
 	rootCmd.AddCommand(ciBuildCmd)

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -120,7 +120,7 @@ func init() {
 	)
 
 	pushBuildCmd.PersistentFlags().StringVar(
-		&ciBuildOpts.GCSRoot,
+		&pushBuildOpts.GCSRoot,
 		"gcs-root",
 		"",
 		"Specify an alternate GCS path to push artifacts to",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -78,9 +78,6 @@ type Options struct {
 	// was not plumbed through
 	GCSRoot string
 
-	// [DEPRECATED] Specify a suffix to append to the upload destination on GCS.
-	GCSSuffix string
-
 	// Version to be used. Usually automatically discovered, but it can be
 	// used to overwrite this behavior.
 	Version string
@@ -146,11 +143,7 @@ func (bi *Instance) setBuildType() {
 
 func (bi *Instance) setGCSRoot() {
 	if bi.opts.GCSRoot == "" {
-		if bi.opts.GCSSuffix != "" {
-			bi.opts.GCSRoot = bi.opts.BuildType + "-" + bi.opts.GCSSuffix
-		} else {
-			bi.opts.GCSRoot = bi.opts.BuildType
-		}
+		bi.opts.GCSRoot = bi.opts.BuildType
 	}
 
 	logrus.Infof("GCS root has been set to %s", bi.opts.GCSRoot)

--- a/pkg/gcp/gcs/gcs.go
+++ b/pkg/gcp/gcs/gcs.go
@@ -59,7 +59,6 @@ var DefaultGCSCopyOptions = &Options{
 }
 
 // CopyToGCS copies a local directory to the specified GCS path
-// TODO: Consider using IsPathNormalized here
 func CopyToGCS(src, gcsPath string, opts *Options) error {
 	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
 	gcsPath, gcsPathErr := NormalizeGCSPath(gcsPath)
@@ -83,7 +82,6 @@ func CopyToGCS(src, gcsPath string, opts *Options) error {
 }
 
 // CopyToLocal copies a GCS path to the specified local directory
-// TODO: Consider using IsPathNormalized here
 func CopyToLocal(gcsPath, dst string, opts *Options) error {
 	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
 	gcsPath, gcsPathErr := NormalizeGCSPath(gcsPath)
@@ -95,7 +93,6 @@ func CopyToLocal(gcsPath, dst string, opts *Options) error {
 }
 
 // CopyBucketToBucket copies between two GCS paths.
-// TODO: Consider using IsPathNormalized here
 func CopyBucketToBucket(src, dst string, opts *Options) error {
 	logrus.Infof("Copying %s to %s", src, dst)
 

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -247,29 +247,11 @@ func (i *Images) Exists(registry, version string, fast bool) (bool, error) {
 	logrus.Infof("Validating image manifests in %s", registry)
 	version = i.normalizeVersion(version)
 
-	// TODO: Maybe pull this out into a var?
-	manifestImages := []string{
-		"conformance",
-		"kube-apiserver",
-		"kube-controller-manager",
-		"kube-proxy",
-		"kube-scheduler",
-	}
+	manifestImages := ManifestImages
 
-	// TODO: Maybe pull this out into a var?
-	arches := []string{
-		"amd64",
-		"arm",
-		"arm64",
-		"ppc64le",
-		"s390x",
-	}
-
-	// TODO: Maybe pull this out into a var?
+	arches := SupportedArchitectures
 	if fast {
-		arches = []string{
-			"amd64",
-		}
+		arches = FastArchitectures
 	}
 
 	for _, image := range manifestImages {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -117,6 +117,28 @@ const (
 	BazelBuildDir = "bazel-bin/build"
 )
 
+var (
+	ManifestImages = []string{
+		"conformance",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-proxy",
+		"kube-scheduler",
+	}
+
+	SupportedArchitectures = []string{
+		"amd64",
+		"arm",
+		"arm64",
+		"ppc64le",
+		"s390x",
+	}
+
+	FastArchitectures = []string{
+		"amd64",
+	}
+)
+
 // ImagePromoterImages abtracts the manifest used by the image promoter
 type ImagePromoterImages []struct {
 	Name string              `json:"name"`

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -56,6 +56,7 @@ const (
 	DefaultRelengStagingProject     = "k8s-staging-releng"
 	DefaultDiskSize                 = "500"
 	BucketPrefix                    = "kubernetes-release-"
+	BucketPrefixK8sInfra            = "k8s-release-"
 
 	versionReleaseRE   = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`
 	versionBuildRE     = `([0-9]{1,})\+([0-9a-f]{5,40})`
@@ -91,6 +92,12 @@ const (
 
 	// WindowsLocalPath is the directory where Windows GCE scripts are created.
 	WindowsLocalPath = ReleaseStagePath + "/full/kubernetes/cluster/gce/windows"
+
+	// CIBucketLegacy is the default bucket for Kubernetes CI releases
+	CIBucketLegacy = "kubernetes-release-dev"
+
+	// CIBucketK8sInfra is the community infra bucket for Kubernetes CI releases
+	CIBucketK8sInfra = "k8s-release-dev"
 
 	// TestBucket is the default bucket for mocked Kubernetes releases
 	TestBucket = "kubernetes-release-gcb"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1738.

- pkg/build: Fully remove GCSSuffix option
- pkg/release: Add vars for expected images and arches
- pkg/build: Add setter for GCS buckets

/assign @saschagrunert @hasheddan 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/build: Fully remove GCSSuffix option
- pkg/release: Add vars for expected images and arches
- pkg/build: Add setter for GCS buckets
```
