### PR TITLE
Update k8s-cloud-builder to v1.16.0-1 and k8s-ci-builder to use go1.16

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.15.8
+    version: 1.16.0
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -140,7 +140,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.15.8-1
+    version: v1.16.0-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.0
+    version: 1.16
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,8 @@
 variants:
+  cross1.16:
+    CONFIG: 'cross1.16'
+    KUBE_CROSS_VERSION: 'v1.16.0-1'
+    SKOPEO_VERSION: 'v1.2.0'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.8-1'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.15.8
+GO_VERSION ?= 1.16.0
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.15.8'
+    GO_VERSION: '1.16'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
#### What this PR does / why we need it:
Since the golang updates in k/k are merged we now can bump the internal
image versions, too. (xref: https://github.com/kubernetes/kubernetes/pull/98572)

part of https://github.com/kubernetes/release/issues/1834

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @justaugustus @saschagrunert 
/hold 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Update k8s-cloud-builder to v1.16.0-1
- Update k8s-ci-builder to use go1.16 
```
