### PR TITLE
Generate full json release notes on first minor

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -837,12 +837,21 @@ func releaseNotesJSON(repoPath, tag string) (jsonString string, err error) {
 		startTag = fmt.Sprintf("v%d.%d.%d", tagVersion.Major, tagVersion.Minor, tagVersion.Patch-1)
 		tagChoice = "previous patch release"
 	} else {
-		// From 1.20 the notes fot the first alpha start from the previous minor
-		if tagVersion.Pre[0].String() == "alpha" && tagVersion.Pre[1].VersionNum == 1 {
+		// From 1.20 the notes for the first alpha start from the previous minor
+		if len(tagVersion.Pre) == 2 &&
+			tagVersion.Pre[0].String() == "alpha" &&
+			tagVersion.Pre[1].VersionNum == 1 {
 			startTag = util.SemverToTagString(semver.Version{
 				Major: tagVersion.Major, Minor: tagVersion.Minor - 1, Patch: 0,
 			})
 			tagChoice = "previous minor version"
+		} else if len(tagVersion.Pre) == 0 && tagVersion.Patch == 0 {
+			// If we are writing the notes for the first minor version (eg 1.20.0)
+			// we choose as the start tag also the previous minor
+			startTag = util.SemverToTagString(semver.Version{
+				Major: tagVersion.Major, Minor: tagVersion.Minor - 1, Patch: 0,
+			})
+			tagChoice = "previous minor version because we are in a new minor version"
 		} else {
 			// All others from the previous existing tag
 			startTag, err = repo.PreviousTag(tag, branchName)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR modifies the behavior of `krel release-notes` to generate the complete set of release notes in json when creating the website PR for the first minor version (eg 1.20.0) and skipping all prereleases. Previously, krel would generate the notes starting from the last tag (generally the last RC).  

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

I've used this patch to generate the website notes for v1.20.0:  https://github.com/kubernetes-sigs/release-notes/pull/217

#### Does this PR introduce a user-facing change?
```release-note
- `krel release-notes` will now generate the complete release notes in JSON when updating the website with the first minor (eg 1.20.0) 
```
