### PR TITLE
Allow specifying RepoRoot

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -52,7 +52,7 @@ type Options struct {
 	// Specify an alternate bucket for pushes (normally 'devel' or 'ci').
 	Bucket string
 
-	// Specify an alternate build directory. Will be automatically determined
+	// Specify an alternate build directory (relative to RepoRoot). Will be automatically determined
 	// if not set.
 	BuildDir string
 
@@ -64,6 +64,10 @@ type Options struct {
 
 	// If set, push docker images to specified registry/project.
 	Registry string
+
+	// Absolute path to the kubernetes repository root directory
+	// defaults to current working directory
+	RepoRoot string
 
 	// Comma separated list which can be used to upload additional version
 	// files to GCS. The path is relative and is append to a GCS path. (--ci

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"testing"
+)
+
+func TestBuildDirFromRepoRoot(t *testing.T) {
+	testCases := []struct {
+		name             string
+		instance         *Instance
+		isBazel          bool
+		expectedBuildDir string
+	}{
+		{
+			name: "empty repoRoot",
+			instance: &Instance{
+				opts: &Options{
+					Version: "fakeVersion",
+				},
+			},
+			expectedBuildDir: "_output",
+		},
+		{
+			name: "non-empty repoRoot, bazel",
+			instance: &Instance{
+				opts: &Options{
+					Version:  "fakeVersion",
+					RepoRoot: "/fake/repo/root",
+				},
+			},
+			isBazel:          true,
+			expectedBuildDir: "/fake/repo/root/bazel-bin/build",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			setupBuildDir(tc.instance, tc.isBazel)
+			if tc.instance.opts.BuildDir != tc.expectedBuildDir {
+				t.Errorf("buildDir mismatched, got: %v, want: %v", tc.instance.opts.BuildDir, tc.expectedBuildDir)
+			}
+		})
+	}
+}

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -32,11 +32,14 @@ import (
 // Build starts a Kubernetes build with the options defined in the build
 // `Instance`.
 func (bi *Instance) Build() error {
-	workingDir, dirErr := os.Getwd()
-	if dirErr != nil {
-		return errors.Wrapf(dirErr, "getting working directory")
+	workingDir := bi.opts.RepoRoot
+	if workingDir == "" {
+		var dirErr error
+		workingDir, dirErr = os.Getwd()
+		if dirErr != nil {
+			return errors.Wrapf(dirErr, "getting working directory")
+		}
 	}
-
 	logrus.Infof("Current working directory: %s", workingDir)
 
 	workingDirRelative := filepath.Base(workingDir)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add a RepoRoot option to build `Options` to override assuming current working directory as the kubernetes repo root.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/1891

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

I went the route of setting up the buildDir derived from the RepoRoot, since that's used in most places further down. 

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/cc @saschagrunert @BenTheElder 