### PR TITLE
cross: increase gcb job timeout to 30 min

### DIFF
--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 1800s
 
 options:
   substitution_option: ALLOW_LOOSE


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cross: increase GCB job timeout to 30 min because job kube-cross timeout: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-kube-cross/1351860030952968192

slack 🧵 https://kubernetes.slack.com/archives/C2C40FMNF/p1611148239057800?thread_ts=1610736817.029800&cid=C2C40FMNF

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/assign @justaugustus @ameukam 
