### PR TITLE
Use http agent for lookup of remote release notes

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -409,7 +409,7 @@ func (c *Changelog) lookupRemoteReleaseNotes(
 
 	// Retrieve the markdown version
 	remoteMarkdown := remoteBase + "release-notes-draft.md"
-	markdownStr, err = c.impl.GetURLResponse(remoteMarkdown, false)
+	markdownStr, err = c.impl.GetURLResponse(remoteMarkdown)
 	if err != nil {
 		return "", "", errors.Wrapf(err,
 			"fetch release notes markdown from remote: %s", remoteMarkdown,
@@ -419,7 +419,7 @@ func (c *Changelog) lookupRemoteReleaseNotes(
 
 	// Retrieve the JSON version
 	remoteJSON := remoteBase + "release-notes-draft.json"
-	jsonStr, err = c.impl.GetURLResponse(remoteJSON, false)
+	jsonStr, err = c.impl.GetURLResponse(remoteJSON)
 	if err != nil {
 		logrus.Warnf(
 			"Unable to fetch release notes JSON from remote %s: %v",

--- a/pkg/changelog/changelogfakes/fake_impl.go
+++ b/pkg/changelog/changelogfakes/fake_impl.go
@@ -19,7 +19,7 @@ package changelogfakes
 
 import (
 	"io"
-	"os"
+	"io/fs"
 	"sync"
 	"text/template"
 
@@ -151,11 +151,10 @@ type FakeImpl struct {
 		result1 string
 		result2 error
 	}
-	GetURLResponseStub        func(string, bool) (string, error)
+	GetURLResponseStub        func(string) (string, error)
 	getURLResponseMutex       sync.RWMutex
 	getURLResponseArgsForCall []struct {
 		arg1 string
-		arg2 bool
 	}
 	getURLResponseReturns struct {
 		result1 string
@@ -312,17 +311,17 @@ type FakeImpl struct {
 	rmReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StatStub        func(string) (os.FileInfo, error)
+	StatStub        func(string) (fs.FileInfo, error)
 	statMutex       sync.RWMutex
 	statArgsForCall []struct {
 		arg1 string
 	}
 	statReturns struct {
-		result1 os.FileInfo
+		result1 fs.FileInfo
 		result2 error
 	}
 	statReturnsOnCall map[int]struct {
-		result1 os.FileInfo
+		result1 fs.FileInfo
 		result2 error
 	}
 	TagStringToSemverStub        func(string) (semver.Version, error)
@@ -362,12 +361,12 @@ type FakeImpl struct {
 	validateAndFinishReturnsOnCall map[int]struct {
 		result1 error
 	}
-	WriteFileStub        func(string, []byte, os.FileMode) error
+	WriteFileStub        func(string, []byte, fs.FileMode) error
 	writeFileMutex       sync.RWMutex
 	writeFileArgsForCall []struct {
 		arg1 string
 		arg2 []byte
-		arg3 os.FileMode
+		arg3 fs.FileMode
 	}
 	writeFileReturns struct {
 		result1 error
@@ -952,19 +951,18 @@ func (fake *FakeImpl) GenerateTOCReturnsOnCall(i int, result1 string, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) GetURLResponse(arg1 string, arg2 bool) (string, error) {
+func (fake *FakeImpl) GetURLResponse(arg1 string) (string, error) {
 	fake.getURLResponseMutex.Lock()
 	ret, specificReturn := fake.getURLResponseReturnsOnCall[len(fake.getURLResponseArgsForCall)]
 	fake.getURLResponseArgsForCall = append(fake.getURLResponseArgsForCall, struct {
 		arg1 string
-		arg2 bool
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.GetURLResponseStub
 	fakeReturns := fake.getURLResponseReturns
-	fake.recordInvocation("GetURLResponse", []interface{}{arg1, arg2})
+	fake.recordInvocation("GetURLResponse", []interface{}{arg1})
 	fake.getURLResponseMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -978,17 +976,17 @@ func (fake *FakeImpl) GetURLResponseCallCount() int {
 	return len(fake.getURLResponseArgsForCall)
 }
 
-func (fake *FakeImpl) GetURLResponseCalls(stub func(string, bool) (string, error)) {
+func (fake *FakeImpl) GetURLResponseCalls(stub func(string) (string, error)) {
 	fake.getURLResponseMutex.Lock()
 	defer fake.getURLResponseMutex.Unlock()
 	fake.GetURLResponseStub = stub
 }
 
-func (fake *FakeImpl) GetURLResponseArgsForCall(i int) (string, bool) {
+func (fake *FakeImpl) GetURLResponseArgsForCall(i int) string {
 	fake.getURLResponseMutex.RLock()
 	defer fake.getURLResponseMutex.RUnlock()
 	argsForCall := fake.getURLResponseArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *FakeImpl) GetURLResponseReturns(result1 string, result2 error) {
@@ -1715,7 +1713,7 @@ func (fake *FakeImpl) RmReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) Stat(arg1 string) (os.FileInfo, error) {
+func (fake *FakeImpl) Stat(arg1 string) (fs.FileInfo, error) {
 	fake.statMutex.Lock()
 	ret, specificReturn := fake.statReturnsOnCall[len(fake.statArgsForCall)]
 	fake.statArgsForCall = append(fake.statArgsForCall, struct {
@@ -1740,7 +1738,7 @@ func (fake *FakeImpl) StatCallCount() int {
 	return len(fake.statArgsForCall)
 }
 
-func (fake *FakeImpl) StatCalls(stub func(string) (os.FileInfo, error)) {
+func (fake *FakeImpl) StatCalls(stub func(string) (fs.FileInfo, error)) {
 	fake.statMutex.Lock()
 	defer fake.statMutex.Unlock()
 	fake.StatStub = stub
@@ -1753,28 +1751,28 @@ func (fake *FakeImpl) StatArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeImpl) StatReturns(result1 os.FileInfo, result2 error) {
+func (fake *FakeImpl) StatReturns(result1 fs.FileInfo, result2 error) {
 	fake.statMutex.Lock()
 	defer fake.statMutex.Unlock()
 	fake.StatStub = nil
 	fake.statReturns = struct {
-		result1 os.FileInfo
+		result1 fs.FileInfo
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) StatReturnsOnCall(i int, result1 os.FileInfo, result2 error) {
+func (fake *FakeImpl) StatReturnsOnCall(i int, result1 fs.FileInfo, result2 error) {
 	fake.statMutex.Lock()
 	defer fake.statMutex.Unlock()
 	fake.StatStub = nil
 	if fake.statReturnsOnCall == nil {
 		fake.statReturnsOnCall = make(map[int]struct {
-			result1 os.FileInfo
+			result1 fs.FileInfo
 			result2 error
 		})
 	}
 	fake.statReturnsOnCall[i] = struct {
-		result1 os.FileInfo
+		result1 fs.FileInfo
 		result2 error
 	}{result1, result2}
 }
@@ -1967,7 +1965,7 @@ func (fake *FakeImpl) ValidateAndFinishReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) WriteFile(arg1 string, arg2 []byte, arg3 os.FileMode) error {
+func (fake *FakeImpl) WriteFile(arg1 string, arg2 []byte, arg3 fs.FileMode) error {
 	var arg2Copy []byte
 	if arg2 != nil {
 		arg2Copy = make([]byte, len(arg2))
@@ -1978,7 +1976,7 @@ func (fake *FakeImpl) WriteFile(arg1 string, arg2 []byte, arg3 os.FileMode) erro
 	fake.writeFileArgsForCall = append(fake.writeFileArgsForCall, struct {
 		arg1 string
 		arg2 []byte
-		arg3 os.FileMode
+		arg3 fs.FileMode
 	}{arg1, arg2Copy, arg3})
 	stub := fake.WriteFileStub
 	fakeReturns := fake.writeFileReturns
@@ -1999,13 +1997,13 @@ func (fake *FakeImpl) WriteFileCallCount() int {
 	return len(fake.writeFileArgsForCall)
 }
 
-func (fake *FakeImpl) WriteFileCalls(stub func(string, []byte, os.FileMode) error) {
+func (fake *FakeImpl) WriteFileCalls(stub func(string, []byte, fs.FileMode) error) {
 	fake.writeFileMutex.Lock()
 	defer fake.writeFileMutex.Unlock()
 	fake.WriteFileStub = stub
 }
 
-func (fake *FakeImpl) WriteFileArgsForCall(i int) (string, []byte, os.FileMode) {
+func (fake *FakeImpl) WriteFileArgsForCall(i int) (string, []byte, fs.FileMode) {
 	fake.writeFileMutex.RLock()
 	defer fake.writeFileMutex.RUnlock()
 	argsForCall := fake.writeFileArgsForCall[i]

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -82,7 +82,7 @@ type impl interface {
 	Abs(path string) (string, error)
 
 	// Used in `lookupRemoteReleaseNotes()`
-	GetURLResponse(url string, trim bool) (string, error)
+	GetURLResponse(url string) (string, error)
 
 	// Used in `commitChanges()`
 	Add(repo *git.Repo, filename string) error
@@ -196,8 +196,12 @@ func (*defaultImpl) Abs(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-func (*defaultImpl) GetURLResponse(url string, trim bool) (string, error) {
-	return http.GetURLResponse(url, trim)
+func (*defaultImpl) GetURLResponse(url string) (string, error) {
+	content, err := http.NewAgent().Get(url)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }
 
 func (*defaultImpl) Add(repo *git.Repo, filename string) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This agent allows retries and should be more future proof.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
We should probably do this for all users of the previous `GetURLResponse` API.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
