### PR TITLE
Use http agent for kubecross version retrieval

### DIFF
--- a/pkg/kubecross/impl.go
+++ b/pkg/kubecross/impl.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package kubecross
 
-import "sigs.k8s.io/release-utils/http"
+import (
+	"bytes"
+
+	"sigs.k8s.io/release-utils/http"
+)
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
@@ -27,5 +31,9 @@ type impl interface {
 type defaultImpl struct{}
 
 func (*defaultImpl) GetURLResponse(url string, trim bool) (string, error) {
-	return http.GetURLResponse(url, trim)
+	content, err := http.NewAgent().Get(url)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(content)), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This agent allows retries and should be more future proof.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Follow-up of https://github.com/kubernetes/release/pull/1969
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
