### PR TITLE
Simplify debian-base image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ CHANGELOG-*.html
 
 # downloaded and built binaries
 bin
+qemu-*-static
+rootfs.tar

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -26,16 +26,14 @@ TAR_FILE ?= rootfs.tar
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
-TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=5.2.0-2
-
-SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=debian:$(CONFIG)-slim
+	QEMUARCH=x86_64
 endif
 ifeq ($(ARCH),arm)
 	BASEIMAGE?=arm32v7/debian:$(CONFIG)-slim
@@ -72,49 +70,39 @@ push-manifest:
 	docker manifest push --purge ${IMAGE}:${IMAGE_VERSION}
 
 build: clean
-	cp -r ./$(CONFIG) $(TEMP_DIR)/
-	cat $(CONFIG)/Dockerfile.build \
-		| sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
-		| sed "s|ARCH|$(QEMUARCH)|g" \
-		> $(TEMP_DIR)/$(CONFIG)/Dockerfile.build
+	# Fix possible issues with the local umask
+	umask 0022
 
-ifeq ($(ARCH),amd64)
-	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	sed "/CROSS_BUILD_/d" $(TEMP_DIR)/$(CONFIG)/Dockerfile.build > $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp
-else
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
 
-	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)/$(CONFIG)
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(CONFIG)
 	# Ensure we don't get surprised by umask settings
-	chmod 0755 $(TEMP_DIR)/$(CONFIG)/qemu-$(QEMUARCH)-static
-
-	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
-	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/$(CONFIG)/Dockerfile.build > $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp
-endif
-	mv $(TEMP_DIR)/$(CONFIG)/Dockerfile.build.tmp $(TEMP_DIR)/$(CONFIG)/Dockerfile.build
+	chmod 0755 $(CONFIG)/qemu-$(QEMUARCH)-static
 
 	docker buildx build \
 		--pull \
 		--load \
 		--platform linux/$(ARCH) \
+		--build-arg BASEIMAGE=$(BASEIMAGE) \
+		--build-arg ARCH=$(QEMUARCH) \
 		-t $(BUILD_IMAGE) \
-		-f $(TEMP_DIR)/$(CONFIG)/Dockerfile.build $(TEMP_DIR)/$(CONFIG)
+		-f $(CONFIG)/Dockerfile.build \
+		$(CONFIG)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
-	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(CONFIG)/$(TAR_FILE)
+	docker export $(BUILD_IMAGE) > $(CONFIG)/$(TAR_FILE)
 	docker buildx build \
 		--load \
 		--platform linux/$(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
-		$(TEMP_DIR)/$(CONFIG)
-	rm -rf $(TEMP_DIR)
-ifneq ($(ARCH),amd64)
+		$(CONFIG)
 	docker buildx rm $$BUILDER
-endif
+	rm $(CONFIG)/qemu-$(QEMUARCH)-static
+	rm $(CONFIG)/rootfs.tar
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)

--- a/images/build/debian-base/buster/Dockerfile.build
+++ b/images/build/debian-base/buster/Dockerfile.build
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+ARG BASEIMAGE
+FROM $BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so
-# e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+ARG ARCH
+COPY qemu-$ARCH-static /usr/bin/
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -26,6 +25,16 @@ COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
 
 # Convenience script for building on this base image.
 COPY clean-install /usr/local/bin/clean-install
+
+# An attempt to fix issues like:
+# ```
+# Error while loading /usr/sbin/dpkg-split: No such file or directory
+# Error while loading /usr/sbin/dpkg-deb: No such file or directory
+# ```
+# See: https://github.com/docker/buildx/issues/495
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split
+RUN ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb
+RUN ln -s /bin/tar /usr/sbin/tar
 
 # Update system packages.
 RUN apt-get update \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The usage of a temp dir is not necessary if we use the
`--build-arg`/`ARG` syntax within the image build. We also do not have
to assume that we're running always on x86_64, which means that the
image build should now also work on arm machines for example.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:

/hold for manual testing

We also have to do this change for the other images if it gets accepted.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
