### PR TITLE
go-runner: add a REGISTRY substitution to allow registry selection

### DIFF
--- a/images/Makefile.common-image
+++ b/images/Makefile.common-image
@@ -27,10 +27,16 @@ ARCHS = $(patsubst linux/%,%,$(PLATFORMS))
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+.PHONY: check-env
+check-env:
+ifndef REGISTRY
+	$(error REGISTRY is undefined, please set to registry you want to push)
+endif
+
 # build with buildx
 # https://github.com/docker/buildx/issues/59
 .PHONY: container
-container: init-docker-buildx
+container: check-env init-docker-buildx
 	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
 	@for platform in $(PLATFORMS); do \
 		echo "Starting build for $${platform} platform"; \

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # include the common image-building Makefiles
-include $(CURDIR)/../../Makefile.common-image $(CURDIR)/../Makefile.build-image
+include $(CURDIR)/../../Makefile.common-image
 
 IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
     - REVISION=$_REVISION
     - GO_VERSION=$_GO_VERSION
     - DISTROLESS_IMAGE=$_DISTROLESS_IMAGE
+    - REGISTRY=$_REGISTRY
     args:
     - '-c'
     - |
@@ -43,6 +44,7 @@ substitutions:
   _REVISION: '0'
   _GO_VERSION: '0.0.0'
   _DISTROLESS_IMAGE: 'static-debian00'
+  _REGISTRY: 'fake.repository/registry-name'
 
 tags:
 - 'go-runner'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
same work we did for kube-cross: https://github.com/kubernetes/release/pull/1943 we are applying for go-runner


k/test-infra PR to update the jobs: https://github.com/kubernetes/test-infra/pull/21316

/assign @justaugustus @saschagrunert @hasheddan 

tracking issue: https://github.com/kubernetes/release/issues/1850

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
