### PR TITLE
move references from TOOL_BRANCH to be TOOL_REF

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -865,7 +865,7 @@ func releaseNotesJSON(repoPath, tag string) (jsonString string, err error) {
 	}
 
 	// Chech if release branch already exists
-	_, err = repo.RevParse(releaseBranch)
+	_, err = repo.RevParseTag(releaseBranch)
 	if err == nil {
 		logrus.Infof("Working on branch %s instead of %s", releaseBranch, git.DefaultBranch)
 		branchName = releaseBranch

--- a/gcb/build/cloudbuild.yaml
+++ b/gcb/build/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
   dir: 'go/src/k8s.io'
   args:
   - clone
-  - --branch=${_TOOL_BRANCH}
+  - --branch=${_TOOL_REF}
   - ${_TOOL_REPO}
   waitFor: [ '-' ]
 
@@ -55,7 +55,7 @@ substitutions:
   _KUBERNETES_REPO: 'https://github.com/kubernetes/kubernetes.git'
   _KUBERNETES_BRANCH: 'master'
   _TOOL_REPO: 'https://github.com/kubernetes/release.git'
-  _TOOL_BRANCH: 'master'
+  _TOOL_REF: 'master'
   _RELEASE_TYPE: 'release-in-a-container'
   _CI: ''
   _NOMOCK: ''

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -18,6 +18,12 @@ secrets:
 
 steps:
 - name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: gcr.io/cloud-builders/git
   entrypoint: "bash"
   dir: "go/src/k8s.io/release"
   args:

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -18,11 +18,14 @@ secrets:
 
 steps:
 - name: gcr.io/cloud-builders/git
-  dir: "go/src/k8s.io"
+  entrypoint: "bash"
+  dir: "go/src/k8s.io/release"
   args:
-  - "clone"
-  - "--branch=${_TOOL_BRANCH}"
-  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+  - '-c'
+  - |
+    git fetch
+    echo "Checking out ${_TOOL_REF}"
+    git checkout ${_TOOL_REF}
 
 - name: k8s.gcr.io/releng/releng-ci:v0.5.0
   dir: "go/src/k8s.io/release"
@@ -38,7 +41,7 @@ steps:
   env:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
-  - "TOOL_BRANCH=${_TOOL_BRANCH}"
+  - "TOOL_REF=${_TOOL_REF}"
   secretEnv:
   - GITHUB_TOKEN
   args:

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -18,6 +18,12 @@ secrets:
 
 steps:
 - name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: gcr.io/cloud-builders/git
   entrypoint: "bash"
   dir: "go/src/k8s.io/release"
   args:

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -18,11 +18,14 @@ secrets:
 
 steps:
 - name: gcr.io/cloud-builders/git
-  dir: "go/src/k8s.io"
+  entrypoint: "bash"
+  dir: "go/src/k8s.io/release"
   args:
-  - "clone"
-  - "--branch=${_TOOL_BRANCH}"
-  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+  - '-c'
+  - |
+    git fetch
+    echo "Checking out ${_TOOL_REF}"
+    git checkout ${_TOOL_REF}
 
 - name: k8s.gcr.io/releng/releng-ci:v0.5.0
   dir: "go/src/k8s.io/release"
@@ -38,7 +41,7 @@ steps:
   env:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
-  - "TOOL_BRANCH=${_TOOL_BRANCH}"
+  - "TOOL_REF=${_TOOL_REF}"
   secretEnv:
   - GITHUB_TOKEN
   args:

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -202,6 +202,20 @@ type FakeStageImpl struct {
 		result1 string
 		result2 error
 	}
+	RevParseTagStub        func(*git.Repo, string) (string, error)
+	revParseTagMutex       sync.RWMutex
+	revParseTagArgsForCall []struct {
+		arg1 *git.Repo
+		arg2 string
+	}
+	revParseTagReturns struct {
+		result1 string
+		result2 error
+	}
+	revParseTagReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	StageLocalArtifactsStub        func(*build.Options) error
 	stageLocalArtifactsMutex       sync.RWMutex
 	stageLocalArtifactsArgsForCall []struct {
@@ -1129,6 +1143,71 @@ func (fake *FakeStageImpl) RevParseReturnsOnCall(i int, result1 string, result2 
 	}{result1, result2}
 }
 
+func (fake *FakeStageImpl) RevParseTag(arg1 *git.Repo, arg2 string) (string, error) {
+	fake.revParseTagMutex.Lock()
+	ret, specificReturn := fake.revParseTagReturnsOnCall[len(fake.revParseTagArgsForCall)]
+	fake.revParseTagArgsForCall = append(fake.revParseTagArgsForCall, struct {
+		arg1 *git.Repo
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.RevParseTagStub
+	fakeReturns := fake.revParseTagReturns
+	fake.recordInvocation("RevParseTag", []interface{}{arg1, arg2})
+	fake.revParseTagMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) RevParseTagCallCount() int {
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
+	return len(fake.revParseTagArgsForCall)
+}
+
+func (fake *FakeStageImpl) RevParseTagCalls(stub func(*git.Repo, string) (string, error)) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = stub
+}
+
+func (fake *FakeStageImpl) RevParseTagArgsForCall(i int) (*git.Repo, string) {
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
+	argsForCall := fake.revParseTagArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) RevParseTagReturns(result1 string, result2 error) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = nil
+	fake.revParseTagReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) RevParseTagReturnsOnCall(i int, result1 string, result2 error) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = nil
+	if fake.revParseTagReturnsOnCall == nil {
+		fake.revParseTagReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.revParseTagReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeStageImpl) StageLocalArtifacts(arg1 *build.Options) error {
 	fake.stageLocalArtifactsMutex.Lock()
 	ret, specificReturn := fake.stageLocalArtifactsReturnsOnCall[len(fake.stageLocalArtifactsArgsForCall)]
@@ -1469,6 +1548,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.pushReleaseArtifactsMutex.RUnlock()
 	fake.revParseMutex.RLock()
 	defer fake.revParseMutex.RUnlock()
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
 	fake.stageLocalArtifactsMutex.RLock()
 	defer fake.stageLocalArtifactsMutex.RUnlock()
 	fake.stageLocalSourceTreeMutex.RLock()

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -131,6 +131,7 @@ type stageImpl interface {
 	) (*release.Versions, error)
 	OpenRepo(repoPath string) (*git.Repo, error)
 	RevParse(repo *git.Repo, rev string) (string, error)
+	RevParseTag(repo *git.Repo, rev string) (string, error)
 	Checkout(repo *git.Repo, rev string, args ...string) error
 	CurrentBranch(repo *git.Repo) (string, error)
 	CommitEmpty(repo *git.Repo, msg string) error
@@ -189,6 +190,10 @@ func (d *defaultStageImpl) OpenRepo(repoPath string) (*git.Repo, error) {
 
 func (d *defaultStageImpl) RevParse(repo *git.Repo, rev string) (string, error) {
 	return repo.RevParse(rev)
+}
+
+func (d *defaultStageImpl) RevParseTag(repo *git.Repo, rev string) (string, error) {
+	return repo.RevParseTag(rev)
 }
 
 func (d *defaultStageImpl) Checkout(repo *git.Repo, rev string, args ...string) error {
@@ -328,7 +333,7 @@ func (d *DefaultStage) TagRepository() error {
 		logrus.Infof("Preparing version %s", version)
 
 		// Ensure that the tag not already exists
-		if _, err := d.impl.RevParse(repo, version); err == nil {
+		if _, err := d.impl.RevParseTag(repo, version); err == nil {
 			return errors.Errorf("tag %s already exists", version)
 		}
 

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -238,7 +238,7 @@ func TestTagRepository(t *testing.T) {
 	}{
 		{ // success new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CurrentBranchReturnsOnCall(0, "release-1.20", nil)
 			},
 			versions:            newRCVersions,
@@ -248,7 +248,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on CommitEmpty new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CurrentBranchReturnsOnCall(0, "release-1.20", nil)
 				mock.CommitEmptyReturns(err)
 			},
@@ -259,7 +259,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on CurrentBranch new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CurrentBranchReturnsOnCall(0, "release-1.20", nil)
 				mock.CurrentBranchReturns("", err)
 			},
@@ -270,7 +270,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on Checkout new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CurrentBranchReturnsOnCall(0, "release-1.20", nil)
 				mock.CheckoutReturns(err)
 			},
@@ -281,7 +281,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on RevParse new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", nil)
+				mock.RevParseTagReturns("", nil)
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -299,7 +299,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // success new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -308,7 +308,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on Checkout new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CheckoutReturns(err)
 			},
 			versions:            newRCVersions,
@@ -318,7 +318,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // failure on RevParse new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", nil)
+				mock.RevParseTagReturns("", nil)
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -327,7 +327,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // success new beta
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 			},
 			versions:      newBetaVersions,
 			releaseBranch: git.DefaultBranch,
@@ -335,7 +335,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // new beta failure on Tag
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.TagReturns(err)
 			},
 			versions:      newBetaVersions,
@@ -344,7 +344,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // new beta failure on CurrentBranch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CurrentBranchReturns("", err)
 			},
 			versions:      newBetaVersions,
