### PR TITLE
Promote v1 API

### DIFF
--- a/cmd/cip-mm/main.go
+++ b/cmd/cip-mm/main.go
@@ -23,8 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/log"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/log"
 )
 
 var cmd = &cobra.Command{

--- a/cmd/gcbuilder/cmd/root.go
+++ b/cmd/gcbuilder/cmd/root.go
@@ -23,8 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/gcp/build"
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/gcp/build"
+	"k8s.io/release/v1/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/gcbuilder/main.go
+++ b/cmd/gcbuilder/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/gcbuilder/cmd"
+import "k8s.io/release/v1/cmd/gcbuilder/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/gh2gcs/README.md
+++ b/cmd/gh2gcs/README.md
@@ -13,7 +13,7 @@ Google Cloud has [documentation on installing and configuring the Google Cloud S
 The simplest way to install the `gh2gcs` CLI is via `go get`:
 
 ```
-$ go get k8s.io/release/cmd/gh2gcs
+$ go get k8s.io/release/v1/cmd/gh2gcs
 ```
 
 This will install `gh2gcs` to `$(go env GOPATH)/bin/gh2gcs`.

--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -28,10 +28,10 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/gh2gcs"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/gh2gcs"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/gh2gcs/main.go
+++ b/cmd/gh2gcs/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/gh2gcs/cmd"
+import "k8s.io/release/v1/cmd/gh2gcs/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/kpromo/cmd/manifest/files.go
+++ b/cmd/kpromo/cmd/manifest/files.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/promobot"
+	"k8s.io/release/v1/pkg/promobot"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/kpromo/cmd/root.go
+++ b/cmd/kpromo/cmd/root.go
@@ -22,9 +22,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/cmd/kpromo/cmd/manifest"
-	"k8s.io/release/cmd/kpromo/cmd/run"
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/cmd/kpromo/cmd/manifest"
+	"k8s.io/release/v1/cmd/kpromo/cmd/run"
+	"k8s.io/release/v1/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/promobot"
+	"k8s.io/release/v1/pkg/promobot"
 )
 
 // filesCmd represents the subcommand for `kpromo run files`

--- a/cmd/kpromo/main.go
+++ b/cmd/kpromo/main.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/kpromo/cmd"
+import "k8s.io/release/v1/cmd/kpromo/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -30,7 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 const (

--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -23,10 +23,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/http"
-	"k8s.io/release/pkg/mail"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/http"
+	"k8s.io/release/v1/pkg/mail"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/cmd/krel/cmd/changelog.go
+++ b/cmd/krel/cmd/changelog.go
@@ -24,8 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/changelog"
-	"k8s.io/release/pkg/github"
+	"k8s.io/release/v1/pkg/changelog"
+	"k8s.io/release/v1/pkg/github"
 )
 
 // changelogCmd represents the subcommand for `krel changelog`

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/changelog"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/changelog"
+	"k8s.io/release/v1/pkg/git"
 )
 
 func (s *sut) getChangelogOptions(tag string) *changelog.Options {

--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/release"
 )
 
 const ciBuildCmdDescription = `

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/fastforward"
-	kgit "k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/fastforward"
+	kgit "k8s.io/release/v1/pkg/git"
 )
 
 var ffOpts = &fastforward.Options{}

--- a/cmd/krel/cmd/ff_test.go
+++ b/cmd/krel/cmd/ff_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/fastforward"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/fastforward"
+	"k8s.io/release/v1/pkg/git"
 )
 
 func (s *sut) getFfOptions() *fastforward.Options {

--- a/cmd/krel/cmd/history.go
+++ b/cmd/krel/cmd/history.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/gcp/gcb"
 )
 
 var historyOpts = gcb.NewHistoryOptions()

--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -28,11 +28,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/release"
 )
 
 const pushCmdDescription = `

--- a/cmd/krel/cmd/release.go
+++ b/cmd/krel/cmd/release.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/anago"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/anago"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // releaseCmd represents the subcommand for `krel release`

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -35,14 +35,14 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/editor"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/document"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/editor"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/document"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/cmd/krel/cmd/root.go
+++ b/cmd/krel/cmd/root.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/log"
 )
 
 const (

--- a/cmd/krel/cmd/stage.go
+++ b/cmd/krel/cmd/stage.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/anago"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/anago"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // stageCmd represents the subcommand for `krel stage`

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -32,10 +32,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/http"
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/http"
+	"k8s.io/release/v1/pkg/object"
 )
 
 const (

--- a/cmd/krel/cmd/version.go
+++ b/cmd/krel/cmd/version.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/version"
+	"k8s.io/release/v1/pkg/version"
 )
 
 type versionOptions struct {

--- a/cmd/krel/main.go
+++ b/cmd/krel/main.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/krel/cmd"
+import "k8s.io/release/v1/cmd/krel/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/kubepkg/cmd/debs.go
+++ b/cmd/kubepkg/cmd/debs.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/kubepkg/options"
+	"k8s.io/release/v1/pkg/kubepkg/options"
 )
 
 // debsCmd represents the base command when called without any subcommands

