### PR TITLE
[go1.16] Build official images

### DIFF
--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,7 +20,7 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.4.3-4
+IMAGE_VERSION ?= v0.4.3-5
 CONFIG ?= buster
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
@@ -28,7 +28,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16rc1
+GO_VERSION ?= 1.16
 DISTROLESS_IMAGE ?= static-debian10
 
 PLATFORMS ?= linux/amd64

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,6 +1,5 @@
-
 variants:
   default:
-    IMAGE_VERSION: 'v0.4.3-4'
-    GO_VERSION: '1.16rc1'
+    IMAGE_VERSION: 'v0.4.3-5'
+    GO_VERSION: '1.16'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
-    version: v0.4.3-4
+    version: v0.4.3-5
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -98,7 +98,7 @@ dependencies:
 
   # Golang images
   - name: "gcr.io/k8s-staging-releng/releng-ci"
-    version: v0.3.0
+    version: v0.4.0
     refPaths:
     - path: images/releng/ci/cloudbuild.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.16rc1
+    version: 1.16
     refPaths:
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -96,6 +96,7 @@ dependencies:
     refPaths:
     - path: images/build/go-runner/VERSION
 
+  # Golang images
   - name: "gcr.io/k8s-staging-releng/releng-ci"
     version: v0.3.0
     refPaths:
@@ -111,7 +112,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: v2.3.1-go1.16rc1-buster.1
+    version: v2.3.1-go1.16-buster.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -125,13 +126,13 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.16.0-rc.1-2
+    version: v1.16.0-1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: config variant"
-    version: go1.15
+    version: go1.16
     refPaths:
     - path: images/build/cross/Makefile
       match: CONFIG \?= go\d+.\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -118,7 +118,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/build-image/go-runner: image revision"
-    version: 1
+    version: 0
     refPaths:
     - path: images/build/go-runner/Makefile
       match: REVISION \?= \d+

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -19,12 +19,12 @@ include $(CURDIR)/../Makefile.build-image
 SHELL=/bin/bash -o pipefail
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.16.0-rc.1-2
-CONFIG ?= go1.15
+IMAGE_VERSION ?= v1.16.0-1
+CONFIG ?= go1.16
 TYPE ?= default
 
 # Build args
-GO_VERSION?=1.16rc1
+GO_VERSION?=1.16
 PROTOBUF_VERSION?=3.7.0
 ETCD_VERSION?=v3.4.13
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,15 +2,15 @@ variants:
   canary:
     TYPE: 'default'
     CONFIG: 'canary'
-    GO_VERSION: '1.16rc1'
-    IMAGE_VERSION: 'v1.16.0-rc.1-canary-1'
+    GO_VERSION: '1.16'
+    IMAGE_VERSION: 'v1.16.0-canary-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.16:
     TYPE: 'default'
     CONFIG: 'go1.16'
-    GO_VERSION: '1.16rc1'
-    IMAGE_VERSION: 'v1.16.0-rc.1-2'
+    GO_VERSION: '1.16'
+    IMAGE_VERSION: 'v1.16.0-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15:

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -19,10 +19,10 @@ IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)
 GO_MINOR_VERSION ?= 1.16
 OS_CODENAME ?= buster
-REVISION ?= 1
+REVISION ?= 0
 
 # Build args
-GO_VERSION ?= 1.16rc1
+GO_VERSION ?= 1.16
 DISTROLESS_IMAGE ?= static-debian10
 
 # Configuration

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,9 +1,9 @@
 variants:
   go1.16-buster:
     CONFIG: 'go1.16-buster'
-    IMAGE_VERSION: 'v2.3.1-go1.16rc1-buster.1'
+    IMAGE_VERSION: 'v2.3.1-go1.16-buster.0'
     GO_MINOR_VERSION: '1.16'
     OS_CODENAME: 'buster'
-    REVISION: '1'
-    GO_VERSION: '1.16rc1'
+    REVISION: '0'
+    GO_VERSION: '1.16'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -24,8 +24,8 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.3.0'
-  _GO_VERSION: '1.16rc1'
+  _IMAGE_VERSION: 'v0.4.0'
+  _GO_VERSION: '1.16'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes/release/issues/1834.)

go1.16 is out! 🎉 
ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1613509049283800

- kube-cross: Build v1.16.0-1 image
- go-runner: Build v2.3.1-go1.16-buster.0 image
- releng-ci: Build v0.4.0 image
- vulndash: Build v0.4.3-5 image 

/assign @hasheddan @saschagrunert @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

`vulndash` is built for completeness, based on the current `dependencies.yaml`
definitions. The vulndash image will not be promoted.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- kube-cross: Build v1.16.0-1 image
- go-runner: Build v2.3.1-go1.16-buster.0 image
- releng-ci: Build v0.4.0 image
- vulndash: Build v0.4.3-5 image 
```
