### PR TITLE
Allow spec with gs:// prefix in URLPrefixForBucket()

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/command"
+	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/http"
 	"k8s.io/release/pkg/tar"
@@ -302,6 +303,7 @@ func GetKubecrossVersion(branches ...string) (string, error) {
 
 // URLPrefixForBucket returns the URL prefix for the provided bucket string
 func URLPrefixForBucket(bucket string) string {
+	bucket = strings.TrimPrefix(bucket, gcs.GcsPrefix)
 	urlPrefix := fmt.Sprintf("https://storage.googleapis.com/%s", bucket)
 	if bucket == ProductionBucket {
 		urlPrefix = ProductionBucketURL


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR modifies the `release.URLPrefixForBucket()` function to correctly return URLs from buckets which include the `gs://` prefix. 

The function now trims the prefix from the bucket name, so it should be backwards compatible.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
