### PR TITLE
Add do_not_publish map flag to remove release note from final document

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -670,9 +670,6 @@ we're pulling the correct go-runner arch from the manifest list.</p>
 <p>Kubelet: assume that swap is disabled when <code>/proc/swaps</code> does not exist (<a href="https://github.com/kubernetes/kubernetes/pull/93931">#93931</a>, <a href="https://github.com/SataQiu">@SataQiu</a>) [SIG Node]</p>
 </li>
 <li>
-<p>NONE (<a href="https://github.com/kubernetes/kubernetes/pull/71269">#71269</a>, <a href="https://github.com/DeliangFan">@DeliangFan</a>) [SIG Node]</p>
-</li>
-<li>
 <p>New Azure instance types do now have correct max data disk count information. (<a href="https://github.com/kubernetes/kubernetes/pull/94340">#94340</a>, <a href="https://github.com/ialidzhikov">@ialidzhikov</a>) [SIG Cloud Provider and Storage]</p>
 </li>
 <li>
@@ -724,7 +721,6 @@ we're pulling the correct go-runner arch from the manifest list.</p>
 <li>Service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset is removed.  All Standard load balancers will always enable tcp resets. (<a href="https://github.com/kubernetes/kubernetes/pull/94297">#94297</a>, <a href="https://github.com/MarcPow">@MarcPow</a>) [SIG Cloud Provider]</li>
 <li>Stop propagating SelfLink (deprecated in 1.16) in kube-apiserver (<a href="https://github.com/kubernetes/kubernetes/pull/94397">#94397</a>, <a href="https://github.com/wojtek-t">@wojtek-t</a>) [SIG API Machinery and Testing]</li>
 <li>Strip unnecessary security contexts on Windows (<a href="https://github.com/kubernetes/kubernetes/pull/93475">#93475</a>, <a href="https://github.com/ravisantoshgudimetla">@ravisantoshgudimetla</a>) [SIG Node, Testing and Windows]</li>
-<li>To ensure the code be strong,  add unit test for GetAddressAndDialer (<a href="https://github.com/kubernetes/kubernetes/pull/93180">#93180</a>, <a href="https://github.com/FreeZhang61">@FreeZhang61</a>) [SIG Node]</li>
 <li>Update CNI plugins to v0.8.7 (<a href="https://github.com/kubernetes/kubernetes/pull/94367">#94367</a>, <a href="https://github.com/justaugustus">@justaugustus</a>) [SIG Cloud Provider, Network, Node, Release and Testing]</li>
 <li>Update cri-tools to <a href="https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.19.0">v1.19.0</a> (<a href="https://github.com/kubernetes/kubernetes/pull/94307">#94307</a>, <a href="https://github.com/xmudrii">@xmudrii</a>) [SIG Cloud Provider]</li>
 <li>Update etcd client side to v3.4.13 (<a href="https://github.com/kubernetes/kubernetes/pull/94259">#94259</a>, <a href="https://github.com/jingyih">@jingyih</a>) [SIG API Machinery and Cloud Provider]</li>

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -387,9 +387,6 @@ func createDraftPR(repoPath, tag string) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "preparing local fork of kubernetes/sig-release")
 	}
-	defer func() {
-		err = sigReleaseRepo.Cleanup()
-	}()
 
 	// The release path inside the repository
 	releasePath := filepath.Join("releases", fmt.Sprintf("release-%d.%d", tagVersion.Major, tagVersion.Minor))
@@ -478,6 +475,10 @@ func createDraftPR(repoPath, tag string) (err error) {
 		logrus.Warn("Changes were made locally, user needs to perform manual push and create pull request.")
 		return nil
 	}
+
+	defer func() {
+		err = sigReleaseRepo.Cleanup()
+	}()
 
 	// Create the commit
 	if err := createDraftCommit(

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -223,6 +223,11 @@ func New(
 	for _, pr := range releaseNotes.History() {
 		note := releaseNotes.Get(pr)
 
+		if note.DoNotPublish {
+			logrus.Infof("skipping PR %d as (marked to not be published)", pr)
+			continue
+		}
+
 		cvedata, hasCVE := note.DataFields["cve"]
 		if hasCVE {
 			logrus.Infof("Release note for PR #%d has CVE vulnerability info", note.PrNumber)

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -109,6 +109,9 @@ type ReleaseNotesMap struct {
 		// ActionRequired indicates whether or not the release-note-action-required
 		// label was set on the PR
 		ActionRequired *bool `json:"action_required,omitempty" yaml:"action_required,omitempty"`
+
+		// DoNotPublish by default represents release-note-none label on GitHub
+		DoNotPublish *bool `json:"do_not_publish,omitempty" yaml:"do_not_publish,omitempty"`
 	} `json:"releasenote"`
 
 	DataFields map[string]ReleaseNotesDataField `json:"datafields,omitempty" yaml:"datafields,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

As release notes division of release team, we'd like a way to remove PRs with irrelevant release notes content from the final document.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #1786
Supersedes #1831

#### Special notes for your reviewer:
Generating JSON is not checking for `DoNotPublish` flag yet, should I worry about it in this PR or should I work on it separately?

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- krel release-notes now has 'do_not_publish' field in map to override release-note-none
- fixes regression where k/sig-release local copy might be deleted when user does not want to create automated PR at the end of create-draft-pr workflow
```