@@ -353,7 +353,7 @@ func TestTagRepository(t *testing.T) {
 		},
 		{ // new beta failure on Checkout
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseReturns("", err)
+				mock.RevParseTagReturns("", err)
 				mock.CheckoutReturns(err)
 			},
 			versions:      newBetaVersions,

--- a/pkg/binary/binaryfakes/fake_binary_implementation.go
+++ b/pkg/binary/binaryfakes/fake_binary_implementation.go
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
 Copyright The Kubernetes Authors.
+=======
+Copyright 2021 The Kubernetes Authors.
+>>>>>>> 46259458... mocks: update mocks
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -93,7 +93,7 @@ func (c *Changelog) Run() error {
 	}
 
 	remoteBranch := git.Remotify(branch)
-	head, err := c.impl.RevParse(repo, remoteBranch)
+	head, err := c.impl.RevParseTag(repo, remoteBranch)
 	if err != nil {
 		return errors.Wrap(err, "get latest branch commit")
 	}

--- a/pkg/changelog/changelogfakes/fake_impl.go
+++ b/pkg/changelog/changelogfakes/fake_impl.go
@@ -285,6 +285,20 @@ type FakeImpl struct {
 		result1 string
 		result2 error
 	}
+	RevParseTagStub        func(*git.Repo, string) (string, error)
+	revParseTagMutex       sync.RWMutex
+	revParseTagArgsForCall []struct {
+		arg1 *git.Repo
+		arg2 string
+	}
+	revParseTagReturns struct {
+		result1 string
+		result2 error
+	}
+	revParseTagReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	RmStub        func(*git.Repo, bool, ...string) error
 	rmMutex       sync.RWMutex
 	rmArgsForCall []struct {
@@ -1573,6 +1587,71 @@ func (fake *FakeImpl) RevParseReturnsOnCall(i int, result1 string, result2 error
 	}{result1, result2}
 }
 
