### PR TITLE
Removing klog lib in favor of logrus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/klog/v2 v2.4.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/mdtoc v1.0.1
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,6 @@ github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTD
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
-github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
@@ -1213,8 +1211,6 @@ k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
-k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/legacy-cloud-providers v0.17.4/go.mod h1:FikRNoD64ECjkxO36gkDgJeiQWwyZTuBkhu+yxOc1Js=

--- a/pkg/cip/audit/auditor.go
+++ b/pkg/cip/audit/auditor.go
@@ -26,8 +26,8 @@ import (
 	"runtime/debug"
 
 	"cloud.google.com/go/errorreporting"
+	"github.com/sirupsen/logrus"
 
-	"k8s.io/klog/v2"
 	reg "k8s.io/release/pkg/cip/dockerregistry"
 	"k8s.io/release/pkg/cip/logclient"
 	"k8s.io/release/pkg/cip/remotemanifest"
@@ -71,8 +71,8 @@ func InitRealServerContext(
 
 // RunAuditor runs an HTTP server.
 func (s *ServerContext) RunAuditor() {
-	klog.Info("Starting Auditor")
-	klog.Infoln(s)
+	logrus.Info("Starting Auditor")
+	logrus.Infoln(s)
 
 	// nolint[errcheck]
 	defer s.LoggingFacility.Close()
@@ -90,11 +90,11 @@ func (s *ServerContext) RunAuditor() {
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
-		klog.Infof("Defaulting to port %s", port)
+		logrus.Infof("Defaulting to port %s", port)
 	}
 	// Start HTTP server.
-	klog.Infof("Listening on port %s", port)
-	klog.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+	logrus.Infof("Listening on port %s", port)
+	logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }
 
 // ParsePubSubMessage parses an HTTP request body into a reg.GCRPubSubPayload.
@@ -185,7 +185,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 			)
 
 			logAlert.Printf("%s\n%s\n", panicStr, string(stacktrace))
-			klog.Errorln(panicStr)
+			logrus.Errorln(panicStr)
 		}
 	}()
 	// (1) Parse request payload.
@@ -242,7 +242,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 			)
 
 			logInfo.Println(msg)
-			klog.Infoln(msg)
+			logrus.Infoln(msg)
 			_, _ = w.Write([]byte(msg))
 			return
 		}
@@ -310,12 +310,12 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 		panic(msg)
 	}
 
-	klog.Infof("(%s): looking for child digest %v", s.ID, gcrPayload.Digest)
+	logrus.Infof("(%s): looking for child digest %v", s.ID, gcrPayload.Digest)
 	if parentDigest, hasParent := sc.ParentDigest[gcrPayload.Digest]; hasParent {
 		msg := fmt.Sprintf(
 			"(%s) TRANSACTION VERIFIED: %v: agrees with manifest (parent digest %v)\n", s.ID, gcrPayload, parentDigest)
 		logInfo.Println(msg)
-		klog.Infoln(msg)
+		logrus.Infoln(msg)
 		_, _ = w.Write([]byte(msg))
 
 		return

--- a/pkg/cip/dockerregistry/checks.go
+++ b/pkg/cip/dockerregistry/checks.go
@@ -28,12 +28,12 @@ import (
 	"sync"
 
 	containeranalysis "cloud.google.com/go/containeranalysis/apiv1"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/klog/v2"
 	"k8s.io/release/pkg/cip/stream"
 )
 
@@ -354,7 +354,7 @@ func (check *ImageVulnCheck) Run() error {
 					})
 					fixableSevereOccurrences++
 				} else {
-					klog.Error(vulnErr)
+					logrus.Error(vulnErr)
 				}
 			}
 

