### PR TITLE
Remove `stage-ci` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,6 @@ RELEASE_TOOLS ?=
 release-tools: ## Compiles a set of release tools, specified by $RELEASE_TOOLS
 	./compile-release-tools $(RELEASE_TOOLS)
 
-##@ GCB Jobs
-
-.PHONY: stage-ci
-
-stage-ci: ## Compiles/installs krel and submits a MOCK streamed stage build to GCB (used for Prow)
-	RELEASE_TOOLS="krel" $(MAKE) release-tools
-	krel stage --stream
-
 ##@ Images
 
 .PHONY: update-images


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This target is nowhere used and is just misleading that we run any job
with it. We usually use the k8s-ci-builder jobs for that purpose.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `stage-ci` Makefile target since it is not used.
```
