### PR TITLE
kube-cross: Adds mingw-w64 for Windows binary compilation

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -128,7 +128,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.16.1-1
+    version: v1.16.1-2
     refPaths:
     - path: images/build/cross/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,7 +16,7 @@
 SHELL=/bin/bash -o pipefail
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.16.1-1
+IMAGE_VERSION ?= v1.16.2-1
 CONFIG ?= go1.16
 TYPE ?= default
 

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -64,7 +64,7 @@ RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
     echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
     && apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
     && apt-get update \
-    && apt-get install -y build-essential \
+    && apt-get install -y build-essential mingw-w64 \
     && for platform in ${KUBE_DYNAMIC_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \
 fi
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -3,14 +3,14 @@ variants:
     TYPE: 'default'
     CONFIG: 'canary'
     GO_VERSION: '1.16.1'
-    IMAGE_VERSION: 'v1.16.1-canary-1'
+    IMAGE_VERSION: 'v1.16.1-canary-2'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.16:
     TYPE: 'default'
     CONFIG: 'go1.16'
     GO_VERSION: '1.16.1'
-    IMAGE_VERSION: 'v1.16.1-1'
+    IMAGE_VERSION: 'v1.16.1-2'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/sig windows

#### What this PR does / why we need it:

For compiling Windows binaries, we're typically using the docker image ``dockcross/windows-static-x64``, which is currently hosted on dockerhub.

Adding the ``mingw-w64`` package into the ``kube-cross`` image will allow us to use it for Windows binaries as well, so we won't have to rely on any docker image. Because we won't have to pull another image, this will also speed up the building process of some images (e.g: pause image).

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
Related: https://github.com/kubernetes/kubernetes/issues/99360
or

None
-->

#### Special notes for your reviewer:

Image Building logs: https://paste.ubuntu.com/p/PRMKSkr4sW/

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- kube-cross: Adds mingw-w64 for Windows binary compilation
- kube-cross: Build v1.16.1-2 image
```
