### PR TITLE
Hardcode k8s.gcr.io/releng/releng-ci:v0.5.0 to build krel in GCB

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - "--branch=${_TOOL_BRANCH}"
   - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
-- name: k8s.gcr.io/build-image/kube-cross:${_KUBE_CROSS_VERSION}
+- name: k8s.gcr.io/releng/releng-ci:v0.5.0
   dir: "go/src/k8s.io/release"
   env:
   - "GOPATH=/workspace/go"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
#### What this PR does / why we need it:

The go versions needed to build the kubernetes source and our tools have diverged. This PR hardcodes `releng-ci:v0.5.0` to build our tools instead of relying on the specified `kube-cross` version

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Switch to hardcoded releng-ci:v0.5.0 image to build `krel` in GCB jobs
```
