### PR TITLE
GCS object store implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ verify-published-rpms: ## Ensure rpms have been published
 
 ##@ Verify
 
-.PHONY: verify verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint verify-shellcheck
+.PHONY: verify verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod verify-shellcheck
 
 # TODO: Uncomment verify-shellcheck once we finish shellchecking the repo.
 #       ref: https://github.com/kubernetes/release/issues/726
-verify: release-tools verify-boilerplate verify-dependencies verify-go-mod verify-golangci-lint #verify-shellcheck ## Runs verification scripts to ensure correct execution
+verify: release-tools verify-boilerplate verify-dependencies verify-golangci-lint verify-go-mod #verify-shellcheck ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check
 	./hack/verify-boilerplate.sh

--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -31,10 +31,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/http"
-	"k8s.io/utils/pointer"
+	"k8s.io/release/pkg/object"
 )
 
 type TestGridOptions struct {
@@ -186,13 +185,8 @@ func processDashboards(testgridJobs []TestGridJob, date string, opts *TestGridOp
 
 		gcsPath := filepath.Join(opts.bucket, "testgridshot", opts.branch, date, filepath.Base(jobFile))
 
-		GCSCopyOptions := &gcs.Options{
-			Concurrent:   pointer.BoolPtr(true),
-			Recursive:    pointer.BoolPtr(true),
-			NoClobber:    pointer.BoolPtr(true),
-			AllowMissing: pointer.BoolPtr(true),
-		}
-		if err := gcs.CopyToGCS(jobFile, gcsPath, GCSCopyOptions); err != nil {
+		gcs := object.NewGCS()
+		if err := gcs.CopyToRemote(jobFile, gcsPath); err != nil {
 			return testgridJobs, errors.Wrapf(err, "failed to upload the file %s to GCS bucket %s", jobFile, gcsPath)
 		}
 		testgridJobs[i].GCSLocation = fmt.Sprintf("https://storage.googleapis.com/%s", gcsPath)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp/gcs"
+	"k8s.io/release/pkg/object"
 	"k8s.io/release/pkg/release"
 )
 
@@ -28,12 +28,18 @@ var DefaultExtraVersionMarkers = []string{}
 
 // Instance is the main structure for creating and pushing builds.
 type Instance struct {
-	opts *Options
+	opts     *Options
+	objStore object.GCS
 }
 
 // NewInstance can be used to create a new build `Instance`.
+// TODO: Prefer functional options here instead
 func NewInstance(opts *Options) *Instance {
-	instance := &Instance{opts}
+	instance := &Instance{
+		opts:     opts,
+		objStore: *object.NewGCS(),
+	}
+
 	instance.setBuildType()
 	instance.setBucket()
 	instance.setGCSRoot()
@@ -117,7 +123,7 @@ func (bi *Instance) getGCSBuildPath(version string) (string, error) {
 		bi.setBucket()
 	}
 
-	buildPath, err := gcs.GetReleasePath(
+	buildPath, err := bi.objStore.GetReleasePath(
 		bi.opts.Bucket,
 		bi.opts.GCSRoot,
 		version,

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -26,7 +26,6 @@ import (
 
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/gcp/auth"
-	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/release"
 )
 
@@ -119,12 +118,12 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 		return false, errors.Wrap(gcsBuildRootErr, "get GCS build root")
 	}
 
-	kubernetesTar, kubernetesTarErr := gcs.NormalizeGCSPath(gcsBuildRoot, release.KubernetesTar)
+	kubernetesTar, kubernetesTarErr := bi.objStore.NormalizePath(gcsBuildRoot, release.KubernetesTar)
 	if kubernetesTarErr != nil {
 		return false, errors.Wrap(kubernetesTarErr, "get tarball path")
 	}
 
-	binPath, binPathErr := gcs.NormalizeGCSPath(gcsBuildRoot, "bin")
+	binPath, binPathErr := bi.objStore.NormalizePath(gcsBuildRoot, "bin")
 	if binPathErr != nil {
 		return false, errors.Wrap(binPathErr, "get binary path")
 	}
@@ -139,7 +138,7 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 	existErrors := []error{}
 	for _, path := range gcsBuildPaths {
 		logrus.Infof("Checking if GCS build path (%s) exists", path)
-		exists, existErr := gcs.PathExists(path)
+		exists, existErr := bi.objStore.PathExists(path)
 		if existErr != nil || !exists {
 			existErrors = append(existErrors, existErr)
 		}

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -37,7 +37,7 @@ import (
 
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/gcp/gcs"
+	"k8s.io/release/pkg/object"
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/tar"
 	"sigs.k8s.io/yaml"
@@ -52,6 +52,7 @@ const (
 
 // TODO: Pull some of these options in cmd/gcbuilder, so they don't have to be public.
 type Options struct {
+	objStore       object.Store
 	BuildDir       string
 	ConfigDir      string
 	CloudbuildFile string
@@ -69,6 +70,7 @@ type Options struct {
 // NewDefaultOptions returns a new default `*Options` instance.
 func NewDefaultOptions() *Options {
 	return &Options{
+		objStore:       object.NewGCS(),
 		Project:        release.DefaultKubernetesStagingProject,
 		CloudbuildFile: DefaultCloudbuildFile,
 	}
@@ -156,10 +158,9 @@ func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
 	u := uuid.New()
 	uploaded := fmt.Sprintf("%s/%s.tgz", targetBucket, u.String())
 	logrus.Infof("Uploading %s to %s...", name, uploaded)
-	if err := gcs.CopyToGCS(
+	if err := o.objStore.CopyToRemote(
 		name,
 		uploaded,
-		gcs.DefaultGCSCopyOptions,
 	); err != nil {
 		return "", errors.Wrap(err, "upload files to GCS")
 	}

--- a/pkg/object/gcs.go
+++ b/pkg/object/gcs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gcs
+package object
 
 import (
 	"os"

--- a/pkg/object/gcs.go
+++ b/pkg/object/gcs.go
@@ -105,9 +105,9 @@ var (
 )
 
 // CopyToGCS copies a local directory to the specified GCS path
-func (g *GCS) CopyToGCS(src, gcsPath string) error {
+func (g *GCS) CopyToRemote(src, gcsPath string) error {
 	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
-	gcsPath, gcsPathErr := g.NormalizeGCSPath(gcsPath)
+	gcsPath, gcsPathErr := g.NormalizePath(gcsPath)
 	if gcsPathErr != nil {
 		return errors.Wrap(gcsPathErr, "normalize GCS path")
 	}
@@ -130,7 +130,7 @@ func (g *GCS) CopyToGCS(src, gcsPath string) error {
 // CopyToLocal copies a GCS path to the specified local directory
 func (g *GCS) CopyToLocal(gcsPath, dst string) error {
 	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
-	gcsPath, gcsPathErr := g.NormalizeGCSPath(gcsPath)
+	gcsPath, gcsPathErr := g.NormalizePath(gcsPath)
 	if gcsPathErr != nil {
 		return errors.Wrap(gcsPathErr, "normalize GCS path")
 	}
@@ -142,12 +142,12 @@ func (g *GCS) CopyToLocal(gcsPath, dst string) error {
 func (g *GCS) CopyBucketToBucket(src, dst string) error {
 	logrus.Infof("Copying %s to %s", src, dst)
 
-	src, srcErr := g.NormalizeGCSPath(src)
+	src, srcErr := g.NormalizePath(src)
 	if srcErr != nil {
 		return errors.Wrap(srcErr, "normalize GCS path")
 	}
 
-	dst, dstErr := g.NormalizeGCSPath(dst)
+	dst, dstErr := g.NormalizePath(dst)
 	if dstErr != nil {
 		return errors.Wrap(dstErr, "normalize GCS path")
 	}
@@ -255,14 +255,14 @@ func (g *GCS) getPath(
 	}
 
 	// Ensure any constructed GCS path is prefixed with `gs://`
-	return g.NormalizeGCSPath(gcsPathParts...)
+	return g.NormalizePath(gcsPathParts...)
 }
 
 // NormalizeGCSPath takes a GCS path and ensures that the `GcsPrefix` is
 // prepended to it.
 // TODO: Should there be an append function for paths to prevent multiple calls
 //       like in build.checkBuildExists()?
-func (g *GCS) NormalizeGCSPath(gcsPathParts ...string) (string, error) {
+func (g *GCS) NormalizePath(gcsPathParts ...string) (string, error) {
 	gcsPath := ""
 
 	// Ensure there is at least one element in the gcsPathParts slice before
@@ -350,7 +350,7 @@ func (g *GCS) IsPathNormalized(gcsPath string) bool {
 
 // RsyncRecursive runs `gsutil rsync` in recursive mode. The caller of this
 // function has to ensure that the provided paths are prefixed with gs:// if
-// necessary (see `NormalizeGCSPath()`).
+// necessary (see `NormalizePath()`).
 func (g *GCS) RsyncRecursive(src, dst string) error {
 	return errors.Wrap(
 		gcp.GSUtil(concurrentFlag, "rsync", recursiveFlag, src, dst),

--- a/pkg/object/gcs_test.go
+++ b/pkg/object/gcs_test.go
@@ -133,7 +133,7 @@ func TestGetMarkerPath(t *testing.T) {
 	}
 }
 
-func TestNormalizeGCSPath(t *testing.T) {
+func TestNormalizePath(t *testing.T) {
 	for _, tc := range []struct {
 		gcsPathParts []string
 		expected     string
@@ -197,7 +197,7 @@ func TestNormalizeGCSPath(t *testing.T) {
 			shouldError: true,
 		},
 	} {
-		actual, err := testGCS.NormalizeGCSPath(tc.gcsPathParts...)
+		actual, err := testGCS.NormalizePath(tc.gcsPathParts...)
 
 		require.Equal(t, tc.expected, actual)
 

--- a/pkg/object/gcs_test.go
+++ b/pkg/object/gcs_test.go
@@ -20,10 +20,41 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/release/pkg/object"
 )
 
-var gcs = object.NewGCS(object.DefaultGCSCopyOptions)
+var testGCS = object.NewGCS()
+
+func TestGCSSetOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		gcs      *object.GCS
+		opt      bool
+		expected bool
+	}{
+		{
+			name:     "should be false",
+			gcs:      testGCS,
+			opt:      false,
+			expected: false,
+		},
+	} {
+		t.Logf("test case: %v", tc.name)
+
+		testGCS.SetOptions(
+			testGCS.WithConcurrent(tc.opt),
+			testGCS.WithRecursive(tc.opt),
+			testGCS.WithNoClobber(tc.opt),
+			testGCS.WithAllowMissing(tc.opt),
+		)
+
+		require.Equal(t, tc.expected, testGCS.Concurrent())
+		require.Equal(t, tc.expected, testGCS.Recursive())
+		require.Equal(t, tc.expected, testGCS.NoClobber())
+		require.Equal(t, tc.expected, testGCS.AllowMissing())
+	}
+}
 
 // TODO: Add production use cases
 func TestGetReleasePath(t *testing.T) {
@@ -56,7 +87,7 @@ func TestGetReleasePath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := gcs.GetReleasePath(
+		actual, err := testGCS.GetReleasePath(
 			tc.bucket,
 			tc.gcsRoot,
 			tc.version,
@@ -87,7 +118,7 @@ func TestGetMarkerPath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := gcs.GetMarkerPath(
+		actual, err := testGCS.GetMarkerPath(
 			tc.bucket,
 			tc.gcsRoot,
 		)
@@ -166,7 +197,7 @@ func TestNormalizeGCSPath(t *testing.T) {
 			shouldError: true,
 		},
 	} {
-		actual, err := gcs.NormalizeGCSPath(tc.gcsPathParts...)
+		actual, err := testGCS.NormalizeGCSPath(tc.gcsPathParts...)
 
 		require.Equal(t, tc.expected, actual)
 
@@ -196,7 +227,7 @@ func TestIsPathNormalized(t *testing.T) {
 			expected: true,
 		},
 	} {
-		actual := gcs.IsPathNormalized(tc.gcsPath)
+		actual := testGCS.IsPathNormalized(tc.gcsPath)
 
 		require.Equal(t, tc.expected, actual)
 	}

--- a/pkg/object/gcs_test.go
+++ b/pkg/object/gcs_test.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gcs_test
+package object_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"k8s.io/release/pkg/gcp/gcs"
+	"k8s.io/release/pkg/object"
 )
 
 // TODO: Add production use cases
@@ -55,7 +54,7 @@ func TestGetReleasePath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := gcs.GetReleasePath(
+		actual, err := object.GetReleasePath(
 			tc.bucket,
 			tc.gcsRoot,
 			tc.version,
@@ -86,7 +85,7 @@ func TestGetMarkerPath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := gcs.GetMarkerPath(
+		actual, err := object.GetMarkerPath(
 			tc.bucket,
 			tc.gcsRoot,
 		)
@@ -165,7 +164,7 @@ func TestNormalizeGCSPath(t *testing.T) {
 			shouldError: true,
 		},
 	} {
-		actual, err := gcs.NormalizeGCSPath(tc.gcsPathParts...)
+		actual, err := object.NormalizeGCSPath(tc.gcsPathParts...)
 
 		require.Equal(t, tc.expected, actual)
 
@@ -195,7 +194,7 @@ func TestIsPathNormalized(t *testing.T) {
 			expected: true,
 		},
 	} {
-		actual := gcs.IsPathNormalized(tc.gcsPath)
+		actual := object.IsPathNormalized(tc.gcsPath)
 
 		require.Equal(t, tc.expected, actual)
 	}

--- a/pkg/object/gcs_test.go
+++ b/pkg/object/gcs_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/release/pkg/object"
 )
 
+var gcs = object.NewGCS(object.DefaultGCSCopyOptions)
+
 // TODO: Add production use cases
 func TestGetReleasePath(t *testing.T) {
 	for _, tc := range []struct {
@@ -54,7 +56,7 @@ func TestGetReleasePath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := object.GetReleasePath(
+		actual, err := gcs.GetReleasePath(
 			tc.bucket,
 			tc.gcsRoot,
 			tc.version,
@@ -85,7 +87,7 @@ func TestGetMarkerPath(t *testing.T) {
 			shouldError: false,
 		},
 	} {
-		actual, err := object.GetMarkerPath(
+		actual, err := gcs.GetMarkerPath(
 			tc.bucket,
 			tc.gcsRoot,
 		)
@@ -164,7 +166,7 @@ func TestNormalizeGCSPath(t *testing.T) {
 			shouldError: true,
 		},
 	} {
-		actual, err := object.NormalizeGCSPath(tc.gcsPathParts...)
+		actual, err := gcs.NormalizeGCSPath(tc.gcsPathParts...)
 
 		require.Equal(t, tc.expected, actual)
 
@@ -194,7 +196,7 @@ func TestIsPathNormalized(t *testing.T) {
 			expected: true,
 		},
 	} {
-		actual := object.IsPathNormalized(tc.gcsPath)
+		actual := gcs.IsPathNormalized(tc.gcsPath)
 
 		require.Equal(t, tc.expected, actual)
 	}

--- a/pkg/object/store.go
+++ b/pkg/object/store.go
@@ -18,11 +18,18 @@ package object
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
-//counterfeiter:generate . store
+//counterfeiter:generate . Store
 type Store interface {
 	// TODO: Implement interface
-}
-
-type DefaultStore struct {
-	// TODO: Implement store
+	// TODO: Consider a method to set options
+	// TODO: Choose GCS-agnostic names
+	CopyToGCS(src, gcsPath string) error
+	CopyToLocal(gcsPath, dst string) error
+	CopyBucketToBucket(src, dst string) error
+	GetReleasePath(bucket, gcsRoot, version string, fast bool) (string, error)
+	GetMarkerPath(bucket, gcsRoot string) (string, error)
+	NormalizeGCSPath(gcsPathParts ...string) (string, error)
+	IsPathNormalized(gcsPath string) bool
+	RsyncRecursive(src, dst string) error
+	PathExists(gcsPath string) (bool, error)
 }

--- a/pkg/object/store.go
+++ b/pkg/object/store.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . store
+type Store interface {
+	// TODO: Implement interface
+}
+
+type DefaultStore struct {
+	// TODO: Implement store
+}

--- a/pkg/object/store.go
+++ b/pkg/object/store.go
@@ -20,8 +20,8 @@ package object
 
 //counterfeiter:generate . Store
 type Store interface {
-	// TODO: Implement interface
-	// TODO: Consider a method to set options
+	SetOptions(opts ...OptFn)
+
 	// TODO: Choose GCS-agnostic names
 	CopyToGCS(src, gcsPath string) error
 	CopyToLocal(gcsPath, dst string) error
@@ -33,3 +33,5 @@ type Store interface {
 	RsyncRecursive(src, dst string) error
 	PathExists(gcsPath string) (bool, error)
 }
+
+type OptFn func(Store)

--- a/pkg/object/store.go
+++ b/pkg/object/store.go
@@ -20,18 +20,25 @@ package object
 
 //counterfeiter:generate . Store
 type Store interface {
+	// Configure options
 	SetOptions(opts ...OptFn)
 
-	// TODO: Choose GCS-agnostic names
-	CopyToGCS(src, gcsPath string) error
-	CopyToLocal(gcsPath, dst string) error
+	// Path operations
+	NormalizePath(pathParts ...string) (string, error)
+	IsPathNormalized(path string) bool
+	PathExists(path string) (bool, error)
+
+	// Copy operations
+	// TODO: Determine if these methods should even be part of the interface
+	// TODO: Maybe overly specific. Consider reducing these down to Copy()
+	CopyToRemote(local, remote string) error
+	CopyToLocal(remote, local string) error
 	CopyBucketToBucket(src, dst string) error
+	RsyncRecursive(src, dst string) error
+
+	// TODO: Overly specific. We should only care these methods during a release.
 	GetReleasePath(bucket, gcsRoot, version string, fast bool) (string, error)
 	GetMarkerPath(bucket, gcsRoot string) (string, error)
-	NormalizeGCSPath(gcsPathParts ...string) (string, error)
-	IsPathNormalized(gcsPath string) bool
-	RsyncRecursive(src, dst string) error
-	PathExists(gcsPath string) (bool, error)
 }
 
 type OptFn func(Store)

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -27,19 +27,23 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/http"
+	"k8s.io/release/pkg/object"
 	"k8s.io/release/pkg/util"
 )
 
 // Publisher is the structure for publishing anything release related
 type Publisher struct {
-	client publisherClient
+	client   publisherClient
+	objStore object.Store
 }
 
 // NewPublisher creates a new Publisher instance
 func NewPublisher() *Publisher {
-	return &Publisher{&defaultPublisher{}}
+	return &Publisher{
+		client:   &defaultPublisher{},
+		objStore: object.NewGCS(),
+	}
 }
 
 // SetClient can be used to set the internal publisher client
@@ -104,7 +108,7 @@ func (p *Publisher) PublishVersion(
 		return errors.Errorf("invalid version %s", version)
 	}
 
-	markerPath, markerPathErr := gcs.GetMarkerPath(
+	markerPath, markerPathErr := p.objStore.GetMarkerPath(
 		bucket,
 		gcsRoot,
 	)
@@ -112,7 +116,7 @@ func (p *Publisher) PublishVersion(
 		return errors.Wrap(markerPathErr, "get version marker path")
 	}
 
-	releasePath, releasePathErr := gcs.GetReleasePath(
+	releasePath, releasePathErr := p.objStore.GetReleasePath(
 		bucket,
 		gcsRoot,
 		version,
@@ -191,12 +195,12 @@ func (p *Publisher) VerifyLatestUpdate(
 ) (needsUpdate bool, err error) {
 	logrus.Infof("Testing %s > %s (published)", version, publishFile)
 
-	publishFileDst, publishFileDstErr := gcs.NormalizeGCSPath(markerPath, publishFile)
+	publishFileDst, publishFileDstErr := p.objStore.NormalizePath(markerPath, publishFile)
 	if publishFileDstErr != nil {
 		return false, errors.Wrap(publishFileDstErr, "get marker file destination")
 	}
 
-	// TODO: Should we add a pkg/gcp/gcs function for `gsutil cat`?
+	// TODO: Should we add a object.`GCS` method for `gsutil cat`?
 	gcsVersion, err := p.client.GSUtilOutput("cat", publishFileDst)
 	if err != nil {
 		logrus.Infof("%s does not exist but will be created", publishFileDst)
@@ -235,7 +239,7 @@ func (p *Publisher) PublishToGcs(
 	privateBucket bool,
 ) error {
 	releaseStage := filepath.Join(buildDir, ReleaseStagePath)
-	publishFileDst, publishFileDstErr := gcs.NormalizeGCSPath(markerPath, publishFile)
+	publishFileDst, publishFileDstErr := p.objStore.NormalizePath(markerPath, publishFile)
 	if publishFileDstErr != nil {
 		return errors.Wrap(publishFileDstErr, "get marker file destination")
 	}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -40,9 +40,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/http"
+	"k8s.io/release/pkg/object"
 	"k8s.io/release/pkg/tar"
 	"k8s.io/release/pkg/util"
 )
@@ -303,7 +303,7 @@ func GetKubecrossVersion(branches ...string) (string, error) {
 
 // URLPrefixForBucket returns the URL prefix for the provided bucket string
 func URLPrefixForBucket(bucket string) string {
-	bucket = strings.TrimPrefix(bucket, gcs.GcsPrefix)
+	bucket = strings.TrimPrefix(bucket, object.GcsPrefix)
 	urlPrefix := fmt.Sprintf("https://storage.googleapis.com/%s", bucket)
 	if bucket == ProductionBucket {
 		urlPrefix = ProductionBucketURL

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -26,12 +26,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp/gcs"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/github"
+	"k8s.io/release/pkg/object"
 	"k8s.io/release/pkg/tar"
 	"k8s.io/release/pkg/util"
-	"k8s.io/utils/pointer"
 )
 
 // PrepareWorkspaceStage sets up the workspace by cloning a new copy of k/k.
@@ -69,7 +68,7 @@ func PrepareWorkspaceStage(directory string) error {
 	return nil
 }
 
-// PrepareWorkspaceRelease sets up the workspace by downloading and extractig
+// PrepareWorkspaceRelease sets up the workspace by downloading and extracting
 // the staged sources on the provided bucket.
 func PrepareWorkspaceRelease(directory, buildVersion, bucket string) error {
 	logrus.Infof("Preparing workspace for release in %s", directory)
@@ -89,9 +88,10 @@ func PrepareWorkspaceRelease(directory, buildVersion, bucket string) error {
 	// On `release`, we lookup the staged sources and use them directly
 	src := filepath.Join(bucket, StagePath, buildVersion, SourcesTar)
 	dst := filepath.Join(tempDir, SourcesTar)
-	opt := gcs.DefaultGCSCopyOptions
-	opt.AllowMissing = pointer.BoolPtr(false)
-	if err := gcs.CopyToLocal(src, dst, gcs.DefaultGCSCopyOptions); err != nil {
+
+	gcs := object.NewGCS()
+	gcs.WithAllowMissing(false)
+	if err := gcs.CopyToLocal(src, dst); err != nil {
 		return errors.Wrap(err, "copying staged sources from GCS")
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup feature design api-change

#### What this PR does / why we need it:

This includes several elements of https://github.com/kubernetes/release/pull/1750, but I changed my strategy a little.

This PR only implements the `object` package, which has a `Store` interface, and a concrete implementation using GCS (which is a refactor of the `pkg/gcp/gcs`).

A little less "boiling the ocean", like https://github.com/kubernetes/release/pull/1750.
Once this lands, I'll pull it into the build client refactor.

- pkg: Add package for operations on object stores (like GCS)
- pkg: Move existing GCS implementation to the `object` package
- pkg/object: `GCS` implementation now satisfies `Store`
- pkg/object: Allow setting object.GCS with functional options
- pkg/object: Choose method names that are less GCS-specific
- Update all references to GCS methods 

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- GCS object store implementation
```
