### PR TITLE
Add new substitution to control release engineering kube-cross version

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/build-image/kube-cross:${_RELENG_CROSS_VERSION}
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -51,19 +51,20 @@ const (
 
 // TODO: Pull some of these options in cmd/gcbuilder, so they don't have to be public.
 type Options struct {
-	objStore       object.Store
-	BuildDir       string
-	ConfigDir      string
-	CloudbuildFile string
-	LogDir         string
-	ScratchBucket  string
-	Project        string
-	AllowDirty     bool
-	NoSource       bool
-	Async          bool
-	DiskSize       string
-	Variant        string
-	EnvPassthrough string
+	objStore           object.Store
+	BuildDir           string
+	ConfigDir          string
+	CloudbuildFile     string
+	LogDir             string
+	ScratchBucket      string
+	Project            string
+	AllowDirty         bool
+	NoSource           bool
+	Async              bool
+	DiskSize           string
+	Variant            string
+	EnvPassthrough     string
+	RelengCrossVersion string
 }
 
 // NewDefaultOptions returns a new default `*Options` instance.

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -37,6 +37,10 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
+const (
+	defaultRelengCrossVersion = "v1.16.1-1"
+)
+
 // GCB is the main structure of this package.
 type GCB struct {
 	options        *Options
@@ -79,24 +83,26 @@ func (g *GCB) SetReleaseClient(client Release) {
 
 type Options struct {
 	build.Options
-	NoMock       bool
-	Stage        bool
-	Release      bool
-	Stream       bool
-	BuildAtHead  bool
-	Branch       string
-	ReleaseType  string
-	BuildVersion string
-	GcpUser      string
-	LogLevel     string
-	LastJobs     int64
+	NoMock             bool
+	Stage              bool
+	Release            bool
+	Stream             bool
+	BuildAtHead        bool
+	Branch             string
+	ReleaseType        string
+	BuildVersion       string
+	GcpUser            string
+	LogLevel           string
+	RelengCrossVersion string
+	LastJobs           int64
 }
 
 // NewDefaultOptions returns a new default `*Options` instance.
 func NewDefaultOptions() *Options {
 	return &Options{
-		LogLevel: logrus.StandardLogger().GetLevel().String(),
-		Options:  *build.NewDefaultOptions(),
+		LogLevel:           logrus.StandardLogger().GetLevel().String(),
+		Options:            *build.NewDefaultOptions(),
+		RelengCrossVersion: defaultRelengCrossVersion,
 	}
 }
 
@@ -349,6 +355,9 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolBranch string) (map[str
 	}
 
 	gcbSubs["BUILDVERSION"] = buildVersion
+
+	// The Release Engineering tools use their own kubecross version
+	gcbSubs["RELENG_CROSS_VERSION"] = g.options.RelengCrossVersion
 
 	kubecrossBranches := []string{
 		g.options.Branch,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This adds a new substitution for the stage build named `RELENG_CROSS_VERSION`.
It defines a specific version of kube-cross to use when compiling the release engineering tools (eg `krel`) in a GCB build job.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
- The `kube-cross` version used to compile the release engineering tools in our Cloud Build jobs can now be specified with a new substitution:  `RELENG_CROSS_VERSION`
```
