### PR TITLE
Pass correct gcsRoot in krel anago push

### DIFF
--- a/cmd/krel/cmd/anago/push.go
+++ b/cmd/krel/cmd/anago/push.go
@@ -190,7 +190,7 @@ func runPushRelease(
 	}
 
 	if err := release.NewPublisher().PublishVersion(
-		"release", opts.Version, opts.BuildDir, opts.Bucket, "", nil, false, false,
+		"release", opts.Version, opts.BuildDir, opts.Bucket, "release", nil, false, false,
 	); err != nil {
 		return errors.Wrap(err, "publish release")
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR makes `krel anago push` send the correct gcsRoot ("release") to release.Publisher.PublishVersion() when called from `runPushRelease`. 

#### Which issue(s) this PR fixes:
Related to #1748

#### Special notes for your reviewer:

/assign @justaugustus 

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
