### PR TITLE
Revert "Merge pull request #1839 from sozercan/fix-arch"

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -92,15 +92,10 @@ else
 endif
 	mv $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp $(TEMP_DIR)/$(CONFIG)/Dockerfile.build
 
-	docker buildx build \
-		--pull \
-		--platform $(ARCH) \
-		-t $(BUILD_IMAGE) \
-		-f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
+	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(CONFIG)/$(TAR_FILE)
-	docker buildx build \
-		--platform $(ARCH) \
+	docker build \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -74,10 +74,7 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
-	docker buildx build \
-		--pull \
-		--platform $(ARCH) \
-		-t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -46,9 +46,8 @@ ifneq ($(ARCH),amd64)
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
 
-	docker buildx build \
+	docker build \
 		--pull \
-		--platform $(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug regression
/priority critical-urgent

#### What this PR does / why we need it:

This reverts commit 1fd673ed7f56c2d0e26d6c034671aa98cd07a6ce, reversing
changes made to ce6512e39d7cf0196db3d106ed3ac39ea6f7c85f.

https://github.com/kubernetes/release/pull/1839 broke the Debian base image builds:
- https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-debian-base/1349451422436954112
- https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-debian-iptables/1349451422495674368
- https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-debian-hyperkube-base/1349451422466314240

Looking back at the Makefile, the fix is a little more complicated than the PR prescribes, given the QEMU usage (and probably why I didn't tackle on the initial migration of these builds).
I'd like to teach the Debian base images to use [`Makefile.common-image`](https://github.com/kubernetes/release/blob/master/images/Makefile.common-image) / [`Makefile.build-image`](https://github.com/kubernetes/release/blob/master/images/build/Makefile.build-image) and can look at that next week, but for now, let's get the builds back in a working state.

FYI @sozercan 

/assign @hasheddan @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
