### PR TITLE
Update go-github to v33.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-containerregistry v0.2.1
-	github.com/google/go-github/v29 v29.0.3
+	github.com/google/go-github/v33 v33.0.0
 	github.com/google/uuid v1.1.2
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
 	github.com/mitchellh/mapstructure v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/google/go-containerregistry v0.2.1 h1:LLZgLTDguTVJ9eEHh/zTtr347CpFhH6
 github.com/google/go-containerregistry v0.2.1/go.mod h1:Ts3Wioz1r5ayWx8sS6vLcWltWcM1aqFjd/eVrkFhrWM=
 github.com/google/go-github/v29 v29.0.3 h1:IktKCTwU//aFHnpA+2SLIi7Oo9uhAzgsdZNbcAqhgdc=
 github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
+github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
+github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -584,7 +584,7 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 	return finalErr
 }
 
-func (g *GitHub) downloadAssetsParallel(assets []github.ReleaseAsset, owner, repo, releaseDir string) (finalErr error) {
+func (g *GitHub) downloadAssetsParallel(assets []*github.ReleaseAsset, owner, repo, releaseDir string) (finalErr error) {
 	errChan := make(chan error, len(assets))
 	for i := range assets {
 		asset := assets[i]

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	gogithub "github.com/google/go-github/v29/github"
+	gogithub "github.com/google/go-github/v33/github"
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/release/pkg/git"

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"sync"
 
-	githuba "github.com/google/go-github/v29/github"
+	githuba "github.com/google/go-github/v33/github"
 	"k8s.io/release/pkg/github"
 )
 

--- a/pkg/github/internal/retry.go
+++ b/pkg/github/internal/retry.go
@@ -19,7 +19,7 @@ package internal
 import (
 	"time"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/github/internal/retry_test.go
+++ b/pkg/github/internal/retry_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"k8s.io/release/pkg/github/internal"
 )

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 )
 
 func NewReplayer(replayDir string) Client {

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	gogithub "github.com/google/go-github/v29/github"
+	gogithub "github.com/google/go-github/v33/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 

--- a/pkg/kubepkg/kubepkgfakes/fake_impl.go
+++ b/pkg/kubepkg/kubepkgfakes/fake_impl.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"k8s.io/release/pkg/kubepkg"
 	"k8s.io/release/pkg/release"
 )

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"sync"
 
-	gogithub "github.com/google/go-github/v29/github"
+	gogithub "github.com/google/go-github/v33/github"
 	"github.com/nozzle/throttler"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v29/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/github/githubfakes"


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
This updates go-github to the latest release and adapts import paths as
well as necessary code changes.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Should incorporate with https://github.com/kubernetes/release/pull/1844
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
