### PR TITLE
Cleanup buildx builder after its usage

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -85,8 +85,7 @@ else
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
-	docker buildx create --use
-	docker buildx inspect --bootstrap
+	BUILDER=$(shell docker buildx create --use)
 
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)/$(CONFIG)
 	# Ensure we don't get surprised by umask settings
@@ -113,6 +112,9 @@ endif
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		$(TEMP_DIR)/$(CONFIG)
 	rm -rf $(TEMP_DIR)
+ifneq ($(ARCH),amd64)
+	docker buildx rm $$BUILDER
+endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -76,8 +76,7 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
-	docker buildx create --use
-	docker buildx inspect --bootstrap
+	BUILDER=$(shell docker buildx create --use)
 endif
 	docker buildx build \
 		--pull \
@@ -86,6 +85,9 @@ endif
 		-t $(IMAGE)-$(ARCH):$(TAG) \
 		$(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
+ifneq ($(ARCH),amd64)
+	docker buildx rm $$BUILDER
+endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(TAG)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -46,8 +46,7 @@ ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
-	docker buildx create --use
-	docker buildx inspect --bootstrap
+	BUILDER=$(shell docker buildx create --use)
 endif
 	docker buildx build \
 		--pull \
@@ -58,6 +57,9 @@ endif
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		--build-arg=IPTABLES_VERSION=$(IPTABLES_VERSION) \
 		$(TEMP_DIR)/$(CONFIG)
+ifneq ($(ARCH),amd64)
+	docker buildx rm $$BUILDER
+endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
To not swamp a system with created builders we now sanely remove them after their usage.

We also removed the `docker buildx inspect --bootstrap` command because it does not output the previously created builder.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
