### PR TITLE
pkg/cip: Drop klog v1 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/apimachinery v0.19.2
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.4.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/mdtoc v1.0.1

--- a/pkg/cip/audit/auditor.go
+++ b/pkg/cip/audit/auditor.go
@@ -27,7 +27,7 @@ import (
 
 	"cloud.google.com/go/errorreporting"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	reg "k8s.io/release/pkg/cip/dockerregistry"
 	"k8s.io/release/pkg/cip/logclient"
 	"k8s.io/release/pkg/cip/remotemanifest"

--- a/pkg/cip/dockerregistry/checks.go
+++ b/pkg/cip/dockerregistry/checks.go
@@ -33,7 +33,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/release/pkg/cip/stream"
 )
 

--- a/pkg/cip/dockerregistry/grow_manifest.go
+++ b/pkg/cip/dockerregistry/grow_manifest.go
@@ -23,7 +23,8 @@ import (
 	"path/filepath"
 
 	"golang.org/x/xerrors"
-	"k8s.io/klog"
+
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/cip/dockerregistry/inventory.go
+++ b/pkg/cip/dockerregistry/inventory.go
@@ -36,7 +36,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/release/pkg/cip/gcloud"
 	cipJson "k8s.io/release/pkg/cip/json"
 	"k8s.io/release/pkg/cip/stream"

--- a/pkg/cip/gcloud/token.go
+++ b/pkg/cip/gcloud/token.go
@@ -25,7 +25,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Token is the oauth2 access token used for API calls over HTTP.

--- a/pkg/cip/remotemanifest/git.go
+++ b/pkg/cip/remotemanifest/git.go
@@ -26,7 +26,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	reg "k8s.io/release/pkg/cip/dockerregistry"
 )
 

--- a/pkg/cip/report/gcp.go
+++ b/pkg/cip/report/gcp.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/errorreporting"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // NewGcpErrorReportingClient returns a new Stackdriver Error Reporting client.

--- a/pkg/cip/stream/http.go
+++ b/pkg/cip/stream/http.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // HTTP is a wrapper around the net/http's Request type.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/release/pull/1767 pulled in a dependency on `k8s.io/klog`, but we're using `k8s.io/klog/v2` in other packages that have been migrated in from sigs.k8s.io/k8s-container-image-promoter.

Eventually we'll move this packages over to `logrus`, but I want to maintain compatibility with the CIP repo for now.

/assign @saschagrunert @cpanato @xmudrii  

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/cip: Drop klog v1 dependency
```
