### PR TITLE
Fix gitVersion parsing to include lightweight tags

### DIFF
--- a/compile-release-tools
+++ b/compile-release-tools
@@ -79,7 +79,7 @@ compile_with_flags() {
     -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     -X $pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
     -X $pkg.gitTreeState=$git_tree_state \
-    -X $pkg.gitVersion=$(git describe --abbrev=0 || echo unknown)" \
+    -X $pkg.gitVersion=$(git describe --tags --abbrev=0 || echo unknown)" \
     -o "$RELEASE_TOOL_BIN/$tool" "./cmd/$tool" \
     || return 1
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Running `krel version` currently returns the following output:

```
GitVersion:    v0.5.0
GitCommit:     63beebb74cf71bc89a767feaa501bc21833e8166
GitTreeState:  clean
BuildDate:     2020-12-04T17:52:06Z
GoVersion:     go1.15.3
Compiler:      gc
Platform:      linux/amd64
```

The `GitVersion` is incorrect because the latest version/tag is v0.6.0. I've checked is the v0.6.0 tag on the master branch and it is.

I've further investigated this problem and found that the command we use, `git describe --abbrev=0`, returns only annotated tags. The annotated tag must be created using `git tag -a`, i.e. it can't be created from a commit.

Running `git for-each-ref refs/tags` shows the following output:

```
...
b47c17f03e05b83543eee3abc7b204f555daf7c6 tag	refs/tags/v0.5.0
403156f3a746f50fd5f227317fb0e0a72bbb20b0 commit	refs/tags/v0.6.0
```

This means that the v0.6.0 tag is a lightweight tag (created from a commit), and the command we use returns only annotated tags. 

There is the `--tags` flag which does the following (from [`git describe` docs](https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---tags)):

> --tags
Instead of using only the annotated tags, use any tag found in refs/tags namespace. This option enables matching a lightweight (non-annotated) tag.

I've tested compiling krel with this flag and I get the correct output:

```
GitVersion:    v0.6.0
GitCommit:     a60d3d484d032e9167927b3b7f78365e4aefb2d2
GitTreeState:  clean
BuildDate:     2020-12-04T18:04:21Z
GoVersion:     go1.15.3
Compiler:      gc
Platform:      linux/amd64
```

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/priority important-soon
/assign @saschagrunert @puerco 