### PR TITLE
Fix s390x build failures in setcap.

### DIFF
--- a/images/build/setcap/Dockerfile
+++ b/images/build/setcap/Dockerfile
@@ -16,4 +16,15 @@ ARG BASEIMAGE
 
 FROM ${BASEIMAGE}
 
-RUN apt-get update && apt-get -y --no-install-recommends install libcap2-bin
+# An attempt to fix issues like:
+# ```
+# Error while loading /usr/sbin/dpkg-split: No such file or directory
+# Error while loading /usr/sbin/dpkg-deb: No such file or directory
+# ```
+# See: https://github.com/docker/buildx/issues/495
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split \
+    && ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb \
+    && ln -s /bin/tar /usr/sbin/tar \
+    && ln -s /bin/rm /usr/sbin/rm \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install libcap2-bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:
s390x builds in Prow fail with errors like:
```
...
#6 21.11 Error while loading /usr/sbin/dpkg-split: No such file or directory
#6 21.12 Error while loading /usr/sbin/dpkg-deb: No such file or directory
...
```
Error log from prow:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-setcap/1360387990383235072

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
