### PR TITLE
Switch to buildx for building multi architecture images

### DIFF
--- a/cmd/vulndash/cloudbuild.yaml
+++ b/cmd/vulndash/cloudbuild.yaml
@@ -8,7 +8,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'
     dir: ./cmd/vulndash
     env:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -151,7 +151,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.3.0
+    version: buster-v1.4.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
 
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'
     dir: ./images/build/cross
     env:

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,15 +19,15 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.3.0
+IMAGE_VERSION ?= buster-v1.4.0
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar
-ARCH?=amd64
+ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 TEMP_DIR:=$(shell mktemp -d)
-QEMUVERSION=v4.2.0-6
+QEMUVERSION=v5.2.0-2
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 
@@ -92,10 +92,14 @@ else
 endif
 	mv $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp $(TEMP_DIR)/$(CONFIG)/Dockerfile.build
 
-	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
+	docker buildx build \
+		--pull -t $(BUILD_IMAGE) \
+		--platform linux/$(ARCH) \
+		-f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(CONFIG)/$(TAR_FILE)
-	docker build \
+	docker buildx build \
+		--platform linux/$(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: make
     dir: ./images/build/debian-base
     env:
@@ -16,6 +16,7 @@ steps:
       - PULL_BASE_REF=$_PULL_BASE_REF
       - IMAGE_VERSION=$_IMAGE_VERSION
       - CONFIG=$_CONFIG
+      - HOME=/root  # for docker buildx
     args:
       - all-push
 

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.3.0'
+    IMAGE_VERSION: 'buster-v1.4.0'
   stretch:
     CONFIG: 'stretch'
-    IMAGE_VERSION: 'stretch-v1.1.0'
+    IMAGE_VERSION: 'stretch-v1.2.0'

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -74,7 +74,8 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
-	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker buildx build \
+		--pull --platform linux/$(ARCH) -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -11,6 +11,7 @@ steps:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID
       - IMAGE=gcr.io/$PROJECT_ID/debian-hyperkube-base
+      - HOME=/root  # for docker buildx
     args:
       - all-push
 

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -45,9 +45,9 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
 endif
-
-	docker build \
+	docker buildx build \
 		--pull \
+		--platform linux/$(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: make
     dir: ./images/build/debian-iptables
     env:
@@ -17,6 +17,7 @@ steps:
       - CONFIG=$_CONFIG
       - DEBIAN_BASE_VERSION=$_DEBIAN_BASE_VERSION
       - IPTABLES_VERSION=$_IPTABLES_VERSION
+      - HOME=/root  # for docker buildx
     args:
       - all-push
 

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -8,7 +8,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'
     dir: ./images/build/go-runner
     env:

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -11,7 +11,7 @@ options:
 
 steps:
   # TODO: Update image version
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'
     dir: ./images/releng/k8s-ci-builder
     env:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This updates the `debian-{base,hyperkube-base,iptables}` images to use
docker buildx (aka buildkit) for multi architecture images.

The corresponding qemu version for `debian-base` has been bumped to
version 5.2.0.

#### Which issue(s) this PR fixes:

Working follow-up of https://github.com/kubernetes/release/pull/1849

#### Special notes for your reviewer:

/hold for discussion if we really want to bump qemu

#### Does this PR introduce a user-facing change?

```release-note
- Switch to docker buildx for building `debian-base`, `debian-iptables` and `debian-hyperkube-base` container images
```
