### PR TITLE
debian-iptables: Build buster-v1.6.0 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -182,7 +182,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents"
-    version: buster-v1.4.0
+    version: buster-v1.6.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -196,7 +196,7 @@ dependencies:
       match: TAG\?=[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: buster-v1.5.0
+    version: buster-v1.6.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.5.0
+IMAGE_VERSION ?= buster-v1.6.0
 CONFIG ?= buster
-DEBIAN_BASE_VERSION ?= buster-v1.4.0
+DEBIAN_BASE_VERSION ?= buster-v1.6.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -18,7 +18,8 @@ FROM ${BASEIMAGE}
 
 # Install iptables and ebtables packages from buster-backports
 ARG IPTABLES_VERSION
-RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list \
+RUN ln -s /bin/rm /usr/sbin/rm \
+    && echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get -t buster-backports -y --no-install-recommends install \
         iptables=${IPTABLES_VERSION}* \

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.5.0'
-    DEBIAN_BASE_VERSION: 'buster-v1.4.0'
+    IMAGE_VERSION: 'buster-v1.6.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.6.0'
     IPTABLES_VERSION: '1.8.5'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A new debian-iptables image based on `k8s.gcr.io/build-image/debian-base:buster-v1.6.0`. This fixes a handful of CVEs, such as some in openssl.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?


```release-note
debian-iptables: Build buster-v1.6.0 image
```
