### PR TITLE
Fix non-amd64 arch config for debian images

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -92,10 +92,15 @@ else
 endif
 	mv $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp $(TEMP_DIR)/$(CONFIG)/Dockerfile.build
 
-	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
+	docker buildx build \
+		--pull \
+		--platform $(ARCH) \
+		-t $(BUILD_IMAGE) \
+		-f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(CONFIG)/$(TAR_FILE)
-	docker build \
+	docker buildx build \
+		--platform $(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -74,7 +74,10 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
-	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker buildx build \
+		--pull \
+		--platform $(ARCH) \
+		-t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -46,8 +46,9 @@ ifneq ($(ARCH),amd64)
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
 
-	docker build \
+	docker buildx build \
 		--pull \
+		--platform $(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Non-AMD64 debian images are not marked correct arch in image config. Looks like they are just build as amd64 images with manifest list pointing to different architectures.

To verify:

```
$ docker buildx imagetools inspect  k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0 
Name:      k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0
...
  Name:      k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
...

$ docker pull k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2
k8s.gcr.io/build-image/debian-iptables@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2: Pulling from build-image/debian-iptables
Digest: sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2
Status: Downloaded newer image for k8s.gcr.io/build-image/debian-iptables@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2
k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2

$ docker inspect -f '{{json .Architecture}}' k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0@sha256:3d7ede6013b0516f1ec3852590895d4a7b6ec8f5e15bebc1a55237bba4538da2
"amd64"
```

This causes an issue with building Kubernetes with Docker v20.10.
`image with reference k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0 was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64`
https://github.com/docker/for-linux/issues/1170

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mark debian images with their corresponding architectures
```

cc @justaugustus 