### PR TITLE
Updates for k8s-cloud-builder and k8s-ci-builder 

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -5,9 +5,9 @@ variants:
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.8-1'
+    KUBE_CROSS_VERSION: 'v1.15.10-1'
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15-legacy:
     CONFIG: 'cross1.15-legacy'
-    KUBE_CROSS_VERSION: 'v1.15.8-legacy-1'
+    KUBE_CROSS_VERSION: 'v1.15.10-legacy-1'
     SKOPEO_VERSION: 'v1.2.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -23,9 +23,3 @@ variants:
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'
-  '1.17':
-    CONFIG: '1.17'
-    GO_VERSION: '1.13.15'
-    BAZEL_VERSION: '2.2.0'
-    OLD_BAZEL_VERSION: '0.23.2'
-    SKOPEO_VERSION: 'v1.2.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -7,19 +7,19 @@ variants:
     SKOPEO_VERSION: 'v1.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.15.5'
+    GO_VERSION: '1.16.1'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.15.3'
+    GO_VERSION: '1.16.1'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: '1.13.15'
+    GO_VERSION: '1.16.1'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Since the golang updates in k/k are merged we now can bump the internal
image versions, too.

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/1940

#### Special notes for your reviewer:
/assign @justaugustus @saschagrunert @hasheddan @puerco @xmudrii 
/hold
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder to v1.15.10-1 and v1.15.10-legacy-1
Update k8s-ci-builder to use go 1.15.10 for 1.20/1.19 branches
```
