### PR TITLE
images: fix Archs expansion in makefile

### DIFF
--- a/images/Makefile.common-image
+++ b/images/Makefile.common-image
@@ -22,6 +22,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 # TODO: Uncomment once all images using this Makefile can be built on all
 #       supported Kubernetes server platforms.
 #PLATFORMS ?= linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
+ARCHS = $(patsubst linux/%,%,$(PLATFORMS))
 
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -56,8 +57,8 @@ push: container
 
 .PHONY: manifest
 manifest: push
-	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(IMAGE)-$(subst linux/,,$(firstword $(PLATFORMS))):$(IMAGE_VERSION)
-	@for platform in $(PLATFORMS); do docker manifest annotate --arch "$${platform##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${platform##*/}:${IMAGE_VERSION}; done
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(shell echo $(ARCHS) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(IMAGE_VERSION)~g")
+	@for platform in $(ARCHS); do docker manifest annotate --arch "$${platform}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${platform}:${IMAGE_VERSION}; done
 	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
 
 # enable buildx


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When we start the new build for `kube-cross` image we got this error

```
docker manifest create --amend gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1 gcr.io/k8s-staging-build-image/kube-cross-amd64:v1.15.7-canary-1
Created manifest list gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1
manifest for image gcr.io/k8s-staging-build-image/kube-cross-arm64:v1.15.7-canary-1 does not exist in gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1
manifest for image gcr.io/k8s-staging-build-image/kube-cross-ppc64le:v1.15.7-canary-1 does not exist in gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1
make: *** [/workspace/images/build/cross/../../Makefile.common-image:60: manifest] Error 1
ERROR
```

which looks like when we run the `docker manifest create --amend` we need to add all the images for the archs we built.

This piece of the make file https://github.com/kubernetes/release/blob/master/images/Makefile.common-image#L59 add the images to the command, but now we have more `platforms` and the command `subst` just replace one entry and not all entries in the `PLATFORMS` variable

for kube-cross we used to have just one platform and that works fine, but now we introduce more (can see in this PR: https://github.com/kubernetes/release/pull/1853/files) and the command broke.

this PR fix this issue by parsing the `PLATFORMS` and removing the `linux/` from the `PLATFORMS` variable.

before:
```
docker manifest create --amend gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1 gcr.io/k8s-staging-build-image/kube-cross-amd64:v1.15.7-canary-1
```

after the fix:

```
docker manifest create --amend gcr.io/k8s-staging-build-image/kube-cross:v1.15.7-canary-1 gcr.io/k8s-staging-build-image/kube-cross-amd64:v1.15.7-canary-1 gcr.io/k8s-staging-build-image/kube-cross-arm64:v1.15.7-canary-1 gcr.io/k8s-staging-build-image/kube-cross-ppc64le:v1.15.7-canary-1
```

/assign @justaugustus @saschagrunert @hasheddan @ameukam 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
images: fix Archs expansion in makefile
```
