### PR TITLE
images: Build go-runner:buster-v2.2.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.2.0
+    version: buster-v2.2.1
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,7 +16,7 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.2.0
+IMAGE_VERSION ?= buster-v2.2.1
 CONFIG ?= buster
 
 # Build args

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.2.0'
+    IMAGE_VERSION: 'buster-v2.2.1'
     GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Part of go1.15.5 updates: https://github.com/kubernetes/release/issues/1651.

- images: Build go-runner:buster-v2.2.1

  No image content changes.
  Rebuild to pick up fixes to the distroless images to include an `armhf`
  variant in their manifests to allow us to continue releasing all of the
  arch artifacts we do today.

  ref: https://github.com/GoogleContainerTools/distroless/pull/638

Thanks to @mattmoor and @chanseokoh for pushing this along on the `distroless` side! :two_hearts: 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- images: Build go-runner:buster-v2.2.1

  No image content changes.
  Rebuild to pick up fixes to the distroless images to include an `armhf`
  variant in their manifests to allow us to continue releasing all of the
  arch artifacts we do today.
```
