### PR TITLE
Add `krel history` subcommand

### DIFF
--- a/cmd/krel/cmd/history.go
+++ b/cmd/krel/cmd/history.go
@@ -22,35 +22,41 @@ import (
 	"k8s.io/release/pkg/gcp/gcb"
 )
 
-var gcbmgrHistoryOpts = &gcb.HistoryOptions{}
+var historyOpts = gcb.NewHistoryOptions()
 
-// gcbmgrHistoryCmd is a krel gcbmgr subcommand which generates information about the command that the operator ran for a specific release cut
-var gcbmgrHistoryCmd = &cobra.Command{
-	Use:           "history --branch release-1.18 --date-from 2020-06-18 [--date-to 2020-06-19]",
+// historyCmd is a krel gcbmgr subcommand which generates information about the
+// command that the operator ran for a specific release cut.
+var historyCmd = &cobra.Command{
+	Use:           "history --branch release-1.19 --date-from 2020-06-18 [--date-to 2020-06-19]",
 	Short:         "Run history to build a list of commands that ran when cutting a specific Kubernetes release",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		gcbmgrHistoryOpts.Branch = gcbmgrOpts.Branch
-		gcbmgrHistoryOpts.Project = gcbmgrOpts.Project
-		return gcb.NewHistory(gcbmgrHistoryOpts).Run()
+		return gcb.NewHistory(historyOpts).Run()
 	},
 }
 
 func init() {
-	gcbmgrHistoryCmd.PersistentFlags().StringVar(
-		&gcbmgrHistoryOpts.DateFrom,
+	historyCmd.PersistentFlags().StringVar(
+		&historyOpts.Branch,
+		"branch",
+		historyOpts.Branch,
+		"The release branch for which the release should be build",
+	)
+
+	historyCmd.PersistentFlags().StringVar(
+		&historyOpts.DateFrom,
 		"date-from",
-		"",
-		"Get the jobs starting from a specific date. Format to use yyyy-mm-dd",
+		historyOpts.DateFrom,
+		"Get the jobs starting from a specific date.",
 	)
 
-	gcbmgrHistoryCmd.PersistentFlags().StringVar(
-		&gcbmgrHistoryOpts.DateTo,
+	historyCmd.PersistentFlags().StringVar(
+		&historyOpts.DateTo,
 		"date-to",
-		"",
-		"Get the jobs ending from a specific date. Format to use yyyy-mm-dd",
+		historyOpts.DateTo,
+		"Get the jobs ending from a specific date.",
 	)
 
-	gcbmgrCmd.AddCommand(gcbmgrHistoryCmd)
+	rootCmd.AddCommand(historyCmd)
 }

--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -25,6 +25,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/release/pkg/gcp/build"
+	"k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/release"
 )
 
 type History struct {
@@ -43,6 +45,16 @@ type HistoryOptions struct {
 	DateTo         string
 	DateFromParsed string
 	DateToParsed   string
+}
+
+// NewHistoryOptions creates a new default HistoryOptions instance.
+func NewHistoryOptions() *HistoryOptions {
+	return &HistoryOptions{
+		Branch:   git.DefaultBranch,
+		Project:  release.DefaultKubernetesStagingProject,
+		DateFrom: time.Now().Format("2006-01-30"),
+		DateTo:   time.Now().Format("2006-01-30"),
+	}
 }
 
 var status = map[string]string{


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This is the same implementation as in `krel gcbmgr history` and will
be used as replacement to it once `krel gcbmgr` goes end of life.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `krel history` subcommand (as replacement to `krel gcbmgr history`)
```
