### PR TITLE
Move shared hash functions into own package

### DIFF
--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// SHA512ForFile returns the hex-encoded sha512 hash for the provided filename.
+func SHA512ForFile(filename string) (string, error) {
+	return ForFile(filename, sha512.New())
+}
+
+// SHA256ForFile returns the hex-encoded sha256 hash for the provided filename.
+func SHA256ForFile(filename string) (string, error) {
+	return ForFile(filename, sha256.New())
+}
+
+// ForFile returns the hex-encoded hash for the provided filename and hasher.
+func ForFile(filename string, hasher hash.Hash) (string, error) {
+	if hasher == nil {
+		return "", errors.New("provided hasher is nil")
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", errors.Wrapf(err, "open file %s", filename)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logrus.Warnf("Unable to close file %q: %v", filename, err)
+		}
+	}()
+
+	hasher.Reset()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", errors.Wrapf(err, "hash file %s", filename)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash_test
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"hash"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	kHash "k8s.io/release/pkg/hash"
+)
+
+func TestSHA512ForFile(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func() string
+		expected    string
+		shouldError bool
+	}{
+		{ // success
+			prepare: func() string {
+				f, err := ioutil.TempFile("", "")
+				require.Nil(t, err)
+
+				_, err = f.WriteString("test")
+				require.Nil(t, err)
+
+				return f.Name()
+			},
+			expected: "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f88" +
+				"19a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc" +
+				"5fa9ad8e6f57f50028a8ff",
+			shouldError: false,
+		},
+		{ // error open file
+			prepare:     func() string { return "" },
+			shouldError: true,
+		},
+	} {
+		filename := tc.prepare()
+
+		res, err := kHash.SHA512ForFile(filename)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, res)
+		}
+	}
+}
+
+func TestSHA256ForFile(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func() string
+		expected    string
+		shouldError bool
+	}{
+		{ // success
+			prepare: func() string {
+				f, err := ioutil.TempFile("", "")
+				require.Nil(t, err)
+
+				_, err = f.WriteString("test")
+				require.Nil(t, err)
+
+				return f.Name()
+			},
+			expected:    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			shouldError: false,
+		},
+		{ // error open file
+			prepare:     func() string { return "" },
+			shouldError: true,
+		},
+	} {
+		filename := tc.prepare()
+
+		res, err := kHash.SHA256ForFile(filename)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, res)
+		}
+	}
+}
+
+func TestForFile(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func() (string, hash.Hash)
+		expected    string
+		shouldError bool
+	}{
+		{ // success
+			prepare: func() (string, hash.Hash) {
+				f, err := ioutil.TempFile("", "")
+				require.Nil(t, err)
+
+				_, err = f.WriteString("test")
+				require.Nil(t, err)
+
+				return f.Name(), sha1.New()
+			},
+			expected:    "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+			shouldError: false,
+		},
+		{ // error hasher is nil
+			prepare: func() (string, hash.Hash) {
+				return "", nil
+			},
+			shouldError: true,
+		},
+		{ // error file does not exist is nil
+			prepare: func() (string, hash.Hash) {
+				return "", sha256.New()
+			},
+			shouldError: true,
+		},
+	} {
+		filename, hasher := tc.prepare()
+
+		res, err := kHash.ForFile(filename, hasher)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, res)
+		}
+	}
+}

--- a/pkg/promobot/hash.go
+++ b/pkg/promobot/hash.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/xerrors"
 
 	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/filepromoter"
+	"k8s.io/release/pkg/hash"
 )
 
 // GenerateManifestOptions holds the parameters for a hash-files operation.
@@ -75,7 +75,7 @@ func GenerateManifest(ctx context.Context, options GenerateManifestOptions) (*ap
 
 		if !info.IsDir() {
 			relativePath := strings.TrimPrefix(p, basedir)
-			sha256, err := filepromoter.ComputeSHA256ForFile(p)
+			sha256, err := hash.SHA256ForFile(p)
 			if err != nil {
 				return xerrors.Errorf("error hashing file %q: %w", p, err)
 			}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Hashing files is a common task within this library, which means we now
expose a dedicated package to re-use the functionality. Tests have been
added as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `hash` package to unify file based hash creation
```