--- a/cmd/kubepkg/cmd/root.go
+++ b/cmd/kubepkg/cmd/root.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/kubepkg"
-	"k8s.io/release/pkg/kubepkg/options"
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/kubepkg"
+	"k8s.io/release/v1/pkg/kubepkg/options"
+	"k8s.io/release/v1/pkg/log"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/kubepkg/cmd/rpms.go
+++ b/cmd/kubepkg/cmd/rpms.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/kubepkg/options"
+	"k8s.io/release/v1/pkg/kubepkg/options"
 )
 
 // rpmsCmd represents the base command when called without any subcommands

--- a/cmd/kubepkg/main.go
+++ b/cmd/kubepkg/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/kubepkg/cmd"
+import "k8s.io/release/v1/cmd/kubepkg/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/release/pkg/announce"
+	"k8s.io/release/v1/pkg/announce"
 )
 
 // releaseNotesCmd represents the subcommand for `krel release-notes`

--- a/cmd/publish-release/cmd/root.go
+++ b/cmd/publish-release/cmd/root.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/log"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/publish-release/main.go
+++ b/cmd/publish-release/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"k8s.io/release/cmd/publish-release/cmd"
+	"k8s.io/release/v1/cmd/publish-release/cmd"
 )
 
 func main() {

--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -7,7 +7,7 @@ This directory contains a tool called `release-notes` and a set of library utili
 The simplest way to install the `release-notes` CLI is via `go get`:
 
 ```
-GO111MODULE=on go get k8s.io/release/cmd/release-notes
+GO111MODULE=on go get k8s.io/release/v1/cmd/release-notes
 ```
 
 This will install `release-notes` to `$(go env GOPATH)/bin/release-notes`.

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -28,13 +28,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/log"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/document"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/log"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/document"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 	"sigs.k8s.io/mdtoc/pkg/mdtoc"
 )
 

--- a/cmd/schedule-builder/README.md
+++ b/cmd/schedule-builder/README.md
@@ -7,7 +7,7 @@ This simple tool has the objective to parse the yaml file located in [SIG-Releas
 The simplest way to install the `schedule-builder` CLI is via `go get`:
 
 ```
-$ go get k8s.io/release/cmd/schedule-builder
+$ go get k8s.io/release/v1/cmd/schedule-builder
 ```
 
 This will install `schedule-builder` to `$(go env GOPATH)/bin/schedule-builder`.

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/schedule-builder/main.go
+++ b/cmd/schedule-builder/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/schedule-builder/cmd"
+import "k8s.io/release/v1/cmd/schedule-builder/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/vulndash/cmd/root.go
+++ b/cmd/vulndash/cmd/root.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8s.io/release/pkg/log"
-	adapter "k8s.io/release/pkg/vulndash/adapter"
+	"k8s.io/release/v1/pkg/log"
+	adapter "k8s.io/release/v1/pkg/vulndash/adapter"
 )
 
 var validRegistryHostnames = []string{"gcr.io", "us.gcr.io", "asia.gcr.io", "eu.gcr.io"}

--- a/cmd/vulndash/main.go
+++ b/cmd/vulndash/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "k8s.io/release/cmd/vulndash/cmd"
+import "k8s.io/release/v1/cmd/vulndash/cmd"
 
 func main() {
 	cmd.Execute()

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -69,7 +69,7 @@ compile_with_flags() {
   local tool="$1"
 
   git_tree_state=dirty
-  pkg=k8s.io/release/pkg/version
+  pkg=k8s.io/release/v1/pkg/version
 
   if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then
     git_tree_state=clean

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module k8s.io/release
+module k8s.io/release/v1
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1242,6 +1242,7 @@ k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/legacy-cloud-providers v0.18.8/go.mod h1:tgp4xYf6lvjrWnjQwTOPvWQE9IVqSBGPF4on0IyICQE=
 k8s.io/release v0.3.2-0.20200513161026-05b87eb96960/go.mod h1:fcMNfhJFSHSBFv4BSrzJV2mesdz3yJeEqsqKs8cxjGU=
+k8s.io/release v0.4.2 h1:GlhSh0dciGwtbEFFpYLVjW0326f+DtM2XwxTtWTHtks=
 k8s.io/release v0.4.2/go.mod h1:Kuj+iBm1aa/xxVyK8SVHrmxXn3g1IZUlB3ekJwx+NTw=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -36,5 +36,5 @@ done
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./... | grep -v k8s.io/release/cmd)
+GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./... | grep -v k8s.io/release/v1/cmd)
 go tool cover -html coverage.out -o coverage.html

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/log"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
-	"k8s.io/release/pkg/version"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/log"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
+	"k8s.io/release/v1/pkg/version"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/anago"
-	"k8s.io/release/pkg/anago/anagofakes"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/anago"
+	"k8s.io/release/v1/pkg/anago/anagofakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 var err = errors.New("error")

