### PR TITLE
Make staging of extra files optional

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -115,6 +115,10 @@ type Options struct {
 	// Validate that the remove image digests exists, needs `skopeo` in
 	// `$PATH`.
 	ValidateRemoteImageDigests bool
+
+	// Stage additional files defined by `ExtraGcpStageFiles` and
+	// `ExtraWindowsStageFiles`, otherwise they will be skipped.
+	StageExtraFiles bool
 }
 
 // TODO: Refactor so that version is not required as a parameter

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -41,7 +41,9 @@ type stageFile struct {
 
 const extraDir = "extra"
 
-var gcpStageFiles = []stageFile{
+// ExtraGcpStageFiles defines extra GCP files to be staged if `StageExtraFiles`
+// in `Options` is set to `true`.
+var ExtraGcpStageFiles = []stageFile{
 	{
 		srcPath:  filepath.Join(release.GCEPath, "configure-vm.sh"),
 		dstPath:  extraDir + "/gce/configure-vm.sh",
@@ -69,7 +71,9 @@ var gcpStageFiles = []stageFile{
 	},
 }
 
-var windowsStageFiles = []stageFile{
+// ExtraWindowsStageFiles defines extra Windows files to be staged if
+// `StageExtraFiles` in `Options` is set to `true`.
+var ExtraWindowsStageFiles = []stageFile{
 	{
 		srcPath:  filepath.Join(release.WindowsLocalPath, "configure.ps1"),
 		dstPath:  extraDir + "/gce/windows/configure.ps1",
@@ -294,21 +298,18 @@ func (bi *Instance) StageLocalArtifacts() error {
 		return errors.Wrap(err, "copy source directory into destination")
 	}
 
-	extraPath := filepath.Join(stageDir, extraDir)
-	if util.Exists(extraPath) {
+	if bi.opts.StageExtraFiles {
 		// Copy helpful GCP scripts to local GCS staging directory for push
 		logrus.Info("Copying extra GCP stage files")
-		if err := bi.copyStageFiles(stageDir, gcpStageFiles); err != nil {
+		if err := bi.copyStageFiles(stageDir, ExtraGcpStageFiles); err != nil {
 			return errors.Wrapf(err, "copy GCP stage files")
 		}
 
 		// Copy helpful Windows scripts to local GCS staging directory for push
 		logrus.Info("Copying extra Windows stage files")
-		if err := bi.copyStageFiles(stageDir, windowsStageFiles); err != nil {
+		if err := bi.copyStageFiles(stageDir, ExtraWindowsStageFiles); err != nil {
 			return errors.Wrapf(err, "copy Windows stage files")
 		}
-	} else {
-		logrus.Infof("Skipping not existing extra dir %s", extraPath)
 	}
 
 	// Copy the plain binaries to GCS. This is useful for install scripts that


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now add a new push `build.Options` value `StageExtraFiles`, which
allows the user to add pre-defined files to be copied into the staging
area.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #1840


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `StageExtraFiles` to `build.Options` to allow staging `ExtraGcpStageFiles` and `ExtraWindowsStageFiles`
```
