### PR TITLE
krel: add option to post the testgridshot straight to github issue

### DIFF
--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -83,8 +83,8 @@ func (o *promoteOptions) Validate() error {
 	}
 
 	// Check that the GitHub token is set
-	token, isset := os.LookupEnv(github.TokenEnvKey)
-	if !isset || token == "" {
+	token, isSet := os.LookupEnv(github.TokenEnvKey)
+	if !isSet || token == "" {
 		return errors.New("cannot promote images if GitHub token is not set")
 	}
 	return nil

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -28,6 +28,25 @@ import (
 )
 
 type FakeClient struct {
+	CreateCommentStub        func(context.Context, string, string, int, string) (*githuba.IssueComment, *githuba.Response, error)
+	createCommentMutex       sync.RWMutex
+	createCommentArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+		arg5 string
+	}
+	createCommentReturns struct {
+		result1 *githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}
+	createCommentReturnsOnCall map[int]struct {
+		result1 *githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}
 	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)
 	createPullRequestMutex       sync.RWMutex
 	createPullRequestArgsForCall []struct {
@@ -94,6 +113,24 @@ type FakeClient struct {
 	}
 	getCommitReturnsOnCall map[int]struct {
 		result1 *githuba.Commit
+		result2 *githuba.Response
+		result3 error
+	}
+	GetIssueStub        func(context.Context, string, string, int) (*githuba.Issue, *githuba.Response, error)
+	getIssueMutex       sync.RWMutex
+	getIssueArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+	}
+	getIssueReturns struct {
+		result1 *githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}
+	getIssueReturnsOnCall map[int]struct {
+		result1 *githuba.Issue
 		result2 *githuba.Response
 		result3 error
 	}
