### PR TITLE
pkg/cip: Use --no-dry-run instead of --dry-run

### DIFF
--- a/pkg/cip/cli/root.go
+++ b/pkg/cip/cli/root.go
@@ -31,7 +31,6 @@ var (
 
 type RootOptions struct {
 	LogLevel string
-	DryRun   bool
 	Version  bool
 }
 

--- a/pkg/cip/cli/run.go
+++ b/pkg/cip/cli/run.go
@@ -40,7 +40,7 @@ type RunOptions struct {
 	Threads                 int
 	MaxImageSize            int
 	SeverityThreshold       int
-	DryRun                  bool
+	NoDryRun                bool
 	JSONLogSummary          bool
 	ParseOnly               bool
 	MinimalSnapshot         bool
@@ -142,7 +142,7 @@ func RunPromoteCmd(opts *RunOptions) error {
 		sc, err = reg.MakeSyncContext(
 			mfests,
 			opts.Threads,
-			opts.DryRun,
+			opts.NoDryRun,
 			opts.UseServiceAcct,
 		)
 		if err != nil {
@@ -159,8 +159,9 @@ func RunPromoteCmd(opts *RunOptions) error {
 		sc, err = reg.MakeSyncContext(
 			mfests,
 			opts.Threads,
-			opts.DryRun,
-			opts.UseServiceAcct)
+			opts.NoDryRun,
+			opts.UseServiceAcct,
+		)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -211,7 +212,7 @@ So a 'fixable' vulnerability may not necessarily be immediately actionable. For
 example, even though a fixed version of the binary is available, it doesn't
 necessarily mean that a new version of the image layer is available.`,
 			)
-		} else if opts.DryRun {
+		} else if !opts.NoDryRun {
 			logrus.Info("********** START (DRY RUN) **********")
 		} else {
 			logrus.Info("********** START **********")
@@ -250,7 +251,7 @@ necessarily mean that a new version of the image layer is available.`,
 			sc, err = reg.MakeSyncContext(
 				mfests,
 				opts.Threads,
-				opts.DryRun,
+				opts.NoDryRun,
 				opts.UseServiceAcct,
 			)
 			if err != nil {
@@ -303,7 +304,7 @@ necessarily mean that a new version of the image layer is available.`,
 	}
 
 	// Check the pull request
-	if opts.DryRun {
+	if !opts.NoDryRun {
 		err = sc.RunChecks([]reg.PreCheck{})
 		if err != nil {
 			return errors.Wrap(err, "running prechecks before promotion")
@@ -364,7 +365,7 @@ necessarily mean that a new version of the image layer is available.`,
 	// nolint: gocritic
 	if opts.SeverityThreshold >= 0 {
 		logrus.Info("********** FINISHED (VULN CHECK) **********")
-	} else if opts.DryRun {
+	} else if !opts.NoDryRun {
 		logrus.Info("********** FINISHED (DRY RUN) **********")
 	} else {
 		logrus.Info("********** FINISHED **********")

--- a/pkg/cip/dockerregistry/inventory.go
+++ b/pkg/cip/dockerregistry/inventory.go
@@ -59,11 +59,11 @@ func GetSrcRegistry(rcs []RegistryContext) (*RegistryContext, error) {
 func MakeSyncContext(
 	mfests []Manifest,
 	threads int,
-	dryRun, useSvcAcc bool,
+	noDryRun, useSvcAcc bool,
 ) (SyncContext, error) {
 	sc := SyncContext{
 		Threads:           threads,
-		DryRun:            dryRun,
+		NoDryRun:          noDryRun,
 		UseServiceAccount: useSvcAcc,
 		Inv:               make(MasterInventory),
 		InvIgnore:         []ImageName{},
@@ -1959,7 +1959,7 @@ func MKPopulateRequestsForPromotionEdges(
 			return
 		}
 
-		if sc.DryRun {
+		if !sc.NoDryRun {
 			logrus.Info("---------- BEGIN PROMOTION (DRY RUN) ----------")
 		} else {
 			logrus.Info("---------- BEGIN PROMOTION ----------")
@@ -2220,7 +2220,7 @@ func (sc *SyncContext) Promote(
 
 	captured := make(CapturedRequests)
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		processRequestDryRun := MkRequestCapturer(&captured)
 		processRequest = processRequestDryRun
 	} else {
@@ -2233,7 +2233,7 @@ func (sc *SyncContext) Promote(
 
 	err := sc.ExecRequests(populateRequests, processRequest)
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		sc.PrintCapturedRequests(&captured)
 	}
 
@@ -2405,7 +2405,7 @@ func (sc *SyncContext) GarbageCollect(
 
 	captured := make(CapturedRequests)
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		processRequestDryRun := MkRequestCapturer(&captured)
 		processRequest = processRequestDryRun
 	} else {
@@ -2421,7 +2421,7 @@ func (sc *SyncContext) GarbageCollect(
 		logrus.Info(err)
 	}
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		sc.PrintCapturedRequests(&captured)
 	}
 }
@@ -2529,7 +2529,7 @@ func (sc *SyncContext) ClearRepository(
 
 	captured := make(CapturedRequests)
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		processRequestDryRun := MkRequestCapturer(&captured)
 		processRequest = processRequestDryRun
 	} else {
@@ -2566,7 +2566,7 @@ func (sc *SyncContext) ClearRepository(
 		logrus.Info(err)
 	}
 
-	if sc.DryRun {
+	if !sc.NoDryRun {
 		sc.PrintCapturedRequests(&captured)
 	}
 }

--- a/pkg/cip/dockerregistry/types.go
+++ b/pkg/cip/dockerregistry/types.go
@@ -78,7 +78,7 @@ type CollectedLogs struct {
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
 	Threads           int
-	DryRun            bool
+	NoDryRun          bool
 	UseServiceAccount bool
 	Inv               MasterInventory
 	InvIgnore         []ImageName


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Similar to our `--nomock` flags for other tools, we should use a
`--no-dry-run` for `cip`, since the default nil value for booleans is
`false`.

Meaning: If `--dry-run` is not explicitly set to `true`, our tooling will
initiate an image promotion.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @xmudrii 
cc: @kubernetes/release-engineering 
/priority critical-urgent

Caught in https://kubernetes.slack.com/archives/C2C40FMNF/p1606776666277400?thread_ts=1606741064.265000&cid=C2C40FMNF.
Nice eye, Marko!

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/cip: Use --no-dry-run instead of --dry-run

  Similar to our `--nomock` flags for other tools, we should use a
  `--no-dry-run` for `cip`, since the default nil value for booleans is
  `false`.

  Meaning: If `--dry-run` is not explicitly set to `true`, our tooling will
  initiate an image promotion.
```
