### PR TITLE
vulndash: add filter to get vulnerabilities for a specific registry hostname

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.3.1-1
+IMAGE_VERSION ?= v0.4.0-1
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,5 +1,6 @@
+
 variants:
   default:
-    IMAGE_VERSION: 'v0.3.1-1'
+    IMAGE_VERSION: 'v0.4.0-1'
     GO_VERSION: '1.15.5'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
-    version: v0.3.1-1
+    version: v0.4.0-1
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `vulndash` service is trying to get the vulnerabilities report for all images in the GCP Container registry.
In our production registry, we have 3 hostnames: `us.gcr.io`, `asia.gcr.io`, and `eu.gcr.io` which contain similar images.

The job today is timing out because there is a long list of images to process and we might don't need to process images in other registries since they are similar to each one.

This PR adds a new filter to make us able to select which registry hostname we want to check.

for more context: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1605861516125600

A test-infra PR comes next to set the flag for the job

/assign @justaugustus @hasheddan @spiffxp 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
vulndash: add filter to get vulnerabilities for a specific registry hostname
```
