### PR TITLE
kube-cross: enable custom BASEIMAGE

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -22,6 +22,7 @@ TYPE ?= default
 
 # Build args
 GO_VERSION?=1.16.1
+BASEIMAGE?=golang:$(GO_VERSION)
 PROTOBUF_VERSION?=3.7.0
 ETCD_VERSION?=v3.4.13
 
@@ -62,7 +63,7 @@ container: check-env init-docker-buildx
 			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
 			--tag $(IMAGE)-$${platform##*/}:$(TAG)-$(CONFIG)-$(TYPE) \
 			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG)-$(TYPE) \
-			--build-arg=GO_VERSION=$(GO_VERSION) \
+			--build-arg=BASEIMAGE=$(BASEIMAGE) \
 			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
 			--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
 			--file $(TYPE)/Dockerfile \

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -15,8 +15,8 @@
 # This file creates a standard build environment for building cross
 # platform go binary for the architecture kubernetes cares about.
 
-ARG GO_VERSION
-FROM golang:${GO_VERSION}
+ARG BASEIMAGE
+FROM ${BASEIMAGE}
 
 ##------------------------------------------------------------
 # global ARGs & ENVs

--- a/images/build/cross/legacy/Dockerfile
+++ b/images/build/cross/legacy/Dockerfile
@@ -15,8 +15,8 @@
 # This file creates a standard build environment for building cross
 # platform go binary for the architecture kubernetes cares about.
 
-ARG GO_VERSION
-FROM golang:${GO_VERSION}
+ARG BASEIMAGE
+FROM ${BASEIMAGE}
 
 ##------------------------------------------------------------
 # global ARGs & ENVs


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The ability to customize BASEIMAGE for kube-cross instead of using the default golang BASEIMAGE.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #1963

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
