### PR TITLE
Build images using golang 1.15.8

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.4.3-2
+IMAGE_VERSION ?= v0.4.3-3
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
@@ -28,7 +28,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16rc1
+GO_VERSION ?= 1.15.8
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,6 +1,6 @@
 
 variants:
   default:
-    IMAGE_VERSION: 'v0.4.3-2'
-    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'v0.4.3-3'
+    GO_VERSION: '1.15.8'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,7 +95,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: buster-v2.3.0
+    version: buster-v2.3.1
     refPaths:
     - path: images/build/go-runner/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
-    version: v0.4.3-2
+    version: v0.4.3-3
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.16rc1
+    version: 1.15.8
     refPaths:
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -103,13 +103,13 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.16.0-rc.1-1
+    version: v1.15.8-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: config variant"
-    version: go1.16
+    version: go1.15
     refPaths:
     - path: images/build/cross/Makefile
       match: CONFIG \?= go\d+.\d+
@@ -117,7 +117,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.15.7-2
+    version: v1.15.8-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,7 +81,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "gcr.io/k8s-staging-releng/releng-ci"
-    version: v0.2.0
+    version: v0.2.1
     refPaths:
     - path: images/releng/ci/cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.16.0-rc.1-1
-CONFIG ?= go1.16
+IMAGE_VERSION ?= v1.15.8-1
+CONFIG ?= go1.15
 
 # Build args
-GO_VERSION?=1.16rc1
+GO_VERSION?=1.15.8
 PROTOBUF_VERSION?=3.7.0
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.16rc1'
-    IMAGE_VERSION: 'v1.16.0-rc.1-canary-1'
+    GO_VERSION: '1.15.8'
+    IMAGE_VERSION: 'v1.15.8-canary-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.16:
@@ -13,7 +13,7 @@ variants:
     ETCD_VERSION: 'v3.4.13'
   go1.15:
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.7'
-    IMAGE_VERSION: 'v1.15.7-2'
+    GO_VERSION: '1.15.8'
+    IMAGE_VERSION: 'v1.15.8-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -16,11 +16,11 @@
 include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
 
 IMGNAME = go-runner
-IMAGE_VERSION ?= buster-v2.3.0
+IMAGE_VERSION ?= buster-v2.3.1
 CONFIG ?= buster
 
 # Build args
-GO_VERSION ?= 1.16rc1
+GO_VERSION ?= 1.15.8
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.3.0'
-    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'buster-v2.3.1'
+    GO_VERSION: '1.15.8'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.7-2'
+    KUBE_CROSS_VERSION: 'v1.15.8-1'
     SKOPEO_VERSION: 'v1.2.0'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -24,8 +24,8 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.2.0'
-  _GO_VERSION: '1.16rc1'
+  _IMAGE_VERSION: 'v0.2.1'
+  _GO_VERSION: '1.15.8'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:
Go 1.15.8 was released on Feb 4th 2021: https://groups.google.com/g/golang-announce/c/rUbPPotvaFM

This PR bumps the golang version to 1.15.8 in the following images: kube-cross, go-runner, vulndash, releng-ci

#### Which issue(s) this PR fixes:

Part of #1895 

#### Special notes for your reviewer:

My first attempt at a golang bump. I built this PR following @ameukam's work on 1.15.7

#### Does this PR introduce a user-facing change?

```release-note
Golang bump to 1.15.8 resulting in the following new images:
- kube-cross:v1.15.8-1
- go-runner:buster-v2.3.1
- vulndash:v0.4.3-3
- releng-ci:v0.2.1
```
