### PR TITLE
[WIP] Major Themes Support

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -241,6 +241,13 @@ func init() {
 		[]string{},
 		"specify a location to recursively look for release notes *.y[a]ml file mappings",
 	)
+
+	cmd.PersistentFlags().StringVar(
+		&opts.MajorThemes,
+		"themes-from",
+		"",
+		"read major themes from this directory",
+	)
 }
 
 func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
@@ -305,6 +312,13 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 		doc, err := document.New(releaseNotes, opts.StartRev, opts.EndRev)
 		if err != nil {
 			return errors.Wrapf(err, "creating release note document")
+		}
+
+		if opts.MajorThemes != "" {
+			doc.MajorThemes, err = notes.ReadMajorThemes(opts.MajorThemes)
+			if err != nil {
+				return errors.Wrap(err, "Unable to read major themes")
+			}
 		}
 
 		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, opts.GoTemplate)

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -43,6 +43,7 @@ type Document struct {
 	CurrentRevision         string         `json:"release_tag"`
 	PreviousRevision        string
 	CVEList                 []notes.CVEData
+	MajorThemes             []notes.MajorTheme
 }
 
 // FileMetadata contains metadata about files associated with the release.

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -62,7 +62,13 @@ filename | sha512 hash
 {{end -}}
 {{- end -}}
 # Changelog since {{$PreviousRevision}}
+{{with .MajorThemes -}}
+## What’s New (Major Themes)
 
+{{range .}}
+### {{.Title}}
+{{.Description}}
+{{end}}{{end}}
 {{with .NotesWithActionRequired -}}
 ## Urgent Upgrade Notes 
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -21,7 +21,10 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"io/ioutil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,6 +39,7 @@ import (
 
 	"k8s.io/release/pkg/github"
 	"k8s.io/release/pkg/notes/options"
