### PR TITLE
Reference `krel release` in output

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -493,21 +493,20 @@ func (d *DefaultStage) StageArtifacts() error {
 		}
 	}
 
-	noMockFlag := ""
+	args := ""
 	if d.options.NoMock {
-		noMockFlag = "--nomock"
+		args += " --nomock"
 	}
+	if d.options.ReleaseType != DefaultOptions().ReleaseType {
+		args += " --type=" + d.options.ReleaseType
+	}
+	if d.options.ReleaseBranch != DefaultOptions().ReleaseBranch {
+		args += " --branch=" + d.options.ReleaseBranch
+	}
+	args += " --build-version=" + d.options.BuildVersion
 
 	logrus.Infof(
-		"To release this staged build, run:\n\n"+
-			"$ krel gcbmgr --no-anago --release "+
-			"--type %s "+
-			"--branch %s "+
-			"--build-version=%s %s",
-		d.options.ReleaseType,
-		d.options.ReleaseBranch,
-		d.options.BuildVersion,
-		noMockFlag,
+		"To release this staged build, run:\n\n$ krel release%s", args,
 	)
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We can directly use `krel release` in the last log output of `krel stage`. The CLI parameters are only appended if not equally to the default ones.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1673 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
