### PR TITLE
releng: kube-cross set canary to use go 1.16

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   canary:
     CONFIG: 'canary'
-    GO_VERSION: '1.15.8'
-    IMAGE_VERSION: 'v1.15.8-canary-1'
+    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'v1.16.0-rc.1-canary-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.16:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

this reverts the change made here: https://github.com/kubernetes/release/pull/1896 for kubecross, the canary I think should stay to use go 1.16

#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/assign @justaugustus @saschagrunert @puerco 