### PR TITLE
Pass correct gcsRoot in release PublishVersion()

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -318,7 +318,7 @@ func (d *DefaultRelease) PushArtifacts() error {
 		}
 
 		if err := d.impl.PublishVersion(
-			"release", version, buildDir, bucket, "", nil, false, false,
+			"release", version, buildDir, bucket, "release", nil, false, false,
 		); err != nil {
 			return errors.Wrap(err, "publish release")
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

Pass the correct gcsRoot  when running `PublishVersion()` in anago:PushArtifacts

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
