### PR TITLE
Moving fastforward from cmd to pkg

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -21,23 +21,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"k8s.io/release/pkg/fastforward"
 	kgit "k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/util"
 )
 
-type ffOptions struct {
-	repoPath       string
-	branch         string
-	mainRef        string
-	nonInteractive bool
-	cleanup        bool
-}
-
-var ffOpts = &ffOptions{}
+var ffOpts = &fastforward.Options{}
 
 // ffCmd represents the base command when called without any subcommands
 var ffCmd = &cobra.Command{
@@ -62,172 +52,16 @@ as real push if the '--nomock' flag is specified.
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runFf(ffOpts, rootOpts)
+		ffOpts.NoMock = rootOpts.nomock
+		return fastforward.Run(ffOpts)
 	},
 }
 
-const pushUpstreamQuestion = `Are you ready to push the local branch fast-forward changes upstream?
-Please only answer after you have validated the changes.`
-
 func init() {
-	ffCmd.PersistentFlags().StringVar(&ffOpts.repoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
-	ffCmd.PersistentFlags().StringVar(&ffOpts.branch, "branch", "", "branch")
-	ffCmd.PersistentFlags().StringVar(&ffOpts.mainRef, "ref", kgit.Remotify(kgit.DefaultBranch), "ref on the main branch")
-	ffCmd.PersistentFlags().BoolVar(&ffOpts.cleanup, "cleanup", false, "cleanup the repository after the run")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.RepoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.Branch, "branch", "", "branch")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.MainRef, "ref", kgit.Remotify(kgit.DefaultBranch), "ref on the main branch")
+	ffCmd.PersistentFlags().BoolVar(&ffOpts.Cleanup, "cleanup", false, "cleanup the repository after the run")
 
 	rootCmd.AddCommand(ffCmd)
