### PR TITLE
Only restore branch if available

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -290,11 +290,13 @@ func (c *Changelog) Run() error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := repo.Checkout(currentBranch); err != nil {
-			logrus.Errorf("Restore branch %s: %v", currentBranch, err)
-		}
-	}()
+	if currentBranch != "" {
+		defer func() {
+			if err := repo.Checkout(currentBranch); err != nil {
+				logrus.Errorf("Restore branch %s: %v", currentBranch, err)
+			}
+		}()
+	}
 
 	logrus.Infof("Checking out %s branch", git.DefaultBranch)
 	if err := repo.Checkout(git.DefaultBranch); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We're not always on a branch on changelog generation, which means that
we only try to recover the previous path if available.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to not checkout the previous branch if there is no branch available during changelog generation.
```
