### PR TITLE
[go1.16] Build go1.16rc1 images

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.4.3-1
+IMAGE_VERSION ?= v0.4.3-2
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
@@ -28,7 +28,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.15.7
+GO_VERSION ?= 1.16rc1
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,6 +1,6 @@
 
 variants:
   default:
-    IMAGE_VERSION: 'v0.4.3-1'
-    GO_VERSION: '1.15.7'
+    IMAGE_VERSION: 'v0.4.3-2'
+    GO_VERSION: '1.16rc1'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -103,13 +103,13 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.15.7-2
+    version: v1.16.0-rc.1-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: config variant"
-    version: go1.15
+    version: go1.16
     refPaths:
     - path: images/build/cross/Makefile
       match: CONFIG \?= go\d+.\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,7 +95,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.2.4
+    version: buster-v2.3.0
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,7 +81,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "gcr.io/k8s-staging-releng/releng-ci"
-    version: v0.1.3
+    version: v0.2.0
     refPaths:
     - path: images/releng/ci/cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.15.7
+    version: 1.16rc1
     refPaths:
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
-    version: v0.4.3-1
+    version: v0.4.3-2
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.15.7-2
-CONFIG ?= go1.15
+IMAGE_VERSION ?= v1.16.0-rc.1-1
+CONFIG ?= go1.16
 
 # Build args
-GO_VERSION?=1.15.7
+GO_VERSION?=1.16rc1
 PROTOBUF_VERSION?=3.7.0
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,8 +1,14 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.7'
-    IMAGE_VERSION: 'v1.15.7-canary-2'
+    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'v1.16.0-rc.1-canary-1'
+    PROTOBUF_VERSION: '3.7.0'
+    ETCD_VERSION: 'v3.4.13'
+  go1.16:
+    CONFIG: 'go1.16'
+    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'v1.16.0-rc.1-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15:

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.2.4
+IMAGE_VERSION ?= buster-v2.3.0
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.15.7
+GO_VERSION ?= 1.16rc1
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.2.4'
-    GO_VERSION: '1.15.7'
+    IMAGE_VERSION: 'buster-v2.3.0'
+    GO_VERSION: '1.16rc1'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -24,8 +24,8 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.1.3'
-  _GO_VERSION: '1.15.7'
+  _IMAGE_VERSION: 'v0.2.0'
+  _GO_VERSION: '1.16rc1'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Update Golang-based images to go1.16rc1
- kube-cross: Build v1.16.0-rc.1-1 image
- go-runner: Build buster-v2.3.0 image
- releng-ci: Build v0.2.0 image
- vulndash: Build v0.4.3-2 image

Tracking issue for go1.16: https://github.com/kubernetes/release/issues/1834

/hold until upstream Golang images are available
cc: @kubernetes/release-engineering 
/assign @saschagrunert @hasheddan @cpanato 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Update Golang-based images to go1.16rc1
  - kube-cross: Build v1.16.0-rc.1-1 image
  - go-runner: Build buster-v2.3.0 image
  - releng-ci: Build v0.2.0 image
  - vulndash: Build v0.4.3-2 image
```
