### PR TITLE
Print the announce send command after release

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -586,5 +586,16 @@ func (d *DefaultRelease) Archive() error {
 	if err := d.impl.ArchiveRelease(archiverOptions); err != nil {
 		return errors.Wrap(err, "running the release archival process")
 	}
+
+	args := ""
+	if d.options.NoMock {
+		args += " --nomock"
+	}
+	args += " --tag=" + d.state.versions.Prime()
+
+	logrus.Infof(
+		"To announce this release, run:\n\n$ krel announce send%s", args,
+	)
+
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug regression

#### What this PR does / why we need it:

This PR adds a log message after a successful release with the `krel announce send` command used to announce the release. We had this previously with anago, but it appears that we lost it in the migration.

It's implemented in the same way as [printing the `krel release` command](https://github.com/kubernetes/release/blob/0ce000fbf22954af79b917b791db5b1b5b8e41ae/pkg/anago/stage.go#L524-L538) after the stage job.

#### Which issue(s) this PR fixes:

Addresses an action item from kubernetes/sig-release#1365:
 - Release logs are not showing the `krel announce` command

#### Does this PR introduce a user-facing change?

```release-note
Print the krel announce send command after a successful release run
```

/priority important-soon
/assign @puerco @saschagrunert 