### PR TITLE
Implement pagination in github package

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,11 +45,30 @@ const (
 
 // GitHub is a wrapper around GitHub related functionality
 type GitHub struct {
-	client Client
+	client  Client
+	options *Options
 }
 
 type githubClient struct {
 	*github.Client
+}
+
+// Options is a set of options to configure the behavior of the GitHub package
+type Options struct {
+	// How many items to request in calls to the github API
+	// that require pagination.
+	ItemsPerPage int
+}
+
+func (o *Options) GetItemsPerPage() int {
+	return o.ItemsPerPage
+}
+
+// DefaultOptions return an options struct with commonly used settings
+func DefaultOptions() *Options {
+	return &Options{
+		ItemsPerPage: 50,
+	}
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -159,7 +178,10 @@ func NewWithToken(token string) (*GitHub, error) {
 		))
 	}
 	logrus.Debugf("Using %s GitHub client", state)
-	return &GitHub{&githubClient{github.NewClient(client)}}, nil
+	return &GitHub{
+		client:  &githubClient{github.NewClient(client)},
+		options: DefaultOptions(),
+	}, nil
 }
 
 func NewEnterprise(baseURL, uploadURL string) (*GitHub, error) {
@@ -182,7 +204,10 @@ func NewEnterpriseWithToken(baseURL, uploadURL, token string) (*GitHub, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to new github client: %s", err)
 	}
-	return &GitHub{&githubClient{ghclient}}, nil
+	return &GitHub{
+		client:  &githubClient{ghclient},
+		options: DefaultOptions(),
+	}, nil
 }
 
 func (g *githubClient) GetCommit(
@@ -420,6 +445,16 @@ func (g *GitHub) Client() Client {
 	return g.client
 }
 
+// SetOptions gets an options set for the GitHub object
+func (g *GitHub) SetOptions(opts *Options) {
+	g.options = opts
+}
+
+// Options return a pointer to the options struct
+func (g *GitHub) Options() *Options {
+	return g.options
+}
+
 // TagsPerBranch is an abstraction over a simple branch to latest tag association
 type TagsPerBranch map[string]string
 
@@ -436,7 +471,7 @@ type TagsPerBranch map[string]string
 func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 	// List tags for all pages
 	allTags := []*github.RepositoryTag{}
-	opts := &github.ListOptions{PerPage: 100}
+	opts := &github.ListOptions{PerPage: g.options.GetItemsPerPage()}
 	for {
 		tags, resp, err := g.client.ListTags(
 			context.Background(), git.DefaultGithubOrg, git.DefaultGithubRepo,

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -260,13 +260,14 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
-	ListReleaseAssetsStub        func(context.Context, string, string, int64) ([]*githuba.ReleaseAsset, error)
+	ListReleaseAssetsStub        func(context.Context, string, string, int64, *githuba.ListOptions) ([]*githuba.ReleaseAsset, error)
 	listReleaseAssetsMutex       sync.RWMutex
 	listReleaseAssetsArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 int64
+		arg5 *githuba.ListOptions
 	}
 	listReleaseAssetsReturns struct {
 		result1 []*githuba.ReleaseAsset
@@ -1256,7 +1257,7 @@ func (fake *FakeClient) ListPullRequestsWithCommitReturnsOnCall(i int, result1 [
 	}{result1, result2, result3}
 }
 
-func (fake *FakeClient) ListReleaseAssets(arg1 context.Context, arg2 string, arg3 string, arg4 int64) ([]*githuba.ReleaseAsset, error) {
+func (fake *FakeClient) ListReleaseAssets(arg1 context.Context, arg2 string, arg3 string, arg4 int64, arg5 *githuba.ListOptions) ([]*githuba.ReleaseAsset, error) {
 	fake.listReleaseAssetsMutex.Lock()
 	ret, specificReturn := fake.listReleaseAssetsReturnsOnCall[len(fake.listReleaseAssetsArgsForCall)]
 	fake.listReleaseAssetsArgsForCall = append(fake.listReleaseAssetsArgsForCall, struct {
@@ -1264,13 +1265,14 @@ func (fake *FakeClient) ListReleaseAssets(arg1 context.Context, arg2 string, arg
 		arg2 string
 		arg3 string
 		arg4 int64
-	}{arg1, arg2, arg3, arg4})
+		arg5 *githuba.ListOptions
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.ListReleaseAssetsStub
 	fakeReturns := fake.listReleaseAssetsReturns
-	fake.recordInvocation("ListReleaseAssets", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ListReleaseAssets", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.listReleaseAssetsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1284,17 +1286,17 @@ func (fake *FakeClient) ListReleaseAssetsCallCount() int {
 	return len(fake.listReleaseAssetsArgsForCall)
 }
 
-func (fake *FakeClient) ListReleaseAssetsCalls(stub func(context.Context, string, string, int64) ([]*githuba.ReleaseAsset, error)) {
+func (fake *FakeClient) ListReleaseAssetsCalls(stub func(context.Context, string, string, int64, *githuba.ListOptions) ([]*githuba.ReleaseAsset, error)) {
 	fake.listReleaseAssetsMutex.Lock()
 	defer fake.listReleaseAssetsMutex.Unlock()
 	fake.ListReleaseAssetsStub = stub
 }
 
-func (fake *FakeClient) ListReleaseAssetsArgsForCall(i int) (context.Context, string, string, int64) {
+func (fake *FakeClient) ListReleaseAssetsArgsForCall(i int) (context.Context, string, string, int64, *githuba.ListOptions) {
 	fake.listReleaseAssetsMutex.RLock()
 	defer fake.listReleaseAssetsMutex.RUnlock()
 	argsForCall := fake.listReleaseAssetsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeClient) ListReleaseAssetsReturns(result1 []*githuba.ReleaseAsset, result2 error) {

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -241,9 +241,9 @@ func (c *githubNotesRecordClient) DeleteReleaseAsset(
 }
 
 func (c *githubNotesRecordClient) ListReleaseAssets(
-	ctx context.Context, owner, repo string, releaseID int64,
+	ctx context.Context, owner, repo string, releaseID int64, opts *github.ListOptions,
 ) ([]*github.ReleaseAsset, error) {
-	assets, err := c.client.ListReleaseAssets(ctx, owner, repo, releaseID)
+	assets, err := c.client.ListReleaseAssets(ctx, owner, repo, releaseID, opts)
 	if err != nil {
 		return assets, err
 	}

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -247,7 +247,7 @@ func (c *githubNotesReplayClient) DeleteReleaseAsset(
 }
 
 func (c *githubNotesReplayClient) ListReleaseAssets(
-	ctx context.Context, owner, repo string, releaseID int64,
+	ctx context.Context, owner, repo string, releaseID int64, opts *github.ListOptions,
 ) ([]*github.ReleaseAsset, error) {
 	data, err := c.readRecordedData(gitHubAPIListReleaseAssets)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind feature 

#### What this PR does / why we need it:

The first commit in this PR adds proper pagination support to functions in the `github` package that were missing it.

It works by adding a new Options struct to the `github` package to configure the size of pages we get from calls to GitHub.

The next PR alters the following functions to paginate according to the page size defined in `Options.ItemsPerPage`:

* ListBranches()
* ListReleaseAssets()
* TagExists()
* LatestGitHubTagsPerBranch()


#### Which issue(s) this PR fixes:

Ref: https://app.slack.com/client/T09NY5SBT/CJH2GBF7Y/thread/CJH2GBF7Y-1607502787.026300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- The GitHub package now has a basic options struct to control how it behaves
- Add `ItemsPerPage` option to the `github` pkg to control the size of pages we ask from github
- Add pagination when calling the GitHub API from the following functions: `ListBranches() ListReleaseAssets() TagExists() LatestGitHubTagsPerBranch()`

```
