### PR TITLE
Simplify build image Makefile's

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -73,7 +73,7 @@ build: clean
 	# Fix possible issues with the local umask
 	umask 0022
 
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	# Enable execution of multi-architecture containers
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)

--- a/images/build/debian-hyperkube-base/.gitignore
+++ b/images/build/debian-hyperkube-base/.gitignore
@@ -1,1 +1,2 @@
 /cni-tars
+/cni-bin

--- a/images/build/debian-hyperkube-base/Dockerfile
+++ b/images/build/debian-hyperkube-base/Dockerfile
@@ -55,4 +55,4 @@ RUN clean-install \
     util-linux \
     xfsprogs
 
-COPY cni-bin/bin /opt/cni/bin
+COPY cni-bin /opt/cni/bin

--- a/images/build/debian-hyperkube-base/Makefile
+++ b/images/build/debian-hyperkube-base/Makefile
@@ -27,7 +27,6 @@ BASE_REGISTRY?=k8s.gcr.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-iptables-$(ARCH):buster-v1.5.0
 CNI_VERSION?=v0.8.7
 
-TEMP_DIR:=$(shell mktemp -d)
 CNI_TARBALL=cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz
 
 QEMUVERSION=5.2.0-2
@@ -66,28 +65,24 @@ clean:
 	rm -rf cni-tars/
 
 build: cni-tars/$(CNI_TARBALL)
-	cp Dockerfile $(TEMP_DIR)
+	# Fix possible issues with the local umask
+	umask 0022
 
-	mkdir -p ${TEMP_DIR}/cni-bin/bin
-	tar -xz -C ${TEMP_DIR}/cni-bin/bin -f "cni-tars/${CNI_TARBALL}"
+	mkdir -p cni-bin
+	tar xfz "./cni-tars/${CNI_TARBALL}" -C cni-bin
 
-ifneq ($(ARCH),amd64)
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	# Enable execution of multi-architecture containers
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
-endif
 	docker buildx build \
 		--pull \
 		--load \
 		--platform linux/$(ARCH) \
 		-t $(IMAGE)-$(ARCH):$(TAG) \
 		--build-arg BASEIMAGE=$(BASEIMAGE) \
-		$(TEMP_DIR)
-	rm -rf $(TEMP_DIR)
-ifneq ($(ARCH),amd64)
+		.
 	docker buildx rm $$BUILDER
-endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(TAG)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -24,7 +24,6 @@ DEBIAN_BASE_VERSION ?= buster-v1.4.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
-TEMP_DIR:=$(shell mktemp -d)
 
 BASE_REGISTRY?=k8s.gcr.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
@@ -39,14 +38,13 @@ export DOCKER_CLI_EXPERIMENTAL := enabled
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 
 build:
-	cp -r ./$(CONFIG) $(TEMP_DIR)/
+	# Fix possible issues with the local umask
+	umask 0022
 
-ifneq ($(ARCH),amd64)
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	# Enable execution of multi-architecture containers
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
-endif
 	docker buildx build \
 		--pull \
 		--load \
@@ -56,10 +54,8 @@ endif
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		--build-arg=IPTABLES_VERSION=$(IPTABLES_VERSION) \
 		--build-arg=BASEIMAGE=$(BASEIMAGE) \
-		$(TEMP_DIR)/$(CONFIG)
-ifneq ($(ARCH),amd64)
+		$(CONFIG)
 	docker buildx rm $$BUILDER
-endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -35,12 +35,13 @@ QEMUVERSION=5.2.0-2
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
 build:
-ifneq ($(ARCH),amd64)
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	# Fix possible issues with the local umask
+	umask 0022
+
+	# Enable execution of multi-architecture containers
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
-endif
 	docker buildx build \
 		--pull \
 		--load \
@@ -50,9 +51,7 @@ endif
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		--build-arg=BASEIMAGE=$(BASEIMAGE) \
 		.
-ifneq ($(ARCH),amd64)
 	docker buildx rm $$BUILDER
-endif
 
 push: build
 	docker push $(IMAGE)-$(ARCH):$(IMAGE_VERSION)
@@ -77,4 +76,3 @@ push-manifest:
 	docker manifest push --purge ${IMAGE}:${IMAGE_VERSION}
 
 all: all-push
-


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We now create a builder in any case for builds on non x86_64 machines.
We can also avoid temp directories by not copying content around.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
