### PR TITLE
Add `--stream` flag to krel stage/release

### DIFF
--- a/cmd/krel/cmd/release.go
+++ b/cmd/krel/cmd/release.go
@@ -110,6 +110,14 @@ func init() {
 			"Submit a Google Cloud Build job",
 		)
 
+	releaseCmd.PersistentFlags().
+		BoolVar(
+			&stream,
+			streamFlag,
+			false,
+			"Run the Google Cloud Build job synchronously",
+		)
+
 	if err := releaseCmd.PersistentFlags().MarkHidden(submitJobFlag); err != nil {
 		logrus.Fatal(err)
 	}
@@ -125,7 +133,7 @@ func runRelease(options *anago.ReleaseOptions) error {
 	options.NoMock = rootOpts.nomock
 	rel := anago.NewRelease(options)
 	if submitJob {
-		return rel.Submit()
+		return rel.Submit(stream)
 	}
 	return rel.Run()
 }

--- a/cmd/krel/cmd/stage.go
+++ b/cmd/krel/cmd/stage.go
@@ -68,11 +68,13 @@ Build (GCB) job which does:
 var (
 	stageOptions = anago.DefaultStageOptions()
 	submitJob    = true
+	stream       = false
 )
 
 const (
 	buildVersionFlag = "build-version"
 	submitJobFlag    = "submit"
+	streamFlag       = "stream"
 )
 
 func init() {
@@ -114,6 +116,14 @@ func init() {
 			"Submit a Google Cloud Build job",
 		)
 
+	stageCmd.PersistentFlags().
+		BoolVar(
+			&stream,
+			streamFlag,
+			false,
+			"Run the Google Cloud Build job synchronously",
+		)
+
 	for _, flag := range []string{buildVersionFlag, submitJobFlag} {
 		if err := stageCmd.PersistentFlags().MarkHidden(flag); err != nil {
 			logrus.Fatal(err)
@@ -127,7 +137,7 @@ func runStage(options *anago.StageOptions) error {
 	options.NoMock = rootOpts.nomock
 	stage := anago.NewStage(options)
 	if submitJob {
-		return stage.Submit()
+		return stage.Submit(stream)
 	}
 	return stage.Run()
 }

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -205,9 +205,9 @@ func (s *Stage) SetClient(client stageClient) {
 }
 
 // Submit can be used to submit a staging Google Cloud Build (GCB) job.
-func (s *Stage) Submit() error {
+func (s *Stage) Submit(stream bool) error {
 	logrus.Info("Submitting stage GCB job")
-	if err := s.client.Submit(); err != nil {
+	if err := s.client.Submit(stream); err != nil {
 		return errors.Wrap(err, "submit stage job")
 	}
 	return nil
@@ -323,9 +323,9 @@ func (r *Release) SetClient(client releaseClient) {
 }
 
 // Submit can be used to submit a releasing Google Cloud Build (GCB) job.
-func (r *Release) Submit() error {
+func (r *Release) Submit(stream bool) error {
 	logrus.Info("Submitting release GCB job")
-	if err := r.client.Submit(); err != nil {
+	if err := r.client.Submit(stream); err != nil {
 		return errors.Wrap(err, "submit release job")
 	}
 	return nil

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -278,7 +278,7 @@ func TestSubmitStage(t *testing.T) {
 		tc.prepare(mock)
 		sut.SetClient(mock)
 
-		err := sut.Submit()
+		err := sut.Submit(false)
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {
@@ -311,7 +311,7 @@ func TestSubmitRelease(t *testing.T) {
 		tc.prepare(mock)
 		sut.SetClient(mock)
 
-		err := sut.Submit()
+		err := sut.Submit(false)
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {

--- a/pkg/anago/anagofakes/fake_release_client.go
+++ b/pkg/anago/anagofakes/fake_release_client.go
@@ -102,9 +102,10 @@ type FakeReleaseClient struct {
 	pushGitObjectsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SubmitStub        func() error
+	SubmitStub        func(bool) error
 	submitMutex       sync.RWMutex
 	submitArgsForCall []struct {
+		arg1 bool
 	}
 	submitReturns struct {
 		result1 error
@@ -550,17 +551,18 @@ func (fake *FakeReleaseClient) PushGitObjectsReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
-func (fake *FakeReleaseClient) Submit() error {
+func (fake *FakeReleaseClient) Submit(arg1 bool) error {
 	fake.submitMutex.Lock()
 	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
 	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.SubmitStub
 	fakeReturns := fake.submitReturns
-	fake.recordInvocation("Submit", []interface{}{})
+	fake.recordInvocation("Submit", []interface{}{arg1})
 	fake.submitMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -574,10 +576,17 @@ func (fake *FakeReleaseClient) SubmitCallCount() int {
 	return len(fake.submitArgsForCall)
 }
 
-func (fake *FakeReleaseClient) SubmitCalls(stub func() error) {
+func (fake *FakeReleaseClient) SubmitCalls(stub func(bool) error) {
 	fake.submitMutex.Lock()
 	defer fake.submitMutex.Unlock()
 	fake.SubmitStub = stub
+}
+
+func (fake *FakeReleaseClient) SubmitArgsForCall(i int) bool {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	argsForCall := fake.submitArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeReleaseClient) SubmitReturns(result1 error) {

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -92,9 +92,10 @@ type FakeStageClient struct {
 	stageArtifactsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SubmitStub        func() error
+	SubmitStub        func(bool) error
 	submitMutex       sync.RWMutex
 	submitArgsForCall []struct {
+		arg1 bool
 	}
 	submitReturns struct {
 		result1 error
@@ -497,17 +498,18 @@ func (fake *FakeStageClient) StageArtifactsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeStageClient) Submit() error {
+func (fake *FakeStageClient) Submit(arg1 bool) error {
 	fake.submitMutex.Lock()
 	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
 	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.SubmitStub
 	fakeReturns := fake.submitReturns
-	fake.recordInvocation("Submit", []interface{}{})
+	fake.recordInvocation("Submit", []interface{}{arg1})
 	fake.submitMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -521,10 +523,17 @@ func (fake *FakeStageClient) SubmitCallCount() int {
 	return len(fake.submitArgsForCall)
 }
 
-func (fake *FakeStageClient) SubmitCalls(stub func() error) {
+func (fake *FakeStageClient) SubmitCalls(stub func(bool) error) {
 	fake.submitMutex.Lock()
 	defer fake.submitMutex.Unlock()
 	fake.SubmitStub = stub
+}
+
+func (fake *FakeStageClient) SubmitArgsForCall(i int) bool {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	argsForCall := fake.submitArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStageClient) SubmitReturns(result1 error) {

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -37,7 +37,7 @@ import (
 //counterfeiter:generate . releaseClient
 type releaseClient interface {
 	// Submit can be used to submit a Google Cloud Build (GCB) job.
-	Submit() error
+	Submit(stream bool) error
 
 	// Validate if the provided `ReleaseOptions` are correctly set.
 	ValidateOptions() error
@@ -199,8 +199,9 @@ func (d *defaultReleaseImpl) PublishVersion(
 		PublishVersion("release", version, buildDir, bucket, gcsRoot, nil, false, false)
 }
 
-func (d *DefaultRelease) Submit() error {
+func (d *DefaultRelease) Submit(stream bool) error {
 	options := gcb.NewDefaultOptions()
+	options.Stream = stream
 	options.Release = true
 	options.NoMock = d.options.NoMock
 	options.Branch = d.options.ReleaseBranch

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -257,7 +257,7 @@ func TestSubmitReleaseImpl(t *testing.T) {
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
-		err := sut.Submit()
+		err := sut.Submit(false)
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -37,7 +37,7 @@ import (
 //counterfeiter:generate . stageClient
 type stageClient interface {
 	// Submit can be used to submit a Google Cloud Build (GCB) job.
-	Submit() error
+	Submit(stream bool) error
 
 	// Validate if the provided `ReleaseOptions` are correctly set.
 	ValidateOptions() error
@@ -233,8 +233,9 @@ func (d *defaultStageImpl) PushContainerImages(
 	return build.NewInstance(options).PushContainerImages()
 }
 
-func (d *DefaultStage) Submit() error {
+func (d *DefaultStage) Submit(stream bool) error {
 	options := gcb.NewDefaultOptions()
+	options.Stream = stream
 	options.Stage = true
 	options.NoMock = d.options.NoMock
 	options.Branch = d.options.ReleaseBranch

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -520,7 +520,7 @@ func TestSubmitStageImpl(t *testing.T) {
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
-		err := sut.Submit()
+		err := sut.Submit(false)
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The flag was previously supported by `krel gcbmgr` to stream the Google
Cloud Build log output.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--stream` flag to `krel stage/release`
```
