### PR TITLE
Integrate branch state check into krel stage/release

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -132,9 +132,7 @@ type State struct {
 	// The release versions generated after GenerateReleaseVersion()
 	versions *release.Versions
 
-	// TODO: This was the `$PARENT_BRANCH` in `anago`.
 	// Indicates if we're going to create a new release branch.
-	// Has to be set by the SetBuildCandidate method.
 	createReleaseBranch bool
 }
 
@@ -232,9 +230,9 @@ func (s *Stage) Run() error {
 		return errors.Wrap(err, "check prerequisites")
 	}
 
-	logger.WithStep().Info("Setting build candidate")
-	if err := s.client.SetBuildCandidate(); err != nil {
-		return errors.Wrap(err, "set build candidate")
+	logger.WithStep().Info("Checking release branch state")
+	if err := s.client.CheckReleaseBranchState(); err != nil {
+		return errors.Wrap(err, "check release branch state")
 	}
 
 	logger.WithStep().Info("Generating release version")
@@ -349,9 +347,9 @@ func (r *Release) Run() error {
 		return errors.Wrap(err, "check prerequisites")
 	}
 
-	logger.WithStep().Info("Setting build candidate")
-	if err := r.client.SetBuildCandidate(); err != nil {
-		return errors.Wrap(err, "set build candidate")
+	logger.WithStep().Info("Checking release branch state")
+	if err := r.client.CheckReleaseBranchState(); err != nil {
+		return errors.Wrap(err, "check release branch state")
 	}
 
 	logger.WithStep().Info("Generating release version")

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -68,9 +68,9 @@ func TestRunStage(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // SetBuildCandidate fails
+		{ // CheckReleaseBranchState fails
 			prepare: func(mock *anagofakes.FakeStageClient) {
-				mock.SetBuildCandidateReturns(err)
+				mock.CheckReleaseBranchStateReturns(err)
 			},
 			shouldError: true,
 		},
@@ -147,9 +147,9 @@ func TestRunRelease(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // SetBuildCandidate fails
+		{ // CheckReleaseBranchState fails
 			prepare: func(mock *anagofakes.FakeReleaseClient) {
-				mock.SetBuildCandidateReturns(err)
+				mock.CheckReleaseBranchStateReturns(err)
 			},
 			shouldError: true,
 		},

--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -42,6 +42,16 @@ type FakeReleaseClient struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckReleaseBranchStateStub        func() error
+	checkReleaseBranchStateMutex       sync.RWMutex
+	checkReleaseBranchStateArgsForCall []struct {
+	}
+	checkReleaseBranchStateReturns struct {
+		result1 error
+	}
+	checkReleaseBranchStateReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CreateAnnouncementStub        func() error
 	createAnnouncementMutex       sync.RWMutex
 	createAnnouncementArgsForCall []struct {
@@ -90,16 +100,6 @@ type FakeReleaseClient struct {
 		result1 error
 	}
 	pushGitObjectsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SetBuildCandidateStub        func() error
-	setBuildCandidateMutex       sync.RWMutex
-	setBuildCandidateArgsForCall []struct {
-	}
-	setBuildCandidateReturns struct {
-		result1 error
-	}
-	setBuildCandidateReturnsOnCall map[int]struct {
 		result1 error
 	}
 	SubmitStub        func() error
@@ -228,6 +228,59 @@ func (fake *FakeReleaseClient) CheckPrerequisitesReturnsOnCall(i int, result1 er
 		})
 	}
 	fake.checkPrerequisitesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseClient) CheckReleaseBranchState() error {
+	fake.checkReleaseBranchStateMutex.Lock()
+	ret, specificReturn := fake.checkReleaseBranchStateReturnsOnCall[len(fake.checkReleaseBranchStateArgsForCall)]
+	fake.checkReleaseBranchStateArgsForCall = append(fake.checkReleaseBranchStateArgsForCall, struct {
+	}{})
+	stub := fake.CheckReleaseBranchStateStub
+	fakeReturns := fake.checkReleaseBranchStateReturns
+	fake.recordInvocation("CheckReleaseBranchState", []interface{}{})
+	fake.checkReleaseBranchStateMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeReleaseClient) CheckReleaseBranchStateCallCount() int {
+	fake.checkReleaseBranchStateMutex.RLock()
+	defer fake.checkReleaseBranchStateMutex.RUnlock()
+	return len(fake.checkReleaseBranchStateArgsForCall)
+}
+
+func (fake *FakeReleaseClient) CheckReleaseBranchStateCalls(stub func() error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = stub
+}
+
+func (fake *FakeReleaseClient) CheckReleaseBranchStateReturns(result1 error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = nil
+	fake.checkReleaseBranchStateReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeReleaseClient) CheckReleaseBranchStateReturnsOnCall(i int, result1 error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = nil
+	if fake.checkReleaseBranchStateReturnsOnCall == nil {
+		fake.checkReleaseBranchStateReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkReleaseBranchStateReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -497,59 +550,6 @@ func (fake *FakeReleaseClient) PushGitObjectsReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
-func (fake *FakeReleaseClient) SetBuildCandidate() error {
-	fake.setBuildCandidateMutex.Lock()
-	ret, specificReturn := fake.setBuildCandidateReturnsOnCall[len(fake.setBuildCandidateArgsForCall)]
-	fake.setBuildCandidateArgsForCall = append(fake.setBuildCandidateArgsForCall, struct {
-	}{})
-	stub := fake.SetBuildCandidateStub
-	fakeReturns := fake.setBuildCandidateReturns
-	fake.recordInvocation("SetBuildCandidate", []interface{}{})
-	fake.setBuildCandidateMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeReleaseClient) SetBuildCandidateCallCount() int {
-	fake.setBuildCandidateMutex.RLock()
-	defer fake.setBuildCandidateMutex.RUnlock()
-	return len(fake.setBuildCandidateArgsForCall)
-}
-
-func (fake *FakeReleaseClient) SetBuildCandidateCalls(stub func() error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = stub
-}
-
-func (fake *FakeReleaseClient) SetBuildCandidateReturns(result1 error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = nil
-	fake.setBuildCandidateReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeReleaseClient) SetBuildCandidateReturnsOnCall(i int, result1 error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = nil
-	if fake.setBuildCandidateReturnsOnCall == nil {
-		fake.setBuildCandidateReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setBuildCandidateReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeReleaseClient) Submit() error {
 	fake.submitMutex.Lock()
 	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
@@ -663,6 +663,8 @@ func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	defer fake.archiveMutex.RUnlock()
 	fake.checkPrerequisitesMutex.RLock()
 	defer fake.checkPrerequisitesMutex.RUnlock()
+	fake.checkReleaseBranchStateMutex.RLock()
+	defer fake.checkReleaseBranchStateMutex.RUnlock()
 	fake.createAnnouncementMutex.RLock()
 	defer fake.createAnnouncementMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
@@ -673,8 +675,6 @@ func (fake *FakeReleaseClient) Invocations() map[string][][]interface{} {
 	defer fake.pushArtifactsMutex.RUnlock()
 	fake.pushGitObjectsMutex.RLock()
 	defer fake.pushGitObjectsMutex.RUnlock()
-	fake.setBuildCandidateMutex.RLock()
-	defer fake.setBuildCandidateMutex.RUnlock()
 	fake.submitMutex.RLock()
 	defer fake.submitMutex.RUnlock()
 	fake.validateOptionsMutex.RLock()

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -20,6 +20,7 @@ package anagofakes
 import (
 	"sync"
 
+	"github.com/blang/semver"
 	"k8s.io/release/pkg/announce"
 	"k8s.io/release/pkg/build"
 	"k8s.io/release/pkg/gcp/gcb"
@@ -27,6 +28,21 @@ import (
 )
 
 type FakeReleaseImpl struct {
+	BranchNeedsCreationStub        func(string, string, semver.Version) (bool, error)
+	branchNeedsCreationMutex       sync.RWMutex
+	branchNeedsCreationArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 semver.Version
+	}
+	branchNeedsCreationReturns struct {
+		result1 bool
+		result2 error
+	}
+	branchNeedsCreationReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	CheckReleaseBucketStub        func(*build.Options) error
 	checkReleaseBucketMutex       sync.RWMutex
 	checkReleaseBucketArgsForCall []struct {
@@ -182,6 +198,72 @@ type FakeReleaseImpl struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreation(arg1 string, arg2 string, arg3 semver.Version) (bool, error) {
+	fake.branchNeedsCreationMutex.Lock()
+	ret, specificReturn := fake.branchNeedsCreationReturnsOnCall[len(fake.branchNeedsCreationArgsForCall)]
+	fake.branchNeedsCreationArgsForCall = append(fake.branchNeedsCreationArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 semver.Version
+	}{arg1, arg2, arg3})
+	stub := fake.BranchNeedsCreationStub
+	fakeReturns := fake.branchNeedsCreationReturns
+	fake.recordInvocation("BranchNeedsCreation", []interface{}{arg1, arg2, arg3})
+	fake.branchNeedsCreationMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreationCallCount() int {
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
+	return len(fake.branchNeedsCreationArgsForCall)
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreationCalls(stub func(string, string, semver.Version) (bool, error)) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = stub
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreationArgsForCall(i int) (string, string, semver.Version) {
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
+	argsForCall := fake.branchNeedsCreationArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreationReturns(result1 bool, result2 error) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = nil
+	fake.branchNeedsCreationReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeReleaseImpl) BranchNeedsCreationReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = nil
+	if fake.branchNeedsCreationReturnsOnCall == nil {
+		fake.branchNeedsCreationReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.branchNeedsCreationReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeReleaseImpl) CheckReleaseBucket(arg1 *build.Options) error {
@@ -957,6 +1039,8 @@ func (fake *FakeReleaseImpl) ValidateImagesReturnsOnCall(i int, result1 error) {
 func (fake *FakeReleaseImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
 	fake.checkReleaseBucketMutex.RLock()
 	defer fake.checkReleaseBucketMutex.RUnlock()
 	fake.copyStagedFromGCSMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -42,6 +42,16 @@ type FakeStageClient struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckReleaseBranchStateStub        func() error
+	checkReleaseBranchStateMutex       sync.RWMutex
+	checkReleaseBranchStateArgsForCall []struct {
+	}
+	checkReleaseBranchStateReturns struct {
+		result1 error
+	}
+	checkReleaseBranchStateReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GenerateChangelogStub        func() error
 	generateChangelogMutex       sync.RWMutex
 	generateChangelogArgsForCall []struct {
@@ -70,16 +80,6 @@ type FakeStageClient struct {
 		result1 error
 	}
 	prepareWorkspaceReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SetBuildCandidateStub        func() error
-	setBuildCandidateMutex       sync.RWMutex
-	setBuildCandidateArgsForCall []struct {
-	}
-	setBuildCandidateReturns struct {
-		result1 error
-	}
-	setBuildCandidateReturnsOnCall map[int]struct {
 		result1 error
 	}
 	StageArtifactsStub        func() error
@@ -228,6 +228,59 @@ func (fake *FakeStageClient) CheckPrerequisitesReturnsOnCall(i int, result1 erro
 		})
 	}
 	fake.checkPrerequisitesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) CheckReleaseBranchState() error {
+	fake.checkReleaseBranchStateMutex.Lock()
+	ret, specificReturn := fake.checkReleaseBranchStateReturnsOnCall[len(fake.checkReleaseBranchStateArgsForCall)]
+	fake.checkReleaseBranchStateArgsForCall = append(fake.checkReleaseBranchStateArgsForCall, struct {
+	}{})
+	stub := fake.CheckReleaseBranchStateStub
+	fakeReturns := fake.checkReleaseBranchStateReturns
+	fake.recordInvocation("CheckReleaseBranchState", []interface{}{})
+	fake.checkReleaseBranchStateMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageClient) CheckReleaseBranchStateCallCount() int {
+	fake.checkReleaseBranchStateMutex.RLock()
+	defer fake.checkReleaseBranchStateMutex.RUnlock()
+	return len(fake.checkReleaseBranchStateArgsForCall)
+}
+
+func (fake *FakeStageClient) CheckReleaseBranchStateCalls(stub func() error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = stub
+}
+
+func (fake *FakeStageClient) CheckReleaseBranchStateReturns(result1 error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = nil
+	fake.checkReleaseBranchStateReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) CheckReleaseBranchStateReturnsOnCall(i int, result1 error) {
+	fake.checkReleaseBranchStateMutex.Lock()
+	defer fake.checkReleaseBranchStateMutex.Unlock()
+	fake.CheckReleaseBranchStateStub = nil
+	if fake.checkReleaseBranchStateReturnsOnCall == nil {
+		fake.checkReleaseBranchStateReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkReleaseBranchStateReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -387,59 +440,6 @@ func (fake *FakeStageClient) PrepareWorkspaceReturnsOnCall(i int, result1 error)
 		})
 	}
 	fake.prepareWorkspaceReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeStageClient) SetBuildCandidate() error {
-	fake.setBuildCandidateMutex.Lock()
-	ret, specificReturn := fake.setBuildCandidateReturnsOnCall[len(fake.setBuildCandidateArgsForCall)]
-	fake.setBuildCandidateArgsForCall = append(fake.setBuildCandidateArgsForCall, struct {
-	}{})
-	stub := fake.SetBuildCandidateStub
-	fakeReturns := fake.setBuildCandidateReturns
-	fake.recordInvocation("SetBuildCandidate", []interface{}{})
-	fake.setBuildCandidateMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeStageClient) SetBuildCandidateCallCount() int {
-	fake.setBuildCandidateMutex.RLock()
-	defer fake.setBuildCandidateMutex.RUnlock()
-	return len(fake.setBuildCandidateArgsForCall)
-}
-
-func (fake *FakeStageClient) SetBuildCandidateCalls(stub func() error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = stub
-}
-
-func (fake *FakeStageClient) SetBuildCandidateReturns(result1 error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = nil
-	fake.setBuildCandidateReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeStageClient) SetBuildCandidateReturnsOnCall(i int, result1 error) {
-	fake.setBuildCandidateMutex.Lock()
-	defer fake.setBuildCandidateMutex.Unlock()
-	fake.SetBuildCandidateStub = nil
-	if fake.setBuildCandidateReturnsOnCall == nil {
-		fake.setBuildCandidateReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setBuildCandidateReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -663,14 +663,14 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.buildMutex.RUnlock()
 	fake.checkPrerequisitesMutex.RLock()
 	defer fake.checkPrerequisitesMutex.RUnlock()
+	fake.checkReleaseBranchStateMutex.RLock()
+	defer fake.checkReleaseBranchStateMutex.RUnlock()
 	fake.generateChangelogMutex.RLock()
 	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
 	defer fake.generateReleaseVersionMutex.RUnlock()
 	fake.prepareWorkspaceMutex.RLock()
 	defer fake.prepareWorkspaceMutex.RUnlock()
-	fake.setBuildCandidateMutex.RLock()
-	defer fake.setBuildCandidateMutex.RUnlock()
 	fake.stageArtifactsMutex.RLock()
 	defer fake.stageArtifactsMutex.RUnlock()
 	fake.submitMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -20,6 +20,7 @@ package anagofakes
 import (
 	"sync"
 
+	"github.com/blang/semver"
 	"k8s.io/release/pkg/build"
 	"k8s.io/release/pkg/changelog"
 	"k8s.io/release/pkg/gcp/gcb"
@@ -28,6 +29,21 @@ import (
 )
 
 type FakeStageImpl struct {
+	BranchNeedsCreationStub        func(string, string, semver.Version) (bool, error)
+	branchNeedsCreationMutex       sync.RWMutex
+	branchNeedsCreationArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 semver.Version
+	}
+	branchNeedsCreationReturns struct {
+		result1 bool
+		result2 error
+	}
+	branchNeedsCreationReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	CheckReleaseBucketStub        func(*build.Options) error
 	checkReleaseBucketMutex       sync.RWMutex
 	checkReleaseBucketArgsForCall []struct {
@@ -250,6 +266,72 @@ type FakeStageImpl struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreation(arg1 string, arg2 string, arg3 semver.Version) (bool, error) {
+	fake.branchNeedsCreationMutex.Lock()
+	ret, specificReturn := fake.branchNeedsCreationReturnsOnCall[len(fake.branchNeedsCreationArgsForCall)]
+	fake.branchNeedsCreationArgsForCall = append(fake.branchNeedsCreationArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 semver.Version
+	}{arg1, arg2, arg3})
+	stub := fake.BranchNeedsCreationStub
+	fakeReturns := fake.branchNeedsCreationReturns
+	fake.recordInvocation("BranchNeedsCreation", []interface{}{arg1, arg2, arg3})
+	fake.branchNeedsCreationMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreationCallCount() int {
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
+	return len(fake.branchNeedsCreationArgsForCall)
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreationCalls(stub func(string, string, semver.Version) (bool, error)) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = stub
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreationArgsForCall(i int) (string, string, semver.Version) {
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
+	argsForCall := fake.branchNeedsCreationArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreationReturns(result1 bool, result2 error) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = nil
+	fake.branchNeedsCreationReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) BranchNeedsCreationReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.branchNeedsCreationMutex.Lock()
+	defer fake.branchNeedsCreationMutex.Unlock()
+	fake.BranchNeedsCreationStub = nil
+	if fake.branchNeedsCreationReturnsOnCall == nil {
+		fake.branchNeedsCreationReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.branchNeedsCreationReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeStageImpl) CheckReleaseBucket(arg1 *build.Options) error {
@@ -1366,6 +1448,8 @@ func (fake *FakeStageImpl) TagReturnsOnCall(i int, result1 error) {
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.branchNeedsCreationMutex.RLock()
+	defer fake.branchNeedsCreationMutex.RUnlock()
 	fake.checkReleaseBucketMutex.RLock()
 	defer fake.checkReleaseBucketMutex.RUnlock()
 	fake.checkoutMutex.RLock()

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -46,6 +46,42 @@ func TestCheckPrerequisitesRelease(t *testing.T) {
 	require.Nil(t, sut.CheckPrerequisites())
 }
 
+func TestCheckReleaseBranchStateRelease(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeReleaseImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeReleaseImpl) {},
+			shouldError: false,
+		},
+		{ // BranchNeedsCreation fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.BranchNeedsCreationReturns(false, err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultReleaseOptions()
+		sut := anago.NewDefaultRelease(opts)
+
+		sut.SetState(
+			generateTestingReleaseState(&testStateParameters{versionsTag: &testVersionTag}),
+		)
+
+		mock := &anagofakes.FakeReleaseImpl{}
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+
+		err := sut.CheckReleaseBranchState()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
 func TestGenerateReleaseVersionRelease(t *testing.T) {
 	for _, tc := range []struct {
 		prepare             func(*anagofakes.FakeReleaseImpl)

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -47,6 +47,42 @@ func TestCheckPrerequisitesStage(t *testing.T) {
 	require.Nil(t, sut.CheckPrerequisites())
 }
 
+func TestCheckReleaseBranchStateStage(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func(*anagofakes.FakeStageImpl)
+		shouldError bool
+	}{
+		{ // success
+			prepare:     func(*anagofakes.FakeStageImpl) {},
+			shouldError: false,
+		},
+		{ // BranchNeedsCreation fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.BranchNeedsCreationReturns(false, err)
+			},
+			shouldError: true,
+		},
+	} {
+		opts := anago.DefaultStageOptions()
+		sut := anago.NewDefaultStage(opts)
+
+		sut.SetState(
+			generateTestingStageState(&testStateParameters{versionsTag: &testVersionTag}),
+		)
+
+		mock := &anagofakes.FakeStageImpl{}
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+
+		err := sut.CheckReleaseBranchState()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
 func TestGenerateReleaseVersionStage(t *testing.T) {
 	for _, tc := range []struct {
 		prepare             func(*anagofakes.FakeStageImpl)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This integrates the correct state check for the release branch, which also sets the indicator if the branch has to be created or not.

#### Which issue(s) this PR fixes:

Refers to #1673 

#### Special notes for your reviewer:

/hold
Requires https://github.com/kubernetes/release/pull/1740 and https://github.com/kubernetes/release/pull/1753

#### Does this PR introduce a user-facing change?

```release-note
Added release branch state check for `krel stage/release`.
```
