### PR TITLE
go-runner: Build buster-v2.2.2 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.2.1
+    version: buster-v2.2.2
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,17 +16,14 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.2.1
+IMAGE_VERSION ?= buster-v2.2.2
 CONFIG ?= buster
 
 # Build args
 GO_VERSION ?= 1.15.5
 DISTROLESS_IMAGE ?= static-debian10
 
-# TODO: Re-enable linux/ppc64le builds once upstream distroless builds are fixed
-#       ref: https://github.com/GoogleContainerTools/distroless/pull/622
-#PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x
-PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/s390x
+PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x
 
 HOST_GOOS ?= $(shell go env GOOS)
 HOST_GOARCH ?= $(shell go env GOARCH)

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.2.1'
+    IMAGE_VERSION: 'buster-v2.2.2'
     GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup feature

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/release/issues/1651

Rebuild go1.15.5 image with all arches enabled.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- go-runner: Build buster-v2.2.2 image
  Rebuild go1.15.5 image with all arches enabled
```
