### PR TITLE
Fix krel history default dates

### DIFF
--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -88,8 +88,8 @@ func NewHistoryOptions() *HistoryOptions {
 	return &HistoryOptions{
 		Branch:   git.DefaultBranch,
 		Project:  release.DefaultKubernetesStagingProject,
-		DateFrom: time.Now().Format("2006-01-30"),
-		DateTo:   time.Now().Format("2006-01-30"),
+		DateFrom: time.Now().Format("2006-01-02"),
+		DateTo:   time.Now().Format("2006-01-02"),
 	}
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The parser wrongly interpreted the date not as YYYY-MM-DD, which is now
fixed.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix default `krel history` dates
```