--- a/pkg/anago/anagofakes/fake_release_impl.go
+++ b/pkg/anago/anagofakes/fake_release_impl.go
@@ -21,11 +21,11 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"k8s.io/release/pkg/announce"
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/announce"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeReleaseImpl struct {

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -21,11 +21,11 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/changelog"
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/changelog"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeStageImpl struct {

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -25,14 +25,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/announce"
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/log"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/announce"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/log"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // releaseClient is a client for release a previously staged release.

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/anago"
-	"k8s.io/release/pkg/anago/anagofakes"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/anago"
+	"k8s.io/release/v1/pkg/anago/anagofakes"
+	"k8s.io/release/v1/pkg/release"
 )
 
 func generateTestingReleaseState(params *testStateParameters) *anago.ReleaseState {

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -26,12 +26,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/changelog"
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/log"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/changelog"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/log"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // stageClient is a client for staging releases.

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/anago"
-	"k8s.io/release/pkg/anago/anagofakes"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/anago"
+	"k8s.io/release/v1/pkg/anago/anagofakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 func generateTestingStageState(params *testStateParameters) *anago.StageState {

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -26,10 +26,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -28,10 +28,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/hash"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/hash"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // ghPageBody is a generic template to build the GitHub

--- a/pkg/api/files/manifest_test.go
+++ b/pkg/api/files/manifest_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/release/pkg/api/files"
+	"k8s.io/release/v1/pkg/api/files"
 )
 
 func TestValidateFilestores(t *testing.T) {

--- a/pkg/api/files/validation.go
+++ b/pkg/api/files/validation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/object"
 )
 
 // Validate checks for semantic errors in the yaml fields (the structure of the

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/binary"
-	"k8s.io/release/pkg/binary/binaryfakes"
+	"k8s.io/release/v1/pkg/binary"
+	"k8s.io/release/v1/pkg/binary/binaryfakes"
 )
 
 type TestHeader struct {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/release"
 )
 
 var DefaultExtraVersionMarkers = []string{}

