### PR TITLE
Switch `GetURLResponseWithTimeOut` to `http.NewAgent().WithTimeout(…)Get`

### DIFF
--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -124,7 +124,7 @@ func runTestGridShot(opts *TestGridOptions) error {
 	testgridJobs := []TestGridJob{}
 	for _, board := range opts.boards {
 		testGridDashboard := fmt.Sprintf("%s/sig-release-%s-%s/summary", opts.testgridURL, opts.branch, board)
-		content, err := http.GetURLResponseWithTimeOut(testGridDashboard, 30*time.Second)
+		content, err := http.NewAgent().WithTimeout(30 * time.Second).Get(testGridDashboard)
 		if err != nil {
 			return errors.Wrapf(err,
 				"unable to retrieve release announcement form url: %s", testGridDashboard,
@@ -178,7 +178,7 @@ func processDashboards(testgridJobs []TestGridJob, date string, opts *TestGridOp
 		rendertronURL := fmt.Sprintf("%s/%s?width=3000&height=2500", opts.renderTronURL, url.PathEscape(testGridJobURL))
 		logrus.Infof("rendertronURL for %s: %s", testGridJobURL, rendertronURL)
 
-		content, err := http.GetURLResponseWithTimeOut(rendertronURL, 300*time.Second)
+		content, err := http.NewAgent().WithTimeout(300 * time.Second).Get(rendertronURL)
 		if err != nil {
 			return testgridJobs, errors.Wrapf(err, "failed to get the testgrid screenshot")
 		}


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

The old API will be removed in future release-utils versions and we can
switch to the more flexible HTTP agent implementation.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/release-utils/pull/9
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
