### PR TITLE
Add function github.GetMilestone()

### DIFF
--- a/pkg/github/githubfakes/fake_client.go
+++ b/pkg/github/githubfakes/fake_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -238,6 +238,24 @@ type FakeClient struct {
 	}
 	listCommitsReturnsOnCall map[int]struct {
 		result1 []*githuba.RepositoryCommit
+		result2 *githuba.Response
+		result3 error
+	}
+	ListMilestonesStub        func(context.Context, string, string, *githuba.MilestoneListOptions) ([]*githuba.Milestone, *githuba.Response, error)
+	listMilestonesMutex       sync.RWMutex
+	listMilestonesArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.MilestoneListOptions
+	}
+	listMilestonesReturns struct {
+		result1 []*githuba.Milestone
+		result2 *githuba.Response
+		result3 error
+	}
+	listMilestonesReturnsOnCall map[int]struct {
+		result1 []*githuba.Milestone
 		result2 *githuba.Response
 		result3 error
 	}
@@ -1185,6 +1203,76 @@ func (fake *FakeClient) ListCommitsReturnsOnCall(i int, result1 []*githuba.Repos
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListMilestones(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.MilestoneListOptions) ([]*githuba.Milestone, *githuba.Response, error) {
+	fake.listMilestonesMutex.Lock()
+	ret, specificReturn := fake.listMilestonesReturnsOnCall[len(fake.listMilestonesArgsForCall)]
+	fake.listMilestonesArgsForCall = append(fake.listMilestonesArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.MilestoneListOptions
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListMilestonesStub
+	fakeReturns := fake.listMilestonesReturns
+	fake.recordInvocation("ListMilestones", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listMilestonesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListMilestonesCallCount() int {
+	fake.listMilestonesMutex.RLock()
+	defer fake.listMilestonesMutex.RUnlock()
+	return len(fake.listMilestonesArgsForCall)
+}
+
+func (fake *FakeClient) ListMilestonesCalls(stub func(context.Context, string, string, *githuba.MilestoneListOptions) ([]*githuba.Milestone, *githuba.Response, error)) {
+	fake.listMilestonesMutex.Lock()
+	defer fake.listMilestonesMutex.Unlock()
+	fake.ListMilestonesStub = stub
+}
+
+func (fake *FakeClient) ListMilestonesArgsForCall(i int) (context.Context, string, string, *githuba.MilestoneListOptions) {
+	fake.listMilestonesMutex.RLock()
+	defer fake.listMilestonesMutex.RUnlock()
+	argsForCall := fake.listMilestonesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) ListMilestonesReturns(result1 []*githuba.Milestone, result2 *githuba.Response, result3 error) {
+	fake.listMilestonesMutex.Lock()
+	defer fake.listMilestonesMutex.Unlock()
+	fake.ListMilestonesStub = nil
+	fake.listMilestonesReturns = struct {
+		result1 []*githuba.Milestone
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListMilestonesReturnsOnCall(i int, result1 []*githuba.Milestone, result2 *githuba.Response, result3 error) {
+	fake.listMilestonesMutex.Lock()
+	defer fake.listMilestonesMutex.Unlock()
+	fake.ListMilestonesStub = nil
+	if fake.listMilestonesReturnsOnCall == nil {
+		fake.listMilestonesReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.Milestone
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.listMilestonesReturnsOnCall[i] = struct {
+		result1 []*githuba.Milestone
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) ListPullRequestsWithCommit(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 *githuba.PullRequestListOptions) ([]*githuba.PullRequest, *githuba.Response, error) {
 	fake.listPullRequestsWithCommitMutex.Lock()
 	ret, specificReturn := fake.listPullRequestsWithCommitReturnsOnCall[len(fake.listPullRequestsWithCommitArgsForCall)]
@@ -1627,6 +1715,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listBranchesMutex.RUnlock()
 	fake.listCommitsMutex.RLock()
 	defer fake.listCommitsMutex.RUnlock()
+	fake.listMilestonesMutex.RLock()
+	defer fake.listMilestonesMutex.RUnlock()
 	fake.listPullRequestsWithCommitMutex.RLock()
 	defer fake.listPullRequestsWithCommitMutex.RUnlock()
 	fake.listReleaseAssetsMutex.RLock()

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -46,6 +46,7 @@ const (
 	gitHubAPIGetReleaseByTag            gitHubAPI = "GetReleaseByTag"
 	gitHubAPIListReleaseAssets          gitHubAPI = "ListReleaseAssets"
 	gitHubAPICreateComment              gitHubAPI = "CreateComment"
+	gitHubAPIListMilestones             gitHubAPI = "ListMilestones"
 )
 
 type apiRecord struct {
@@ -253,6 +254,19 @@ func (c *githubNotesRecordClient) ListReleaseAssets(
 	}
 
 	return assets, nil
+}
+
+func (c *githubNotesRecordClient) ListMilestones(
+	ctx context.Context, owner, repo string, opts *github.MilestoneListOptions,
+) ([]*github.Milestone, *github.Response, error) {
+	mstones, resp, err := c.client.ListMilestones(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIListMilestones, mstones, resp); err != nil {
+		return nil, nil, err
+	}
+	return mstones, resp, nil
 }
 
 func (c *githubNotesRecordClient) CreateComment(ctx context.Context, owner, repo string, number int, message string) (*github.IssueComment, *github.Response, error) {

--- a/pkg/github/replay.go
+++ b/pkg/github/replay.go
@@ -207,6 +207,21 @@ func (c *githubNotesReplayClient) ListBranches(
 	return branches, record.response(), nil
 }
 
+func (c *githubNotesReplayClient) ListMilestones(
+	ctx context.Context, owner, repo string, opts *github.MilestoneListOptions,
+) (mstones []*github.Milestone, resp *github.Response, err error) {
+	data, err := c.readRecordedData(gitHubAPIListMilestones)
+	if err != nil {
+		return nil, nil, err
+	}
+	mstones = make([]*github.Milestone, 0)
+	record := apiRecord{Result: mstones}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return mstones, record.response(), nil
+}
+
 func (c *githubNotesReplayClient) readRecordedData(api gitHubAPI) ([]byte, error) {
 	c.replayMutex.Lock()
 	defer c.replayMutex.Unlock()


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds a new function `github.GetMilestone()` that queries the GitHub API to find a given milestone in a repository from its title string. Adds a new capability to the clients to list
milestones as well as a test.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
New function `github.GetMilestone()` that queries the GitHub API to find  a given milestone in a repository from its title string
```
