### PR TITLE
Remove GitHub tokens in util.StripSensitiveData()

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -43,6 +43,7 @@ var (
 	regexpCRLF       *regexp.Regexp = regexp.MustCompile(`\015$`)
 	regexpCtrlChar   *regexp.Regexp = regexp.MustCompile(`\x1B[\[(]([0-9]{1,2}(;[0-9]{1,2})?)?[mKB]`)
 	regexpOauthToken *regexp.Regexp = regexp.MustCompile(`[a-f0-9]{40}:x-oauth-basic`)
+	regexpGitToken   *regexp.Regexp = regexp.MustCompile(`git:[a-f0-9]{35,40}@github.com`)
 )
 
 // UserInputError a custom error to handle more user input info
@@ -519,7 +520,11 @@ func StripControlCharacters(logData []byte) []byte {
 // StripSensitiveData removes data deemed sensitive or non public
 // from a byte slice (ported from the original bash anago)
 func StripSensitiveData(logData []byte) []byte {
-	return regexpOauthToken.ReplaceAllLiteral(logData, []byte("__SANITIZED__:x-oauth-basic"))
+	// Remove OAuth tokens
+	logData = regexpOauthToken.ReplaceAllLiteral(logData, []byte("__SANITIZED__:x-oauth-basic"))
+	// Remove GitHub tokens
+	logData = regexpGitToken.ReplaceAllLiteral(logData, []byte("//git:__SANITIZED__:@github.com"))
+	return logData
 }
 
 // CleanLogFile cleans control characters and sensitive data from a file

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -488,9 +488,11 @@ func TestStripSensitiveData(t *testing.T) {
 		mustChange bool
 	}{
 		{text: "a", mustChange: false},
-		{text: `s;!3Vc2]x~qL&'Sc/W/>^}8pau\.xr;;5uL:mL:h:x-oauth-basic`, mustChange: false},                // Non base64 token
-		{text: `ab0ff5efdbafcf1def98cac7bd4fa5856d53d000:x-oauth-basic`, mustChange: true},                 // Visible token
-		{text: `X-Some-Header: ab0ff5efdbafcf1def98cac7bd4fa5856d53d000:x-oauth-basic;`, mustChange: true}, // in string
+		{text: `s;!3Vc2]x~qL&'Sc/W/>^}8pau\.xr;;5uL:mL:h:x-oauth-basic`, mustChange: false},                                                                        // Non base64 token
+		{text: `ab0ff5efdbafcf1def98cac7bd4fa5856d53d000:x-oauth-basic`, mustChange: true},                                                                         // Visible token
+		{text: `X-Some-Header: ab0ff5efdbafcf1def98cac7bd4fa5856d53d000:x-oauth-basic;`, mustChange: true},                                                         // in string
+		{text: `error: failed to push some refs to 'https://git:538b8ca9618eaf316b8ca37bcf78da2c24639c14@github.com/kubernetes/kubernetes.git'`, mustChange: true}, // GitHub token
+		{text: `error: failed to push some refs to 'https://git:538b8c9618a316bca3bcf78da2c24639c35@github.com/kubernetes/kubernetes.git'`, mustChange: true},      // 35-char GitHub token
 	}
 	for _, tc := range testCases {
 		testBytes := []byte(tc.text)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds to `util.StripSensitiveData()` the capability to remove GitHub tokens from strings and logfiles in addition to the original OAuth checks in the original anago.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
- The log file sanitizer now removes GitHub tokens in addition to the original anago checks
```
