### PR TITLE
OWNERS: Update SIG leadership and Release Managers (promotions, new members, retirement)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
     - alejandrox1
     - justaugustus
     - saschagrunert
-    - tpepper
   release-engineering-approvers:
     - cpanato # Release Manager
     - feiskyer # Release Manager

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,15 +8,13 @@ aliases:
     - tpepper
   release-engineering-approvers:
     - cpanato # Release Manager
-    - dougm # Release Manager
     - feiskyer # Release Manager
     - hasheddan # Release Manager
-    - hoegaarden # Release Manager
     - idealhack # Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
-    - tpepper # subproject owner / Release Manager
+    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - gianarb # Release Manager Associate
@@ -53,13 +51,11 @@ aliases:
     - listx
   krel-approvers:
     - hasheddan
-    - hoegaarden
     - justaugustus
     - saschagrunert
   krel-reviewers:
     - cpanato
     - hasheddan
-    - hoegaarden
     - justaugustus
     - puerco
     - saschagrunert

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -43,6 +43,14 @@ aliases:
     - dims
     - justaugustus
     - listx
+  cip-approvers:
+    - justaugustus
+    - justinsb
+    - listx
+  cip-reviewers:
+    - justaugustus
+    - justinsb
+    - listx
   krel-approvers:
     - hasheddan
     - hoegaarden

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,6 +17,7 @@ aliases:
     - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
+    - ameukam # Release Manager Associate
     - gianarb # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,14 @@
 
 aliases:
   sig-release-leads:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
+    - alejandrox1 # SIG Technical Lead
+    - hasheddan # SIG Technical Lead
+    - justaugustus # SIG Chair
+    - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
     - feiskyer # Release Manager
-    - hasheddan # Release Manager
+    - hasheddan # subproject owner / Release Manager
     - idealhack # Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,6 +13,7 @@ aliases:
     - hasheddan # Release Manager
     - hoegaarden # Release Manager
     - idealhack # Release Manager
+    - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
     - tpepper # subproject owner / Release Manager
@@ -23,7 +24,6 @@ aliases:
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
-    - puerco # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - verolop # Release Manager Associate
   build-admins:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -80,8 +80,10 @@ aliases:
     - puerco
     - saschagrunert
   vulndash-approvers:
+    - cpanato
     - justaugustus
     - listx
   vulndash-reviewers:
+    - cpanato
     - justaugustus
     - listx


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The access portion of: https://github.com/kubernetes/sig-release/pull/1331

- Add container image promoter reviewers/approvers
- Promote @puerco to full-fledged Release Manager
- Add Carlos as vulndash reviewer/approver
- Add @ameukam as Release Manager Associate
- Tim, @hoegaarden, and @dougm retire as Release Managers
- @tpepper is now Emeritus Chair
  ...but remains as subproject owner!
- @hasheddan joins as SIG TL and Senior Release Manager

/assign @saschagrunert @hasheddan 
cc: @kubernetes/sig-release-leads @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
