### PR TITLE
Set correct architecture for debian-iptables images

### DIFF
--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -39,7 +39,8 @@ SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 
 build:
 	cp -r ./$(CONFIG) $(TEMP_DIR)/
-	cd $(TEMP_DIR)/$(CONFIG) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+	cd $(TEMP_DIR)/$(CONFIG) && \
+		sed -i "s|ARCH|${ARCH}|g; s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
 
 ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+FROM --platform=linux/ARCH BASEIMAGE
 
 # Install iptables and ebtables packages from buster-backports
 ARG IPTABLES_VERSION

--- a/images/build/debian-iptables/stretch/Dockerfile
+++ b/images/build/debian-iptables/stretch/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+FROM --platform=linux/ARCH BASEIMAGE
 
 # Install other dependencies and then clean up apt caches
 RUN clean-install \


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When not building with docker buildx we have to specify the platform
from which we want to build the container image via the `FROM --platform`
syntax. We now apply this approach to the `debian-iptables` images,
which are the base for the `kube-proxy` image we release.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/kubernetes/issues/98229
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `debian-iptables` multi architecture images to contain the right architecture field in the manifst.
```
