### PR TITLE
Fix announcement creation in krel release

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -39,6 +39,11 @@ const (
 
 	// gitRoot is the local repository root of k/k.
 	gitRoot = workspaceDir + "/src/k8s.io/kubernetes"
+
+	// releaseNotesHTMLFile is the name of the release notes in HTML
+	releaseNotesHTMLFile = "/src/release-notes.html"
+	// releaseNotesJSONFile is the file containing the release notes in json format
+	releaseNotesJSONFile = "/src/release-notes.json"
 )
 
 // Options are settings which will be used by `StageOptions` as well as

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -29,7 +29,7 @@ import (
 func generateTestingReleaseState(params *testStateParameters) *anago.ReleaseState {
 	state := anago.DefaultReleaseState()
 	if params.versionsTag != nil {
-		state.SetVersions(release.NewReleaseVersions("", *params.versionsTag, "", "", ""))
+		state.SetVersions(release.NewReleaseVersions(*params.versionsTag, *params.versionsTag, "", "", ""))
 	}
 
 	if params.createReleaseBranch != nil {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -442,8 +442,8 @@ func (d *DefaultStage) GenerateChangelog() error {
 		Tag:          d.state.versions.Prime(),
 		Branch:       branch,
 		Bucket:       d.options.Bucket(),
-		HTMLFile:     filepath.Join(workspaceDir, "src/release-notes.html"),
-		JSONFile:     filepath.Join(workspaceDir, "src/release-notes.json"),
+		HTMLFile:     filepath.Join(workspaceDir, releaseNotesHTMLFile),
+		JSONFile:     filepath.Join(workspaceDir, releaseNotesJSONFile),
 		Dependencies: true,
 		Tars: filepath.Join(
 			gitRoot,

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -88,12 +88,28 @@ func CreateForBranch(opts *Options) error {
 func CreateForRelease(opts *Options) error {
 	logrus.Infof("Creating %s announcement in %s", opts.tag, opts.workDir)
 
+	changelog := ""
+
+	// Read the changelog from the specified file if we got one
+	if opts.changelogFile != "" {
+		changelogData, err := ioutil.ReadFile(opts.changelogFile)
+		if err != nil {
+			return errors.Wrap(err, "reading changelog html file")
+		}
+		changelog = string(changelogData)
+	}
+
+	// ... unless it is overridden by passing the HTML directly
+	if opts.changelogHTML != "" {
+		changelog = opts.changelogHTML
+	}
+
 	if err := create(
 		opts.workDir,
 		fmt.Sprintf("Kubernetes %s is live!", opts.tag),
 		fmt.Sprintf(releaseAnnouncement,
 			opts.tag, opts.changelogPath, filepath.Base(opts.changelogPath),
-			opts.tag, opts.changelogHTML, opts.changelogPath,
+			opts.tag, changelog, opts.changelogPath,
 			filepath.Base(opts.changelogPath), opts.tag,
 		),
 	); err != nil {

--- a/pkg/announce/options.go
+++ b/pkg/announce/options.go
@@ -17,11 +17,22 @@ limitations under the License.
 package announce
 
 type Options struct {
-	workDir       string
-	tag           string
-	branch        string
+	// workDir is the directory where announcement.html and
+	// announcement-subject.txt will be written
+	workDir string
+	// Release tag we will build the announcement for
+	tag    string
+	branch string
+	// Changelog path is the path used to build the link to the changelog
+	// in the announcement HTML. For example CHANGELOG/CHANGELOG-1.20.md
 	changelogPath string
+	// Changelog HTML is the changelog in HTML format. This will be
+	// embedded in the announcement HTML, overrides changelogFile if
+	// both are present.
 	changelogHTML string
+	// changelogFile is the path to an HTML file containing the changelog
+	// which will be embedded in the announcement template
+	changelogFile string
 }
 
 // NewOptions can be used to create a new Options instance
@@ -51,5 +62,10 @@ func (o *Options) WithChangelogPath(changelogPath string) *Options {
 
 func (o *Options) WithChangelogHTML(changelogHTML string) *Options {
 	o.changelogHTML = changelogHTML
+	return o
+}
+
+func (o *Options) WithChangelogFile(changelogFile string) *Options {
+	o.changelogFile = changelogFile
 	return o
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR updates the values which are plugged into the `CreateAnnouncement()` function of the default release implementation. This change fixes the bug which broke the announcement creation during the cut of v1.20.0-rc.0

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/sig-release/issues/1365

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
```release-note
- The announce package now support reading the changelog from a file defined in `changelogFile`
```