--- a/pkg/build/buildfakes/fake_impl.go
+++ b/pkg/build/buildfakes/fake_impl.go
@@ -20,7 +20,7 @@ package buildfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 type FakeImpl struct {

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -24,9 +24,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/gcp/auth"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/gcp/auth"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // Build starts a Kubernetes build with the options defined in the build

--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/pkg/build/make_test.go
+++ b/pkg/build/make_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/build"
-	"k8s.io/release/pkg/build/buildfakes"
+	"k8s.io/release/v1/pkg/build"
+	"k8s.io/release/v1/pkg/build/buildfakes"
 )
 
 var err = errors.New("error")

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -28,9 +28,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/tar"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/tar"
+	"k8s.io/release/v1/pkg/util"
 )
 
 type stageFile struct {

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -29,9 +29,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // Options are the main settings for generating the changelog.

--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/changelog"
-	"k8s.io/release/pkg/changelog/changelogfakes"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/notes"
+	"k8s.io/release/v1/pkg/changelog"
+	"k8s.io/release/v1/pkg/changelog/changelogfakes"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/notes"
 )
 
 func TestRun(t *testing.T) {

--- a/pkg/changelog/changelogfakes/fake_impl.go
+++ b/pkg/changelog/changelogfakes/fake_impl.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/yuin/goldmark/parser"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/document"
-	"k8s.io/release/pkg/notes/options"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/document"
+	"k8s.io/release/v1/pkg/notes/options"
 )
 
 type FakeImpl struct {

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -29,13 +29,13 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"sigs.k8s.io/mdtoc/pkg/mdtoc"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/http"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/document"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/http"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/document"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/util"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/pkg/cip/audit/auditor.go
+++ b/pkg/cip/audit/auditor.go
@@ -28,10 +28,10 @@ import (
 	"cloud.google.com/go/errorreporting"
 	"github.com/sirupsen/logrus"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/logclient"
-	"k8s.io/release/pkg/cip/remotemanifest"
-	"k8s.io/release/pkg/cip/report"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/cip/logclient"
+	"k8s.io/release/v1/pkg/cip/remotemanifest"
+	"k8s.io/release/v1/pkg/cip/report"
 )
 
 // InitRealServerContext creates a ServerContext with facilities that are meant

--- a/pkg/cip/audit/auditor_test.go
+++ b/pkg/cip/audit/auditor_test.go
@@ -27,12 +27,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/cip/audit"
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/logclient"
-	"k8s.io/release/pkg/cip/remotemanifest"
-	"k8s.io/release/pkg/cip/report"
-	"k8s.io/release/pkg/cip/stream"
+	"k8s.io/release/v1/pkg/cip/audit"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/cip/logclient"
+	"k8s.io/release/v1/pkg/cip/remotemanifest"
+	"k8s.io/release/v1/pkg/cip/report"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 func TestParsePubSubMessageBody(t *testing.T) {

--- a/pkg/cip/audit/types.go
+++ b/pkg/cip/audit/types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package audit
 
 import (
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/logclient"
-	"k8s.io/release/pkg/cip/remotemanifest"
-	"k8s.io/release/pkg/cip/report"
-	"k8s.io/release/pkg/cip/stream"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/cip/logclient"
+	"k8s.io/release/v1/pkg/cip/remotemanifest"
+	"k8s.io/release/v1/pkg/cip/report"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 // GcrReadingFacility holds functions used to create streams for reading the

--- a/pkg/cip/cli/audit.go
+++ b/pkg/cip/cli/audit.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/cip/audit"
+	"k8s.io/release/v1/pkg/cip/audit"
 )
 
 type AuditOptions struct {

--- a/pkg/cip/cli/run.go
+++ b/pkg/cip/cli/run.go
@@ -23,9 +23,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/gcloud"
-	"k8s.io/release/pkg/cip/stream"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/cip/gcloud"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 type RunOptions struct {

--- a/pkg/cip/cli/version.go
+++ b/pkg/cip/cli/version.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/release/pkg/version"
+	"k8s.io/release/v1/pkg/version"
 )
 
 type VersionOptions struct {

--- a/pkg/cip/dockerregistry/checks.go
+++ b/pkg/cip/dockerregistry/checks.go
@@ -34,7 +34,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/release/pkg/cip/stream"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 // MBToBytes converts a value from MiB to Bytes.

--- a/pkg/cip/dockerregistry/checks_test.go
+++ b/pkg/cip/dockerregistry/checks_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
 )
 
 func TestImageRemovalCheck(t *testing.T) {

--- a/pkg/cip/dockerregistry/grow_manifest_test.go
+++ b/pkg/cip/dockerregistry/grow_manifest_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
 )
 
 func TestFindManifest(t *testing.T) {

--- a/pkg/cip/dockerregistry/inventory.go
+++ b/pkg/cip/dockerregistry/inventory.go
@@ -38,9 +38,9 @@ import (
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"k8s.io/release/pkg/cip/gcloud"
-	cipJson "k8s.io/release/pkg/cip/json"
-	"k8s.io/release/pkg/cip/stream"
+	"k8s.io/release/v1/pkg/cip/gcloud"
+	cipJson "k8s.io/release/v1/pkg/cip/json"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 // GetSrcRegistry gets the source registry.

--- a/pkg/cip/dockerregistry/inventory_test.go
+++ b/pkg/cip/dockerregistry/inventory_test.go
@@ -27,9 +27,9 @@ import (
 	cr "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
-	"k8s.io/release/pkg/cip/json"
-	"k8s.io/release/pkg/cip/stream"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
+	"k8s.io/release/v1/pkg/cip/json"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 type ParseJSONStreamResult struct {

--- a/pkg/cip/dockerregistry/set.go
+++ b/pkg/cip/dockerregistry/set.go
@@ -17,7 +17,7 @@ limitations under the License.
 package inventory
 
 import (
-	"k8s.io/release/pkg/cip/container"
+	"k8s.io/release/v1/pkg/cip/container"
 )
 
 // Various set manipulation operations. Some set operations are missing,

--- a/pkg/cip/dockerregistry/types.go
+++ b/pkg/cip/dockerregistry/types.go
@@ -23,8 +23,8 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"k8s.io/release/pkg/cip/gcloud"
-	"k8s.io/release/pkg/cip/stream"
+	"k8s.io/release/v1/pkg/cip/gcloud"
+	"k8s.io/release/v1/pkg/cip/stream"
 )
 
 // RequestResult contains information about the result of running a request

--- a/pkg/cip/remotemanifest/fake.go
+++ b/pkg/cip/remotemanifest/fake.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "k8s.io/release/pkg/cip/dockerregistry"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
 )
 
 // Fake is a fake remote manifest. It is fake in the sense that it

--- a/pkg/cip/remotemanifest/git.go
+++ b/pkg/cip/remotemanifest/git.go
@@ -27,7 +27,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	reg "k8s.io/release/pkg/cip/dockerregistry"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
 )
 
 const (

--- a/pkg/cip/remotemanifest/types.go
+++ b/pkg/cip/remotemanifest/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "k8s.io/release/pkg/cip/dockerregistry"
+	reg "k8s.io/release/v1/pkg/cip/dockerregistry"
 )
 
 // Facility requires a single method, called Fetch(), which corresponds to

--- a/pkg/fastforward/fastforward.go
+++ b/pkg/fastforward/fastforward.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	kgit "k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/util"
+	kgit "k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // Options is the main structure for configuring a fast forward.

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/hash"
+	api "k8s.io/release/v1/pkg/api/files"
+	"k8s.io/release/v1/pkg/hash"
 )
 
 // syncFileInfo tracks a file during the synchronization operation.

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -27,8 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 
-	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/object"
+	api "k8s.io/release/v1/pkg/api/files"
+	"k8s.io/release/v1/pkg/object"
 )
 
 // FilestorePromoter manages the promotion of files.

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -29,8 +29,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/object"
+	api "k8s.io/release/v1/pkg/api/files"
+	"k8s.io/release/v1/pkg/object"
 )
 
 type gcsSyncFilestore struct {

--- a/pkg/filepromoter/manifest.go
+++ b/pkg/filepromoter/manifest.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	api "k8s.io/release/pkg/api/files"
+	api "k8s.io/release/v1/pkg/api/files"
 )
 
 // ManifestPromoter promotes files as described in Manifest.

