### PR TITLE
Remove BUILD_POINT in favor of BUILD_VERSION

### DIFF
--- a/gcb/release-krel/cloudbuild.yaml
+++ b/gcb/release-krel/cloudbuild.yaml
@@ -53,7 +53,6 @@ steps:
 tags:
 - ${_GCP_USER_TAG}
 - ${_RELEASE_BRANCH}
-- ${_BUILD_POINT}
 - ${_NOMOCK_TAG}
 - RELEASE
 - ${_GIT_TAG}

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -56,7 +56,6 @@ steps:
 tags:
 - ${_GCP_USER_TAG}
 - ${_RELEASE_BRANCH}
-- ${_BUILD_POINT}
 - ${_NOMOCK_TAG}
 - RELEASE
 - ${_GIT_TAG}

--- a/gcb/stage-krel/cloudbuild.yaml
+++ b/gcb/stage-krel/cloudbuild.yaml
@@ -53,7 +53,6 @@ steps:
 tags:
 - ${_GCP_USER_TAG}
 - ${_RELEASE_BRANCH}
-- ${_BUILD_POINT}
 - ${_NOMOCK_TAG}
 - STAGE
 - ${_GIT_TAG}

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -98,7 +98,6 @@ steps:
 tags:
 - ${_GCP_USER_TAG}
 - ${_RELEASE_BRANCH}
-- ${_BUILD_POINT}
 - ${_NOMOCK_TAG}
 - STAGE
 - ${_GIT_TAG}

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -325,9 +325,6 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolBranch string) (map[str
 		}
 	}
 
-	buildpoint := buildVersion
-	buildpoint = strings.ReplaceAll(buildpoint, "+", "-")
-	gcbSubs["BUILD_POINT"] = buildpoint
 	gcbSubs["BUILDVERSION"] = buildVersion
 
 	kubecrossBranches := []string{
@@ -341,9 +338,9 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolBranch string) (map[str
 	}
 	gcbSubs["KUBE_CROSS_VERSION"] = kubecrossVersion
 
-	v, err := util.TagStringToSemver(buildpoint)
+	v, err := util.TagStringToSemver(buildVersion)
 	if err != nil {
-		return gcbSubs, errors.Errorf("Failed to parse the build point %s", buildpoint)
+		return gcbSubs, errors.Wrap(err, "parse build version")
 	}
 
 	gcbSubs["MAJOR_VERSION_TAG"] = strconv.FormatUint(v.Major, 10)

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -515,7 +515,7 @@ func dropDynamicSubstitutions(orig map[string]string) (result map[string]string)
 	result = orig
 
 	for k := range result {
-		if k == "BUILDVERSION" || k == "BUILD_POINT" || k == "GCP_USER_TAG" || k == "KUBE_CROSS_VERSION" {
+		if k == "BUILDVERSION" || k == "GCP_USER_TAG" || k == "KUBE_CROSS_VERSION" {
 			delete(result, k)
 		}
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The `BUILD_POINT` GCB substitution was just a slightly modified
`BUILD_VERSION` without providing any other additional value. We now
remove the `BUILD_POINT` and just stick to the `BUILD_VERSION`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `BUILD_POINT` GCB substitution in favor of `BUILD_VERSION`.
```
