### PR TITLE
Fix package tests

### DIFF
--- a/hack/packages/verify-published.sh
+++ b/hack/packages/verify-published.sh
@@ -41,6 +41,13 @@ for release in $(curl -s https://api.github.com/repos/kubernetes/kubernetes/rele
 	if [[ "${release}" =~ $unstable_versions ]]; then
 		# alpha, beta, rc releases should be ignored
 		echo "Unstable version ${release} ignored"
+	elif [[ "${release}" == "v1.20.3" ]]; then
+		# v1.20.3 was interrupted due to a conformance metada
+		# problem. We ignore this release as no packages were
+		# published
+		#
+		# ref: https://groups.google.com/g/kubernetes-dev/c/oUpY9vWgzJo
+		echo "Ignoring v1.20.3: no packages were created"
 	elif [[ $supported_versions != *"${minor#v}"* ]]; then
 		# release we don't care about (e.g. older releases)
 		skipped="${skipped} ${release}"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

A [problem with conformance metada was discovered](https://groups.google.com/g/kubernetes-dev/c/oUpY9vWgzJo) while we were in the middle of the `v1.20.3` release and the release process had to be interrupted. As a result no rpms or debs were produced. The lack of packages is causing [`verify-packages-debs`](https://testgrid.k8s.io/sig-release-releng-informing#verify-packages-debs) and [`verify-packages-rpms` ](https://testgrid.k8s.io/sig-release-releng-informing#verify-packages-rpms)to permanently fail.

This patch hardcodes an exception into the test to skip the package check for this specific version. 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

I did not test the deb check but should work.

#### Does this PR introduce a user-facing change?

```release-note
`hack/packages/verify-published.sh` will skip v1.20.3 when checking packages as none were produced 
```
