### PR TITLE
Fix GCR authentication for base images

### DIFF
--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
-    entrypoint: make
+    entrypoint: bash
     dir: ./images/build/debian-base
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -18,7 +18,10 @@ steps:
       - CONFIG=$_CONFIG
       - HOME=/root  # for docker buildx
     args:
-      - all-push
+    - -c
+    - |
+      gcloud auth configure-docker && \
+      make all-push
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and

--- a/images/build/debian-hyperkube-base/cloudbuild.yaml
+++ b/images/build/debian-hyperkube-base/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
-    entrypoint: make
+    entrypoint: bash
     dir: ./images/build/debian-hyperkube-base
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,10 @@ steps:
       - IMAGE=gcr.io/$PROJECT_ID/debian-hyperkube-base
       - HOME=/root  # for docker buildx
     args:
-      - all-push
+    - -c
+    - |
+      gcloud auth configure-docker && \
+      make all-push
 
 tags:
 - 'debian-hyperkube-base'

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
-    entrypoint: make
+    entrypoint: bash
     dir: ./images/build/debian-iptables
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -19,7 +19,10 @@ steps:
       - IPTABLES_VERSION=$_IPTABLES_VERSION
       - HOME=/root  # for docker buildx
     args:
-      - all-push
+    - -c
+    - |
+      gcloud auth configure-docker && \
+      make all-push
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
The overwriting of `$HOME` during cloud build execution will cause that
we loose the pre-setup authentication with GCR. To fix the behavior we
now manually add a call to `gcloud auth configure-docker`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
