### PR TITLE
images/kubecross: create a REGISTRY substitution to allow registry selection

### DIFF
--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -17,6 +17,7 @@ steps:
     - IMAGE_VERSION=$_IMAGE_VERSION
     - PROTOBUF_VERSION=$_PROTOBUF_VERSION
     - ETCD_VERSION=$_ETCD_VERSION
+    - REGISTRY=$_REGISTRY
     # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
     # set the home to /root explicitly to if using docker buildx
     - HOME=/root
@@ -37,6 +38,7 @@ substitutions:
   _IMAGE_VERSION: 'v0.0.0-0'
   _PROTOBUF_VERSION: '0.0.0'
   _ETCD_VERSION: 'v0.0.0'
+  _REGISTRY: 'fake.repository/registry-name'
 
 tags:
 - 'kube-cross'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When building the image in another GCP project we need to push the image to the current project and not to the default one that is set in the makefile

this adds an env var to the GCB to set the REGISTRY env variable to be `gcr.io/$PROJECT_ID`

A previous fix was made but was a mistake because the env var stays in the POD level and not goes to the GCB (xref: https://github.com/kubernetes/test-infra/pull/21307)

/assign @justaugustus 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