+func (fake *FakeImpl) RevParseTag(arg1 *git.Repo, arg2 string) (string, error) {
+	fake.revParseTagMutex.Lock()
+	ret, specificReturn := fake.revParseTagReturnsOnCall[len(fake.revParseTagArgsForCall)]
+	fake.revParseTagArgsForCall = append(fake.revParseTagArgsForCall, struct {
+		arg1 *git.Repo
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.RevParseTagStub
+	fakeReturns := fake.revParseTagReturns
+	fake.recordInvocation("RevParseTag", []interface{}{arg1, arg2})
+	fake.revParseTagMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) RevParseTagCallCount() int {
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
+	return len(fake.revParseTagArgsForCall)
+}
+
+func (fake *FakeImpl) RevParseTagCalls(stub func(*git.Repo, string) (string, error)) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = stub
+}
+
+func (fake *FakeImpl) RevParseTagArgsForCall(i int) (*git.Repo, string) {
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
+	argsForCall := fake.revParseTagArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) RevParseTagReturns(result1 string, result2 error) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = nil
+	fake.revParseTagReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) RevParseTagReturnsOnCall(i int, result1 string, result2 error) {
+	fake.revParseTagMutex.Lock()
+	defer fake.revParseTagMutex.Unlock()
+	fake.RevParseTagStub = nil
+	if fake.revParseTagReturnsOnCall == nil {
+		fake.revParseTagReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.revParseTagReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImpl) Rm(arg1 *git.Repo, arg2 bool, arg3 ...string) error {
 	fake.rmMutex.Lock()
 	ret, specificReturn := fake.rmReturnsOnCall[len(fake.rmArgsForCall)]
@@ -1997,6 +2076,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.repoDirMutex.RUnlock()
 	fake.revParseMutex.RLock()
 	defer fake.revParseMutex.RUnlock()
+	fake.revParseTagMutex.RLock()
+	defer fake.revParseTagMutex.RUnlock()
 	fake.rmMutex.RLock()
 	defer fake.rmMutex.RUnlock()
 	fake.statMutex.RLock()

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -46,6 +46,7 @@ type impl interface {
 	OpenRepo(repoPath string) (*git.Repo, error)
 	CurrentBranch(repo *git.Repo) (branch string, err error)
 	RevParse(repo *git.Repo, rev string) (string, error)
+	RevParseTag(repo *git.Repo, rev string) (string, error)
 	CreateDownloadsTable(
 		w io.Writer, bucket, tars, prevTag, newTag string,
 	) error
@@ -105,6 +106,10 @@ func (*defaultImpl) CurrentBranch(repo *git.Repo) (string, error) {
 
 func (*defaultImpl) RevParse(repo *git.Repo, rev string) (string, error) {
 	return repo.RevParse(rev)
+}
+
+func (*defaultImpl) RevParseTag(repo *git.Repo, rev string) (string, error) {
+	return repo.RevParseTag(rev)
 }
 
 func (*defaultImpl) CreateDownloadsTable(

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -186,7 +186,7 @@ func (g *GCB) Submit() error {
 
 	toolOrg := release.GetToolOrg()
 	toolRepo := release.GetToolRepo()
-	toolBranch := release.GetToolBranch()
+	toolRef := release.GetToolRef()
 
 	if err := gcp.PreCheck(); err != nil {
 		return errors.Wrap(err, "pre-checking for GCP package usage")
@@ -196,7 +196,7 @@ func (g *GCB) Submit() error {
 		return errors.Wrap(err, "open release repo")
 	}
 
-	if err := g.repoClient.CheckState(toolOrg, toolRepo, toolBranch, g.options.NoMock); err != nil {
+	if err := g.repoClient.CheckState(toolOrg, toolRepo, toolRef, g.options.NoMock); err != nil {
 		return errors.Wrap(err, "verifying repository state")
 	}
 
@@ -211,7 +211,7 @@ func (g *GCB) Submit() error {
 		g.options.Async = false
 	}
 
-	gcbSubs, gcbSubsErr := g.SetGCBSubstitutions(toolOrg, toolRepo, toolBranch)
+	gcbSubs, gcbSubsErr := g.SetGCBSubstitutions(toolOrg, toolRepo, toolRef)
 	if gcbSubs == nil || gcbSubsErr != nil {
 		return gcbSubsErr
 	}
@@ -293,12 +293,12 @@ func (g *GCB) Submit() error {
 
 // SetGCBSubstitutions takes a set of `Options` and returns a map of GCB
 // substitutions.
-func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolBranch string) (map[string]string, error) {
+func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string]string, error) {
 	gcbSubs := map[string]string{}
 
 	gcbSubs["TOOL_ORG"] = toolOrg
 	gcbSubs["TOOL_REPO"] = toolRepo
-	gcbSubs["TOOL_BRANCH"] = toolBranch
+	gcbSubs["TOOL_REF"] = toolRef
 
 	gcpUser := g.options.GcpUser
 	if gcpUser == "" {

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -159,7 +159,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		gcbOpts     *gcb.Options
 		toolOrg     string
 		toolRepo    string
-		toolBranch  string
+		toolRef     string
 		expected    map[string]string
 		repoMock    gcb.Repository
 		versionMock gcb.Version
@@ -180,7 +180,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeAlpha,
 				"TYPE_TAG":               release.ReleaseTypeAlpha,
 				"MAJOR_VERSION_TAG":      "1",
@@ -205,7 +205,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         git.DefaultBranch,
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeBeta,
 				"TYPE_TAG":               release.ReleaseTypeBeta,
 				"MAJOR_VERSION_TAG":      "1",
@@ -229,7 +229,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -253,7 +253,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         "release-1.15",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeOfficial,
 				"TYPE_TAG":               release.ReleaseTypeOfficial,
 				"MAJOR_VERSION_TAG":      "1",
@@ -275,12 +275,12 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			releaseMock: mockRelease("v1.16.0"),
 			toolOrg:     "honk",
 			toolRepo:    "best-tools",
-			toolBranch:  "tool-branch",
+			toolRef:     "tool-branch",
 			expected: map[string]string{
 				"RELEASE_BRANCH":         "release-1.16",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
-				"TOOL_BRANCH":            "tool-branch",
+				"TOOL_REF":               "tool-branch",
 				"TYPE":                   release.ReleaseTypeOfficial,
 				"TYPE_TAG":               release.ReleaseTypeOfficial,
 				"MAJOR_VERSION_TAG":      "1",
@@ -302,12 +302,12 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 			releaseMock: mockRelease("1.19.0-beta.0"),
 			toolOrg:     "honk",
 			toolRepo:    "best-tools",
-			toolBranch:  "tool-branch",
+			toolRef:     "tool-branch",
 			expected: map[string]string{
 				"RELEASE_BRANCH":         "release-1.19",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
-				"TOOL_BRANCH":            "tool-branch",
+				"TOOL_REF":               "tool-branch",
 				"TYPE":                   release.ReleaseTypeBeta,
 				"TYPE_TAG":               release.ReleaseTypeBeta,
 				"MAJOR_VERSION_TAG":      "1",
@@ -331,7 +331,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -355,7 +355,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
-				"TOOL_BRANCH":            "",
+				"TOOL_REF":               "",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -375,7 +375,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		sut.SetReleaseClient(tc.releaseMock)
 
 		subs, err := sut.SetGCBSubstitutions(
-			tc.toolOrg, tc.toolRepo, tc.toolBranch,
+			tc.toolOrg, tc.toolRepo, tc.toolRef,
 		)
 		require.Nil(t, err)
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -437,9 +437,10 @@ func (r *Repo) Cleanup() error {
 	return os.RemoveAll(r.dir)
 }
 
-// RevParse parses a git revision and returns a SHA1 on success, otherwise an
+// RevParseTag parses a git revision and returns a SHA1 on success, otherwise an
 // error.
-func (r *Repo) RevParse(rev string) (string, error) {
+// If the revision does not match a tag add the remote origin in the revision.
+func (r *Repo) RevParseTag(rev string) (string, error) {
 	matched, err := regexp.MatchString(`v\d+\.\d+\.\d+.*`, rev)
 	if err != nil {
 		return "", err
@@ -458,7 +459,31 @@ func (r *Repo) RevParse(rev string) (string, error) {
 	return ref.String(), nil
 }
 
-// RevParseShort parses a git revision and returns a SHA1 trimmed to the length
+// RevParse parses a git revision and returns a SHA1 on success, otherwise an
+// error.
+func (r *Repo) RevParse(rev string) (string, error) {
+	// Try to resolve the rev
+	ref, err := r.inner.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return "", err
+	}
+
+	return ref.String(), nil
+}
+
+// RevParseTagShort parses a git revision and returns a SHA1 trimmed to the length
+// 10 on success, otherwise an error.
+// If the revision does not match a tag add the remote origin in the revision.
+func (r *Repo) RevParseTagShort(rev string) (string, error) {
+	fullRev, err := r.RevParseTag(rev)
+	if err != nil {
+		return "", err
+	}
+
+	return fullRev[:10], nil
+}
+
+// RevParseTagShort parses a git revision and returns a SHA1 trimmed to the length
 // 10 on success, otherwise an error.
 func (r *Repo) RevParseShort(rev string) (string, error) {
 	fullRev, err := r.RevParse(rev)
@@ -518,7 +543,7 @@ func (r *Repo) LatestNonPatchFinalToMinor() (DiscoverResult, error) {
 	latestVersion := versions[0]
 	latestVersionTag := util.SemverToTagString(latestVersion)
 	logrus.Debugf("Latest non patch version %s", latestVersionTag)
-	end, err := r.RevParse(latestVersionTag)
+	end, err := r.RevParseTag(latestVersionTag)
 	if err != nil {
 		return DiscoverResult{}, err
 	}
@@ -526,7 +551,7 @@ func (r *Repo) LatestNonPatchFinalToMinor() (DiscoverResult, error) {
 	previousVersion := versions[1]
 	previousVersionTag := util.SemverToTagString(previousVersion)
 	logrus.Debugf("Previous non patch version %s", previousVersionTag)
-	start, err := r.RevParse(previousVersionTag)
+	start, err := r.RevParseTag(previousVersionTag)
 	if err != nil {
 		return DiscoverResult{}, err
 	}
@@ -568,13 +593,13 @@ func (r *Repo) latestNonPatchFinalVersions() ([]semver.Version, error) {
 
 func (r *Repo) releaseBranchOrMainRef(major, minor uint64) (sha, rev string, err error) {
 	relBranch := fmt.Sprintf("release-%d.%d", major, minor)
-	sha, err = r.RevParse(relBranch)
+	sha, err = r.RevParseTag(relBranch)
 	if err == nil {
 		logrus.Debugf("Found release branch %s", relBranch)
 		return sha, relBranch, nil
 	}
 
-	sha, err = r.RevParse(DefaultBranch)
+	sha, err = r.RevParseTag(DefaultBranch)
 	if err == nil {
 		logrus.Debugf("No release branch found, using %s", DefaultBranch)
 		return sha, DefaultBranch, nil
@@ -793,14 +818,14 @@ func (r *Repo) LatestPatchToPatch(branch string) (DiscoverResult, error) {
 
 	logrus.Debugf("Parsing latest tag %s%v", util.TagPrefix, latestTag)
 	latestVersionTag := util.SemverToTagString(latestTag)
-	end, err := r.RevParse(latestVersionTag)
+	end, err := r.RevParseTag(latestVersionTag)
 	if err != nil {
 		return DiscoverResult{}, errors.Wrapf(err, "parsing version %v", latestTag)
 	}
 
 	logrus.Debugf("Parsing previous tag %s%v", util.TagPrefix, prevTag)
 	previousVersionTag := util.SemverToTagString(prevTag)
-	start, err := r.RevParse(previousVersionTag)
+	start, err := r.RevParseTag(previousVersionTag)
 	if err != nil {
 		return DiscoverResult{}, errors.Wrapf(err, "parsing previous version %v", prevTag)
 	}
@@ -829,7 +854,7 @@ func (r *Repo) LatestPatchToLatest(branch string) (DiscoverResult, error) {
 
 	logrus.Debugf("Parsing latest tag %s%v", util.TagPrefix, latestTag)
 	latestVersionTag := util.SemverToTagString(latestTag)
-	start, err := r.RevParse(latestVersionTag)
+	start, err := r.RevParseTag(latestVersionTag)
 	if err != nil {
 		return DiscoverResult{}, errors.Wrapf(err, "parsing version %v", latestTag)
 	}

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -340,6 +340,27 @@ func TestSuccessRevParse(t *testing.T) {
 	tagRev, err := testRepo.sut.RevParse(testRepo.firstTagName)
 	require.Nil(t, err)
 	require.Equal(t, tagRev, testRepo.firstCommit)
+
+	tagRev, err = testRepo.sut.RevParse(testRepo.firstCommit)
+	require.Nil(t, err)
+	require.Equal(t, tagRev, testRepo.firstCommit)
+}
+
+func TestSuccessRevTagParse(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	mainRev, err := testRepo.sut.RevParseTag(git.DefaultBranch)
+	require.Nil(t, err)
+	require.Equal(t, mainRev, testRepo.firstCommit)
+
+	branchRev, err := testRepo.sut.RevParseTag(testRepo.branchName)
+	require.Nil(t, err)
+	require.Equal(t, branchRev, testRepo.thirdBranchCommit)
+
+	tagRev, err := testRepo.sut.RevParseTag(testRepo.firstTagName)
+	require.Nil(t, err)
+	require.Equal(t, tagRev, testRepo.firstCommit)
 }
 
 func TestFailureRevParse(t *testing.T) {
@@ -347,6 +368,17 @@ func TestFailureRevParse(t *testing.T) {
 	defer testRepo.cleanup(t)
 
 	_, err := testRepo.sut.RevParse("wrong")
+	require.NotNil(t, err)
+}
+
+func TestFailureRevParseTag(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	_, err := testRepo.sut.RevParseTag("wrong")
+	require.NotNil(t, err)
+
+	_, err = testRepo.sut.RevParseTag(testRepo.firstCommit)
 	require.NotNil(t, err)
 }
 
@@ -365,6 +397,27 @@ func TestSuccessRevParseShort(t *testing.T) {
 	tagRev, err := testRepo.sut.RevParseShort(testRepo.firstTagName)
 	require.Nil(t, err)
 	require.Equal(t, tagRev, testRepo.firstCommit[:10])
+
+	tagRev, err = testRepo.sut.RevParseShort(testRepo.firstCommit)
+	require.Nil(t, err)
+	require.Equal(t, tagRev, testRepo.firstCommit[:10])
+}
+
+func TestSuccessRevParseTagShort(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	mainRev, err := testRepo.sut.RevParseTagShort(git.DefaultBranch)
+	require.Nil(t, err)
+	require.Equal(t, mainRev, testRepo.firstCommit[:10])
+
+	branchRev, err := testRepo.sut.RevParseTagShort(testRepo.branchName)
+	require.Nil(t, err)
+	require.Equal(t, branchRev, testRepo.thirdBranchCommit[:10])
+
+	tagRev, err := testRepo.sut.RevParseTagShort(testRepo.firstTagName)
+	require.Nil(t, err)
+	require.Equal(t, tagRev, testRepo.firstCommit[:10])
 }
 
 func TestFailureRevParseShort(t *testing.T) {
@@ -372,6 +425,17 @@ func TestFailureRevParseShort(t *testing.T) {
 	defer testRepo.cleanup(t)
 
 	_, err := testRepo.sut.RevParseShort("wrong")
+	require.NotNil(t, err)
+}
+
+func TestFailureRevParseTagShort(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	_, err := testRepo.sut.RevParseTagShort("wrong")
+	require.NotNil(t, err)
+
+	_, err = testRepo.sut.RevParseTagShort(testRepo.firstCommit)
 	require.NotNil(t, err)
 }
 

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -210,7 +210,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			return err
 		}
 		if o.StartRev != "" && o.StartSHA == "" {
-			sha, err := repo.RevParse(o.StartRev)
+			sha, err := repo.RevParseTag(o.StartRev)
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.StartRev)
 			}
@@ -218,7 +218,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 			o.StartSHA = sha
 		}
 		if o.EndRev != "" && o.EndSHA == "" {
-			sha, err := repo.RevParse(o.EndRev)
+			sha, err := repo.RevParseTag(o.EndRev)
 			if err != nil {
 				return errors.Wrapf(err, "resolving %s", o.EndRev)
 			}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -49,9 +49,9 @@ import (
 )
 
 const (
-	DefaultToolRepo   = "release"
-	DefaultToolBranch = git.DefaultBranch
-	DefaultToolOrg    = git.DefaultGithubOrg
+	DefaultToolRepo = "release"
+	DefaultToolRef  = git.DefaultBranch
+	DefaultToolOrg  = git.DefaultGithubOrg
 	// TODO(vdf): Need to reference K8s Infra project here
 	DefaultKubernetesStagingProject = "kubernetes-release-test"
 	DefaultRelengStagingProject     = "k8s-staging-releng"
@@ -190,10 +190,10 @@ func GetToolRepo() string {
 	return env.Default("TOOL_REPO", DefaultToolRepo)
 }
 
-// GetToolBranch checks if the 'TOOL_BRANCH' environment variable is set.
-// If 'TOOL_BRANCH' is non-empty, it returns the value. Otherwise, it returns DefaultToolBranch.
-func GetToolBranch() string {
-	return env.Default("TOOL_BRANCH", DefaultToolBranch)
+// GetToolRef checks if the 'TOOL_REF' environment variable is set.
+// If 'TOOL_REF' is non-empty, it returns the value. Otherwise, it returns DefaultToolRef.
+func GetToolRef() string {
+	return env.Default("TOOL_REF", DefaultToolRef)
 }
 
 // BuiltWithBazel determines whether the most recent Kubernetes release was built with Bazel.

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -81,10 +81,10 @@ func TestGetToolRepoURLSuccess(t *testing.T) {
 	}
 }
 
-func TestGetToolBranchSuccess(t *testing.T) {
+func TestGetToolRefSuccess(t *testing.T) {
 	testcases := []struct {
 		name     string
-		branch   string
+		ref      string
 		expected string
 	}{
 		{
@@ -93,16 +93,16 @@ func TestGetToolBranchSuccess(t *testing.T) {
 		},
 		{
 			name:     "custom branch",
-			branch:   "tool-branch",
+			ref:      "tool-branch",
 			expected: "tool-branch",
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
-		require.Nil(t, os.Setenv("TOOL_BRANCH", tc.branch))
+		require.Nil(t, os.Setenv("TOOL_REF", tc.ref))
 
-		actual := GetToolBranch()
+		actual := GetToolRef()
 		require.Equal(t, tc.expected, actual)
 	}
 }

--- a/pkg/release/releasefakes/fake_repository.go
+++ b/pkg/release/releasefakes/fake_repository.go
@@ -99,6 +99,19 @@ type FakeRepository struct {
 		result1 []*git.Remote
 		result2 error
 	}
+	RevParseStub        func(string) (string, error)
+	revParseMutex       sync.RWMutex
+	revParseArgsForCall []struct {
+		arg1 string
+	}
+	revParseReturns struct {
+		result1 string
+		result2 error
+	}
+	revParseReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -455,6 +468,70 @@ func (fake *FakeRepository) RemotesReturnsOnCall(i int, result1 []*git.Remote, r
 	}{result1, result2}
 }
 
+func (fake *FakeRepository) RevParse(arg1 string) (string, error) {
+	fake.revParseMutex.Lock()
+	ret, specificReturn := fake.revParseReturnsOnCall[len(fake.revParseArgsForCall)]
+	fake.revParseArgsForCall = append(fake.revParseArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.RevParseStub
+	fakeReturns := fake.revParseReturns
+	fake.recordInvocation("RevParse", []interface{}{arg1})
+	fake.revParseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRepository) RevParseCallCount() int {
+	fake.revParseMutex.RLock()
+	defer fake.revParseMutex.RUnlock()
+	return len(fake.revParseArgsForCall)
+}
+
+func (fake *FakeRepository) RevParseCalls(stub func(string) (string, error)) {
+	fake.revParseMutex.Lock()
+	defer fake.revParseMutex.Unlock()
+	fake.RevParseStub = stub
+}
+
+func (fake *FakeRepository) RevParseArgsForCall(i int) string {
+	fake.revParseMutex.RLock()
+	defer fake.revParseMutex.RUnlock()
+	argsForCall := fake.revParseArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRepository) RevParseReturns(result1 string, result2 error) {
+	fake.revParseMutex.Lock()
+	defer fake.revParseMutex.Unlock()
+	fake.RevParseStub = nil
+	fake.revParseReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRepository) RevParseReturnsOnCall(i int, result1 string, result2 error) {
+	fake.revParseMutex.Lock()
+	defer fake.revParseMutex.Unlock()
+	fake.RevParseStub = nil
+	if fake.revParseReturnsOnCall == nil {
+		fake.revParseReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.revParseReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -470,6 +547,8 @@ func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	defer fake.lsRemoteMutex.RUnlock()
 	fake.remotesMutex.RLock()
 	defer fake.remotesMutex.RUnlock()
+	fake.revParseMutex.RLock()
+	defer fake.revParseMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/release/repository.go
+++ b/pkg/release/repository.go
@@ -111,7 +111,7 @@ func (r *Repo) CheckState(expOrg, expRepo, expRev string, nomock bool) error {
 		return errors.Wrap(err, "retrieving repository HEAD")
 	}
 
-	logrus.Infof("repo head %s", head)
+	logrus.Infof("Repo head is: %s", head)
 
 	rev, err := r.repo.RevParse(expRev)
 	if err != nil {

--- a/pkg/release/repository.go
+++ b/pkg/release/repository.go
@@ -44,6 +44,7 @@ func NewRepo() *Repo {
 type Repository interface {
 	Describe(opts *git.DescribeOptions) (string, error)
 	CurrentBranch() (branch string, err error)
+	RevParse(rev string) (string, error)
 	Head() (string, error)
 	Remotes() (res []*git.Remote, err error)
 	LsRemote(...string) (string, error)
@@ -86,7 +87,7 @@ func (r *Repo) GetTag() (string, error) {
 }
 
 // CheckState verifies that the repository is in the requested state
-func (r *Repo) CheckState(expOrg, expRepo, expBranch string, nomock bool) error {
+func (r *Repo) CheckState(expOrg, expRepo, expRev string, nomock bool) error {
 	logrus.Info("Verifying repository state")
 
 	dirty, err := r.repo.IsDirty()
@@ -100,19 +101,32 @@ func (r *Repo) CheckState(expOrg, expRepo, expBranch string, nomock bool) error 
 	}
 	logrus.Info("Repository is in clean state")
 
-	// Verify the branch
 	branch, err := r.repo.CurrentBranch()
 	if err != nil {
 		return errors.Wrap(err, "retrieving current branch")
 	}
-	if branch != expBranch {
-		return errors.Errorf("branch %q expected but got %q", expBranch, branch)
+
+	head, err := r.repo.Head()
+	if err != nil {
+		return errors.Wrap(err, "retrieving rev-parse for HEAD")
 	}
-	if nomock && !(expOrg == DefaultToolOrg && expRepo == DefaultToolRepo && expBranch == DefaultToolBranch) {
+
+	logrus.Infof("repo head %s", head)
+
+	rev, err := r.repo.RevParse(expRev)
+	if err != nil {
+		return errors.Wrapf(err, "retrieving rev-parse for %s", expRev)
+	}
+
+	if rev != head {
+		return errors.Errorf("revision %q expected but got %q", head, rev)
+	}
+
+	if nomock && !(expOrg == DefaultToolOrg && expRepo == DefaultToolRepo && expRev == DefaultToolRef) {
 		return errors.New("disallow using anything other than kubernetes/release:master with nomock flag")
 	}
 
-	logrus.Infof("Found matching branch %q", expBranch)
+	logrus.Infof("Found matching revision %q", expRev)
 
 	// Verify the remote
 	remotes, err := r.repo.Remotes()
@@ -146,8 +160,9 @@ func (r *Repo) CheckState(expOrg, expRepo, expBranch string, nomock bool) error 
 	)
 
 	logrus.Info("Verifying remote HEAD commit")
+	logrus.Infof("Verifying remote HEAD commit -> %s / %s / %s", foundRemote.Name(), expRev, branch)
 	lsRemoteOut, err := r.repo.LsRemote(
-		"--heads", foundRemote.Name(), "refs/heads/"+expBranch,
+		"--heads", foundRemote.Name(), "refs/heads/"+branch,
 	)
 	if err != nil {
 		return errors.Wrap(err, "getting remote HEAD")
@@ -160,10 +175,6 @@ func (r *Repo) CheckState(expOrg, expRepo, expBranch string, nomock bool) error 
 	logrus.Infof("Got remote commit: %s", commit)
 
 	logrus.Info("Verifying that remote commit is equal to the local one")
-	head, err := r.repo.Head()
-	if err != nil {
-		return errors.Wrapf(err, "retrieving repository HEAD")
-	}
 	if head != commit {
 		return errors.Errorf(
 			"Local HEAD (%s) is not equal to latest remote commit (%s)",

--- a/pkg/release/repository_test.go
+++ b/pkg/release/repository_test.go
@@ -94,8 +94,9 @@ func TestCheckStateSuccess(t *testing.T) {
 	sut.mock.RemotesReturns([]*git.Remote{
 		git.NewRemote("origin", []string{"github.com:org/repo"}),
 	}, nil)
-	sut.mock.LsRemoteReturns("dbade8e refs/heads/master", nil)
 	sut.mock.HeadReturns("dbade8e", nil)
+	sut.mock.RevParseReturns("dbade8e", nil)
+	sut.mock.LsRemoteReturns("dbade8e refs/heads/master", nil)
 
 	// When
 	err := sut.repo.CheckState("org", "repo", "branch", false)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

move references from TOOL_BRANCH to be TOOL_REF

to be honest I'm not 100% sure if this is enough, opening the PR for feedback

/assign @saschagrunert @hasheddan @puerco 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/1028


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
move references from TOOL_BRANCH to be TOOL_REF
```
