### PR TITLE
setcap: Build buster-v2.0.0 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -245,6 +245,10 @@ dependencies:
       match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/debian-iptables/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+    - path: images/build/setcap/Makefile
+      match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: images/build/setcap/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-hyperkube-base"
     version: buster-v1.4.0
@@ -265,3 +269,11 @@ dependencies:
     refPaths:
     - path: images/build/debian-hyperkube-base/Makefile
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-iptables-\$\(ARCH\):[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
+  - name: "k8s.gcr.io/build-image/setcap"
+    version: buster-v2.0.0
+    refPaths:
+    - path: images/build/setcap/Makefile
+      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: images/build/setcap/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'

--- a/images/build/setcap/Dockerfile
+++ b/images/build/setcap/Dockerfile
@@ -16,15 +16,5 @@ ARG BASEIMAGE
 
 FROM ${BASEIMAGE}
 
-# An attempt to fix issues like:
-# ```
-# Error while loading /usr/sbin/dpkg-split: No such file or directory
-# Error while loading /usr/sbin/dpkg-deb: No such file or directory
-# ```
-# See: https://github.com/docker/buildx/issues/495
-RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split \
-    && ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb \
-    && ln -s /bin/tar /usr/sbin/tar \
-    && ln -s /bin/rm /usr/sbin/rm \
-    && apt-get update \
+RUN apt-get update \
     && apt-get -y --no-install-recommends install libcap2-bin

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/setcap
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.4.0
+IMAGE_VERSION ?= buster-v2.0.0
 CONFIG ?= buster
-DEBIAN_BASE_VERSION ?= buster-v1.4.0
+DEBIAN_BASE_VERSION ?= buster-v1.6.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.4.0'
-    DEBIAN_BASE_VERSION: 'buster-v1.4.0'
+    IMAGE_VERSION: 'buster-v2.0.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.6.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/1991 / https://github.com/kubernetes/release/pull/1983

- setcap: Build buster-v2.0.0 image

  Uses debian-base:buster-v1.6.0.

  Note: the image major version is arbitrarily bumped here to dissuade any
  inferences that it must match the debian-base image tag

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

~/hold for setcap bump~
This also adds a missing entry for dependencies.yaml.
(ref: https://github.com/kubernetes/release/pull/1684)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- setcap: Build buster-v2.0.0 image

  Uses debian-base:buster-v1.6.0.

  Note: the image major version is arbitrarily bumped here to dissuade any
  inferences that it must match the debian-base image tag
```
