### PR TITLE
git: rev-parse with specified tag regexp

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -144,6 +144,14 @@ func init() {
 		"The git revision to end at. Can be used as alternative to end-sha.",
 	)
 
+	// tagRegexp specifies the regular expression to match git tag names.
+	cmd.PersistentFlags().StringVar(
+		&opts.TagRegexp,
+		"tag-regexp",
+		util.EnvDefault("TAG_REGEXP", git.DefaultTagRegexp),
+		"The regular expression to match git tag names.",
+	)
+
 	// repoPath contains the path to a local Kubernetes repository to avoid the
 	// delay during git clone
 	cmd.PersistentFlags().StringVar(

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -52,6 +52,7 @@ const (
 	DefaultRemote            = "origin"
 	DefaultRef               = "HEAD"
 	DefaultBranch            = "master"
+	DefaultTagRegexp         = `v\d+\.\d+\.\d+.*`
 
 	defaultGithubAuthRoot = "git@github.com:"
 	defaultGitUser        = "Anago GCB"
@@ -441,7 +442,13 @@ func (r *Repo) Cleanup() error {
 // RevParse parses a git revision and returns a SHA1 on success, otherwise an
 // error.
 func (r *Repo) RevParse(rev string) (string, error) {
-	matched, err := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev)
+	return r.RevParseWithTagRegexp(rev, DefaultTagRegexp)
+}
+
+// RevParseWithTagRegexp parses a git revision with a specified tag name pattern.
+// Fallback to parse branch name if revision is not recognized as tag.
+func (r *Repo) RevParseWithTagRegexp(rev string, tagRegexp string) (string, error) {
+	matched, err := regexp.MatchString(tagRegexp, rev)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -68,6 +68,9 @@ type Options struct {
 	// valid git revision. Should not be used together with EndSHA.
 	EndRev string
 
+	// TagRegexp is the regular expression to match git tag names.
+	TagRegexp string
+
 	// Format specifies the format of the release notes. Can be either
 	// `json` or `markdown`.
 	Format string
@@ -146,6 +149,7 @@ func New() *Options {
 		DiscoverMode: RevisionDiscoveryModeNONE,
 		GithubOrg:    git.DefaultGithubOrg,
 		GithubRepo:   git.DefaultGithubRepo,
+		TagRegexp:    git.DefaultTagRegexp,
 		Format:       FormatMarkdown,
 		GoTemplate:   GoTemplateDefault,
 		Pull:         true,
@@ -207,7 +211,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			return err
 		}
 		if o.StartRev != "" && o.StartSHA == "" {
-			sha, err := repo.RevParse(o.StartRev)
+			sha, err := repo.RevParseWithTagRegexp(o.StartRev, o.TagRegexp)
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.StartRev)
 			}
@@ -215,7 +219,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			o.StartSHA = sha
 		}
 		if o.EndRev != "" && o.EndSHA == "" {
-			sha, err := repo.RevParse(o.EndRev)
+			sha, err := repo.RevParseWithTagRegexp(o.EndRev, o.TagRegexp)
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.EndRev)
 			}


### PR DESCRIPTION
The current implementation of `RevParse` tries to match the incoming
revision with `v\d+\.\d+\.\d+.*`. This works in most cases. But this
may not always be the case for downstreams(as a user of relesae-notes
tool).

This change introduces a new flag `--tag-regexp` so that the way to
match git tag names can be customized.

```release-note
NONE
```
