### PR TITLE
GCB: Always file on master when failing to retrieve cross version

### DIFF
--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -356,9 +356,9 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 	kc := kubecross.New()
 	kcVersionBranch, err := kc.ForBranch(g.options.Branch)
 	if err != nil {
-		// If the kubecross version is not set, we will get a 404 from GitHub
-		// we do not err but use the latest version
-		if !strings.Contains(err.Error(), "404") {
+		// If the kubecross version is not set, we will get a 404 from GitHub.
+		// In that case, we do not err but use the latest version (unless we're on main branch)
+		if g.options.Branch == git.DefaultBranch || !strings.Contains(err.Error(), "404") {
 			return gcbSubs, errors.Wrap(err, "retrieve kube-cross version")
 		}
 		logrus.Infof("KubeCross version not set for %s, falling back to latest", g.options.Branch)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

In #1974 we introduced a fallback mechanism to avoid failing and use the latest version of KubeCross when the release branch does not exist. This, however, left open an edge case where the master/main branch could end up without a kubecross version in case of a network error.

This PR fixes the fallback mechanism to always fail when an error occurs while retrieving the kubecross version for the master branch

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Follow-up to #1974

#### Special notes for your reviewer:

/assign @saschagrunert 

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
