### PR TITLE
setcap: add a REGISTRY substitution to allow registry selection

### DIFF
--- a/images/build/setcap/cloudbuild.yaml
+++ b/images/build/setcap/cloudbuild.yaml
@@ -9,8 +9,8 @@ steps:
     dir: ./images/build/setcap
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
-      - REGISTRY=gcr.io/$PROJECT_ID
-      - IMAGE=gcr.io/$PROJECT_ID/setcap
+      - REGISTRY=$_REGISTRY
+      - IMAGE=$_REGISTRY/setcap
       - TAG=$_GIT_TAG
       - PULL_BASE_REF=$_PULL_BASE_REF
       - IMAGE_VERSION=$_IMAGE_VERSION
@@ -30,6 +30,7 @@ substitutions:
   _IMAGE_VERSION: 'v0.0.0'
   _CONFIG: 'codename'
   _DEBIAN_BASE_VERSION: 'v0.0.0'
+  _REGISTRY: 'fake.repository/registry-name'
 
 tags:
 - 'setcap'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
same work we did for kube-cross: https://github.com/kubernetes/release/pull/1943 we are applying for setcap


k/test-infra PR to update the jobs: https://github.com/kubernetes/test-infra/pull/21341

/assign @justaugustus @saschagrunert @hasheddan 

tracking issue: https://github.com/kubernetes/release/issues/1850

/hold for the test-infra job update

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
