### PR TITLE
images/build/debian-iptables: Remove inactive members from OWNERS

### DIFF
--- a/images/build/debian-iptables/OWNERS
+++ b/images/build/debian-iptables/OWNERS
@@ -6,7 +6,6 @@ reviewers:
   - BenTheElder
   - bowei
   - freehan
-  - jingax10
   - mkumatag
   - mrhohn
   - tallclair
@@ -16,7 +15,8 @@ approvers:
   - BenTheElder
   - bowei
   - freehan
-  - jingax10
   - mkumatag
   - mrhohn
   - tallclair
+emeritus_approvers:
+  - jingax10


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves jingax10 from
an approver to an emeritus_approver.


/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
