### PR TITLE
relnotes: --list-v2 lookup PR numbers by merge commits

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -128,11 +128,11 @@ type releaseNotesOptions struct {
 	createWebsitePR    bool
 	dependencies       bool
 	fixNotes           bool
+	listReleaseNotesV2 bool
 	websiteRepo        string
 	mapProviders       []string
 	githubOrg          string
 	draftRepo          string
-	listReleaseNotesV2 bool
 }
 
 type releaseNotesResult struct {

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -121,17 +121,18 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 }
 
 type releaseNotesOptions struct {
-	repoPath        string
-	tag             string
-	userFork        string
-	createDraftPR   bool
-	createWebsitePR bool
-	dependencies    bool
-	fixNotes        bool
-	websiteRepo     string
-	mapProviders    []string
-	githubOrg       string
-	draftRepo       string
+	repoPath           string
+	tag                string
+	userFork           string
+	createDraftPR      bool
+	createWebsitePR    bool
+	dependencies       bool
+	fixNotes           bool
+	websiteRepo        string
+	mapProviders       []string
+	githubOrg          string
+	draftRepo          string
+	listReleaseNotesV2 bool
 }
 
 type releaseNotesResult struct {
@@ -210,6 +211,13 @@ func init() {
 		"fork",
 		"",
 		"the user's fork in the form org/repo. Used to submit Pull Requests for the website and draft",
+	)
+
+	releaseNotesCmd.PersistentFlags().BoolVar(
+		&releaseNotesOpts.listReleaseNotesV2,
+		"list-v2",
+		false,
+		"enable experimental implementation to list commits (ListReleaseNotesV2)",
 	)
 
 	rootCmd.AddCommand(releaseNotesCmd)
@@ -951,6 +959,7 @@ func gatherNotesFrom(repoPath, startTag string) (*notes.ReleaseNotes, error) {
 	notesOptions.EndRev = releaseNotesOpts.tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
+	notesOptions.ListReleaseNotesV2 = releaseNotesOpts.listReleaseNotesV2
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-github/v33 v33.0.0
 	github.com/google/licenseclassifier/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.1.4
+	github.com/mattn/go-isatty v0.0.12
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/GoogleCloudPlatform/testgrid v0.0.38
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.0
+	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/containers/image/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -125,7 +125,6 @@ github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/checkpoint-restore/go-criu/v4 v4.0.2/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
-github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
 github.com/cheggaaa/pb/v3 v3.0.5/go.mod h1:X1L61/+36nz9bjIsrDU52qHKOQukUQe2Ge+YvGuquCw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -124,6 +125,9 @@ github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/checkpoint-restore/go-criu/v4 v4.0.2/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
+github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
+github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
+github.com/cheggaaa/pb/v3 v3.0.5/go.mod h1:X1L61/+36nz9bjIsrDU52qHKOQukUQe2Ge+YvGuquCw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -211,6 +215,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -488,11 +493,15 @@ github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEX
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -934,6 +943,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -217,7 +217,7 @@ func New(
 		note := releaseNotes.Get(pr)
 
 		if note.DoNotPublish {
-			logrus.Infof("skipping PR %d as (marked to not be published)", pr)
+			logrus.Debugf("skipping PR %d as (marked to not be published)", pr)
 			continue
 		}
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -982,7 +982,9 @@ func prettifySIGList(sigs []string) string {
 // ApplyMap Modifies the content of the release using information from
 //  a ReleaseNotesMap
 func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap) error {
-	logrus.Infof("Applying map to note from PR %d", rn.PrNumber)
+	logrus.WithFields(logrus.Fields{
+		"pr": rn.PrNumber,
+	}).Debugf("Applying map to note")
 	reRenderMarkdown := false
 	if noteMap.ReleaseNote.Author != nil {
 		rn.Author = *noteMap.ReleaseNote.Author

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	gogithub "github.com/google/go-github/v33/github"
 	"github.com/nozzle/throttler"
@@ -245,10 +246,18 @@ func GatherReleaseNotes(opts *options.Options) (*ReleaseNotes, error) {
 		return nil, errors.Wrapf(err, "retrieving notes gatherer")
 	}
 
-	releaseNotes, err := gatherer.ListReleaseNotes()
+	var releaseNotes *ReleaseNotes
+	startTime := time.Now()
+	if gatherer.options.ListReleaseNotesV2 {
+		logrus.Warn("EXPERIMENTAL IMPLEMENTATION ListReleaseNotesV2 ENABLED")
+		releaseNotes, err = gatherer.ListReleaseNotesV2()
+	} else {
+		releaseNotes, err = gatherer.ListReleaseNotes()
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "listing release notes")
 	}
+	logrus.Infof("finished gathering release notes in %v", time.Since(startTime))
 
 	return releaseNotes, nil
 }
@@ -662,7 +671,7 @@ func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, e
 	prs, err := g.prsFromCommit(commit)
 	if err != nil {
 		if err == errNoPRIDFoundInCommitMessage || err == errNoPRFoundForCommitSHA {
-			logrus.Infof(
+			logrus.Debugf(
 				"No matches found when parsing PR from commit SHA %s",
 				commit.GetSHA(),
 			)
@@ -674,12 +683,12 @@ func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, e
 	for _, pr := range prs {
 		prBody := pr.GetBody()
 
-		logrus.Infof(
+		logrus.Debugf(
 			"Got PR #%d for commit: %s", pr.GetNumber(), commit.GetSHA(),
 		)
 
 		if MatchesExcludeFilter(prBody) {
-			logrus.Infof(
+			logrus.Debugf(
 				"Skipping PR #%d because it contains no release note",
 				pr.GetNumber(),
 			)
@@ -722,7 +731,7 @@ func (g *Gatherer) prsFromCommit(commit *gogithub.RepositoryCommit) (
 ) {
 	githubPRs, err := g.prsForCommitFromMessage(*commit.Commit.Message)
 	if err != nil {
-		logrus.Infof("No PR found for commit %s: %v", commit.GetSHA(), err)
+		logrus.Debugf("No PR found for commit %s: %v", commit.GetSHA(), err)
 		return g.prsForCommitFromSHA(*commit.SHA)
 	}
 	return githubPRs, err

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -222,10 +222,17 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 
 	// the stopping point to be set should be the last shared commit between release branch and primary (master) branch
 	// usually, following the left / first parents, it would be
-	// * tag: v1.20.0, some merge commit
+
+	// ^ master
 	// |
-	// * Anago GCB release commit (begin branch out of release-1.20)
+	// * tag: 1.21.0-alpha.x / 1.21.0-beta.y
 	// |
+	// : :
+	// | |
+	// | * tag: v1.20.0, some merge commit pointed by opts.StartSHA
+	// | |
+	// | * Anago GCB release commit (begin branch out of release-1.20)
+	// |/
 	// * last shared commit
 
 	// this means the stopping point is 2 commits behind the tag pointed by opts.StartSHA

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -72,6 +72,8 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 	bar := pb.New(pairsCount).SetWriter(os.Stdout).Start()
 
 	for _, pair := range pairs {
+		// pair needs to be scoped in parameter so that the specific variable read
+		// happens when the goroutine is declared, not when referenced inside
 		go func(pair *commitPrPair) {
 			noteMaps := []*ReleaseNotesMap{}
 			for _, provider := range mapProviders {

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -175,7 +175,6 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 		ActionRequired: labelExactMatch(pr, "release-note-action-required"),
 		DoNotPublish:   labelExactMatch(pr, "release-note-none"),
 	}, nil
-
 }
 
 func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair, error) {

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notes
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/release/pkg/notes/options"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	gitobject "github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/nozzle/throttler"
+	"github.com/sirupsen/logrus"
+)
+
+type commitPrPair struct {
+	Commit *gitobject.Commit
+	PrNum  int
+}
+
+type releaseNotesAggregator struct {
+	releaseNotes *ReleaseNotes
+	sync.RWMutex
+}
+
+func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
+	// left parent of Git commits is always the main branch parent
+	pairs, err := g.listLeftParentCommits(g.options)
+	if err != nil {
+		return nil, errors.Wrap(err, "listing offline commits")
+	}
+
+	// load map providers specified in options
+	mapProviders := []MapProvider{}
+	for _, initString := range g.options.MapProviderStrings {
+		provider, err := NewProviderFromInitString(initString)
+		if err != nil {
+			return nil, errors.Wrap(err, "while getting release notes map providers")
+		}
+		mapProviders = append(mapProviders, provider)
+	}
+
+	t := throttler.New(maxParallelRequests, len(pairs))
+
+	aggregator := releaseNotesAggregator{
+		releaseNotes: NewReleaseNotes(),
+	}
+
+	pairsCount := len(pairs)
+	logrus.Infof("processing release notes for %d commits", pairsCount)
+	bar := pb.Full.Start(pairsCount)
+
+	for _, pair := range pairs {
+		noteMaps := []*ReleaseNotesMap{}
+
+		for _, provider := range mapProviders {
+			noteMaps, err = provider.GetMapsForPR(pair.PrNum)
+			if err != nil {
+				logrus.Errorf("[ignored] pr: %d err: %v", pair.PrNum, err)
+				noteMaps = []*ReleaseNotesMap{}
+			}
+		}
+
+		go func() {
+			releaseNote, err := g.buildReleaseNote(pair)
+			if err == nil && releaseNote != nil {
+				for _, noteMap := range noteMaps {
+					if err := releaseNote.ApplyMap(noteMap); err != nil {
+						logrus.Errorf("[ignored] pr: %d err: %v", pair.PrNum, err)
+					}
+				}
+				aggregator.Lock()
+				aggregator.releaseNotes.Set(pair.PrNum, releaseNote)
+				aggregator.Unlock()
+			} else if err != nil {
+				logrus.Errorf("sha: %s pr: %d err: %v", pair.Commit.Hash.String(), pair.PrNum, err)
+			}
+			bar.Increment()
+			t.Done(nil)
+		}()
+
+		if t.Throttle() > 0 {
+			break
+		}
+	}
+
+	if err := t.Err(); err != nil {
+		return nil, err
+	}
+
+	bar.Finish()
+
+	return aggregator.releaseNotes, nil
+}
+
+func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
+	pr, _, err := g.client.GetPullRequest(g.context, g.options.GithubOrg, g.options.GithubRepo, pair.PrNum)
+	if err != nil {
+		return nil, err
+	}
+
+	prBody := pr.GetBody()
+
+	text, err := noteTextFromString(prBody)
+	if err != nil {
+		logrus.Debugf("sha: %s pr: %d err: %v", pair.Commit.Hash.String(), pair.PrNum, err)
+		return nil, nil
+	}
+
+	documentation := DocumentationFromString(prBody)
+
+	author := pr.GetUser().GetLogin()
+	authorURL := pr.GetUser().GetHTMLURL()
+	prURL := pr.GetHTMLURL()
+	isFeature := hasString(labelsWithPrefix(pr, "kind"), "feature")
+	noteSuffix := prettifySIGList(labelsWithPrefix(pr, "sig"))
+
+	isDuplicateSIG := false
+	if len(labelsWithPrefix(pr, "sig")) > 1 {
+		isDuplicateSIG = true
+	}
+
+	isDuplicateKind := false
+	if len(labelsWithPrefix(pr, "kind")) > 1 {
+		isDuplicateKind = true
+	}
+
+	// TODO(wilsonehusin): extract / follow original in ReleasenoteFromCommit
+	indented := strings.ReplaceAll(text, "\n", "\n  ")
+	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
+		indented, pr.GetNumber(), prURL, author, authorURL)
+
+	if noteSuffix != "" {
+		markdown = fmt.Sprintf("%s [%s]", markdown, noteSuffix)
+	}
+
+	// Uppercase the first character of the markdown to make it look uniform
+	markdown = strings.ToUpper(string(markdown[0])) + markdown[1:]
+
+	return &ReleaseNote{
+		Commit:         pair.Commit.Hash.String(),
+		Text:           text,
+		Markdown:       markdown,
+		Documentation:  documentation,
+		Author:         author,
+		AuthorURL:      authorURL,
+		PrURL:          prURL,
+		PrNumber:       pr.GetNumber(),
+		SIGs:           labelsWithPrefix(pr, "sig"),
+		Kinds:          labelsWithPrefix(pr, "kind"),
+		Areas:          labelsWithPrefix(pr, "area"),
+		Feature:        isFeature,
+		Duplicate:      isDuplicateSIG,
+		DuplicateKind:  isDuplicateKind,
+		ActionRequired: labelExactMatch(pr, "release-note-action-required"),
+		DoNotPublish:   labelExactMatch(pr, "release-note-none"),
+	}, nil
+
+}
+
+func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair, error) {
+	localRepository, err := git.PlainOpen(opts.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// opts.StartSHA points to a tag (e.g. 1.20.0) which is on a release branch (e.g. release-1.20)
+	// this means traveling through commit history from opts.EndSHA will never reach opts.StartSHA
+
+	// the stopping point to be set should be the last shared commit between release branch and primary (master) branch
+	// usually, following the left / first parents, it would be
+	// * tag: v1.20.0, some merge commit
+	// |
+	// * Anago GCB release commit (begin branch out of release-1.20)
+	// |
+	// * last shared commit
+
+	// this means the stopping point is 2 commits behind the tag pointed by opts.StartSHA
+
+	stopHash := plumbing.NewHash(opts.StartSHA)
+	for i := 0; i < 2; i++ {
+		commitObject, err := localRepository.CommitObject(stopHash)
+		if err != nil {
+			return nil, errors.Wrap(err, "finding last shared commit")
+		}
+		stopHash = commitObject.ParentHashes[0]
+	}
+
+	logrus.Infof("will stop at %s", stopHash)
+
+	currentTagHash := plumbing.NewHash(opts.EndSHA)
+
+	pairs := []*commitPrPair{}
+	hashPointer := currentTagHash
+	for hashPointer != stopHash {
+		hashString := hashPointer.String()
+
+		// Find and collect commit objects
+		commitPointer, err := localRepository.CommitObject(hashPointer)
+		if err != nil {
+			return nil, errors.Wrap(err, "finding CommitObject")
+		}
+
+		// Find and collect PR number from commit message
+		prNums, err := prsNumForCommitFromMessage(commitPointer.Message)
+		if err == errNoPRIDFoundInCommitMessage {
+			logrus.Debugf("sha: %s prs: []", hashString)
+
+			// Advance pointer based on left parent
+			hashPointer = commitPointer.ParentHashes[0]
+			continue
+		}
+		if err != nil {
+			logrus.Warnf("sha: %s err: %s (silenced)", hashString, err.Error())
+
+			// Advance pointer based on left parent
+			hashPointer = commitPointer.ParentHashes[0]
+			continue
+		}
+		logrus.Debugf("sha: %s prs: %v", hashString, prNums)
+
+		// Only taking the first one, assuming they are merged by Prow
+		pairs = append(pairs, &commitPrPair{Commit: commitPointer, PrNum: prNums[0]})
+
+		// Advance pointer based on left parent
+		hashPointer = commitPointer.ParentHashes[0]
+	}
+
+	return pairs, nil
+}

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	gitobject "github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/mattn/go-isatty"
 	"github.com/nozzle/throttler"
 	"github.com/sirupsen/logrus"
 )
@@ -69,7 +70,14 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 
 	pairsCount := len(pairs)
 	logrus.Infof("processing release notes for %d commits", pairsCount)
-	bar := pb.New(pairsCount).SetWriter(os.Stdout).Start()
+
+	// display progress bar in stdout, since stderr is used by logger
+	bar := pb.New(pairsCount).SetWriter(os.Stdout)
+
+	// only display progress bar in user TTY
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		bar.Start()
+	}
 
 	for _, pair := range pairs {
 		// pair needs to be scoped in parameter so that the specific variable read

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -105,6 +105,9 @@ type Options struct {
 	// log level
 	Debug bool
 
+	// EXPERIMENTAL: Feature flag for using v2 implementation to list commits
+	ListReleaseNotesV2 bool
+
 	// RecordDir specifies the directory for API call recordings. Cannot be
 	// used together with ReplayDir.
 	RecordDir string
@@ -118,9 +121,6 @@ type Options struct {
 
 	// MapProviders list of release notes map providers to query during generations
 	MapProviderStrings []string
-
-	// EXPERIMENTAL: Feature flag for using v2 implementation to list commits
-	ListReleaseNotesV2 bool
 }
 
 type RevisionDiscoveryMode string

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -118,6 +118,9 @@ type Options struct {
 
 	// MapProviders list of release notes map providers to query during generations
 	MapProviderStrings []string
+
+	// EXPERIMENTAL: Feature flag for using v2 implementation to list commits
+	ListReleaseNotesV2 bool
 }
 
 type RevisionDiscoveryMode string


### PR DESCRIPTION
Signed-off-by: Wilson E. Husin <whusin@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This introduces an experimental change behind a feature flag `--list-v2` for `krel release-notes`. 
See release notes for details.

Some benchmarks running on `1.21.0-alpha.2`:
- GitHub API call to get list of commits vs local copy Git tree traversal
  ```
  # GitHub API call
  INFO finished getting list of commits: 2048.06ms
  ```
  ```
  # Local copy traversal
  INFO finished getting list of commits: 37.92ms
  ```
- Looking up PR numbers for _all_ commits vs only from merge commits
  ```
  # Find PR number from *all* commits (triggered anti-abuse limit once)
  INFO finished gathering release notes in 1m41.465202636s
  ```
  ```
  # Find PR number from *merge* commits
  INFO finished gathering release notes in 21.363669925s
  ```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer:

This is initial steps towards making `krel release-notes` workflow more reliable and less manual intervention.

TODO:
- [x] update & clarify in-code documentation of rewinding commit
- [x] ensuring this mechanism works for patch releases
- [x] `NONE` detection even when `release-notes-none` label is not present, [case on point](https://github.com/kubernetes/release/pull/1888#issuecomment-771923305)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Downgrade logs on attempting to lookup PRs by commit to Debug as they are filling up console noisily, obstructing the progress log.
- Introducing `--list-v2` feature flag to `krel release-notes`. Behind a feature gate:
  - Looks up for the commit history from the local copy of k/k instead of GitHub API call.
  - The new approach traverses Git history by left parents, only looking for PR information from the merge commits and thus reducing the API calls to GitHub, which should decrease the amount of rate limit errors users are receiving.
  - Incidentally, this fixes a "bug" in previous implementation of including a "merged in the future" PR.
```

1.21 Release Notes team: Making this visible to you all -- if you're interested please give it a try and do a comparison. Same workflow, just add `--list-v2` flag after you clone this.
/cc @ashnehete @melodychn @pmmalinov01 @soniasingla 

Recent contributors to `krel release-notes`: Let me know what you all think! (also hi Chris! I haven't worked with you but have seen your work around release notes JSON, making this visible to you in case it's of interest)
/cc @puerco @saschagrunert @cartyc 

For discussion, probably going to let this up for a while and give folks a chance to comment (if you're not mentioned above and have thoughts, please send them over!)
/hold