### PR TITLE
Add `Env()` API to `command` package

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -33,6 +33,7 @@ import (
 type Command struct {
 	cmds                         []*command
 	stdErrWriters, stdOutWriters []io.Writer
+	env                          []string
 	verbose                      bool
 }
 
@@ -94,6 +95,14 @@ func (c *Command) Pipe(cmd string, args ...string) *Command {
 		Cmd:        pipeCmd,
 		pipeWriter: writer,
 	})
+	return c
+}
+
+// Env specifies the environment added to the command. Each entry is of the
+// form "key=value". The environment of the current process is being preserved,
+// while it is possible to overwrite already existing environment variables.
+func (c *Command) Env(env ...string) *Command {
+	c.env = append(c.env, env...)
 	return c
 }
 
@@ -274,6 +283,8 @@ func (c *Command) run(printOutput bool) (res *Status, err error) {
 		if c.isVerbose() {
 			logrus.Infof("+ %s", c.String())
 		}
+
+		cmd.Env = append(os.Environ(), c.env...)
 
 		if err := cmd.Start(); err != nil {
 			return nil, err

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -325,3 +325,14 @@ func TestCommandsFailure(t *testing.T) {
 	require.NotNil(t, err)
 	require.Nil(t, res)
 }
+
+func TestEnv(t *testing.T) {
+	require.Nil(t, os.Setenv("ABC", "test")) // preserved
+	require.Nil(t, os.Setenv("FOO", "test")) // overwritten
+	res, err := New("sh", "-c", "echo $TEST; echo $FOO; echo $ABC").
+		Env("TEST=123").
+		Env("FOO=bar").
+		RunSuccessOutput()
+	require.Nil(t, err)
+	require.Equal(t, "123\nbar\ntest", res.OutputTrimNL())
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The new `Env()` API of a command can be used to add additional
environment variables to a command. It is possible to still use the
default environment as well as overwriting existing variables.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add `Env()` API to `command` package
```
