### PR TITLE
Use default KUBE_PARALLEL_BUILD_MEMORY

### DIFF
--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -83,11 +83,6 @@ func (m *Make) MakeCross(version string) error {
 		return errors.Wrapf(err, "checking out version %s", version)
 	}
 
-	// Unset the build memory requirement for parallel builds
-	const buildMemoryKey = "KUBE_PARALLEL_BUILD_MEMORY"
-	logrus.Infof("Unsetting %s to force parallel build", buildMemoryKey)
-	os.Setenv(buildMemoryKey, "0")
-
 	logrus.Info("Building binaries")
 	if err := m.impl.Command(
 		"make",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The default KUBE_PARALLEL_BUILD_MEMORY will be 20 GiB. Since we build on
a `n1-highcpu-32` machine (which has 28.8 GiB of memory) we should not
be required to unset this variable any more.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