--- a/pkg/cip/dockerregistry/grow_manifest.go
+++ b/pkg/cip/dockerregistry/grow_manifest.go
@@ -22,9 +22,8 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
-
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -136,7 +135,7 @@ func WriteImages(manifest Manifest, rii RegInvImage) error {
 	// Construct path to the images.yaml.
 	imagesPath := path.Join(p, "..", "..",
 		"images", stagingRepoName, "images.yaml")
-	klog.Infoln("RENDER", imagesPath)
+	logrus.Infoln("RENDER", imagesPath)
 
 	// Write the file.
 	err := ioutil.WriteFile(
@@ -153,7 +152,7 @@ func FindManifest(o *GrowManifestOptions) (Manifest, error) {
 		return Manifest{}, err
 	}
 
-	klog.Infof("%d manifests parsed", len(manifests))
+	logrus.Infof("%d manifests parsed", len(manifests))
 	for _, manifest := range manifests {
 		if manifest.SrcRegistry.Name == o.StagingRepo {
 			return manifest, nil

--- a/pkg/cip/gcloud/token.go
+++ b/pkg/cip/gcloud/token.go
@@ -25,7 +25,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
 )
 
 // Token is the oauth2 access token used for API calls over HTTP.
@@ -53,7 +53,7 @@ func GetServiceAccountToken(
 
 	err := cmd.Run()
 	if err != nil {
-		klog.Errorf("could not execute cmd %v", cmd)
+		logrus.Errorf("could not execute cmd %v", cmd)
 		return "", err
 	}
 
@@ -85,12 +85,12 @@ func ActivateServiceAccounts(keyFilePaths string) error {
 			break
 		}
 		if err != nil {
-			klog.Exitln(err)
+			logrus.Fatal(err)
 		}
 
 		for _, keyFilePath := range record {
 			if err := ActivateServiceAccount(keyFilePath); err != nil {
-				klog.Exitln(err)
+				logrus.Fatal(err)
 			}
 		}
 	}

--- a/pkg/cip/remotemanifest/git.go
+++ b/pkg/cip/remotemanifest/git.go
@@ -23,10 +23,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/klog/v2"
 	reg "k8s.io/release/pkg/cip/dockerregistry"
 )
 
@@ -77,7 +77,7 @@ func (remote *Git) Fetch() ([]reg.Manifest, error) {
 		// We don't really care too much about failures about removing the
 		// (temporary) repoPath directory, because we'll clone a fresh one
 		// anyway in the future. So don't return an error even if this fails.
-		klog.Errorf("Could not remove temporary Git repo %v: %v", repoPath, err)
+		logrus.Errorf("Could not remove temporary Git repo %v: %v", repoPath, err)
 	}
 
 	return manifests, nil
@@ -103,7 +103,7 @@ func cloneToTempDir(
 
 	sha, err := getHeadSha(r)
 	if err == nil {
-		klog.Infof("cloned %v at revision %v", tdir, sha)
+		logrus.Infof("cloned %v at revision %v", tdir, sha)
 	}
 
 	return tdir, nil

--- a/pkg/cip/report/gcp.go
+++ b/pkg/cip/report/gcp.go
@@ -20,8 +20,7 @@ import (
 	"context"
 
 	"cloud.google.com/go/errorreporting"
-
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
 )
 
 // NewGcpErrorReportingClient returns a new Stackdriver Error Reporting client.
@@ -34,11 +33,11 @@ func NewGcpErrorReportingClient(
 		ServiceName: serviceName,
 		OnError: func(err error) {
 			// nolint[lll]
-			klog.Errorf("Could not log error to GCP Stackdriver Error Reporting: %v", err)
+			logrus.Errorf("Could not log error to GCP Stackdriver Error Reporting: %v", err)
 		},
 	})
 	if err != nil {
-		klog.Fatalf("Failed to create errorreporting client: %v", err)
+		logrus.Fatalf("Failed to create errorreporting client: %v", err)
 	}
 
 	return erc

--- a/pkg/cip/stream/http.go
+++ b/pkg/cip/stream/http.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
 )
 
 // HTTP is a wrapper around the net/http's Request type.
@@ -60,7 +60,7 @@ func (h *HTTP) Produce() (stdOut, stdErr io.Reader, err error) {
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(h.Res.Body)
 	if err != nil {
-		klog.Errorf("could not read from HTTP response body")
+		logrus.Errorf("could not read from HTTP response body")
 		return nil, nil, fmt.Errorf(
 			"problems encountered: unexpected response code %d",
 			h.Res.StatusCode,

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -25,8 +25,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	// TODO: Use k/release/pkg/log instead
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
+
 	api "k8s.io/release/pkg/api/files"
 )
 
@@ -66,14 +66,14 @@ func (o *copyFileOp) Run(ctx context.Context) error {
 	defer func() {
 		if f != nil {
 			if err := f.Close(); err != nil {
-				klog.Warningf(
+				logrus.Warnf(
 					"error closing temp file %q: %v",
 					tempFilename, err)
 			}
 		}
 
 		if err := os.Remove(tempFilename); err != nil {
-			klog.Warningf(
+			logrus.Warnf(
 				"unable to remove temp file %q: %v",
 				tempFilename, err)
 		}
@@ -134,7 +134,7 @@ func ComputeSHA256ForFile(filename string) (string, error) {
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			klog.Warningf(
+			logrus.Warnf(
 				"error closing file %q: %v",
 				filename, err)
 		}

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -24,10 +24,9 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 
-	// TODO: Use k/release/pkg/log instead
-	"k8s.io/klog/v2"
 	api "k8s.io/release/pkg/api/files"
 	"k8s.io/release/pkg/object"
 )
@@ -140,7 +139,7 @@ func (p *FilestorePromoter) computeNeededOperations(
 
 		changed := false
 		if destFile.MD5 != sourceFile.MD5 {
-			klog.Warningf("MD5 mismatch on source %q vs dest %q: %q vs %q",
+			logrus.Warnf("MD5 mismatch on source %q vs dest %q: %q vs %q",
 				sourceFile.AbsolutePath,
 				destFile.AbsolutePath,
 				sourceFile.MD5,
@@ -149,7 +148,7 @@ func (p *FilestorePromoter) computeNeededOperations(
 		}
 
 		if destFile.Size != sourceFile.Size {
-			klog.Warningf("Size mismatch on source %q vs dest %q: %d vs %d",
+			logrus.Warnf("Size mismatch on source %q vs dest %q: %d vs %d",
 				sourceFile.AbsolutePath,
 				destFile.AbsolutePath,
 				sourceFile.Size,
@@ -158,7 +157,7 @@ func (p *FilestorePromoter) computeNeededOperations(
 		}
 
 		if !changed {
-			klog.V(2).Infof("metadata match for %q", destFile.AbsolutePath)
+			logrus.Infof("metadata match for %q", destFile.AbsolutePath)
 			continue
 		}
 		ops = append(ops, &copyFileOp{

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -26,10 +26,9 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	// TODO: Use k/release/pkg/log instead
-	"k8s.io/klog/v2"
 	api "k8s.io/release/pkg/api/files"
 	"k8s.io/release/pkg/object"
 )
@@ -61,7 +60,7 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 	}
 	defer func() {
 		if err := in.Close(); err != nil {
-			klog.Warningf("error closing %q: %v", localFile, err)
+			logrus.Warnf("error closing %q: %v", localFile, err)
 		}
 	}()
 
@@ -79,7 +78,7 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 		}
 	}
 
-	klog.Infof("uploading to %s", gcsURL)
+	logrus.Infof("uploading to %s", gcsURL)
 
 	w := s.client.Bucket(s.bucket).Object(absolutePath).NewWriter(ctx)
 
@@ -92,7 +91,7 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 
 	if _, err := io.Copy(w, in); err != nil {
 		if err2 := w.Close(); err2 != nil {
-			klog.Warningf("error closing upload stream: %v", err)
+			logrus.Warnf("error closing upload stream: %v", err)
 			// TODO: Try to delete the possibly partially written file?
 		}
 		return fmt.Errorf("error uploading to %q: %v", gcsURL, err)
@@ -111,7 +110,7 @@ func (s *gcsSyncFilestore) ListFiles(
 	files := make(map[string]*syncFileInfo)
 
 	q := &storage.Query{Prefix: s.prefix}
-	klog.Infof("listing files in bucket %s with prefix %q", s.bucket, s.prefix)
+	logrus.Infof("listing files in bucket %s with prefix %q", s.bucket, s.prefix)
 	it := s.client.Bucket(s.bucket).Objects(ctx, q)
 	for {
 		obj, err := it.Next()

--- a/pkg/filepromoter/manifest.go
+++ b/pkg/filepromoter/manifest.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	// TODO: Use k/release/pkg/log instead
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
+
 	api "k8s.io/release/pkg/api/files"
 )
 
@@ -51,7 +51,7 @@ func (p *ManifestPromoter) BuildOperations(
 		if filestore.Src {
 			continue
 		}
-		klog.Infof("processing destination %q", filestore.Base)
+		logrus.Infof("processing destination %q", filestore.Base)
 		fp := &FilestorePromoter{
 			Source:            source,
 			Dest:              filestore,

--- a/pkg/filepromoter/token.go
+++ b/pkg/filepromoter/token.go
@@ -19,10 +19,9 @@ package filepromoter
 import (
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	// TODO: Use k/release/pkg/log instead
-	"k8s.io/klog/v2"
 	"k8s.io/release/pkg/cip/gcloud"
 )
 
@@ -37,11 +36,11 @@ func (s *gcloudTokenSource) Token() (*oauth2.Token, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	klog.Infof("getting service-account-token for %q", s.ServiceAccount)
+	logrus.Infof("getting service-account-token for %q", s.ServiceAccount)
 
 	token, err := gcloud.GetServiceAccountToken(s.ServiceAccount, true)
 	if err != nil {
-		klog.Warningf("failed to get service-account-token for %q: %v",
+		logrus.Warnf("failed to get service-account-token for %q: %v",
 			s.ServiceAccount, err)
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
follow up of https://github.com/kubernetes/release/pull/1800

I did not realize that have in other places :(

now klog is full removing in favor of logrus

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removing klog lib in favor of logrus

```

/assign @hasheddan @saschagrunert 
