### PR TITLE
Change k/k8s.io branch to "main" in image promotion PRs

### DIFF
--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	k8sioRepo             = "k8s.io"
+	k8sioDefaultBranch    = "main"
 	promotionBranchSuffix = "-image-promotion"
 )
 
@@ -280,7 +281,7 @@ func runPromote(opts *promoteOptions) error {
 	// Create the Pull Request
 	if mustRun(opts, "Create pull request?") {
 		pr, err := gh.CreatePullRequest(
-			git.DefaultGithubOrg, k8sioRepo, git.DefaultBranch,
+			git.DefaultGithubOrg, k8sioRepo, k8sioDefaultBranch,
 			fmt.Sprintf("%s:%s", userForkOrg, branchname),
 			commitMessage, prBody,
 		)


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
During the 1.21.0-alpha.3 release cut the automatic PR for image promotion failed because the default branch in `kubernetes/k8s.io` was renamed to "main" and we had not updated the name in krel. This PR fixes it.

#### Which issue(s) this PR fixes:

Slack Ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1612874602190300?thread_ts=1612863244.184400&cid=CJH2GBF7Y

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- Image promotion pull requests are now created against `main` in `kubernetes/k8s.io` as the default branch has been renamed,
```
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
