### PR TITLE
Remove HasBranch check for krel stage tagging

### DIFF
--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -130,20 +130,6 @@ type FakeStageImpl struct {
 		result1 *release.Versions
 		result2 error
 	}
-	HasBranchStub        func(*git.Repo, string) (bool, error)
-	hasBranchMutex       sync.RWMutex
-	hasBranchArgsForCall []struct {
-		arg1 *git.Repo
-		arg2 string
-	}
-	hasBranchReturns struct {
-		result1 bool
-		result2 error
-	}
-	hasBranchReturnsOnCall map[int]struct {
-		result1 bool
-		result2 error
-	}
 	MakeCrossStub        func(string) error
 	makeCrossMutex       sync.RWMutex
 	makeCrossArgsForCall []struct {
@@ -761,71 +747,6 @@ func (fake *FakeStageImpl) GenerateReleaseVersionReturnsOnCall(i int, result1 *r
 	}
 	fake.generateReleaseVersionReturnsOnCall[i] = struct {
 		result1 *release.Versions
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeStageImpl) HasBranch(arg1 *git.Repo, arg2 string) (bool, error) {
-	fake.hasBranchMutex.Lock()
-	ret, specificReturn := fake.hasBranchReturnsOnCall[len(fake.hasBranchArgsForCall)]
-	fake.hasBranchArgsForCall = append(fake.hasBranchArgsForCall, struct {
-		arg1 *git.Repo
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.HasBranchStub
-	fakeReturns := fake.hasBranchReturns
-	fake.recordInvocation("HasBranch", []interface{}{arg1, arg2})
-	fake.hasBranchMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeStageImpl) HasBranchCallCount() int {
-	fake.hasBranchMutex.RLock()
-	defer fake.hasBranchMutex.RUnlock()
-	return len(fake.hasBranchArgsForCall)
-}
-
-func (fake *FakeStageImpl) HasBranchCalls(stub func(*git.Repo, string) (bool, error)) {
-	fake.hasBranchMutex.Lock()
-	defer fake.hasBranchMutex.Unlock()
-	fake.HasBranchStub = stub
-}
-
-func (fake *FakeStageImpl) HasBranchArgsForCall(i int) (*git.Repo, string) {
-	fake.hasBranchMutex.RLock()
-	defer fake.hasBranchMutex.RUnlock()
-	argsForCall := fake.hasBranchArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeStageImpl) HasBranchReturns(result1 bool, result2 error) {
-	fake.hasBranchMutex.Lock()
-	defer fake.hasBranchMutex.Unlock()
-	fake.HasBranchStub = nil
-	fake.hasBranchReturns = struct {
-		result1 bool
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeStageImpl) HasBranchReturnsOnCall(i int, result1 bool, result2 error) {
-	fake.hasBranchMutex.Lock()
-	defer fake.hasBranchMutex.Unlock()
-	fake.HasBranchStub = nil
-	if fake.hasBranchReturnsOnCall == nil {
-		fake.hasBranchReturnsOnCall = make(map[int]struct {
-			result1 bool
-			result2 error
-		})
-	}
-	fake.hasBranchReturnsOnCall[i] = struct {
-		result1 bool
 		result2 error
 	}{result1, result2}
 }
@@ -1464,8 +1385,6 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
 	defer fake.generateReleaseVersionMutex.RUnlock()
-	fake.hasBranchMutex.RLock()
-	defer fake.hasBranchMutex.RUnlock()
 	fake.makeCrossMutex.RLock()
 	defer fake.makeCrossMutex.RUnlock()
 	fake.openRepoMutex.RLock()

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -215,17 +215,6 @@ func TestTagRepository(t *testing.T) {
 			createReleaseBranch: true,
 			shouldError:         true,
 		},
-		{ // failure on HasBranch new rc creating release branch
-			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
-				mock.CurrentBranchReturnsOnCall(0, "release-1.20", nil)
-				mock.HasBranchReturns(false, err)
-			},
-			versions:            newRCVersions,
-			releaseBranch:       "release-1.20",
-			createReleaseBranch: true,
-			shouldError:         true,
-		},
 		{ // failure on RevParse new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
 				mock.RevParseReturns("", nil)
@@ -256,7 +245,6 @@ func TestTagRepository(t *testing.T) {
 		{ // success new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
 				mock.RevParseReturns("", err)
-				mock.HasBranchReturns(true, nil)
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -266,18 +254,7 @@ func TestTagRepository(t *testing.T) {
 		{ // failure on Checkout new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
 				mock.RevParseReturns("", err)
-				mock.HasBranchReturns(true, nil)
 				mock.CheckoutReturns(err)
-			},
-			versions:            newRCVersions,
-			releaseBranch:       "release-1.20",
-			createReleaseBranch: true,
-			shouldError:         true,
-		},
-		{ // failure on HasBranch new rc checking out release branch
-			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
-				mock.HasBranchReturns(true, err)
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We already have an indicator in the `state` which tells us if the
release branch has to be created or not. Therefore we now can omit the
additional check of `HasBranch()` to simplify the logic.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:

##### Testing new RC
```
> export TOOL_ORG=saschagrunert && export TOOL_BRANCH=has-branch && \
  go run ./cmd/krel stage --type rc --branch release-1.20
```
https://console.cloud.google.com/cloud-build/builds/dac10234-bdb8-43cd-b243-7d106952ee05?project=kubernetes-release-test
```
Step #2: INFO Preparing version v1.20.0-rc.0               
Step #2: INFO Creating release branch release-1.20         
Step #2: INFO Version v1.20.0-rc.0 is the prime version    
Step #2: INFO Creating release branch release-1.20 from commit 18099e1ef7283d 
Step #2: INFO Current branch is "release-1.20"             
Step #2: INFO Creating empty release commit for tag v1.20.0-rc.0 
Step #2: INFO Tagging version v1.20.0-rc.0                 
Step #2: INFO Preparing version v1.21.0-alpha.0            
Step #2: INFO Creating release branch release-1.20         
Step #2: INFO Version v1.21.0-alpha.0 it not the prime, checking out master branch 
Step #2: INFO Current branch is "master"                   
Step #2: INFO Tagging version v1.21.0-alpha.0
```
##### Testing new beta
```
> export TOOL_ORG=saschagrunert && export TOOL_BRANCH=has-branch && \
  go run ./cmd/krel stage --type beta
```
https://console.cloud.google.com/cloud-build/builds/762c7f78-24c0-465c-9b31-61971a3bbf62?project=kubernetes-release-test
```
Step #2: INFO Preparing version v1.20.0-beta.3             
Step #2: INFO Checking out commit 18099e1ef7283d           
Step #2: INFO Current branch is "master"                   
Step #2: INFO Tagging version v1.20.0-beta.3
```
##### Testing new official (patch)
```
> export TOOL_ORG=saschagrunert && export TOOL_BRANCH=has-branch && \
  go run ./cmd/krel stage --branch release-1.19 --type official
```
https://console.cloud.google.com/cloud-build/builds/ca1fdb50-a51c-4e89-b7bd-7f9c211d756c?project=kubernetes-release-test
```
Step #2: INFO Preparing version v1.19.5                    
Step #2: INFO Checking out commit 94a03492283f76           
Step #2: INFO Current branch is ""                         
Step #2: INFO Tagging version v1.19.5                      
Step #2: INFO Preparing version v1.19.6-rc.0               
Step #2: INFO Checking out commit 94a03492283f76           
Step #2: INFO Current branch is ""                         
Step #2: INFO Tagging version v1.19.6-rc.0       
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
