### PR TITLE
debian-base:support for mips64le architecture.

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -24,7 +24,7 @@ CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH = amd64 arm arm64 ppc64le s390x mips64le
 
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v5.2.0-2
@@ -52,6 +52,10 @@ endif
 ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/debian:$(CONFIG)-slim
 	QEMUARCH=s390x
+endif
+ifeq ($(ARCH),mips64le)
+	BASEIMAGE?=debian:$(CONFIG)-slim
+	QEMUARCH=mips64el
 endif
 
 sub-build-%:

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 all: all-build
-
+ifneq ($(ARCH),mips64le)
 REGISTRY ?= gcr.io/k8s-staging-build-image
+else
+REGISTRY ?= gcr.io/k8s-staging-experimental
+endif
+
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 


### PR DESCRIPTION
I found that the current build image does not support the mips64le architecture. I am working on this aspect and hope to contribute local related patches to the community. Due to dependencies, I will continue to submit related patches and look forward to discussing.
```release-note
build infrastructure
```
@feiskyer
@saschagrunert
@justaugustus

