### PR TITLE
Initial commit for rnd

### DIFF
--- a/cmd/rnd/.gitignore
+++ b/cmd/rnd/.gitignore
@@ -1,2 +1,2 @@
 # most likely used for credentials in testing / development
-.direnv
+.envrc

--- a/cmd/rnd/.gitignore
+++ b/cmd/rnd/.gitignore
@@ -1,0 +1,2 @@
+# most likely used for credentials in testing / development
+.direnv

--- a/cmd/rnd/OWNERS
+++ b/cmd/rnd/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - krel-reviewers
+  - wilsonehusin
+approvers:
+  - krel-approvers
+  - wilsonehusin

--- a/cmd/rnd/README.md
+++ b/cmd/rnd/README.md
@@ -1,0 +1,9 @@
+# Release Notes Daemon (rnd)
+
+This is an experimental project, reimagining release notes review and revision through version control, adopting the GitOps philosophy.
+
+Details are available in [`kubernetes/release#1889`](https://github.com/kubernetes/release/issues/1889). This project is incomplete at the moment.
+
+Project status:
+- [x] Implement `fetch` and save content as YAML
+- [ ] Implement `render` where given a Git repository path and release version, render the release notes document

--- a/cmd/rnd/cmd/fetch.go
+++ b/cmd/rnd/cmd/fetch.go
@@ -122,7 +122,7 @@ func rndFetch() error {
 	}
 
 	storagePath := filepath.Join(rnd.StorageWorkDir(releaseTagVersion), "fetched")
-	if err = writeReleaseNotesToGitRepo(releaseNotes, storageGit, storagePath); err != nil {
+	if err := writeReleaseNotesToGitRepo(releaseNotes, storageGit, storagePath); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func rndFetch() error {
 			return err
 		}
 
-		if err = storageGit.PushToRemote("origin", "main"); err != nil {
+		if err := storageGit.PushToRemote("origin", "main"); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/rnd/cmd/fetch.go
+++ b/cmd/rnd/cmd/fetch.go
@@ -1,5 +1,5 @@
 /*
-Copyright © The Kubernetes Authors
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/rnd/cmd/fetch.go
+++ b/cmd/rnd/cmd/fetch.go
@@ -1,0 +1,64 @@
+/*
+Copyright © The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/spf13/cobra"
+)
+
+// ATTENTION: if you're modifying this struct, make sure you update the command help
+type fetchOptions struct {
+	SourceRepo  string `split_words:"true" required:"true" default:"github.com/kubernetes/kubernetes"`
+	StorageRepo string `split_words:"true" required:"true" default:"github.com/wilsonehusin/k8s-release-notes-data"` // TODO: create new repository?
+	StorageDir  string `split_words:"true" required:"true" default:"release-1.21/raw"`
+}
+
+var fetchOpts = &fetchOptions{}
+
+var fetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Fetches the latest changes to store",
+	Long: `rnd fetch -- Fetch latest release notes
+
+This command will look up relevant pull requests in RND_SOURCE_REPO,
+add / update the entries in RND_STORAGE_REPO under RND_STORAGE_DIR.`,
+	PreRunE: func(*cobra.Command, []string) error {
+		return processFetchFlags()
+	},
+	Run: func(*cobra.Command, []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	var optionsUsage bytes.Buffer
+	if err := envconfig.Usagef(progName, fetchOpts, &optionsUsage, optionsUsageTemplate); err != nil {
+		panic(err)
+	}
+	fetchCmd.SetUsageTemplate(fetchCmd.UsageTemplate() + optionsUsageHeader + optionsUsage.String() + rootCmdOptionsUsage())
+	rootCmd.AddCommand(fetchCmd)
+}
+
+func processFetchFlags() error {
+	if err := envconfig.Process(progName, fetchOpts); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/rnd/cmd/fetch.go
+++ b/cmd/rnd/cmd/fetch.go
@@ -27,12 +27,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/release-utils/util"
 
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/notes"
 	notesoptions "k8s.io/release/pkg/notes/options"
 	"k8s.io/release/pkg/rnd"
-	"k8s.io/release/pkg/util"
 )
 
 // ATTENTION: if you're modifying this struct, make sure you update the command help

--- a/cmd/rnd/cmd/root.go
+++ b/cmd/rnd/cmd/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 
-	"k8s.io/release/pkg/log"
+	"sigs.k8s.io/release-utils/log"
 )
 
 const (

--- a/cmd/rnd/cmd/root.go
+++ b/cmd/rnd/cmd/root.go
@@ -51,7 +51,7 @@ the program expects to be run unattended, such as through CI systems`,
 	PersistentPreRunE: func(*cobra.Command, []string) error {
 		return processRootFlags()
 	},
-	Run: func(*cobra.Command, []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
 }

--- a/cmd/rnd/cmd/root.go
+++ b/cmd/rnd/cmd/root.go
@@ -51,8 +51,8 @@ the program expects to be run unattended, such as through CI systems`,
 	PersistentPreRunE: func(*cobra.Command, []string) error {
 		return processRootFlags()
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
 	},
 }
 

--- a/cmd/rnd/cmd/root.go
+++ b/cmd/rnd/cmd/root.go
@@ -1,0 +1,92 @@
+/*
+Copyright © 2021 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/spf13/cobra"
+
+	"k8s.io/release/pkg/log"
+)
+
+const (
+	progName             = "rnd"
+	optionsUsageHeader   = "\nConfigurable environment variables with their default values: (required fields marked with (*))"
+	optionsUsageTemplate = `{{range .}}
+  {{if usage_required .}}(*) {{else}}    {{end}}{{usage_key .}}={{usage_default .}}{{end}}`
+)
+
+type rootOptions struct {
+	LogLevel string `split_words:"true" default:"info"`
+}
+
+var rootOpts = &rootOptions{}
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   progName,
+	Short: "rnd: Release Notes Daemon",
+	Long: `rnd: release notes (daemon) with continuous integration in mind
+
+rnd was designed with container-first ergonomics, since
+the program expects to be run unattended, such as through CI systems`,
+	PersistentPreRunE: func(*cobra.Command, []string) error {
+		return processRootFlags()
+	},
+	Run: func(*cobra.Command, []string) {
+		cmd.Help()
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + optionsUsageHeader + rootCmdOptionsUsage())
+}
+
+func rootCmdOptionsUsage() string {
+	var optionsUsage bytes.Buffer
+	if err := envconfig.Usagef(progName, rootOpts, &optionsUsage, optionsUsageTemplate); err != nil {
+		panic(err)
+	}
+	return optionsUsage.String()
+}
+
+func processRootFlags() error {
+	err := envconfig.Process(progName, rootOpts)
+	if err != nil {
+		return err
+	}
+
+	err = log.SetupGlobalLogger(rootOpts.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/rnd/cmd/root.go
+++ b/cmd/rnd/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 The Kubernetes Authors
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/rnd/main.go
+++ b/cmd/rnd/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright © 2021 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/release/cmd/rnd/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/rnd/main.go
+++ b/cmd/rnd/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 The Kubernetes Authors
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-github/v33 v33.0.0
 	github.com/google/licenseclassifier/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.2.0
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-github/v33 v33.0.0
 	github.com/google/licenseclassifier/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.2.0
-	github.com/kelseyhightower/envconfig v1.4.0 // indirect
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -385,7 +385,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,9 @@ github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfE
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -331,9 +331,11 @@ func CloneOrOpenRepo(repoPath, repoURL string, useSSH bool) (*Repo, error) {
 		_, err := os.Stat(repoPath)
 
 		if err == nil {
+			logrus.Debug("repository path exists, trying to update")
 			// The file or directory exists, just try to update the repo
 			return updateRepo(repoPath)
 		} else if os.IsNotExist(err) {
+			logrus.Debug("repository path does not exist, cloning")
 			// The directory does not exists, we still have to clone it
 			targetDir = repoPath
 		} else {

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -213,6 +213,9 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 }
 
 func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair, error) {
+	logrus.WithFields(logrus.Fields{
+		"RepoPath": opts.RepoPath,
+	}).Debug("opening existing local k/k")
 	localRepository, err := git.PlainOpen(opts.RepoPath)
 	if err != nil {
 		return nil, err

--- a/pkg/rnd/OWNERS
+++ b/pkg/rnd/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-  - krel-reviewers
-  - wilsonehusin # primary implementor for rnd
 approvers:
   - krel-approvers
+  - wilsonehusin # primary implementor for rnd
+reviewers:
+  - krel-reviewers
   - wilsonehusin # primary implementor for rnd

--- a/pkg/rnd/storage.go
+++ b/pkg/rnd/storage.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rnd
 
 import (

--- a/pkg/rnd/storage.go
+++ b/pkg/rnd/storage.go
@@ -1,0 +1,27 @@
+package rnd
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"k8s.io/release/pkg/git"
+)
+
+func StorageWorkDir(releaseTagVersion semver.Version) string {
+	return fmt.Sprintf("release-%d.%d", releaseTagVersion.Major, releaseTagVersion.Minor)
+}
+
+func CloneStorageRepo(repoSlug string) (*git.Repo, error) {
+	repoOrg, repoName, err := git.ParseRepoSlug(repoSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	storageGit, err := git.CleanCloneGitHubRepo(repoOrg, repoName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return storageGit, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/coxntributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

(Note: I keep mentioning _container-default_ design when really more accurately it's _12-factor application in containers_)

- [x] `rnd fetch` allows us to have a system which periodically pulls PR data from kubernetes/kubernetes on GitHub and [store them in repository](https://github.com/wilsonehusin/k8s-release-notes-data)
- [ ] `rnd apply` generates markdown file by combining data under `fetched/` and `maps/` (used for local validation)
- [ ] `rnd publish` submits PR to kubernetes/sig-release to update `release-notes-draft.md`
- [ ] production readiness
  - [ ] ensuring git operations are still fine once containerized
  - [ ] building the container
  - [ ] where to publish the container

Some considerations on how we got here:

- why `rnd fetch` does not store to GCS / cloud bucket storage?
  - at a glance, storing the results of `rnd fetch` to cloud bucket storage seem to be the right solution for the problem. however, this obscures the "current state" which would be helpful for people submitting maps for PRs. having the maps stored in git repository allows contributors to `cp fetched/pr-num.yaml maps/pr-num.yaml` then edit away what they want in any text editor they like as pure YAML. no special / extra tools needed
- why containers?
  -  `rnd` was designed to be executed by machines with as minimal human intervention as possible. having them in containers forces deployments to be fleshed out in configurations and minimizes variances on different CI systems. with the project looking to remove Bazel (https://github.com/kubernetes/kubernetes/issues/88553), container-default design allows us to keep moving regardless of what CI system we end up with next.

Some factors which still need more thoughts and discussions:

- how are we building the container? I'd like to adopt [google/ko](https://github.com/google/ko) out of simplicity, but it also means we might deviate from the rest of this project on how we build containers.
- how are we publishing the container? my knee-jerk reaction as someone without Google Cloud access (yet?) is to use GitHub package registry with bot account (which I can set up). but if we can get a dedicated service account to push to GCR, that sounds good to me too!

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Part of #1889

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
