### PR TITLE
Fix krel stage for build versions without a commit ID

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -97,9 +97,6 @@ func (o *Options) Validate(state *State) error {
 	if err != nil {
 		return errors.Wrapf(err, "invalid build version: %s", o.BuildVersion)
 	}
-	if len(semverBuildVersion.Build) == 0 {
-		return errors.Errorf("build version does not contain build commit")
-	}
 	state.semverBuildVersion = semverBuildVersion
 
 	return nil

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -332,7 +332,14 @@ func (d *DefaultStage) TagRepository() error {
 			return errors.Errorf("tag %s already exists", version)
 		}
 
-		commit := d.state.semverBuildVersion.Build[0]
+		// Usually the build version contains a commit we can reference. If
+		// not, because the build version is exactly a tag, then we fallback to
+		// that tag.
+		commit := d.options.BuildVersion
+		if len(d.state.semverBuildVersion.Build) > 0 {
+			commit = d.state.semverBuildVersion.Build[0]
+		}
+
 		if d.state.createReleaseBranch {
 			logrus.Infof("Creating release branch %s", d.options.ReleaseBranch)
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
If we do not merge anything into the release branch and try to stage a
new release then this will fail without this patch because the build
version does not contain a valid commit ID. We now use the build version
as direct fallback in that case.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold
/priority critical-urgent
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `krel stage` bug to not build the release if the build version is exactly a tag without a commit ID.
```
