### PR TITLE
Always checkout a branch when tagging repo during stage

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -364,9 +364,9 @@ func (d *DefaultStage) TagRepository() error {
 				}
 			}
 		} else {
-			logrus.Infof("Checking out commit %s", commit)
-			if err := d.impl.Checkout(repo, commit); err != nil {
-				return errors.Wrap(err, "checkout release commit")
+			logrus.Infof("Checking out branch %s", d.options.ReleaseBranch)
+			if err := d.impl.Checkout(repo, d.options.ReleaseBranch); err != nil {
+				return errors.Wrapf(err, "checking out branch %s", d.options.ReleaseBranch)
 			}
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR makes sure that a branch is checked before tagging the repository making sure
it is not in detached HEAD as this was causing the empty commit between tags not
to be created.

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/kubernetes/issues/97178

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- When staging releases, we now always checkout a branch and avoid going into detached HEAD
```
