### PR TITLE
[go1.16] images: Build go1.16.1 k8s-{ci,cloud}-builder images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16
+    version: 1.16.1
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -140,7 +140,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.0-1
+    version: v1.16.1-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.16:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.16.0-1'
+    KUBE_CROSS_VERSION: 'v1.16.1-1'
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15:
     CONFIG: 'cross1.15'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16'
+    GO_VERSION: '1.16.1'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency security
/priority critical-urgent
/milestone v1.21

#### What this PR does / why we need it:

(Part of https://github.com/kubernetes/release/issues/1936.)

ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1615216589218000

- k8s-cloud-builder: Build v1.16.1-1 image
- k8s-ci-builder: Build default variant using go1.16.1
- k8s-ci-builder: Update 1.20 and 1.19 variants to go1.15.8

/assign @hasheddan @saschagrunert @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-cloud-builder: Build v1.16.1-1 image
- k8s-ci-builder: Build default variant using go1.16.1
- k8s-ci-builder: Update 1.20 and 1.19 variants to go1.15.8
```
