### PR TITLE
Move from ioutil to os/io packages

### DIFF
--- a/cmd/gh2gcs/cmd/root.go
+++ b/cmd/gh2gcs/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -207,7 +206,7 @@ func run(opts *options) error {
 	releaseCfgs := &gh2gcs.Config{}
 	if opts.configFilePath != "" {
 		logrus.Infof("Reading the config file %s...", opts.configFilePath)
-		data, err := ioutil.ReadFile(opts.configFilePath)
+		data, err := os.ReadFile(opts.configFilePath)
 		if err != nil {
 			return errors.Wrap(err, "failed to read the file")
 		}
@@ -268,7 +267,7 @@ func (o *options) SetAndValidate() error {
 			return errors.Errorf("when %s flag is set you need to specify the %s", downloadOnlyFlag, outputDirFlag)
 		}
 
-		tmpDir, err := ioutil.TempDir("", "gh2gcs")
+		tmpDir, err := os.MkdirTemp("", "gh2gcs")
 		if err != nil {
 			return errors.Wrap(err, "creating temp directory")
 		}

--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -203,7 +202,7 @@ func runBuildReleaseAnnounce(opts *buildReleaseAnnounceOptions, buildOpts *build
 		return err
 	}
 
-	changelogHTML, err := ioutil.ReadFile(opts.changelogHTML)
+	changelogHTML, err := os.ReadFile(opts.changelogHTML)
 	if err != nil {
 		return err
 	}
@@ -237,14 +236,14 @@ func (opts *buildAnnounceOptions) saveAnnouncement(announcementSubject string, a
 
 	absOutputPath := filepath.Join(opts.workDir, "announcement.html")
 	logrus.Infof("Writing HTML file to %s", absOutputPath)
-	err := ioutil.WriteFile(absOutputPath, annoucement.Bytes(), os.FileMode(0644))
+	err := os.WriteFile(absOutputPath, annoucement.Bytes(), os.FileMode(0644))
 	if err != nil {
 		return errors.Wrap(err, "saving announcement.html")
 	}
 
 	absOutputPath = filepath.Join(opts.workDir, "announcement-subject.txt")
 	logrus.Infof("Writing announcement subject to %s", absOutputPath)
-	err = ioutil.WriteFile(absOutputPath, []byte(announcementSubject), os.FileMode(0644))
+	err = os.WriteFile(absOutputPath, []byte(announcementSubject), os.FileMode(0644))
 	if err != nil {
 		return errors.Wrap(err, "saving announcement-subject.txt")
 	}

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +40,7 @@ func (s *sut) getChangelogOptions(tag string) *changelog.Options {
 
 func fileContains(t *testing.T, file, contains string) {
 	require.FileExists(t, file)
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.Nil(t, err)
 	require.Contains(t, string(content), contains)
 }
@@ -85,7 +84,7 @@ func TestNewPatchRelease(t *testing.T) { // nolint: dupl
 		require.Contains(t, lastCommit, x.commitMessage)
 
 		// Verify changelog contents
-		result, err := ioutil.ReadFile(
+		result, err := os.ReadFile(
 			filepath.Join(s.repo.Dir(), changelog.RepoChangelogDir, "CHANGELOG-1.16.md"),
 		)
 		require.Nil(t, err)
@@ -117,7 +116,7 @@ func TestNewAlphaRelease(t *testing.T) {
 	require.Contains(t, lastCommit, "Update directory for v1.18.0-alpha.3 release")
 
 	// Verify changelog contents
-	result, err := ioutil.ReadFile(
+	result, err := os.ReadFile(
 		filepath.Join(s.repo.Dir(), changelog.RepoChangelogDir, "CHANGELOG-1.18.md"),
 	)
 	require.Nil(t, err)
@@ -146,7 +145,7 @@ func TestNewAlpha1Release(t *testing.T) {
 	require.Contains(t, lastCommit, "Update directory for v1.19.0-alpha.1 release")
 
 	// Verify changelog contents
-	result, err := ioutil.ReadFile(
+	result, err := os.ReadFile(
 		filepath.Join(s.repo.Dir(), changelog.RepoChangelogDir, "CHANGELOG-1.19.md"),
 	)
 	require.Nil(t, err)
@@ -174,7 +173,7 @@ func TestNewMinorRelease(t *testing.T) { // nolint: dupl
 	require.Nil(t, s.repo.Checkout(releaseBranch))
 	changelogIter(func(filename string) {
 		require.Nil(t,
-			ioutil.WriteFile(
+			os.WriteFile(
 				filepath.Join(s.repo.Dir(), filename),
 				[]byte("Some content"),
 				0644,
@@ -214,7 +213,7 @@ func TestNewMinorRelease(t *testing.T) { // nolint: dupl
 		require.Contains(t, lastCommit, x.commitMessage)
 
 		// Verify changelog contents
-		result, err := ioutil.ReadFile(
+		result, err := os.ReadFile(
 			filepath.Join(s.repo.Dir(), changelog.RepoChangelogDir, "CHANGELOG-1.17.md"),
 		)
 		require.Nil(t, err)
@@ -239,7 +238,7 @@ func TestNewRCRelease(t *testing.T) {
 	// Verify local results
 	require.Nil(t, s.repo.Checkout(releaseBranch))
 
-	result, err := ioutil.ReadFile(
+	result, err := os.ReadFile(
 		filepath.Join(s.repo.Dir(), changelog.RepoChangelogDir, "CHANGELOG-1.16.md"),
 	)
 	require.Nil(t, err)

--- a/cmd/krel/cmd/promote-images.go
+++ b/cmd/krel/cmd/promote-images.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,7 +184,7 @@ func runPromote(opts *promoteOptions) error {
 	if mustRun(opts, "Grow the manifests to add the new tags?") {
 		if util.Exists(filepath.Join(repo.Dir(), imagesListPath)) {
 			logrus.Debug("Reading the current image promoter manifest (image list)")
-			oldlist, err = ioutil.ReadFile(filepath.Join(repo.Dir(), imagesListPath))
+			oldlist, err = os.ReadFile(filepath.Join(repo.Dir(), imagesListPath))
 			if err != nil {
 				return errors.Wrap(err, "while reading the current promoter image list")
 			}
@@ -235,7 +234,7 @@ func runPromote(opts *promoteOptions) error {
 	if len(oldlist) > 0 {
 		logrus.Debug("Checking if the image list was modified")
 		// read the newly modified manifest
-		newlist, err := ioutil.ReadFile(filepath.Join(repo.Dir(), imagesListPath))
+		newlist, err := os.ReadFile(filepath.Join(repo.Dir(), imagesListPath))
 		if err != nil {
 			return errors.Wrap(err, "while reading the modified manifest images list")
 		}

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -450,14 +449,14 @@ func createDraftPR(repoPath, tag string) (err error) {
 	logrus.Debugf("Release notes draft files will be written to %s", releaseDir)
 
 	// Write the markdown draft
-	err = ioutil.WriteFile(filepath.Join(releaseDir, draftMarkdownFile), []byte(result.markdown), 0644)
+	err = os.WriteFile(filepath.Join(releaseDir, draftMarkdownFile), []byte(result.markdown), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "writing release notes draft")
 	}
 	logrus.Infof("Release Notes Markdown Draft written to %s", filepath.Join(releaseDir, draftMarkdownFile))
 
 	// Write the JSON file of the current notes
-	err = ioutil.WriteFile(filepath.Join(releaseDir, draftJSONFile), []byte(result.json), 0644)
+	err = os.WriteFile(filepath.Join(releaseDir, draftJSONFile), []byte(result.json), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "writing release notes json file")
 	}
@@ -683,7 +682,7 @@ func addReferenceToAssetsFile(repoPath, newJSONFile string) error {
 	}
 
 	// write the modified assets.ts file
-	if err := ioutil.WriteFile(assetsFullPath, assetsBuffer.Bytes(), os.FileMode(0o644)); err != nil {
+	if err := os.WriteFile(assetsFullPath, assetsBuffer.Bytes(), os.FileMode(0o644)); err != nil {
 		return errors.Wrap(err, "writing assets.ts file")
 	}
 
@@ -750,7 +749,7 @@ func createWebsitePR(repoPath, tag string) (err error) {
 	// generate the notes
 	jsonNotesPath := filepath.Join("src", "assets", jsonNotesFilename)
 	logrus.Debugf("Release notes json file will be written to %s", filepath.Join(k8sSigsRepo.Dir(), jsonNotesPath))
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(k8sSigsRepo.Dir(), jsonNotesPath), []byte(jsonStr), os.FileMode(0o644),
 	); err != nil {
 		return errors.Wrapf(err, "writing release notes json file")
@@ -1063,7 +1062,7 @@ func (sd *sessionData) Save() error {
 		return errors.Wrap(err, "marshaling session data")
 	}
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(sd.Path, fmt.Sprintf("maps-%d.json", sd.Date)),
 		jsonData, os.FileMode(0o644)); err != nil {
 		return errors.Wrap(err, "writing session data to disk")
@@ -1073,7 +1072,7 @@ func (sd *sessionData) Save() error {
 
 // readFixSessions reads all the previous fixing data
 func readFixSessions(sessionPath string) (pullRequestChecklist map[int]string, err error) {
-	files, err := ioutil.ReadDir(sessionPath)
+	files, err := os.ReadDir(sessionPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading working directory")
 	}
@@ -1087,7 +1086,7 @@ func readFixSessions(sessionPath string) (pullRequestChecklist map[int]string, e
 		currentSession := &sessionData{}
 		if strings.HasSuffix(fileData.Name(), ".json") {
 			logrus.Debugf("Reading session data from %s", fileData.Name())
-			jsonData, err := ioutil.ReadFile(filepath.Join(sessionPath, fileData.Name()))
+			jsonData, err := os.ReadFile(filepath.Join(sessionPath, fileData.Name()))
 			if err != nil {
 				return nil, errors.Wrapf(err, "reading session data from %s", fileData.Name())
 			}
@@ -1473,7 +1472,7 @@ func editReleaseNote(pr int, workDir string, originalNote, modifiedNote *notes.R
 
 	// Write the new map, removing the instructions
 	mapPath := filepath.Join(workDir, mapsMainDirectory, fmt.Sprintf("pr-%d-map.yaml", pr))
-	err = ioutil.WriteFile(mapPath, newYAML, os.FileMode(0o644))
+	err = os.WriteFile(mapPath, newYAML, os.FileMode(0o644))
 	if err != nil {
 		logrus.Errorf("Error writing map to %s: %s", mapPath, err)
 		return true, errors.Wrap(err, "writing modified release note map")

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -283,7 +283,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 			return errors.Wrapf(err, "opening the supplied output file")
 		}
 	} else {
-		output, err = ioutil.TempFile("", "release-notes-")
+		output, err = os.CreateTemp("", "release-notes-")
 		if err != nil {
 			return errors.Wrapf(err, "creating a temporary file to write the release notes to")
 		}
@@ -291,7 +291,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 
 	// Contextualized release notes can be printed in a variety of formats
 	if opts.Format == options.FormatJSON {
-		byteValue, err := ioutil.ReadAll(output)
+		byteValue, err := io.ReadAll(output)
 		if err != nil {
 			return err
 		}

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -105,7 +105,7 @@ func run(opts *options) error {
 	}
 
 	logrus.Infof("Reading the schedule file %s...", opts.configPath)
-	data, err := ioutil.ReadFile(opts.configPath)
+	data, err := os.ReadFile(opts.configPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read the file")
 	}
@@ -124,7 +124,7 @@ func run(opts *options) error {
 
 	if opts.outputFile != "" {
 		logrus.Infof("Saving schedule to a file %s.", opts.outputFile)
-		err := ioutil.WriteFile(opts.outputFile, []byte(scheduleOut), 0644)
+		err := os.WriteFile(opts.outputFile, []byte(scheduleOut), 0644)
 		if err != nil {
 			return errors.Wrap(err, "failed to save schedule to the file")
 		}

--- a/cmd/schedule-builder/cmd/root_test.go
+++ b/cmd/schedule-builder/cmd/root_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -84,7 +83,7 @@ func TestRun(t *testing.T) {
 				require.Nil(t, err)
 
 				// compare the output generated with the expected
-				outFile, errFile := ioutil.ReadFile(out)
+				outFile, errFile := os.ReadFile(out)
 				require.NoError(t, errFile)
 				require.Equal(t, string(outFile), expectedOut)
 			},
@@ -108,7 +107,7 @@ func TestRun(t *testing.T) {
 	for tcCount, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
 
-		tempDir, err := ioutil.TempDir("/tmp", "schedule-test")
+		tempDir, err := os.MkdirTemp("/tmp", "schedule-test")
 		require.Nil(t, err)
 		defer os.RemoveAll(tempDir)
 

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -21,7 +21,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -131,7 +131,7 @@ func (c cfg) run() error {
 	var w []work
 
 	srcdir := filepath.Join(c.DistroName, c.Package)
-	dstdir, err := ioutil.TempDir(os.TempDir(), "debs")
+	dstdir, err := os.MkdirTemp("", "debs")
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func fetchVersion(url string) (string, error) {
 		return "", err
 	}
 
-	versionBytes, err := ioutil.ReadAll(res.Body)
+	versionBytes, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return "", err

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -18,7 +18,7 @@ package announce
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -99,7 +99,7 @@ func CreateForRelease(opts *Options) error {
 
 	// Read the changelog from the specified file if we got one
 	if opts.changelogFile != "" {
-		changelogData, err := ioutil.ReadFile(opts.changelogFile)
+		changelogData, err := os.ReadFile(opts.changelogFile)
 		if err != nil {
 			return errors.Wrap(err, "reading changelog html file")
 		}
@@ -136,7 +136,7 @@ func CreateForRelease(opts *Options) error {
 
 func create(workDir, subject, message string) error {
 	subjectFile := filepath.Join(workDir, subjectFile)
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		subjectFile, []byte(subject), 0o755,
 	); err != nil {
 		return errors.Wrapf(
@@ -146,7 +146,7 @@ func create(workDir, subject, message string) error {
 	logrus.Debugf("Wrote file %s", subjectFile)
 
 	announcementFile := filepath.Join(workDir, announcementFile)
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		announcementFile, []byte(message), 0o755,
 	); err != nil {
 		return errors.Wrapf(

--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -19,7 +19,6 @@ package announce
 import (
 	"bytes"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -390,7 +389,7 @@ func (o *GitHubPageOptions) ReadTemplate(templatePath string) error {
 	}
 
 	// Otherwise, read a custom template from a file
-	templateData, err := ioutil.ReadFile(templatePath)
+	templateData, err := os.ReadFile(templatePath)
 	if err != nil {
 		return errors.Wrap(err, "reading page template text")
 	}

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -19,7 +19,6 @@ package binary_test
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -94,7 +93,7 @@ func GetTestHeaders() []TestHeader {
 
 // writeTestBinary Writes a test binary and returns the path
 func writeTestBinary(t *testing.T, base64Data *string) *os.File {
-	f, err := ioutil.TempFile(os.TempDir(), "test-binary-")
+	f, err := os.CreateTemp("", "test-binary-")
 	require.Nil(t, err)
 
 	binData, err := base64.StdEncoding.DecodeString(*base64Data)

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -18,7 +18,6 @@ package changelog
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -159,7 +158,7 @@ func (*defaultImpl) RepoDir(repo *git.Repo) string {
 func (*defaultImpl) WriteFile(
 	filename string, data []byte, perm os.FileMode,
 ) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func (*defaultImpl) Stat(name string) (os.FileInfo, error) {
@@ -167,7 +166,7 @@ func (*defaultImpl) Stat(name string) (os.FileInfo, error) {
 }
 
 func (*defaultImpl) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (*defaultImpl) MarkdownToHTML(

--- a/pkg/cip/audit/auditor.go
+++ b/pkg/cip/audit/auditor.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -100,7 +99,7 @@ func (s *ServerContext) RunAuditor() {
 // ParsePubSubMessage parses an HTTP request body into a reg.GCRPubSubPayload.
 func ParsePubSubMessage(body io.Reader) (*reg.GCRPubSubPayload, error) {
 	// Handle basic errors (malformed requests).
-	bodyBytes, err := ioutil.ReadAll(body)
+	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
 		return nil, fmt.Errorf("iotuil.ReadAll: %v", err)
 	}

--- a/pkg/cip/dockerregistry/grow_manifest.go
+++ b/pkg/cip/dockerregistry/grow_manifest.go
@@ -18,7 +18,7 @@ package inventory
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -138,7 +138,7 @@ func WriteImages(manifest Manifest, rii RegInvImage) error {
 	logrus.Infoln("RENDER", imagesPath)
 
 	// Write the file.
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		imagesPath, []byte(rii.ToYAML(YamlMarshalingOpts{})), 0644)
 	return err
 }

--- a/pkg/cip/dockerregistry/inventory.go
+++ b/pkg/cip/dockerregistry/inventory.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -132,7 +131,7 @@ func ParseManifestFromFile(filePath string) (Manifest, error) {
 	var mfest Manifest
 	var empty Manifest
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -159,7 +158,7 @@ func ParseThinManifestFromFile(filePath string) (Manifest, error) {
 	var mfest Manifest
 	var empty Manifest
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -197,7 +196,7 @@ func ParseImagesFromFile(filePath string) (Images, error) {
 	var images Images
 	var empty Images
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -319,7 +318,7 @@ func ValidateThinManifestDirectoryStructure(
 	// For every subfolder in <dir>/manifests, ensure that a
 	// "promoter-manifest.yaml" file exists, and also that a corresponding file
 	// exists in the "images" folder.
-	files, err := ioutil.ReadDir(manifestDir)
+	files, err := os.ReadDir(manifestDir)
 	if err != nil {
 		return err
 	}
@@ -1095,7 +1094,7 @@ func getJSONSFromProcess(req stream.ExternalRequest) (cipJson.Objects, Errors) {
 		)
 	}
 
-	be, err := ioutil.ReadAll(stderrReader)
+	be, err := io.ReadAll(stderrReader)
 	if err != nil {
 		streamErrs = append(
 			streamErrs,

--- a/pkg/cip/remotemanifest/git.go
+++ b/pkg/cip/remotemanifest/git.go
@@ -18,7 +18,6 @@ package remotemanifest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -87,7 +86,7 @@ func cloneToTempDir(
 	repoURL fmt.Stringer,
 	branch string,
 ) (string, error) {
-	tdir, err := ioutil.TempDir("", "k8s.io-")
+	tdir, err := os.MkdirTemp("", "k8s.io-")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -56,7 +55,7 @@ type copyFileOp struct {
 // nolint[gocyclo]
 func (o *copyFileOp) Run(ctx context.Context) error {
 	// Download to our temp file
-	f, err := ioutil.TempFile("", "promoter")
+	f, err := os.CreateTemp("", "promoter")
 	if err != nil {
 		return fmt.Errorf("error creating temp file: %v", err)
 	}

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -18,7 +18,6 @@ package build
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -142,7 +141,7 @@ func (o *Options) ValidateConfigDir() error {
 }
 
 func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create temp file")
 	}
@@ -262,7 +261,7 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 type variants map[string]map[string]string
 
 func getVariants(o *Options) (variants, error) {
-	content, err := ioutil.ReadFile(path.Join(o.ConfigDir, "variants.yaml"))
+	content, err := os.ReadFile(path.Join(o.ConfigDir, "variants.yaml"))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, errors.Wrapf(err, "failed to load variants.yaml")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -343,7 +342,7 @@ func CloneOrOpenRepo(repoPath, repoURL string, useSSH bool) (*Repo, error) {
 		}
 	} else {
 		// No repoPath given, use a random temp dir instead
-		t, err := ioutil.TempDir("", "k8s-")
+		t, err := os.MkdirTemp("", "k8s-")
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to create temp dir")
 		}

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package git_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,7 +74,7 @@ type testRepo struct {
 //
 func newTestRepo(t *testing.T) *testRepo {
 	// Setup the bare repo as base
-	bareTempDir, err := ioutil.TempDir("", "k8s-test-bare-")
+	bareTempDir, err := os.MkdirTemp("", "k8s-test-bare-")
 	require.Nil(t, err)
 
 	bareRepo, err := gogit.PlainInit(bareTempDir, true)
@@ -83,14 +82,14 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.NotNil(t, bareRepo)
 
 	// Clone from the bare to be able to add our test data
-	cloneTempDir, err := ioutil.TempDir("", "k8s-test-clone-")
+	cloneTempDir, err := os.MkdirTemp("", "k8s-test-clone-")
 	require.Nil(t, err)
 	cloneRepo, err := gogit.PlainInit(cloneTempDir, false)
 	require.Nil(t, err)
 
 	// Add the test data set
 	const testFileName = "test-file"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -127,7 +126,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	).RunSuccess())
 
 	const branchTestFileName = "branch-test-file"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -151,7 +150,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, err)
 
 	const secondBranchTestFileName = "branch-test-file-2"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -175,7 +174,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, err)
 
 	const thirdBranchTestFileName = "branch-test-file-3"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, thirdBranchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -577,7 +576,7 @@ func TestCheckoutSuccess(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		testRepo.testFileName,
 		[]byte("hello world"),
 		os.FileMode(0644),
@@ -611,7 +610,7 @@ func TestAddSuccess(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	f, err := ioutil.TempFile(testRepo.sut.Dir(), "test")
+	f, err := os.CreateTemp(testRepo.sut.Dir(), "test")
 	require.Nil(t, err)
 	require.Nil(t, f.Close())
 
@@ -674,7 +673,7 @@ func TestCurrentBranchMain(t *testing.T) {
 func TestRmSuccessForce(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
-	require.Nil(t, ioutil.WriteFile(testRepo.testFileName,
+	require.Nil(t, os.WriteFile(testRepo.testFileName,
 		[]byte("test"), os.FileMode(0755)),
 	)
 
@@ -741,7 +740,7 @@ func TestRmSuccess(t *testing.T) {
 func TestRmFailureModified(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
-	require.Nil(t, ioutil.WriteFile(testRepo.testFileName,
+	require.Nil(t, os.WriteFile(testRepo.testFileName,
 		[]byte("test"), os.FileMode(0755)),
 	)
 	require.NotNil(t, testRepo.sut.Rm(false, testRepo.testFileName))
@@ -862,7 +861,7 @@ func TestIsDirtyFailure(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(testRepo.sut.Dir(), "any-file"),
 		[]byte("test"), os.FileMode(0755)),
 	)

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -18,7 +18,6 @@ package git_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ func TestGetDefaultKubernetesRepoURLSuccess(t *testing.T) {
 
 // createTestRepository creates a test repo, cd into it and returns the path
 func createTestRepository() (repoPath string, err error) {
-	repoPath, err = ioutil.TempDir(os.TempDir(), "sigrelease-test-repo-*")
+	repoPath, err = os.MkdirTemp("", "sigrelease-test-repo-*")
 	if err != nil {
 		return "", errors.Wrap(err, "creating a directory for test repository")
 	}
@@ -335,7 +334,7 @@ func TestHasBranch(t *testing.T) {
 
 	// Create a file and a test commit
 	testfile := filepath.Join(repoPath, "README.md")
-	err = ioutil.WriteFile(testfile, []byte("# WHY SIG-RELEASE ROCKS\n\n"), os.FileMode(0o644))
+	err = os.WriteFile(testfile, []byte("# WHY SIG-RELEASE ROCKS\n\n"), os.FileMode(0o644))
 	require.Nil(t, err, "writing test file")
 
 	err = command.NewWithWorkDir(repoPath, "git", "add", testfile).RunSuccess()
@@ -367,7 +366,7 @@ func TestHasBranch(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	rawRepoDir, err := ioutil.TempDir("", "k8s-test-repo")
+	rawRepoDir, err := os.MkdirTemp("", "k8s-test-repo")
 	require.Nil(t, err)
 	_, err = gogit.PlainInit(rawRepoDir, false)
 	require.Nil(t, err)
@@ -385,7 +384,7 @@ func TestStatus(t *testing.T) {
 	require.True(t, status.IsClean())
 
 	// Create an untracked file
-	require.Nil(t, ioutil.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
 
 	// Status should be modified now
 	status, err = testRepo.Status()
@@ -405,14 +404,14 @@ func TestStatus(t *testing.T) {
 	require.Empty(t, status.String())
 
 	// Modify the file
-	require.Nil(t, ioutil.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Bye SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Bye SIG Release"), 0644))
 	status, err = testRepo.Status()
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf(" M %s\n", testFile), status.String())
 }
 
 func TestShowLastCommit(t *testing.T) {
-	rawRepoDir, err := ioutil.TempDir("", "k8s-test-repo")
+	rawRepoDir, err := os.MkdirTemp("", "k8s-test-repo")
 	require.Nil(t, err)
 	_, err = gogit.PlainInit(rawRepoDir, false)
 	require.Nil(t, err)
@@ -425,7 +424,7 @@ func TestShowLastCommit(t *testing.T) {
 	defer testRepo.Cleanup() // nolint: errcheck
 
 	// Create an untracked file
-	require.Nil(t, ioutil.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
 	require.Nil(t, testRepo.Add(testFile))
 	require.Nil(t, testRepo.Commit(fmt.Sprintf("Commit test file at %s", timeNow)))
 
@@ -439,7 +438,7 @@ func TestShowLastCommit(t *testing.T) {
 func TestFetchRemote(t *testing.T) {
 	testTagName := "test-tag" + strconv.FormatInt(time.Now().UnixNano(), 10)
 	// Create a new empty repo
-	rawRepoDir, err := ioutil.TempDir("", "k8s-test-repo")
+	rawRepoDir, err := os.MkdirTemp("", "k8s-test-repo")
 	require.Nil(t, err)
 	gogitRepo, err := gogit.PlainInit(rawRepoDir, false)
 	require.Nil(t, err)
@@ -488,7 +487,7 @@ func TestRebase(t *testing.T) {
 	testFile := "test-rebase.txt"
 
 	// Create a new empty repo
-	rawRepoDir, err := ioutil.TempDir("", "k8s-test-repo")
+	rawRepoDir, err := os.MkdirTemp("", "k8s-test-repo")
 	require.Nil(t, err)
 	gogitRepo, err := gogit.PlainInit(rawRepoDir, false)
 	require.Nil(t, err)
@@ -516,7 +515,7 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, testRepo.Rebase(fmt.Sprintf("origin/%s", branchName)), "cloning synchronizaed repos")
 
 	// Test 2. Rebase should not fail with pulling changes in the remote
-	require.Nil(t, ioutil.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello SIG Release"), 0644))
 	_, err = wtree.Add(testFile)
 	require.Nil(t, err)
 
@@ -538,7 +537,7 @@ func TestRebase(t *testing.T) {
 	require.NotNil(t, testRepo.Rebase("origin/invalidBranch"), "rebasing to invalid branch")
 
 	// Test 4: Rebase must fail on merge conflicts
-	require.Nil(t, ioutil.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello again SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello again SIG Release"), 0644))
 	_, err = wtree.Add(testFile)
 	require.Nil(t, err)
 
@@ -546,7 +545,7 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, err)
 
 	// Commit the same file in the test repo
-	require.Nil(t, ioutil.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Conflict me!"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Conflict me!"), 0644))
 	require.Nil(t, testRepo.Add(filepath.Join(testRepo.Dir(), testFile)))
 	require.Nil(t, testRepo.Commit("Adding file to cause conflict"))
 

--- a/pkg/github/internal/retry_test.go
+++ b/pkg/github/internal/retry_test.go
@@ -18,7 +18,7 @@ package internal_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -30,7 +30,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// logrus, shut up
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -297,7 +296,7 @@ func (c *githubNotesRecordClient) recordAPICall(
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(c.recordDir, fileName), file, os.FileMode(0644),
 	); err != nil {
 		return err

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -218,7 +217,7 @@ func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error
 	}
 
 	path := filepath.Join(c.replayDir, fmt.Sprintf("%s-%d.json", api, i))
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -18,7 +18,6 @@ package kubepkg
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -125,11 +124,11 @@ func (i *impl) GetKubeVersion(versionType release.VersionType) (string, error) {
 }
 
 func (i *impl) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (i *impl) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 type Build struct {
@@ -218,7 +217,7 @@ func (c *Client) WalkBuilds(builds []Build) (err error) {
 
 	workingDir := os.Getenv("KUBEPKG_WORKING_DIR")
 	if workingDir == "" {
-		workingDir, err = ioutil.TempDir("", "kubepkg")
+		workingDir, err = os.MkdirTemp("", "kubepkg")
 		if err != nil {
 			return err
 		}

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubepkg_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,7 +47,7 @@ func newSUT(opts *options.Options) (*kubepkg.Client, *kubepkgfakes.FakeImpl) {
 func sutWithTemplateDir(
 	t *testing.T, opts *options.Options, buildType options.BuildType,
 ) (sut *kubepkg.Client, cleanup func(), mock *kubepkgfakes.FakeImpl) {
-	tempDir, err := ioutil.TempDir("", "kubepkg-test-")
+	tempDir, err := os.MkdirTemp("", "kubepkg-test-")
 	require.Nil(t, err)
 	cleanup = func() { require.Nil(t, os.RemoveAll(tempDir)) }
 

--- a/pkg/kubepkg/template.go
+++ b/pkg/kubepkg/template.go
@@ -18,7 +18,6 @@ package kubepkg
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -72,7 +71,7 @@ func buildSpecs(bc *buildConfig, specDir string) (workItems []work, err error) {
 			return nil, errors.Wrapf(err, "executing template for %s", item.src)
 		}
 
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			item.dst, buf.Bytes(), item.info.Mode(),
 		); err != nil {
 			return nil, errors.Wrapf(err, "writing file %s", item.dst)

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -20,7 +20,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -72,7 +72,7 @@ func (do *DownloaderOptions) Validate() error {
 		}
 		// And no cache dir was specified
 		if do.CacheDir == "" {
-			dir, err := ioutil.TempDir(os.TempDir(), "license-cache-")
+			dir, err := os.MkdirTemp("", "license-cache-")
 			if err != nil {
 				return errors.Wrap(err, "creating temporary directory")
 			}
@@ -135,7 +135,7 @@ func (ddi *DefaultDownloaderImpl) GetLicenses() (licenses *SPDXLicenseList, err 
 	}
 	defer resp.Body.Close()
 
-	licensesJSON, err := ioutil.ReadAll(resp.Body)
+	licensesJSON, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading license list response body")
 	}
@@ -186,7 +186,7 @@ func (ddi *DefaultDownloaderImpl) cacheData(url string, data []byte) error {
 			return errors.Wrap(err, "creating cache directory")
 		}
 	}
-	return errors.Wrap(ioutil.WriteFile(cacheFileName, data, os.FileMode(0o644)), "writing cache file")
+	return errors.Wrap(os.WriteFile(cacheFileName, data, os.FileMode(0o644)), "writing cache file")
 }
 
 // getCachedData returns cached data for an URL if we have it
@@ -206,7 +206,7 @@ func (ddi *DefaultDownloaderImpl) getCachedData(url string) ([]byte, error) {
 		logrus.Warn("Cached file is empty, removing")
 		return nil, errors.Wrap(os.Remove(cacheFileName), "removing corrupt cached file")
 	}
-	licensesJSON, err := ioutil.ReadFile(cacheFileName)
+	licensesJSON, err := os.ReadFile(cacheFileName)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cached data file")
 	}
@@ -235,7 +235,7 @@ func (ddi *DefaultDownloaderImpl) getLicenseFromURL(url string) (license *SPDXLi
 			return nil, errors.Wrapf(err, "getting %s", url)
 		}
 		defer resp.Body.Close()
-		licenseJSON, err = ioutil.ReadAll(resp.Body)
+		licenseJSON, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading response body")
 		}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -20,7 +20,6 @@ package license
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -85,7 +84,7 @@ type ReaderOptions struct {
 func (ro *ReaderOptions) Validate() error {
 	// if there is no working dir, create one
 	if ro.WorkDir == "" {
-		dir, err := ioutil.TempDir(os.TempDir(), "license-reader-")
+		dir, err := os.MkdirTemp("", "license-reader-")
 		if err != nil {
 			return errors.Wrap(err, "creating working dir")
 		}

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package license_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,7 +95,7 @@ func TestUSPDXWriteLicensesAsText(t *testing.T) {
 	require.Nil(t, spdx.LoadLicenses())
 
 	// Create a test directory
-	tempdir, err := ioutil.TempDir(os.TempDir(), "spdx-test-")
+	tempdir, err := os.MkdirTemp("", "spdx-test-")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 

--- a/pkg/license/license_unit_test.go
+++ b/pkg/license/license_unit_test.go
@@ -18,7 +18,6 @@ package license
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,7 +47,7 @@ const (
 )
 
 func TestCacheData(t *testing.T) {
-	tempdir, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+	tempdir, err := os.MkdirTemp("", testDirPrefix)
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 
@@ -78,7 +77,7 @@ func TestFindLicenseFiles(t *testing.T) {
 		"license.go", "README.md",
 	}
 
-	tempdir, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+	tempdir, err := os.MkdirTemp("", testDirPrefix)
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 
@@ -86,7 +85,7 @@ func TestFindLicenseFiles(t *testing.T) {
 	fileData := []byte("bleh")
 	for _, sub := range []string{"", "/some/sub/dir"} {
 		for _, filename := range files {
-			require.Nil(t, ioutil.WriteFile(
+			require.Nil(t, os.WriteFile(
 				filepath.Join(tempdir, sub, filename), fileData, os.FileMode(0o644),
 			))
 		}
@@ -101,7 +100,7 @@ func TestFindLicenseFiles(t *testing.T) {
 }
 
 func TestGetLicenseFromURL(t *testing.T) {
-	tempdir, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+	tempdir, err := os.MkdirTemp("", testDirPrefix)
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 

--- a/pkg/license/spdx.go
+++ b/pkg/license/spdx.go
@@ -18,7 +18,6 @@ package license
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -108,7 +107,7 @@ type SPDXLicense struct {
 // WriteText writes the SPDX license text to a text file
 func (license *SPDXLicense) WriteText(filePath string) error {
 	return errors.Wrap(
-		ioutil.WriteFile(
+		os.WriteFile(
 			filePath, []byte(license.LicenseText), os.FileMode(0o644),
 		), "while writing license to text file",
 	)

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -19,7 +19,7 @@ package document
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -359,7 +359,7 @@ func (d *Document) template(templateSpec string) (string, error) {
 	}
 
 	// Assume file-based template
-	b, err := ioutil.ReadFile(templatePathOrOnline)
+	b, err := os.ReadFile(templatePathOrOnline)
 	if err != nil {
 		return "", errors.Wrap(err, "reading template")
 	}

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -18,7 +18,6 @@ package document
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ import (
 
 func TestFileMetadata(t *testing.T) {
 	// Given
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -61,7 +60,7 @@ func TestFileMetadata(t *testing.T) {
 		"kubernetes-src.tar.gz",
 		"kubernetes.tar.gz",
 	} {
-		require.Nil(t, ioutil.WriteFile(
+		require.Nil(t, os.WriteFile(
 			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
 		))
 	}
@@ -139,14 +138,14 @@ func TestDocument_RenderMarkdownTemplateFailure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			require.Nil(t, err)
 			defer os.RemoveAll(dir)
 
 			if tt.templateExist {
 				fileName := strings.Split(tt.templateSpec, ":")[1]
 				p := filepath.Join(dir, fileName)
-				require.Nil(t, ioutil.WriteFile(p, []byte(tt.templateContents), 0664))
+				require.Nil(t, os.WriteFile(p, []byte(tt.templateContents), 0664))
 			}
 
 			doc := Document{}
@@ -158,7 +157,7 @@ func TestDocument_RenderMarkdownTemplateFailure(t *testing.T) {
 
 func TestCreateDownloadsTable(t *testing.T) {
 	// Given
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 	setupTestDir(t, dir)
@@ -249,7 +248,7 @@ func setupTestDir(t *testing.T, dir string) {
 		"kubernetes-src.tar.gz",
 		"kubernetes.tar.gz",
 	} {
-		require.Nil(t, ioutil.WriteFile(
+		require.Nil(t, os.WriteFile(
 			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
 		))
 	}
@@ -488,7 +487,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 			templateSpec := tt.templateSpec
 			var dir string
 			if tt.hasDownloads || tt.userTemplate {
-				dir, err = ioutil.TempDir("", "")
+				dir, err = os.MkdirTemp("", "")
 				require.NoError(t, err, "Creating tmpDir")
 				defer os.RemoveAll(dir)
 
@@ -502,7 +501,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 
 					require.NoError(
 						t,
-						ioutil.WriteFile(p, []byte(defaultReleaseNotesTemplate), 0664),
+						os.WriteFile(p, []byte(defaultReleaseNotesTemplate), 0664),
 						"Writing user specified template.")
 				}
 			}
@@ -527,7 +526,7 @@ func makeReleaseNote(kind notes.Kind, markdown string) *notes.ReleaseNote {
 }
 
 func readFile(t *testing.T, path string) string {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	require.NoError(t, err, "Reading file %q", path)
 	return string(b)
 }

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -19,7 +19,7 @@ package notes
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -36,7 +36,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// logrus, shut up
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,7 +93,7 @@ func newTestOptions(t *testing.T) *testOptions {
 //
 func newTestRepo(t *testing.T) *testRepo {
 	// Setup the bare repo as base
-	bareTempDir, err := ioutil.TempDir("", "k8s-test-bare-")
+	bareTempDir, err := os.MkdirTemp("", "k8s-test-bare-")
 	require.Nil(t, err)
 
 	bareRepo, err := git.PlainInit(bareTempDir, true)
@@ -102,14 +101,14 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.NotNil(t, bareRepo)
 
 	// Clone from the bare to be able to add our test data
-	cloneTempDir, err := ioutil.TempDir("", "k8s-test-clone-")
+	cloneTempDir, err := os.MkdirTemp("", "k8s-test-clone-")
 	require.Nil(t, err)
 	cloneRepo, err := git.PlainInit(cloneTempDir, false)
 	require.Nil(t, err)
 
 	// Add the test data set
 	const testFileName = "test-file"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -146,7 +145,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	).RunSuccess())
 
 	const branchTestFileName = "branch-test-file"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),
@@ -170,7 +169,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, err)
 
 	const secondBranchTestFileName = "branch-test-file-2"
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0644),

--- a/pkg/promobot/hash_test.go
+++ b/pkg/promobot/hash_test.go
@@ -18,7 +18,6 @@ package promobot_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestHash(t *testing.T) {
 //  tests is to make the changes explicit, particularly in code
 //  review, not to force manual updates.
 func AssertMatchesFile(t *testing.T, actual, p string) {
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		if os.Getenv("UPDATE_EXPECTED_OUTPUT") == "" {
 			t.Fatalf("error reading file %q: %v", p, err)
@@ -68,7 +67,7 @@ func AssertMatchesFile(t *testing.T, actual, p string) {
 
 	if actual != expected {
 		if os.Getenv("UPDATE_EXPECTED_OUTPUT") != "" {
-			if err := ioutil.WriteFile(p, []byte(actual), 0644); err != nil {
+			if err := os.WriteFile(p, []byte(actual), 0644); err != nil {
 				t.Fatalf("error writing file %q: %v", p, err)
 			}
 		}

--- a/pkg/promobot/promotefiles.go
+++ b/pkg/promobot/promotefiles.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -161,7 +160,7 @@ func readFilestores(p string) ([]api.Filestore, error) {
 		return nil, fmt.Errorf("FilestoresPath is required")
 	}
 
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		return nil, fmt.Errorf("error reading manifest %q: %v", p, err)
 	}
@@ -204,7 +203,7 @@ func readFiles(filesPath string) ([]api.File, error) {
 
 	var files []api.File
 	for _, p := range paths {
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			return nil, xerrors.Errorf("error reading file %q: %w", p, err)
 		}

--- a/pkg/release/archive.go
+++ b/pkg/release/archive.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -290,7 +289,7 @@ func (a *defaultArchiverImpl) CopyReleaseToBucket(releaseBuildDir, archiveBucket
 // GetLogFiles reads a directory and returns the files that are anago logs
 func (a *defaultArchiverImpl) GetLogFiles(logsDir string) ([]string, error) {
 	logFiles := []string{}
-	tmpContents, err := ioutil.ReadDir(logsDir)
+	tmpContents, err := os.ReadDir(logsDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "searching for logfiles in %s", logsDir)
 	}

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -195,7 +194,7 @@ func (i *Images) Validate(registry, version, buildPath string) error {
 				err, "get remote manifest from %s", imageVersion,
 			)
 		}
-		manifestFile, err := ioutil.TempFile("", "manifest-")
+		manifestFile, err := os.CreateTemp("", "manifest-")
 		if err != nil {
 			return errors.Wrap(err, "create temp file for manifest")
 		}
@@ -263,7 +262,7 @@ func (i *Images) Exists(registry, version string, fast bool) (bool, error) {
 				err, "get remote manifest from %s", imageVersion,
 			)
 		}
-		manifestFile, err := ioutil.TempFile("", "manifest-")
+		manifestFile, err := os.CreateTemp("", "manifest-")
 		if err != nil {
 			return false, errors.Wrap(err, "create temp file for manifest")
 		}
@@ -314,7 +313,7 @@ func (i *Images) getManifestImages(
 	releaseImagesPath := filepath.Join(buildPath, ImagesPath)
 	logrus.Infof("Getting manifest images in %s", releaseImagesPath)
 
-	archPaths, err := ioutil.ReadDir(releaseImagesPath)
+	archPaths, err := os.ReadDir(releaseImagesPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "read images path %s", releaseImagesPath)
 	}

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -18,7 +18,6 @@ package release_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,13 +51,13 @@ func TestPublish(t *testing.T) {
 				prepareImages(t, tempDir, mock)
 
 				// arch is not a directory, should be just skipped
-				require.Nil(t, ioutil.WriteFile(
+				require.Nil(t, os.WriteFile(
 					filepath.Join(tempDir, release.ImagesPath, "wrong"),
 					[]byte{}, os.FileMode(0o644),
 				))
 
 				// image is no tarball, should be just skipped
-				require.Nil(t, ioutil.WriteFile(
+				require.Nil(t, os.WriteFile(
 					filepath.Join(tempDir, release.ImagesPath, "amd64", "no-tar"),
 					[]byte{}, os.FileMode(0o644),
 				))
@@ -197,7 +196,7 @@ func TestPublish(t *testing.T) {
 		},
 		{ // failure no images-path
 			prepare: func(*releasefakes.FakeCommandClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-test-")
+				tempDir, err := os.MkdirTemp("", "publish-test-")
 				require.Nil(t, err)
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
@@ -278,7 +277,7 @@ func TestValidate(t *testing.T) {
 		},
 		{ // failure no images-path
 			prepare: func(*releasefakes.FakeCommandClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-test-")
+				tempDir, err := os.MkdirTemp("", "publish-test-")
 				require.Nil(t, err)
 				return tempDir, func() {
 					require.Nil(t, os.RemoveAll(tempDir))
@@ -303,7 +302,7 @@ func TestValidate(t *testing.T) {
 }
 
 func newImagesPath(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("", "publish-test-")
+	tempDir, err := os.MkdirTemp("", "publish-test-")
 	require.Nil(t, err)
 
 	require.Nil(t, os.MkdirAll(
@@ -323,7 +322,7 @@ func prepareImages(t *testing.T, tempDir string, mock *releasefakes.FakeCommandC
 		for _, image := range []string{
 			"conformance-amd64.tar", "kube-apiserver.tar", "kube-proxy.tar",
 		} {
-			require.Nil(t, ioutil.WriteFile(
+			require.Nil(t, os.WriteFile(
 				filepath.Join(archPath, image),
 				[]byte{}, os.FileMode(0o644),
 			))

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -19,7 +19,6 @@ package release
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +113,7 @@ func (d *defaultPublisher) NormalizePath(pathParts ...string) (string, error) {
 }
 
 func (*defaultPublisher) TempDir(dir, pattern string) (name string, err error) {
-	return ioutil.TempDir(dir, pattern)
+	return os.MkdirTemp(dir, pattern)
 }
 
 func (d *defaultPublisher) CopyToLocal(remote, local string) error {
@@ -122,7 +121,7 @@ func (d *defaultPublisher) CopyToLocal(remote, local string) error {
 }
 
 func (*defaultPublisher) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (*defaultPublisher) Unmarshal(data []byte, v interface{}) error {
@@ -134,7 +133,7 @@ func (*defaultPublisher) Marshal(v interface{}) ([]byte, error) {
 }
 
 func (*defaultPublisher) TempFile(dir, pattern string) (f *os.File, err error) {
-	return ioutil.TempFile(dir, pattern)
+	return os.CreateTemp(dir, pattern)
 }
 
 func (d *defaultPublisher) CopyToRemote(local, remote string) error {
@@ -320,7 +319,7 @@ func (p *Publisher) PublishToGcs(
 	}
 
 	latestFile := filepath.Join(uploadDir, "latest")
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		latestFile, []byte(version), os.FileMode(0o644),
 	); err != nil {
 		return errors.Wrap(err, "write latest version file")

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package release_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestPublishVersion(t *testing.T) {
 			version: testVersion,
 			fast:    true,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mock.GSUtilOutputReturnsOnCall(0, olderTestVersion, nil)
@@ -76,7 +75,7 @@ func TestPublishVersion(t *testing.T) {
 			version: testVersion,
 			fast:    true,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mock.GetMarkerPathReturns("", err)
@@ -93,7 +92,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: true,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mockVersionMarkers(mock)
@@ -111,7 +110,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: true,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mockVersionMarkers(mock)
@@ -129,7 +128,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: true,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mockVersionMarkers(mock)
@@ -147,7 +146,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: false,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mockVersionMarkers(mock)
@@ -165,7 +164,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: false,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 				mockVersionMarkers(mock)
 				mock.GetURLResponseReturns("", errors.New(""))
@@ -182,7 +181,7 @@ func TestPublishVersion(t *testing.T) {
 			version:       testVersion,
 			privateBucket: false,
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				mock.GSUtilReturnsOnCall(0, errors.New(""))
@@ -198,7 +197,7 @@ func TestPublishVersion(t *testing.T) {
 			gcsRoot: "release",
 			version: "wrong",
 			prepare: func(mock *releasefakes.FakePublisherClient) (string, func()) {
-				tempDir, err := ioutil.TempDir("", "publish-version-test-")
+				tempDir, err := os.MkdirTemp("", "publish-version-test-")
 				require.Nil(t, err)
 
 				return tempDir, func() {
@@ -234,20 +233,20 @@ func TestPublishReleaseNotesIndex(t *testing.T) {
 	}{
 		{ // success not existing
 			prepare: func(mock *releasefakes.FakePublisherClient) {
-				mock.TempFileCalls(ioutil.TempFile)
+				mock.TempFileCalls(os.CreateTemp)
 			},
 			shouldError: false,
 		},
 		{ // success existing
 			prepare: func(mock *releasefakes.FakePublisherClient) {
-				mock.TempFileCalls(ioutil.TempFile)
+				mock.TempFileCalls(os.CreateTemp)
 				mock.GSUtilStatusReturns(true, nil)
 			},
 			shouldError: false,
 		},
 		{ // failure CopyToRemote
 			prepare: func(mock *releasefakes.FakePublisherClient) {
-				mock.TempFileCalls(ioutil.TempFile)
+				mock.TempFileCalls(os.CreateTemp)
 				mock.CopyToRemoteReturns(err)
 			},
 			shouldError: true,

--- a/pkg/release/push_git_objects_test.go
+++ b/pkg/release/push_git_objects_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package release
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -30,7 +29,7 @@ import (
 
 func getTestGitObjectPusher() (pusher *GitObjectPusher, repoPath string, err error) {
 	// Initialize a test repository for the test pusher
-	repoPath, err = ioutil.TempDir(os.TempDir(), "sigrelease-test-repo-*")
+	repoPath, err = os.MkdirTemp("", "sigrelease-test-repo-*")
 	if err != nil {
 		return nil, "", errors.Wrap(err, "creating a directory for test repository")
 	}

--- a/pkg/release/repository_test.go
+++ b/pkg/release/repository_test.go
@@ -18,7 +18,6 @@ package release_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,7 +37,7 @@ type sut struct {
 }
 
 func newSUT(t *testing.T) *sut {
-	dir, err := ioutil.TempDir("", "k8s-test-")
+	dir, err := os.MkdirTemp("", "k8s-test-")
 	require.Nil(t, err)
 
 	_, err = gogit.PlainInit(dir, false)

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -17,7 +17,6 @@ limitations under the License.
 package release
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ func PrepareWorkspaceStage(directory string) error {
 func PrepareWorkspaceRelease(directory, buildVersion, bucket string) error {
 	logrus.Infof("Preparing workspace for release in %s", directory)
 	logrus.Infof("Searching for staged %s on %s", SourcesTar, bucket)
-	tempDir, err := ioutil.TempDir("", "staged-")
+	tempDir, err := os.MkdirTemp("", "staged-")
 	if err != nil {
 		return errors.Wrap(err, "create staged sources temp dir")
 	}

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testgrid
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/GoogleCloudPlatform/testgrid/config"
@@ -83,7 +82,7 @@ func (t *TestGrid) BlockingTests(branch string) (tests []string, err error) {
 func (t *TestGrid) configFromURL(url string) (cfg *pb.Configuration, err error) {
 	logrus.Info("Retrieving testgrid configuration")
 
-	tmpFile, err := ioutil.TempFile("", "testgrid-jobs-")
+	tmpFile, err := os.CreateTemp("", "testgrid-jobs-")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vulndash/adapter/adapter.go
+++ b/pkg/vulndash/adapter/adapter.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -232,7 +231,7 @@ func UpdateVulnerabilityDashboard(
 
 	dashboardJSON := dashboardPath + "dashboard.json"
 	logrus.Infof("writing the vulnerabilities for %s in the file %s", vulnProject, dashboardJSON)
-	err = ioutil.WriteFile(dashboardJSON, jsonFile, 0644)
+	err = os.WriteFile(dashboardJSON, jsonFile, 0644)
 	if err != nil {
 		return errors.Errorf("Unable to create temporary local"+
 			"JSON file for the dashboard: %v", err)


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
With go1.16 we now default to the os/io packages instead of ioutil. This
should be reflected in the code, too.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