-}
-
-func runFf(opts *ffOptions, rootOpts *rootOptions) error {
-	branch := opts.branch
-	if branch == "" {
-		return errors.New("please specify valid release branch")
-	}
-
-	logrus.Infof("Preparing to fast-forward %s onto the %s branch", opts.mainRef, branch)
-	repo, err := kgit.CloneOrOpenDefaultGitHubRepoSSH(opts.repoPath)
-	if err != nil {
-		return err
-	}
-
-	if !rootOpts.nomock {
-		logrus.Info("Using dry mode, which does not modify any remote content")
-		repo.SetDry()
-	}
-
-	logrus.Infof("Checking if %q is a release branch", branch)
-	if isReleaseBranch := kgit.IsReleaseBranch(branch); !isReleaseBranch {
-		return errors.Errorf("%s is not a release branch", branch)
-	}
-
-	logrus.Info("Checking if branch is available on the default remote")
-	branchExists, err := repo.HasRemoteBranch(branch)
-	if err != nil {
-		return errors.Wrap(err, "checking if branch exists on the default remote")
-	}
-	if !branchExists {
-		return errors.New("branch does not exist on the default remote")
-	}
-
-	if ffOpts.cleanup {
-		defer repo.Cleanup() // nolint: errcheck
-	} else {
-		// Restore the currently checked out branch afterwards
-		currentBranch, err := repo.CurrentBranch()
-		if err != nil {
-			return errors.Wrap(err, "unable to retrieve current branch")
-		}
-		defer func() {
-			if err := repo.Checkout(currentBranch); err != nil {
-				logrus.Errorf("Unable to restore branch %s: %v", currentBranch, err)
-			}
-		}()
-	}
-
-	logrus.Info("Checking out release branch")
-	if err := repo.Checkout(branch); err != nil {
-		return errors.Wrapf(err, "checking out branch %s", branch)
-	}
-
-	logrus.Infof("Finding merge base between %q and %q", kgit.DefaultBranch, branch)
-	mergeBase, err := repo.MergeBase(kgit.DefaultBranch, branch)
-	if err != nil {
-		return err
-	}
-
-	// Verify the tags
-	mainTag, err := repo.Describe(
-		kgit.NewDescribeOptions().
-			WithRevision(kgit.Remotify(kgit.DefaultBranch)).
-			WithAbbrev(0).
-			WithTags(),
-	)
-	if err != nil {
-		return err
-	}
-	mergeBaseTag, err := repo.Describe(
-		kgit.NewDescribeOptions().
-			WithRevision(mergeBase).
-			WithAbbrev(0).
-			WithTags(),
-	)
-	if err != nil {
-		return err
-	}
-	logrus.Infof("Merge base tag is: %s", mergeBaseTag)
-
-	if mainTag != mergeBaseTag {
-		return errors.Errorf(
-			"unable to fast forward: tag %q does not match %q",
-			mainTag, mergeBaseTag,
-		)
-	}
-	logrus.Infof("Verified that the latest tag on the main branch is the same as the merge base tag")
-
-	releaseRev, err := repo.Head()
-	if err != nil {
-		return err
-	}
-	logrus.Infof("Latest release branch revision is %s", releaseRev)
-
-	logrus.Info("Merging main branch changes into release branch")
-	if err := repo.Merge(opts.mainRef); err != nil {
-		return err
-	}
-
-	headRev, err := repo.Head()
-	if err != nil {
-		return err
-	}
-
-	prepushMessage(repo.Dir(), branch, opts.mainRef, releaseRev, headRev)
-
-	pushUpstream := false
-	if opts.nonInteractive {
-		pushUpstream = true
-	} else {
-		_, pushUpstream, err = util.Ask(pushUpstreamQuestion, "yes", 3)
-		if err != nil {
-			return err
-		}
-	}
-
-	if pushUpstream {
-		logrus.Infof("Pushing %s branch", branch)
-		if err := repo.Push(branch); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func prepushMessage(gitRoot, branch, ref, releaseRev, headRev string) {
-	fmt.Printf(`Go look around in %s to make sure things look okay before pushing…
-
-Check for files left uncommitted using:
-
-	git status -s
-
-Validate the fast-forward commit using:
-
-	git show
-
-Validate the changes pulled in from main branch using:
-
-	git log %s..%s
-
-Once the branch fast-forward is complete, the diff will be available after push at:
-
-	https://github.com/%s/%s/compare/%s...%s
-
-`,
-		gitRoot,
-		kgit.Remotify(branch),
-		ref,
-		kgit.DefaultGithubOrg,
-		kgit.DefaultGithubRepo,
-		releaseRev[:11],
-		headRev[:11],
-	)
 }

--- a/cmd/krel/cmd/ff_test.go
+++ b/cmd/krel/cmd/ff_test.go
@@ -21,14 +21,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"k8s.io/release/pkg/fastforward"
 	"k8s.io/release/pkg/git"
 )
 
-func (s *sut) getFfOptions() *ffOptions {
-	return &ffOptions{
-		mainRef:        git.Remotify(git.DefaultBranch),
-		nonInteractive: true,
-		repoPath:       s.repo.Dir(),
+func (s *sut) getFfOptions() *fastforward.Options {
+	return &fastforward.Options{
+		MainRef:        git.Remotify(git.DefaultBranch),
+		NonInteractive: true,
+		RepoPath:       s.repo.Dir(),
 	}
 }
 
@@ -37,11 +38,10 @@ func TestFfFailedWithoutReleaseBranch(t *testing.T) {
 	s := newSUT(t)
 	defer s.cleanup(t)
 
-	ff := &ffOptions{}
+	ff := &fastforward.Options{}
 
 	// When
-	err := runFf(ff, s.getRootOptions())
-
+	err := fastforward.Run(ff)
 	// Then
 	require.NotNil(t, err)
 }
@@ -52,10 +52,10 @@ func TestFfFailedNoReleaseBranch(t *testing.T) {
 	defer s.cleanup(t)
 
 	ffo := s.getFfOptions()
-	ffo.branch = "not-a-release-branch"
+	ffo.Branch = "not-a-release-branch"
 
 	// When
-	err := runFf(ffo, s.getRootOptions())
+	err := fastforward.Run(ffo)
 
 	// Then
 	require.NotNil(t, err)
@@ -67,10 +67,10 @@ func TestFfFailedReleaseBranchDoesNotExist(t *testing.T) {
 	defer s.cleanup(t)
 
 	ffo := s.getFfOptions()
-	ffo.branch = "release-1.999"
+	ffo.Branch = "release-1.999"
 
 	// When
-	err := runFf(ffo, s.getRootOptions())
+	err := fastforward.Run(ffo)
 
 	// Then
 	require.NotNil(t, err)
@@ -82,10 +82,10 @@ func TestFfFailedOldReleaseBranch(t *testing.T) {
 	defer s.cleanup(t)
 
 	ffo := s.getFfOptions()
-	ffo.branch = "release-1.17"
+	ffo.Branch = "release-1.17"
 
 	// When
-	err := runFf(ffo, s.getRootOptions())
+	err := fastforward.Run(ffo)
 
 	// Then
 	require.NotNil(t, err)
@@ -97,10 +97,10 @@ func TestFfSuccessDryRun(t *testing.T) {
 	defer s.cleanup(t)
 
 	ffo := s.getFfOptions()
-	ffo.branch = pseudoReleaseBranch
+	ffo.Branch = pseudoReleaseBranch
 
 	// When
-	err := runFf(ffo, s.getRootOptions())
+	err := fastforward.Run(ffo)
 
 	// Then
 	require.Nil(t, err)
@@ -120,13 +120,12 @@ func TestFfSuccess(t *testing.T) {
 	defer s.cleanup(t)
 
 	ffo := s.getFfOptions()
-	ffo.branch = pseudoReleaseBranch
+	ffo.Branch = pseudoReleaseBranch
 
-	ro := s.getRootOptions()
-	ro.nomock = true
+	ffo.NoMock = true
 
 	// When
-	err := runFf(ffo, ro)
+	err := fastforward.Run(ffo)
 
 	// Then
 	require.Nil(t, err)

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -126,10 +126,3 @@ func (s *sut) lastCommit(t *testing.T, branch string) string {
 	require.Nil(t, err)
 	return res.OutputTrimNL()
 }
-
-func (s *sut) getRootOptions() *rootOptions {
-	return &rootOptions{
-		nomock:   false,
-		logLevel: "debug",
-	}
-}

--- a/pkg/fastforward/fastforward.go
+++ b/pkg/fastforward/fastforward.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fastforward
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	kgit "k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/util"
+)
+
+// Options is the main structure for configuring a fast forward.
+type Options struct {
+	Branch         string
+	MainRef        string
+	NonInteractive bool
+	NoMock         bool
+	Cleanup        bool
+	RepoPath       string
+	LogLevel       string
+}
+
+const pushUpstreamQuestion = `Are you ready to push the local branch fast-forward changes upstream?
+Please only answer after you have validated the changes.`
+
+func Run(opts *Options) error {
+	branch := opts.Branch
+	if branch == "" {
+		return errors.New("please specify valid release branch")
+	}
+
+	logrus.Infof("Preparing to fast-forward %s onto the %s branch", opts.MainRef, branch)
+	repo, err := kgit.CloneOrOpenDefaultGitHubRepoSSH(opts.RepoPath)
+	if err != nil {
+		return err
+	}
+
+	if !opts.NoMock {
+		logrus.Info("Using dry mode, which does not modify any remote content")
+		repo.SetDry()
+	}
+
+	logrus.Infof("Checking if %q is a release branch", branch)
+	if isReleaseBranch := kgit.IsReleaseBranch(branch); !isReleaseBranch {
+		return errors.Errorf("%s is not a release branch", branch)
+	}
+
+	logrus.Info("Checking if branch is available on the default remote")
+	branchExists, err := repo.HasRemoteBranch(branch)
+	if err != nil {
+		return errors.Wrap(err, "checking if branch exists on the default remote")
+	}
+	if !branchExists {
+		return errors.New("branch does not exist on the default remote")
+	}
+
+	if opts.Cleanup {
+		defer repo.Cleanup() // nolint: errcheck
+	} else {
+		// Restore the currently checked out branch afterwards
+		currentBranch, err := repo.CurrentBranch()
+		if err != nil {
+			return errors.Wrap(err, "unable to retrieve current branch")
+		}
+		defer func() {
+			if err := repo.Checkout(currentBranch); err != nil {
+				logrus.Errorf("Unable to restore branch %s: %v", currentBranch, err)
+			}
+		}()
+	}
+
+	logrus.Info("Checking out release branch")
+	if err := repo.Checkout(branch); err != nil {
+		return errors.Wrapf(err, "checking out branch %s", branch)
+	}
+
+	logrus.Infof("Finding merge base between %q and %q", kgit.DefaultBranch, branch)
+	mergeBase, err := repo.MergeBase(kgit.DefaultBranch, branch)
+	if err != nil {
+		return err
+	}
+
+	// Verify the tags
+	mainTag, err := repo.Describe(
+		kgit.NewDescribeOptions().
+			WithRevision(kgit.Remotify(kgit.DefaultBranch)).
+			WithAbbrev(0).
+			WithTags(),
+	)
+	if err != nil {
+		return err
+	}
+	mergeBaseTag, err := repo.Describe(
+		kgit.NewDescribeOptions().
+			WithRevision(mergeBase).
+			WithAbbrev(0).
+			WithTags(),
+	)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("Merge base tag is: %s", mergeBaseTag)
+
+	if mainTag != mergeBaseTag {
+		return errors.Errorf(
+			"unable to fast forward: tag %q does not match %q",
+			mainTag, mergeBaseTag,
+		)
+	}
+	logrus.Infof("Verified that the latest tag on the main branch is the same as the merge base tag")
+
+	releaseRev, err := repo.Head()
+	if err != nil {
+		return err
+	}
+	logrus.Infof("Latest release branch revision is %s", releaseRev)
+
+	logrus.Info("Merging main branch changes into release branch")
+	if err := repo.Merge(opts.MainRef); err != nil {
+		return err
+	}
+
+	headRev, err := repo.Head()
+	if err != nil {
+		return err
+	}
+
+	prepushMessage(repo.Dir(), branch, opts.MainRef, releaseRev, headRev)
+
+	pushUpstream := false
+	if opts.NonInteractive {
+		pushUpstream = true
+	} else {
+		_, pushUpstream, err = util.Ask(pushUpstreamQuestion, "yes", 3)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pushUpstream {
+		logrus.Infof("Pushing %s branch", branch)
+		if err := repo.Push(branch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func prepushMessage(gitRoot, branch, ref, releaseRev, headRev string) {
+	fmt.Printf(`Go look around in %s to make sure things look okay before pushing…
+	
+	Check for files left uncommitted using:
+	
+		git status -s
+	
+	Validate the fast-forward commit using:
+	
+		git show
+	
+	Validate the changes pulled in from main branch using:
+	
+		git log %s..%s
+	
+	Once the branch fast-forward is complete, the diff will be available after push at:
+	
+		https://github.com/%s/%s/compare/%s...%s
+	
+	`,
+		gitRoot,
+		kgit.Remotify(branch),
+		ref,
+		kgit.DefaultGithubOrg,
+		kgit.DefaultGithubRepo,
+		releaseRev[:11],
+		headRev[:11],
+	)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
we are in process of moving fastforward from cmd to pkg. 
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
