### PR TITLE
Fetch remote JSON release notes for official releases

### DIFF
--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -108,9 +108,9 @@ func TestRun(t *testing.T) {
 			},
 			shouldErr: true,
 		},
-		{ // GetURLResponse failed
+		{ // GetURLResponse 0 failed
 			prepare: func(mock *changelogfakes.FakeImpl, _ *changelog.Options) {
-				mock.GetURLResponseReturns("", err)
+				mock.GetURLResponseReturnsOnCall(0, "", err)
 			},
 			shouldErr: true,
 		},


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
In case we try to download the remote release notes draft as markdown,
we also need an equivalent JSON. This patch now assumes that there is a
JSON version side by side to the markdown release notes during official,
non patch release creation.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1087
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed release notes fetching for official (non patch) releases to also assume a JSON version side by side to the markdown draft
```
