### PR TITLE
images: Build debian-base:buster-v1.3.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -151,7 +151,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.2.0
+    version: buster-v1.3.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.2.0
+IMAGE_VERSION ?= buster-v1.3.0
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.2.0'
+    IMAGE_VERSION: 'buster-v1.3.0'
   stretch:
     CONFIG: 'stretch'
     IMAGE_VERSION: 'stretch-v1.1.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is just a periodic bump of the Debian base image tag to buster-v1.3.0 in order to take the latest upstream Debian, and all the fixes that come with it.

#### Which issue(s) this PR fixes:

None, just a number of medium to low severity CVEs.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
images: Build debian-base:buster-v1.3.0
```