@@ -312,6 +349,77 @@ type FakeClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClient) CreateComment(arg1 context.Context, arg2 string, arg3 string, arg4 int, arg5 string) (*githuba.IssueComment, *githuba.Response, error) {
+	fake.createCommentMutex.Lock()
+	ret, specificReturn := fake.createCommentReturnsOnCall[len(fake.createCommentArgsForCall)]
+	fake.createCommentArgsForCall = append(fake.createCommentArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.CreateCommentStub
+	fakeReturns := fake.createCommentReturns
+	fake.recordInvocation("CreateComment", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.createCommentMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) CreateCommentCallCount() int {
+	fake.createCommentMutex.RLock()
+	defer fake.createCommentMutex.RUnlock()
+	return len(fake.createCommentArgsForCall)
+}
+
+func (fake *FakeClient) CreateCommentCalls(stub func(context.Context, string, string, int, string) (*githuba.IssueComment, *githuba.Response, error)) {
+	fake.createCommentMutex.Lock()
+	defer fake.createCommentMutex.Unlock()
+	fake.CreateCommentStub = stub
+}
+
+func (fake *FakeClient) CreateCommentArgsForCall(i int) (context.Context, string, string, int, string) {
+	fake.createCommentMutex.RLock()
+	defer fake.createCommentMutex.RUnlock()
+	argsForCall := fake.createCommentArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakeClient) CreateCommentReturns(result1 *githuba.IssueComment, result2 *githuba.Response, result3 error) {
+	fake.createCommentMutex.Lock()
+	defer fake.createCommentMutex.Unlock()
+	fake.CreateCommentStub = nil
+	fake.createCommentReturns = struct {
+		result1 *githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) CreateCommentReturnsOnCall(i int, result1 *githuba.IssueComment, result2 *githuba.Response, result3 error) {
+	fake.createCommentMutex.Lock()
+	defer fake.createCommentMutex.Unlock()
+	fake.CreateCommentStub = nil
+	if fake.createCommentReturnsOnCall == nil {
+		fake.createCommentReturnsOnCall = make(map[int]struct {
+			result1 *githuba.IssueComment
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.createCommentReturnsOnCall[i] = struct {
+		result1 *githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string, arg7 string) (*githuba.PullRequest, error) {
@@ -583,6 +691,76 @@ func (fake *FakeClient) GetCommitReturnsOnCall(i int, result1 *githuba.Commit, r
 	}
 	fake.getCommitReturnsOnCall[i] = struct {
 		result1 *githuba.Commit
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetIssue(arg1 context.Context, arg2 string, arg3 string, arg4 int) (*githuba.Issue, *githuba.Response, error) {
+	fake.getIssueMutex.Lock()
+	ret, specificReturn := fake.getIssueReturnsOnCall[len(fake.getIssueArgsForCall)]
+	fake.getIssueArgsForCall = append(fake.getIssueArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetIssueStub
+	fakeReturns := fake.getIssueReturns
+	fake.recordInvocation("GetIssue", []interface{}{arg1, arg2, arg3, arg4})
+	fake.getIssueMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) GetIssueCallCount() int {
+	fake.getIssueMutex.RLock()
+	defer fake.getIssueMutex.RUnlock()
+	return len(fake.getIssueArgsForCall)
+}
+
+func (fake *FakeClient) GetIssueCalls(stub func(context.Context, string, string, int) (*githuba.Issue, *githuba.Response, error)) {
+	fake.getIssueMutex.Lock()
+	defer fake.getIssueMutex.Unlock()
+	fake.GetIssueStub = stub
+}
+
+func (fake *FakeClient) GetIssueArgsForCall(i int) (context.Context, string, string, int) {
+	fake.getIssueMutex.RLock()
+	defer fake.getIssueMutex.RUnlock()
+	argsForCall := fake.getIssueArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) GetIssueReturns(result1 *githuba.Issue, result2 *githuba.Response, result3 error) {
+	fake.getIssueMutex.Lock()
+	defer fake.getIssueMutex.Unlock()
+	fake.GetIssueStub = nil
+	fake.getIssueReturns = struct {
+		result1 *githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetIssueReturnsOnCall(i int, result1 *githuba.Issue, result2 *githuba.Response, result3 error) {
+	fake.getIssueMutex.Lock()
+	defer fake.getIssueMutex.Unlock()
+	fake.GetIssueStub = nil
+	if fake.getIssueReturnsOnCall == nil {
+		fake.getIssueReturnsOnCall = make(map[int]struct {
+			result1 *githuba.Issue
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.getIssueReturnsOnCall[i] = struct {
+		result1 *githuba.Issue
 		result2 *githuba.Response
 		result3 error
 	}{result1, result2, result3}
@@ -1425,6 +1603,8 @@ func (fake *FakeClient) UploadReleaseAssetReturnsOnCall(i int, result1 *githuba.
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createCommentMutex.RLock()
+	defer fake.createCommentMutex.RUnlock()
 	fake.createPullRequestMutex.RLock()
 	defer fake.createPullRequestMutex.RUnlock()
 	fake.deleteReleaseAssetMutex.RLock()
@@ -1433,6 +1613,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.downloadReleaseAssetMutex.RUnlock()
 	fake.getCommitMutex.RLock()
 	defer fake.getCommitMutex.RUnlock()
+	fake.getIssueMutex.RLock()
+	defer fake.getIssueMutex.RUnlock()
 	fake.getPullRequestMutex.RLock()
 	defer fake.getPullRequestMutex.RUnlock()
 	fake.getReleaseByTagMutex.RLock()

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -36,6 +36,7 @@ type gitHubAPI string
 const (
 	gitHubAPIGetCommit                  gitHubAPI = "GetCommit"
 	gitHubAPIGetPullRequest             gitHubAPI = "GetPullRequest"
+	gitHubAPIGetIssue                   gitHubAPI = "GetIssue"
 	gitHubAPIGetRepoCommit              gitHubAPI = "GetRepoCommit"
 	gitHubAPIListCommits                gitHubAPI = "ListCommits"
 	gitHubAPIListPullRequestsWithCommit gitHubAPI = "ListPullRequestsWithCommit"
@@ -45,6 +46,7 @@ const (
 	gitHubAPIListBranches               gitHubAPI = "ListBranches"
 	gitHubAPIGetReleaseByTag            gitHubAPI = "GetReleaseByTag"
 	gitHubAPIListReleaseAssets          gitHubAPI = "ListReleaseAssets"
+	gitHubAPICreateComment              gitHubAPI = "CreateComment"
 )
 
 type apiRecord struct {
@@ -113,6 +115,17 @@ func (c *githubNotesRecordClient) GetPullRequest(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 	return pr, resp, nil
+}
+
+func (c *githubNotesRecordClient) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, *github.Response, error) {
+	issue, resp, err := c.client.GetIssue(ctx, owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIGetIssue, issue, resp); err != nil {
+		return nil, nil, err
+	}
+	return issue, resp, nil
 }
 
 func (c *githubNotesRecordClient) GetRepoCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error) {
@@ -241,6 +254,17 @@ func (c *githubNotesRecordClient) ListReleaseAssets(
 	}
 
 	return assets, nil
+}
+
+func (c *githubNotesRecordClient) CreateComment(ctx context.Context, owner, repo string, number int, message string) (*github.IssueComment, *github.Response, error) {
+	issueComment, resp, err := c.client.CreateComment(ctx, owner, repo, number, message)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIGetIssue, issueComment, resp); err != nil {
+		return nil, nil, err
+	}
+	return issueComment, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -94,6 +94,19 @@ func (c *githubNotesReplayClient) GetPullRequest(ctx context.Context, owner, rep
 	return result, record.response(), nil
 }
 
+func (c *githubNotesReplayClient) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPIGetIssue)
+	if err != nil {
+		return nil, nil, err
+	}
+	result := &github.Issue{}
+	record := apiRecord{Result: result}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return result, record.response(), nil
+}
+
 func (c *githubNotesReplayClient) GetRepoCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error) {
 	data, err := c.readRecordedData(gitHubAPIGetRepoCommit)
 	if err != nil {
@@ -247,4 +260,17 @@ func (c *githubNotesReplayClient) ListReleaseAssets(
 		return nil, err
 	}
 	return assets, nil
+}
+
+func (c *githubNotesReplayClient) CreateComment(ctx context.Context, owner, repo string, number int, message string) (*github.IssueComment, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPICreateComment)
+	if err != nil {
+		return nil, nil, err
+	}
+	result := &github.IssueComment{}
+	record := apiRecord{Result: result}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return result, record.response(), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
add an option to push the testgridshot comment straight to a GitHub issue to avoid copy/paste

new flag `github-issue` which is the GH Issue for the Release cut, ie: https://github.com/kubernetes/sig-release/issues/1365


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel: add option to post the testgridshot straight to github issue
```

/assign @saschagrunert @hasheddan @xmudrii 