--- a/pkg/filepromoter/token.go
+++ b/pkg/filepromoter/token.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	"k8s.io/release/pkg/cip/gcloud"
+	"k8s.io/release/v1/pkg/cip/gcloud"
 )
 
 // gcloudTokenSource implements oauth2.TokenSource.

--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/release/pkg/gcp"
+	"k8s.io/release/v1/pkg/gcp"
 )
 
 func GetCurrentGCPUser() (string, error) {

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -35,11 +35,11 @@ import (
 	"google.golang.org/api/cloudbuild/v1"
 	"google.golang.org/api/option"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/tar"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/tar"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -29,12 +29,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/gcp/auth"
-	"k8s.io/release/pkg/gcp/build"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/gcp/auth"
+	"k8s.io/release/v1/pkg/gcp/build"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // GCB is the main structure of this package.

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/gcp/gcb/gcbfakes"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/gcp/gcb/gcbfakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 func mockRepo() gcb.Repository {

--- a/pkg/gcp/gcb/gcbfakes/fake_list_jobs.go
+++ b/pkg/gcp/gcb/gcbfakes/fake_list_jobs.go
@@ -20,7 +20,7 @@ package gcbfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/gcp/gcb"
 )
 
 type FakeListJobs struct {

--- a/pkg/gcp/gcb/gcbfakes/fake_release.go
+++ b/pkg/gcp/gcb/gcbfakes/fake_release.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeRelease struct {

--- a/pkg/gcp/gcb/gcbfakes/fake_repository.go
+++ b/pkg/gcp/gcb/gcbfakes/fake_repository.go
@@ -20,7 +20,7 @@ package gcbfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/gcp/gcb"
 )
 
 type FakeRepository struct {

--- a/pkg/gcp/gcb/gcbfakes/fake_version.go
+++ b/pkg/gcp/gcb/gcbfakes/fake_version.go
@@ -20,8 +20,8 @@ package gcbfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeVersion struct {

--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -26,9 +26,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/cloudbuild/v1"
 
-	"k8s.io/release/pkg/gcp/build"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/gcp/build"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // History is the main structure for retrieving the GCB history output.

--- a/pkg/gcp/gcb/history_test.go
+++ b/pkg/gcp/gcb/history_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/cloudbuild/v1"
 
-	"k8s.io/release/pkg/gcp/gcb"
-	"k8s.io/release/pkg/gcp/gcb/gcbfakes"
+	"k8s.io/release/v1/pkg/gcp/gcb"
+	"k8s.io/release/v1/pkg/gcp/gcb/gcbfakes"
 )
 
 func TestHistoryRun(t *testing.T) {

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -19,7 +19,7 @@ package gcp
 import (
 	"github.com/pkg/errors"
 
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 const (

--- a/pkg/gh2gcs/gh2gcs.go
+++ b/pkg/gh2gcs/gh2gcs.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/object"
 )
 
 // Config contains a slice of `ReleaseConfig` to be used when unmarshalling a

--- a/pkg/git/describe.go
+++ b/pkg/git/describe.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 // DescribeOptions is the type for the argument passed to repo.Describe

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -40,9 +40,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/release/regex"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/release/regex"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/util"
 )
 
 type testRepo struct {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -30,9 +30,9 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/git/gitfakes"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/git/gitfakes"
 )
 
 func newSUT() (*git.Repo, *gitfakes.FakeWorktree) {

--- a/pkg/git/gitfakes/fake_repository.go
+++ b/pkg/git/gitfakes/fake_repository.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 type FakeRepository struct {

--- a/pkg/git/gitfakes/fake_worktree.go
+++ b/pkg/git/gitfakes/fake_worktree.go
@@ -22,7 +22,7 @@ import (
 
 	gita "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 type FakeWorktree struct {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -30,9 +30,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github/internal"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github/internal"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -24,9 +24,9 @@ import (
 	gogithub "github.com/google/go-github/v33/github"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/github/githubfakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/github/githubfakes"
 )
 
 func newSUT() (*github.GitHub, *githubfakes.FakeClient) {

--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 
 	githuba "github.com/google/go-github/v33/github"
-	"k8s.io/release/pkg/github"
+	"k8s.io/release/v1/pkg/github"
 )
 
 type FakeClient struct {

--- a/pkg/github/internal/retry_test.go
+++ b/pkg/github/internal/retry_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/github/internal"
+	"k8s.io/release/v1/pkg/github/internal"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	kHash "k8s.io/release/pkg/hash"
+	kHash "k8s.io/release/v1/pkg/hash"
 )
 
 func TestSHA512ForFile(t *testing.T) {

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	khttp "k8s.io/release/pkg/http"
+	khttp "k8s.io/release/v1/pkg/http"
 )
 
 func TestGetURLResponseSuccess(t *testing.T) {

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -30,11 +30,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/kubepkg/options"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/kubepkg/options"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/util"
 )
 
 type ChannelType string

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/kubepkg"
-	"k8s.io/release/pkg/kubepkg/kubepkgfakes"
-	"k8s.io/release/pkg/kubepkg/options"
+	"k8s.io/release/v1/pkg/kubepkg"
+	"k8s.io/release/v1/pkg/kubepkg/kubepkgfakes"
+	"k8s.io/release/v1/pkg/kubepkg/options"
 )
 
 var err = errors.New("")

--- a/pkg/kubepkg/kubepkgfakes/fake_impl.go
+++ b/pkg/kubepkg/kubepkgfakes/fake_impl.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 
 	"github.com/google/go-github/v33/github"
-	"k8s.io/release/pkg/kubepkg"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/kubepkg"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeImpl struct {

--- a/pkg/kubepkg/options/options.go
+++ b/pkg/kubepkg/options/options.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/util"
 )
 
 type Options struct {

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -28,7 +28,7 @@ import (
 	"github.com/nozzle/throttler"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // ListURL is the json list of all spdx licenses

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -28,7 +28,7 @@ import (
 	licenseclassifier "github.com/google/licenseclassifier/v2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/license"
+	"k8s.io/release/v1/pkg/license"
 
-	"k8s.io/release/pkg/license/licensefakes"
+	"k8s.io/release/v1/pkg/license/licensefakes"
 )
 
 const testFullLicense = `

--- a/pkg/license/licensefakes/fake_downloader_implementation.go
+++ b/pkg/license/licensefakes/fake_downloader_implementation.go
@@ -20,7 +20,7 @@ package licensefakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/license"
+	"k8s.io/release/v1/pkg/license"
 )
 
 type FakeDownloaderImplementation struct {

--- a/pkg/license/licensefakes/fake_reader_implementation.go
+++ b/pkg/license/licensefakes/fake_reader_implementation.go
@@ -20,7 +20,7 @@ package licensefakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/license"
+	"k8s.io/release/v1/pkg/license"
 )
 
 type FakeReaderImplementation struct {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 // SetupGlobalLogger uses to provided log level string and applies it globally.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/log"
+	"k8s.io/release/v1/pkg/log"
 )
 
 func TestToFile(t *testing.T) {

--- a/pkg/mail/mail_test.go
+++ b/pkg/mail/mail_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/sendgrid/rest"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/mail"
-	"k8s.io/release/pkg/mail/mailfakes"
-	it "k8s.io/release/pkg/testing"
+	"k8s.io/release/v1/pkg/mail"
+	"k8s.io/release/v1/pkg/mail/mailfakes"
+	it "k8s.io/release/v1/pkg/testing"
 )
 
 func TestSetDefaultSender(t *testing.T) {

--- a/pkg/mail/mailfakes/fake_apiclient.go
+++ b/pkg/mail/mailfakes/fake_apiclient.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/sendgrid/rest"
-	"k8s.io/release/pkg/mail"
+	"k8s.io/release/v1/pkg/mail"
 )
 
 type FakeAPIClient struct {

--- a/pkg/mail/mailfakes/fake_send_client.go
+++ b/pkg/mail/mailfakes/fake_send_client.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/sendgrid/rest"
 	maila "github.com/sendgrid/sendgrid-go/helpers/mail"
-	"k8s.io/release/pkg/mail"
+	"k8s.io/release/v1/pkg/mail"
 )
 
 type FakeSendClient struct {

--- a/pkg/notes/dependencies.go
+++ b/pkg/notes/dependencies.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/saschagrunert/go-modiff/pkg/modiff"
 
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 type Dependencies struct {

--- a/pkg/notes/dependencies_test.go
+++ b/pkg/notes/dependencies_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/notesfakes"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/notesfakes"
 )
 
 const expected = `## Dependencies

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/hash"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/hash"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/release"
 )
 
 // Document represents the underlying structure of a release notes document.

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/notes"
-	"k8s.io/release/pkg/notes/options"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/notes"
+	"k8s.io/release/v1/pkg/notes/options"
+	"k8s.io/release/v1/pkg/release"
 )
 
 func TestFileMetadata(t *testing.T) {

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -35,8 +35,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/notes/options"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/notes/options"
 )
 
 var (

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github/githubfakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github/githubfakes"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/object"
 )
 
 // MapProvider interface that obtains release notes maps from a source

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	kgithub "k8s.io/release/pkg/github"
+	kgithub "k8s.io/release/v1/pkg/github"
 )
 
 func githubClient(t *testing.T) (kgithub.Client, context.Context) {

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/release/pkg/notes/options"
+	"k8s.io/release/v1/pkg/notes/options"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-git/go-git/v5"

--- a/pkg/notes/notesfakes/fake_mo_diff.go
+++ b/pkg/notes/notesfakes/fake_mo_diff.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/saschagrunert/go-modiff/pkg/modiff"
-	"k8s.io/release/pkg/notes"
+	"k8s.io/release/v1/pkg/notes"
 )
 
 type FakeMoDiff struct {

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -23,8 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
 )
 
 // Options is the global options structure which can be used to build release

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -30,10 +30,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/github"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/github"
 
-	kgit "k8s.io/release/pkg/git"
+	kgit "k8s.io/release/v1/pkg/git"
 )
 
 type testOptions struct {

--- a/pkg/object/gcs.go
+++ b/pkg/object/gcs.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp"
+	"k8s.io/release/v1/pkg/gcp"
 )
 
 type GCS struct {

--- a/pkg/object/gcs_test.go
+++ b/pkg/object/gcs_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/object"
 )
 
 var testGCS = object.NewGCS()

--- a/pkg/object/objectfakes/fake_store.go
+++ b/pkg/object/objectfakes/fake_store.go
@@ -20,7 +20,7 @@ package objectfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/object"
 )
 
 type FakeStore struct {

--- a/pkg/promobot/hash.go
+++ b/pkg/promobot/hash.go
@@ -24,8 +24,8 @@ import (
 
 	"golang.org/x/xerrors"
 
-	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/hash"
+	api "k8s.io/release/v1/pkg/api/files"
+	"k8s.io/release/v1/pkg/hash"
 )
 
 // GenerateManifestOptions holds the parameters for a hash-files operation.

--- a/pkg/promobot/hash_test.go
+++ b/pkg/promobot/hash_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/release/pkg/promobot"
+	"k8s.io/release/v1/pkg/promobot"
 	"k8s.io/utils/diff"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/promobot/promotefiles.go
+++ b/pkg/promobot/promotefiles.go
@@ -29,8 +29,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 
-	api "k8s.io/release/pkg/api/files"
-	"k8s.io/release/pkg/filepromoter"
+	api "k8s.io/release/v1/pkg/api/files"
+	"k8s.io/release/v1/pkg/filepromoter"
 )
 
 // PromoteFilesOptions holds the flag-values for a file promotion

--- a/pkg/promobot/readmanifest_test.go
+++ b/pkg/promobot/readmanifest_test.go
@@ -19,7 +19,7 @@ package promobot_test
 import (
 	"testing"
 
-	"k8s.io/release/pkg/promobot"
+	"k8s.io/release/v1/pkg/promobot"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/release/archive.go
+++ b/pkg/release/archive.go
@@ -26,11 +26,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/object"
 
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/release/archive_test.go
+++ b/pkg/release/archive_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 func TestArchiveRelease(t *testing.T) {

--- a/pkg/release/archive_unit_test.go
+++ b/pkg/release/archive_unit_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/object"
+	"k8s.io/release/v1/pkg/object"
 )
 
 const fictionalTestBucketName = "kubernetes-test-name"

--- a/pkg/release/branch_checker.go
+++ b/pkg/release/branch_checker.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 type BranchChecker struct {

--- a/pkg/release/branch_checker_test.go
+++ b/pkg/release/branch_checker_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 func TestNeedsCreation(t *testing.T) {

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 // Images is a wrapper around container image related functionality

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 func TestPublish(t *testing.T) {

--- a/pkg/release/prerequisites.go
+++ b/pkg/release/prerequisites.go
@@ -23,11 +23,11 @@ import (
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // PrerequisitesChecker is the main type for checking the prerequisites for a

--- a/pkg/release/prerequisites_test.go
+++ b/pkg/release/prerequisites_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 func TestCheckPrerequisites(t *testing.T) {

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -27,10 +27,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/gcp"
-	"k8s.io/release/pkg/http"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/gcp"
+	"k8s.io/release/v1/pkg/http"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // Publisher is the structure for publishing anything release related

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 func TestPublishVersion(t *testing.T) {

--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -23,8 +23,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/util"
 )
 
 // GitObjectPusher is an object that pushes things to a gitrepo

--- a/pkg/release/push_git_objects_test.go
+++ b/pkg/release/push_git_objects_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
 )
 
 func getTestGitObjectPusher() (pusher *GitObjectPusher, repoPath string, err error) {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -38,13 +38,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
-	"k8s.io/release/pkg/git"
-	rhash "k8s.io/release/pkg/hash"
-	"k8s.io/release/pkg/http"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/tar"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/command"
+	"k8s.io/release/v1/pkg/git"
+	rhash "k8s.io/release/v1/pkg/hash"
+	"k8s.io/release/v1/pkg/http"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/tar"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 func TestGetDefaultToolRepoURLSuccess(t *testing.T) {

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/release/regex"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/release/regex"
+	"k8s.io/release/v1/pkg/util"
 )
 
 const (

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 func TestGenerateReleaseVersion(t *testing.T) {

--- a/pkg/release/releasefakes/fake_archiver_impl.go
+++ b/pkg/release/releasefakes/fake_archiver_impl.go
@@ -20,7 +20,7 @@ package releasefakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeArchiverImpl struct {

--- a/pkg/release/releasefakes/fake_repository.go
+++ b/pkg/release/releasefakes/fake_repository.go
@@ -20,8 +20,8 @@ package releasefakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeRepository struct {

--- a/pkg/release/releasefakes/fake_version_client.go
+++ b/pkg/release/releasefakes/fake_version_client.go
@@ -20,7 +20,7 @@ package releasefakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/release"
+	"k8s.io/release/v1/pkg/release"
 )
 
 type FakeVersionClient struct {

--- a/pkg/release/repository.go
+++ b/pkg/release/repository.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
+	"k8s.io/release/v1/pkg/git"
 )
 
 // Repo is a wrapper around a kubernetes/release repository

--- a/pkg/release/repository_test.go
+++ b/pkg/release/repository_test.go
@@ -25,9 +25,9 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
 )
 
 type sut struct {

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/http"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/http"
 )
 
 // Version is a wrapper around version related functionality

--- a/pkg/release/version_test.go
+++ b/pkg/release/version_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/release"
-	"k8s.io/release/pkg/release/releasefakes"
-	"k8s.io/release/pkg/util"
+	"k8s.io/release/v1/pkg/release"
+	"k8s.io/release/v1/pkg/release/releasefakes"
+	"k8s.io/release/v1/pkg/util"
 )
 
 func newVersionSUT() (*release.Version, *releasefakes.FakeVersionClient) {

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -26,10 +26,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/github"
-	"k8s.io/release/pkg/object"
-	"k8s.io/release/pkg/tar"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/github"
+	"k8s.io/release/v1/pkg/object"
+	"k8s.io/release/v1/pkg/tar"
 )
 
 // PrepareWorkspaceStage sets up the workspace by cloning a new copy of k/k.

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/http"
+	"k8s.io/release/v1/pkg/http"
 )
 
 const testgridConfigURL = "https://storage.googleapis.com/k8s-testgrid/config"

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/golang/protobuf/proto" // nolint: staticcheck
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/release/pkg/git"
-	"k8s.io/release/pkg/testgrid"
-	"k8s.io/release/pkg/testgrid/testgridfakes"
+	"k8s.io/release/v1/pkg/git"
+	"k8s.io/release/v1/pkg/testgrid"
+	"k8s.io/release/v1/pkg/testgrid/testgridfakes"
 )
 
 func newSut() (*testgrid.TestGrid, *testgridfakes.FakeClient) {

--- a/pkg/testgrid/testgridfakes/fake_client.go
+++ b/pkg/testgrid/testgridfakes/fake_client.go
@@ -20,7 +20,7 @@ package testgridfakes
 import (
 	"sync"
 
-	"k8s.io/release/pkg/testgrid"
+	"k8s.io/release/v1/pkg/testgrid"
 )
 
 type FakeClient struct {

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/release/pkg/command"
+	"k8s.io/release/v1/pkg/command"
 )
 
 const (

--- a/pkg/vulndash/adapter/adapter_test.go
+++ b/pkg/vulndash/adapter/adapter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
-	adapter "k8s.io/release/pkg/vulndash/adapter"
+	adapter "k8s.io/release/v1/pkg/vulndash/adapter"
 )
 
 func TestGenerateVulnerabilityBreakdown(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind api

#### What this PR does / why we need it:
The project is already being used in test-infra and we should therefore
target to stabilize its API. This change will introduce the `v1` package
which should be later on result in the tag 'v1.0.0'.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/1819
#### Special notes for your reviewer:
/hold for discussion

I would prefer moving everything into a new `internal` package with this PR, while keeping packages public which are actively used by others.

For example I could only find those packages which got externally imported:

- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/build?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/command?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/git?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/github?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/log?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/notes?tab=importedby
- https://pkg.go.dev/k8s.io/release@v0.7.0/pkg/util?tab=importedby
 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Promote v1 API for k/release
```
