### PR TITLE
Update k8s-cloud-builder to v1.15.5-1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -74,9 +74,8 @@ dependencies:
     - path: images/releng/ci/cloudbuild.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # TODO(go): Update to 1.15.5 after kubernetes/kubernetes has been updated
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.15.3
+    version: 1.15.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -117,9 +116,8 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: go\d+.\d+
 
-  # TODO(go): Bump tag to denote go1.15.5 update
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.15.3-1
+    version: v1.15.5-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.3-1'
+    KUBE_CROSS_VERSION: 'v1.15.5-1'
     SKOPEO_VERSION: 'v1.2.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.15.3
+GO_VERSION ?= 1.15.5
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.15.3'
+    GO_VERSION: '1.15.5'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
#### What this PR does / why we need it:
Since the golang updates in k/k are merged we now can bump the internal
image versions, too.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/assign @justaugustus 
/hold
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder to v1.15.5-1 
```
