### PR TITLE
[krel] gcbmgr should forbid nomock stage/releases on user forks

### DIFF
--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -96,7 +96,7 @@ func NewDefaultOptions() *Options {
 //counterfeiter:generate . Repository
 type Repository interface {
 	Open() error
-	CheckState(string, string, string) error
+	CheckState(string, string, string, bool) error
 	GetTag() (string, error)
 }
 
@@ -161,7 +161,7 @@ func (g *GCB) Submit() error {
 		return errors.Wrap(err, "open release repo")
 	}
 
-	if err := g.repoClient.CheckState(toolOrg, toolRepo, toolBranch); err != nil {
+	if err := g.repoClient.CheckState(toolOrg, toolRepo, toolBranch, g.options.NoMock); err != nil {
 		return errors.Wrap(err, "verifying repository state")
 	}
 

--- a/pkg/gcp/gcb/gcbfakes/fake_repository.go
+++ b/pkg/gcp/gcb/gcbfakes/fake_repository.go
@@ -24,12 +24,13 @@ import (
 )
 
 type FakeRepository struct {
-	CheckStateStub        func(string, string, string) error
+	CheckStateStub        func(string, string, string, bool) error
 	checkStateMutex       sync.RWMutex
 	checkStateArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 bool
 	}
 	checkStateReturns struct {
 		result1 error
@@ -63,20 +64,21 @@ type FakeRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRepository) CheckState(arg1 string, arg2 string, arg3 string) error {
+func (fake *FakeRepository) CheckState(arg1 string, arg2 string, arg3 string, arg4 bool) error {
 	fake.checkStateMutex.Lock()
 	ret, specificReturn := fake.checkStateReturnsOnCall[len(fake.checkStateArgsForCall)]
 	fake.checkStateArgsForCall = append(fake.checkStateArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 bool
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.CheckStateStub
 	fakeReturns := fake.checkStateReturns
 	fake.recordInvocation("CheckState", []interface{}{arg1, arg2, arg3})
 	fake.checkStateMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -90,17 +92,17 @@ func (fake *FakeRepository) CheckStateCallCount() int {
 	return len(fake.checkStateArgsForCall)
 }
 
-func (fake *FakeRepository) CheckStateCalls(stub func(string, string, string) error) {
+func (fake *FakeRepository) CheckStateCalls(stub func(string, string, string, bool) error) {
 	fake.checkStateMutex.Lock()
 	defer fake.checkStateMutex.Unlock()
 	fake.CheckStateStub = stub
 }
 
-func (fake *FakeRepository) CheckStateArgsForCall(i int) (string, string, string) {
+func (fake *FakeRepository) CheckStateArgsForCall(i int) (string, string, string, bool) {
 	fake.checkStateMutex.RLock()
 	defer fake.checkStateMutex.RUnlock()
 	argsForCall := fake.checkStateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRepository) CheckStateReturns(result1 error) {

--- a/pkg/release/repository.go
+++ b/pkg/release/repository.go
@@ -86,7 +86,7 @@ func (r *Repo) GetTag() (string, error) {
 }
 
 // CheckState verifies that the repository is in the requested state
-func (r *Repo) CheckState(expOrg, expRepo, expBranch string) error {
+func (r *Repo) CheckState(expOrg, expRepo, expBranch string, nomock bool) error {
 	logrus.Info("Verifying repository state")
 
 	dirty, err := r.repo.IsDirty()
@@ -108,6 +108,10 @@ func (r *Repo) CheckState(expOrg, expRepo, expBranch string) error {
 	if branch != expBranch {
 		return errors.Errorf("branch %q expected but got %q", expBranch, branch)
 	}
+	if nomock && !(expOrg == DefaultToolOrg && expRepo == DefaultToolRepo && expBranch == DefaultToolBranch) {
+		return errors.New("disallow using anything other than kubernetes/release:master with nomock flag")
+	}
+
 	logrus.Infof("Found matching branch %q", expBranch)
 
 	// Verify the remote

--- a/pkg/release/repository_test.go
+++ b/pkg/release/repository_test.go
@@ -99,7 +99,7 @@ func TestCheckStateSuccess(t *testing.T) {
 	sut.mock.HeadReturns("dbade8e", nil)
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.Nil(t, err)
@@ -115,7 +115,7 @@ func TestCheckStateFailedNoRemoteFound(t *testing.T) {
 	}, nil)
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -129,7 +129,7 @@ func TestCheckStateFailedRemoteFailed(t *testing.T) {
 	sut.mock.RemotesReturns(nil, errors.New(""))
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -142,7 +142,7 @@ func TestCheckStateFailedWrongBranch(t *testing.T) {
 	sut.mock.CurrentBranchReturns("wrong", nil)
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -155,7 +155,7 @@ func TestCheckStateFailedBranchFailed(t *testing.T) {
 	sut.mock.CurrentBranchReturns("", errors.New(""))
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -172,7 +172,7 @@ func TestCheckStateFailedLsRemote(t *testing.T) {
 	sut.mock.LsRemoteReturns("", errors.New(""))
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -190,7 +190,7 @@ func TestCheckStateFailedBranchHeadRetrievalFails(t *testing.T) {
 	sut.mock.HeadReturns("", errors.New("no such commit"))
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)
@@ -208,7 +208,7 @@ func TestCheckStateFailedBranchHeadRetrievalNotEqual(t *testing.T) {
 	sut.mock.HeadReturns("123", nil)
 
 	// When
-	err := sut.repo.CheckState("org", "repo", "branch")
+	err := sut.repo.CheckState("org", "repo", "branch", false)
 
 	// Then
 	require.NotNil(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If the user specifies the --nomock flag, then we should disallow using anything other than kubernetes/release:master

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/release/issues/1630

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
