### PR TITLE
Implement --list-v2 in release notes

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -257,6 +257,12 @@ func init() {
 		[]string{},
 		"specify a location to recursively look for release notes *.y[a]ml file mappings",
 	)
+	cmd.PersistentFlags().BoolVar(
+		&opts.ListReleaseNotesV2,
+		"list-v2",
+		false,
+		"enable experimental implementation to list commits (ListReleaseNotesV2)",
+	)
 }
 
 func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new `--list-v2` flag to `release-notes` to enable @wilsonehusin 's experimental code to list release notes locally. 

Having the flag in `release-notes` is much more useful to test the new code.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This flag has already been merged into `krel` in https://github.com/kubernetes/release/pull/1888 . This PRs adds feature parity to the general purpose `release-notes` command.

#### Does this PR introduce a user-facing change?
```release-note
Added a new flag to `release-notes`: `--list-v2`. When defined, it enables the new release notes list code which looks up release notes from merge PRs.
```
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>