### PR TITLE
cloud-builder: add kube-cross-legacy variant

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -3,3 +3,7 @@ variants:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.8-1'
     SKOPEO_VERSION: 'v1.2.0'
+  cross1.15-legacy:
+    CONFIG: 'cross1.15-legacy'
+    KUBE_CROSS_VERSION: 'v1.15.8-legacy-1'
+    SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

we built the kube-cross legacy variant in this PR https://github.com/kubernetes/release/pull/1915 and was missing to build the cloud-builder related image

/assign @saschagrunert @justaugustus @hasheddan @puerco
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
