### PR TITLE
Update debian builder to go1.16.1

### DIFF
--- a/hack/rapture/README.md
+++ b/hack/rapture/README.md
@@ -163,9 +163,10 @@ In addition to manual validation, we also have some periodic package verificatio
 See the [Release Engineering dashboard][release-engineering-dashboard] on Testgrid.
 The following jobs are currently configured to do some aspect of package validation:
 
-- https://testgrid.k8s.io/sig-release-misc#debian-unstable
-- https://testgrid.k8s.io/sig-release-misc#periodic-packages-pushed
-- https://testgrid.k8s.io/sig-release-misc#periodic-packages-install-deb
+- https://testgrid.k8s.io/sig-release-releng-informing#build-packages-debs
+- https://testgrid.k8s.io/sig-release-releng-informing#build-packages-rpms
+- https://testgrid.k8s.io/sig-release-releng-informing#verify-packages-debs
+- https://testgrid.k8s.io/sig-release-releng-informing#verify-packages-rpms
 
 **These tend to break when we are in the middle of a push.**
 
@@ -179,7 +180,7 @@ If there is continued test failure on this dashboard without intervention from t
 [kubernetes-build-admins]:  https://github.com/kubernetes/sig-release/tree/master/release-managers.md#build-admins
 [rapture]: k8s-rapture.sh
 [rapture-readme]: https://g3doc.corp.google.com/cloud/kubernetes/g3doc/release/rapture.md?cl=head
-[release-engineering-dashboard]: https://testgrid.k8s.io/sig-release-misc
+[release-engineering-dashboard]: https://testgrid.k8s.io/sig-release-releng-informing
 [release-management-slack]: https://kubernetes.slack.com/messages/CJH2GBF7Y
 [release-managers]: /release-managers.md#release-managers
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.16.1
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix debian image building during rapture push, by bumping image to go1.16.1 to work with https://github.com/kubernetes/release/pull/1955

also cleanup links to outdated dashboards.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Note though the jobs are currently using a different build mechanism than what being used by rapture

https://github.com/kubernetes/release/blob/9c8248b17a992872981122ccdaf626b364dc3b4d/hack/rapture/k8s-rapture.sh#L122-L123

ref: https://github.com/kubernetes/release/issues/1027

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


/cc @puerco @saschagrunert @kubernetes/build-admins 