### PR TITLE
Display DoNotPublish on edit view

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -1208,10 +1208,11 @@ func fixReleaseNotes(workDir string, releaseNotes *notes.ReleaseNotes) error {
 			Feature:        note.Feature,
 			ActionRequired: note.ActionRequired,
 			Documentation:  note.Documentation,
+			DoNotPublish:   note.DoNotPublish,
 		}
 
 		if noteMaps != nil {
-			fmt.Println("✨ Note contents are modified with a map")
+			fmt.Println("✨ Note contents was previously modified with a map")
 			for _, noteMap := range noteMaps {
 				if err := note.ApplyMap(noteMap); err != nil {
 					return errors.Wrapf(err, "applying notemap for PR #%d", pr)
@@ -1225,6 +1226,7 @@ func fixReleaseNotes(workDir string, releaseNotes *notes.ReleaseNotes) error {
 		fmt.Println(pointIfChanged("Areas", note.Areas, originalNote.Areas), note.Areas)
 		fmt.Println(pointIfChanged("Feature", note.Feature, originalNote.Feature), note.Feature)
 		fmt.Println(pointIfChanged("ActionRequired", note.ActionRequired, originalNote.ActionRequired), note.ActionRequired)
+		fmt.Println(pointIfChanged("DoNotPublish", note.DoNotPublish, originalNote.DoNotPublish), note.DoNotPublish)
 		// TODO: Implement note.Documentation
 
 		// Wrap the note for better readability on the terminal


### PR DESCRIPTION
Signed-off-by: Wilson E. Husin <whusin@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes a missing field to be shown in review (`--fix`) mode which should have been part of #1846

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
