### PR TITLE
[go1.15] Build official images for go1.15.11

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -16,14 +16,14 @@ variants:
   go1.15:
     TYPE: 'default'
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.10'
-    IMAGE_VERSION: 'v1.15.10-1'
+    GO_VERSION: '1.15.11'
+    IMAGE_VERSION: 'v1.15.11-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15-legacy:
     TYPE: 'legacy'
     CONFIG: 'go1.15'
-    GO_VERSION: '1.15.10'
-    IMAGE_VERSION: 'v1.15.10-legacy-1'
+    GO_VERSION: '1.15.11'
+    IMAGE_VERSION: 'v1.15.11-legacy-1'
     PROTOBUF_VERSION: '3.0.2'
     ETCD_VERSION: 'v3.4.13'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -9,9 +9,9 @@ variants:
     DISTROLESS_IMAGE: 'static-debian10'
   go1.15-buster:
     CONFIG: 'go1.15-buster'
-    IMAGE_VERSION: 'v2.3.1-go1.15.10-buster.0'
+    IMAGE_VERSION: 'v2.3.1-go1.15.11-buster.0'
     GO_MINOR_VERSION: '1.15'
     OS_CODENAME: 'buster'
     REVISION: '0'
-    GO_VERSION: '1.15.10'
+    GO_VERSION: '1.15.11'
     DISTROLESS_IMAGE: 'static-debian10'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- kube-cross: Build v1.15.11-1 / v1.15.11-legacy-1 image
- go-runner: Build v2.3.1-go1.15.11-buster.0 image 

/assign @hasheddan @saschagrunert @xmudrii @puerco @justaugustus @ameukam 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/1984

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
- kube-cross: Build v1.15.11-1 / v1.15.11-legacy-1 image
- go-runner: Build v2.3.1-go1.15.11-buster.0 image 
```
