### PR TITLE
kubecross: remove Makefile.build-image dependencie and check if the env vars are set

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# include the common image-building Makefiles
-include $(CURDIR)/../Makefile.build-image
-
 # set default shell
 SHELL=/bin/bash -o pipefail
 
@@ -46,10 +43,15 @@ endif
 
 ARCHS = $(patsubst linux/%,%,$(PLATFORMS))
 
+check-env:
+ifndef REGISTRY
+	$(error REGISTRY is undefined, please set to registry you want to push)
+endif
+
 # build with buildx
 # https://github.com/docker/buildx/issues/59
 .PHONY: container
-container: init-docker-buildx
+container: check-env init-docker-buildx
 	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
 	@for platform in $(PLATFORMS); do \
 		echo "Starting build for $${platform} platform"; \


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Follow up for https://github.com/kubernetes/release/pull/1943

remove the Makefile.build-image script dependency and perform environment check.
For now, it checks if the `REGISTRY` is set

/assign @justaugustus @saschagrunert @hasheddan 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
