### PR TITLE
k8s-rapture: Check if debs and rpms exist before calling rapture addpkg

### DIFF
--- a/hack/rapture/k8s-rapture.sh
+++ b/hack/rapture/k8s-rapture.sh
@@ -134,9 +134,13 @@ publish_debs() {
       rm "${debpath}"
     fi
   done
-
-  log "Pushing debs to kubernetes-${distro}-unstable"
-  rapture --universe=cloud-apt addpkg -keepold "kubernetes-${distro}" bin/stable/${distro}/*.deb
+  if ls bin/stable/${distro}/*.deb 1> /dev/null 2>&1;
+  then
+    log "Pushing debs to kubernetes-${distro}-unstable"
+    rapture --universe=cloud-apt addpkg -keepold "kubernetes-${distro}" bin/stable/${distro}/*.deb
+  else
+    log "No debs found in bin/stable/${distro}/*.deb, skipping rapture addpkg"
+  fi
 
   log "Packages in kubernetes-${distro}-unstable:"
   rapture --universe=cloud-apt listrepo "kubernetes-${distro}-unstable"
@@ -218,8 +222,13 @@ publish_rpms() {
   local repo
   for arch in "${archlist[@]}"; do
     repo="kubernetes-${distro}-${arch}"
-    log "Pushing RPMs to ${repo}-unstable"
-    rapture --universe=cloud-yum addpkg -keepold "${repo}" output/${arch}/*.rpm
+    if ls output/${arch}/*.rpm 1> /dev/null 2>&1;
+    then
+      log "Pushing RPMs to ${repo}-unstable"
+      rapture --universe=cloud-yum addpkg -keepold "${repo}" output/${arch}/*.rpm
+    else
+      log "No RPMs found in output/${arch}/ skipping rapture addpkg"
+    fi
   done
 
   local target


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
k8s-rapture will delete RPMs and debs already pushed to the server
before invoking `rapture addpkg`. But when all files are already up,
the script fails as no files are left to push.

This PR adds a check to skip the `rapture addpkg` invocation if no
files need to be pushed,

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Fixes a bug encountered during the Jan '21 patch releases ([slack ref](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1613599453309000?thread_ts=1613553340.287500&cid=CJH2GBF7Y))

#### Does this PR introduce a user-facing change?

```release-note
k8s-rapture will now check if debs and RPMs exist before calling `rapture addpkg`
```
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