+	"k8s.io/release/pkg/util"
 )
 
 var (
@@ -66,6 +70,13 @@ type CVEData struct {
 	Rating      string  `json:"rating"`
 	LinkedPRs   []int   `json:"linkedPRs"`
 	Description string  `json:"description"`
+}
+
+// MajorTheme struct to define the release major versions
+type MajorTheme struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	SIG         string `json:"sig"`
 }
 
 const (
@@ -1068,4 +1079,51 @@ func (rn *ReleaseNote) ContentHash() (string, error) {
 		return "", errors.Wrap(err, "calculating content hash from map")
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// ParseTheme parse a major theme file
+func ParseTheme(path string) (MajorTheme, error) {
+	theme := MajorTheme{}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return theme, errors.Wrapf(err, "while parsing theme from %s", err)
+	}
+	// split the file into parts
+	parts := strings.SplitN(string(data), "---", 3)
+	if len(parts) != 3 {
+		return theme, errors.New("error getting front matter from md file")
+	}
+	// Parse the YAML
+	if err := yaml.Unmarshal([]byte(parts[1]), &theme); err != nil {
+		return theme, errors.Wrapf(err, "unmarshalling theme file at %s", path)
+	}
+
+	// Add the description markdown
+	theme.Description = parts[2]
+	logrus.Infof("Found release notes theme: %s", theme.Title)
+	return theme, nil
+}
+
+// ReadMajorThemes reads the major themes for the release and returns it
+func ReadMajorThemes(sourceDir string) ([]MajorTheme, error) {
+	if !util.Exists(sourceDir) {
+		return nil, errors.New("Themes source directory does not exist")
+	}
+	logrus.Info("Parsing major themes")
+	themes := make([]MajorTheme, 0)
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".md" {
+			theme, err := ParseTheme(path)
+			if err != nil {
+				return err
+			}
+			themes = append(themes, theme)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing major themes")
+	}
+
+	return themes, nil
 }

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -112,6 +112,9 @@ type Options struct {
 
 	// MapProviders list of release notes map providers to query during generations
 	MapProviderStrings []string
+
+	// Directory to read the major themes from
+	MajorThemes string
 }
 
 type RevisionDiscoveryMode string

--- a/pkg/notes/themes/testdata/sig-api-machinery-deprecation-warnings.md
+++ b/pkg/notes/themes/testdata/sig-api-machinery-deprecation-warnings.md
@@ -1,0 +1,5 @@
+---
+title: Deprecation warnings
+sig: api-machinery
+---
+SIG API Machinery implemented warning mechanisms when using deprecated APIs that are visible to API consumers and metrics visible to cluster administrators. Requests to a deprecated API are returned with a warning containing a target removal release and any replacement API.

--- a/pkg/notes/themes/testdata/sig-architecture-permanent-beta.md
+++ b/pkg/notes/themes/testdata/sig-architecture-permanent-beta.md
@@ -1,0 +1,12 @@
+---
+title: Avoiding permanent beta
+sig: Architecture
+---
+From Kubernetes 1.20 onwards, SIG Architecture will implement a new policy to transition all REST APIs out of beta within nine months. The idea behind the new policy is to avoid features staying in beta for a long time. Once a new API enters beta, it will have nine months to either:
+
+  - reach GA, and deprecate the beta, or
+  - have a new beta version (and deprecate the previous beta).
+
+If a REST API reaches the end of that nine-month countdown, then the next Kubernetes release will deprecate that API version. More information can be found on the [Kubernetes Blog][blog-post].
+
+[blog-post]: https://deploy-preview-21274--kubernetes-io-master-staging.netlify.app/blog/2020/08/21/moving-forward-from-beta/

--- a/pkg/notes/themes/testdata/sig-network-ingress.md
+++ b/pkg/notes/themes/testdata/sig-network-ingress.md
@@ -1,0 +1,6 @@
+---
+title: Ingress graduates to General Availability
+sig: Network
+---
+SIG Network has graduated the widely used `Ingress` API to general availability in Kubernetes 1.19. This change recognises years of hard work by Kubernetes contributors, and paves the way for further work on future networking APIs in Kubernetes.
+

--- a/pkg/notes/themes/testdata/sig-node-seccomp.md
+++ b/pkg/notes/themes/testdata/sig-node-seccomp.md
@@ -1,0 +1,20 @@
+---
+title: seccomp graduates to General Availability
+sig: node
+---
+The seccomp (secure computing mode) support for Kubernetes has graduated to General Availability (GA). This feature can be used to increase the workload security by restricting the system calls for a Pod (applies to all containers) or single containers.
+
+Technically this means that a first class `seccompProfile` field has been added to the Pod and Container `securityContext` objects:
+
+```yaml
+securityContext:
+seccompProfile:
+    type: RuntimeDefault|Localhost|Unconfined # choose one of the three
+    localhostProfile: my-profiles/profile-allow.json # only necessary if type == Localhost
+```
+
+The support for `seccomp.security.alpha.kubernetes.io/pod` and `container.seccomp.security.alpha.kubernetes.io/...` annotations are now deprecated, and will be removed in Kubernetes v1.22.0. Right now, an automatic version skew handling will convert the new field into the annotations and vice versa. This means there is no action required for converting existing workloads in a cluster.
+
+You can find more information about how to restrict container system calls with seccomp in the new [documentation page on Kubernetes.io][seccomp-docs]
+
+[seccomp-docs]: https://kubernetes.io/docs/tutorials/clusters/seccomp/

--- a/pkg/notes/themes/testdata/wg-lts-12months.md
+++ b/pkg/notes/themes/testdata/wg-lts-12months.md
@@ -1,0 +1,9 @@
+---
+title: Increase the Kubernetes support window to one year
+sig: wg-lts
+---
+As of Kubernetes 1.19, bugfix support via patch releases for a Kubernetes minor release has increased from 9 months to 1 year.
+
+A survey conducted in early 2019 by the working group (WG) Long Term Support (LTS) showed that a significant subset of Kubernetes end-users fail to upgrade within the previous 9-month support period. 
+
+A yearly support period provides the cushion end-users appear to desire, and is more in harmony with familiar annual planning cycles.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds enables the assembly of the Release Notes document incorporating the major themes from individual markdown files, which can be edited and PR'ed by each SIG.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Still WIP, I rebased this part from 4 months ago, and I will (re)write the rest. When done, this PR will add:

 - [x] Updates to the notes libraries
 - [ ] Tests for the major theme reader 
 - [ ] Adding support to `krel release-notes` to read the themes from the release directory

#### Does this PR introduce a user-facing change?

```release-note
- Major themes can now be added to release notes from individual markdown files
```
