### PR TITLE
k8s-cloud-builder: add a REGISTRY substitution to allow registry selection

### DIFF
--- a/images/k8s-cloud-builder/cloudbuild.yaml
+++ b/images/k8s-cloud-builder/cloudbuild.yaml
@@ -7,9 +7,9 @@ steps:
     id: build
     args:
     - build
-    - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}
-    - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:latest-${_CONFIG}
-    - --tag=gcr.io/$PROJECT_ID/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+    - --tag=${_REGISTRY}/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}
+    - --tag=${_REGISTRY}/k8s-cloud-builder:latest-${_CONFIG}
+    - --tag=${_REGISTRY}/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
     - --build-arg=KUBE_CROSS_VERSION=${_KUBE_CROSS_VERSION}
     - --build-arg=SKOPEO_VERSION=${_SKOPEO_VERSION}
     - .
@@ -17,8 +17,9 @@ steps:
     id: test
     args:
     - test
-    - --image=gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}
+    - --image=${_REGISTRY}/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}
     - --config=test.yaml
+
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
@@ -27,6 +28,8 @@ substitutions:
   _CONFIG: 'cross0.0'
   _KUBE_CROSS_VERSION: 'v0.0.0-0'
   _SKOPEO_VERSION: 'v0.0.0'
+  _REGISTRY: 'fake.repository/registry-name'
+
 images:
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:${_GIT_TAG}-${_CONFIG}'
   - 'gcr.io/$PROJECT_ID/k8s-cloud-builder:latest-${_CONFIG}'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
same work we did for kube-cross: https://github.com/kubernetes/release/pull/1943 we are applying for k8s-cloud-builder


k/test-infra PR to update the jobs: https://github.com/kubernetes/test-infra/pull/21344

/assign @justaugustus @saschagrunert @hasheddan 

tracking issue: https://github.com/kubernetes/release/issues/1850

/hold for the test-infra job update

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
