### PR TITLE
k8s-ci-builder/releng-ci/kubepkg: add a REGISTRY substitution to allow registry selection

### DIFF
--- a/cloudbuild-kubepkg.yaml
+++ b/cloudbuild-kubepkg.yaml
@@ -8,22 +8,23 @@ steps:
     - build
     - -f
     - ./Dockerfile-kubepkg
-    - --tag=gcr.io/$PROJECT_ID/kubepkg:$_GIT_TAG
-    - --tag=gcr.io/$PROJECT_ID/kubepkg:latest
+    - --tag=$_REGISTRY/kubepkg:$_GIT_TAG
+    - --tag=$_REGISTRY/kubepkg:latest
     - .
   - name: gcr.io/cloud-builders/docker
     args:
     - build
     - -f
     - ./Dockerfile-kubepkg-rpm
-    - --tag=gcr.io/$PROJECT_ID/kubepkg-rpm:$_GIT_TAG
-    - --tag=gcr.io/$PROJECT_ID/kubepkg-rpm:latest
+    - --tag=$_REGISTRY/kubepkg-rpm:$_GIT_TAG
+    - --tag=$_REGISTRY/kubepkg-rpm:latest
     - .
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
+  _REGISTRY: 'fake.repository/registry-name'
 images:
   - 'gcr.io/$PROJECT_ID/kubepkg:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/kubepkg:latest'

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -8,16 +8,16 @@ steps:
     dir: ./images/releng/ci
     args:
       - build
-      - --tag=gcr.io/$PROJECT_ID/releng-ci:$_GIT_TAG
-      - --tag=gcr.io/$PROJECT_ID/releng-ci:$_IMAGE_VERSION
-      - --tag=gcr.io/$PROJECT_ID/releng-ci:latest
+      - --tag=$_REGISTRY/releng-ci:$_GIT_TAG
+      - --tag=$_REGISTRY/releng-ci:$_IMAGE_VERSION
+      - --tag=$_REGISTRY/releng-ci:latest
       - --build-arg=GO_VERSION=${_GO_VERSION}
       - .
   - name: gcr.io/gcp-runtimes/container-structure-test
     dir: ./images/releng/ci
     args:
       - test
-      - --image=gcr.io/$PROJECT_ID/releng-ci:latest
+      - --image=$_REGISTRY/releng-ci:latest
       - --config=test.yaml
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
@@ -26,6 +26,7 @@ substitutions:
   _PULL_BASE_REF: 'dev'
   _IMAGE_VERSION: 'v0.5.0'
   _GO_VERSION: '1.16.1'
+  _REGISTRY: 'fake.repository/registry-name'
 images:
   - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
   - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -16,7 +16,8 @@ steps:
     dir: ./images/releng/k8s-ci-builder
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    - REGISTRY=gcr.io/$PROJECT_ID
+    - REGISTRY=$_REGISTRY
+    - IMAGE_ARG='$_REGISTRY/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
     - HOME=/root
     - TAG=${_GIT_TAG}
     - PULL_BASE_REF=${_PULL_BASE_REF}
@@ -24,7 +25,6 @@ steps:
     - GO_VERSION=${_GO_VERSION}
     - BAZEL_VERSION=${_BAZEL_VERSION}
     - OLD_BAZEL_VERSION=${_OLD_BAZEL_VERSION}
-    - IMAGE_ARG='gcr.io/$PROJECT_ID/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
     - SKOPEO_VERSION=${_SKOPEO_VERSION}
     args:
     - '-c'
@@ -42,6 +42,7 @@ substitutions:
   _BAZEL_VERSION: '0.0.0'
   _OLD_BAZEL_VERSION: '0.0.0'
   _SKOPEO_VERSION: 'v0.0.0'
+  _REGISTRY: 'fake.repository/registry-name'
 
 tags:
 - 'k8s-ci-builder'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
same work we did for kube-cross: https://github.com/kubernetes/release/pull/1943 we are applying for `k8s-ci-builder` and `releng-ci` and `kubepkg`

k/test-infra PR to update the jobs: TBC

/assign @justaugustus @saschagrunert @hasheddan 

tracking issue: https://github.com/kubernetes/release/issues/1850

/hold for the test-infra job update

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
