### PR TITLE
go-runner: bump image version

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,7 +95,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.2.3
+    version: buster-v2.2.4
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,7 +16,7 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.2.3
+IMAGE_VERSION ?= buster-v2.2.4
 CONFIG ?= buster
 
 # Build args

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -7,6 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
+
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.2.3'
+    IMAGE_VERSION: 'buster-v2.2.4'
     GO_VERSION: '1.15.7'
     DISTROLESS_IMAGE: 'static-debian10'


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The job failed last week (week Jan/18th 2021) with some `fatal error: unexpected signal during runtime execution` 
was trying to debug but did not find any path to follow.

The images were built locally (macos) with no issues and then submit manually the jobs to GCB and this time that passed with no errors:

https://console.cloud.google.com/cloud-build/builds/c1cb2983-4d0f-47df-8d12-33790ed3ccbf?project=k8s-staging-build-image

So bumping the version to have a new try and have prow to run the job

for more info: https://kubernetes.slack.com/archives/C2C40FMNF/p1611319947020900?thread_ts=1610736817.029800&cid=C2C40FMNF

This is part of the work described here: https://github.com/kubernetes/release/issues/1851


/assign @hasheddan @saschagrunert @puerco @xmudrii @ameukam 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
