### PR TITLE
Log in to DockerHub during staging before starting build

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -15,6 +15,7 @@ secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
     GITHUB_TOKEN: CiQAIkWjMMb2OjCHCt1hHer4ZBqqD1Mj7+dfTpvkkuzS64nrGm0SUQBLz1D+4Zwp6te6JByO/zvGpHMhW6/i3BJMRYXtNTkyBGMnZuH+J3gQfhcGL2HXjr75lHaCxF4bxPr45xen5D/Kk1+paL+XpOU3KJIADy7uGQ==
+    DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
 
 steps:
 - name: gcr.io/cloud-builders/git
@@ -50,6 +51,7 @@ steps:
   - "TOOL_REF=${_TOOL_REF}"
   secretEnv:
   - GITHUB_TOKEN
+  - DOCKERHUB_TOKEN
   args:
   - "bin/krel"
   - "stage"

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -103,6 +103,16 @@ type FakeStageImpl struct {
 		result1 string
 		result2 error
 	}
+	DockerHubLoginStub        func() error
+	dockerHubLoginMutex       sync.RWMutex
+	dockerHubLoginArgsForCall []struct {
+	}
+	dockerHubLoginReturns struct {
+		result1 error
+	}
+	dockerHubLoginReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GenerateChangelogStub        func(*changelog.Options) error
 	generateChangelogMutex       sync.RWMutex
 	generateChangelogArgsForCall []struct {
@@ -646,6 +656,59 @@ func (fake *FakeStageImpl) CurrentBranchReturnsOnCall(i int, result1 string, res
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) DockerHubLogin() error {
+	fake.dockerHubLoginMutex.Lock()
+	ret, specificReturn := fake.dockerHubLoginReturnsOnCall[len(fake.dockerHubLoginArgsForCall)]
+	fake.dockerHubLoginArgsForCall = append(fake.dockerHubLoginArgsForCall, struct {
+	}{})
+	stub := fake.DockerHubLoginStub
+	fakeReturns := fake.dockerHubLoginReturns
+	fake.recordInvocation("DockerHubLogin", []interface{}{})
+	fake.dockerHubLoginMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) DockerHubLoginCallCount() int {
+	fake.dockerHubLoginMutex.RLock()
+	defer fake.dockerHubLoginMutex.RUnlock()
+	return len(fake.dockerHubLoginArgsForCall)
+}
+
+func (fake *FakeStageImpl) DockerHubLoginCalls(stub func() error) {
+	fake.dockerHubLoginMutex.Lock()
+	defer fake.dockerHubLoginMutex.Unlock()
+	fake.DockerHubLoginStub = stub
+}
+
+func (fake *FakeStageImpl) DockerHubLoginReturns(result1 error) {
+	fake.dockerHubLoginMutex.Lock()
+	defer fake.dockerHubLoginMutex.Unlock()
+	fake.DockerHubLoginStub = nil
+	fake.dockerHubLoginReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) DockerHubLoginReturnsOnCall(i int, result1 error) {
+	fake.dockerHubLoginMutex.Lock()
+	defer fake.dockerHubLoginMutex.Unlock()
+	fake.DockerHubLoginStub = nil
+	if fake.dockerHubLoginReturnsOnCall == nil {
+		fake.dockerHubLoginReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.dockerHubLoginReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeStageImpl) GenerateChangelog(arg1 *changelog.Options) error {
@@ -1532,6 +1595,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.commitEmptyMutex.RUnlock()
 	fake.currentBranchMutex.RLock()
 	defer fake.currentBranchMutex.RUnlock()
+	fake.dockerHubLoginMutex.RLock()
+	defer fake.dockerHubLoginMutex.RUnlock()
 	fake.generateChangelogMutex.RLock()
 	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -402,6 +402,12 @@ func TestBuild(t *testing.T) {
 			},
 			shouldError: true,
 		},
+		{ // DockerHubLogin fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.DockerHubLoginReturns(err)
+			},
+			shouldError: true,
+		},
 	} {
 		opts := anago.DefaultStageOptions()
 		sut := anago.NewDefaultStage(opts)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

During the `v1.21.0-rc.0` cut we had issues pulling images from Docker Hub. Now, krel will log using a docker account into hub before starting the build to try to avoid getting rate limited.

#### Which issue(s) this PR fixes:

Related to problems during the release cut https://github.com/kubernetes/sig-release/issues/1489

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
krel will now log into docker hub using a release engineering account to allow for more image pulls
```
