### PR TITLE
Do not echo fatal messages in GCB on krel compilation

### DIFF
--- a/compile-release-tools
+++ b/compile-release-tools
@@ -77,9 +77,9 @@ compile_with_flags() {
 
   go build -v -ldflags "-s -w \
     -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-    -X $pkg.gitCommit=$(git rev-parse HEAD) \
+    -X $pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
     -X $pkg.gitTreeState=$git_tree_state \
-    -X $pkg.gitVersion=$(git describe --abbrev=0)" \
+    -X $pkg.gitVersion=$(git describe --abbrev=0 || echo unknown)" \
     -o "$RELEASE_TOOL_BIN/$tool" "./cmd/$tool" \
     || return 1
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Google Cloud build does not copy the `.git` directory after clone, which
means we cannot run git commands during the compilation of the release
tools. To not spam the logs with `fatal` messages, we now set the git
commit and version to `unknown` in that case.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
