### PR TITLE
Read and publish CVE information during anago/stage

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -52,7 +52,6 @@ const patchReleaseExpectedContent = `## Changes by Kind
 - Restores compatibility of kube-scheduler with clusters that do not enable the events.k8s.io/v1beta1 API ([#84465](https://github.com/kubernetes/kubernetes/pull/84465), [@yastij](https://github.com/yastij)) [SIG API Machinery and Scheduling]
 - Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries ([#83956](https://github.com/kubernetes/kubernetes/pull/83956), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
 - Update Cluster Autoscaler version to 1.16.2 (CA release docs: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2) ([#84038](https://github.com/kubernetes/kubernetes/pull/84038), [@losipiuk](https://github.com/losipiuk)) [SIG Cluster Lifecycle]
-- Update to use go1.12.12 ([#84064](https://github.com/kubernetes/kubernetes/pull/84064), [@cblecker](https://github.com/cblecker)) [SIG Release and Testing]
 - Upgrade to etcd client 3.3.17 to fix bug where etcd client does not parse IPv6 addresses correctly when members are joining, and to fix bug where failover on multi-member etcd cluster fails certificate check on DNS mismatch ([#83968](https://github.com/kubernetes/kubernetes/pull/83968), [@jpbetz](https://github.com/jpbetz)) [SIG API Machinery and Cloud Provider]`
 
 const patchReleaseDeps = `## Dependencies
@@ -216,7 +215,6 @@ const patchReleaseExpectedHTML = `<!DOCTYPE html>
 <li>Restores compatibility of kube-scheduler with clusters that do not enable the events.k8s.io/v1beta1 API (<a href="https://github.com/kubernetes/kubernetes/pull/84465">#84465</a>, <a href="https://github.com/yastij">@yastij</a>) [SIG API Machinery and Scheduling]</li>
 <li>Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries (<a href="https://github.com/kubernetes/kubernetes/pull/83956">#83956</a>, <a href="https://github.com/liggitt">@liggitt</a>) [SIG API Machinery]</li>
 <li>Update Cluster Autoscaler version to 1.16.2 (CA release docs: <a href="https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2">https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2</a>) (<a href="https://github.com/kubernetes/kubernetes/pull/84038">#84038</a>, <a href="https://github.com/losipiuk">@losipiuk</a>) [SIG Cluster Lifecycle]</li>
-<li>Update to use go1.12.12 (<a href="https://github.com/kubernetes/kubernetes/pull/84064">#84064</a>, <a href="https://github.com/cblecker">@cblecker</a>) [SIG Release and Testing]</li>
 <li>Upgrade to etcd client 3.3.17 to fix bug where etcd client does not parse IPv6 addresses correctly when members are joining, and to fix bug where failover on multi-member etcd cluster fails certificate check on DNS mismatch (<a href="https://github.com/kubernetes/kubernetes/pull/83968">#83968</a>, <a href="https://github.com/jpbetz">@jpbetz</a>) [SIG API Machinery and Cloud Provider]</li>
 </ul>
 <h2>Dependencies</h2>

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -30,11 +30,12 @@ import (
 
 func (s *sut) getChangelogOptions(tag string) *changelog.Options {
 	return &changelog.Options{
-		RepoPath:  s.repo.Dir(),
-		ReplayDir: filepath.Join(testDataDir, "changelog-"+tag),
-		Tag:       tag,
-		Tars:      ".",
-		Branch:    git.DefaultBranch,
+		RepoPath:     s.repo.Dir(),
+		ReplayDir:    filepath.Join(testDataDir, "changelog-"+tag),
+		Tag:          tag,
+		Tars:         ".",
+		Branch:       git.DefaultBranch,
+		CloneCVEMaps: false,
 	}
 }
 

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -491,6 +491,7 @@ func (d *DefaultStage) GenerateChangelog() error {
 		HTMLFile:     releaseNotesHTMLFile,
 		JSONFile:     releaseNotesJSONFile,
 		Dependencies: true,
+		CloneCVEMaps: true,
 		Tars: filepath.Join(
 			gitRoot,
 			fmt.Sprintf("%s-%s", release.BuildDir, d.state.versions.Prime()),

--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -265,6 +265,32 @@ func TestRun(t *testing.T) {
 			},
 			shouldErr: true,
 		},
+		{ // CloneCVEData returns error
+			prepare: func(mock *changelogfakes.FakeImpl, o *changelog.Options) {
+				o.CloneCVEMaps = true
+				mock.TagStringToSemverReturns(semver.Version{
+					Major: 1,
+					Minor: 19,
+					Patch: 3,
+				}, nil)
+				mock.CloneCVEDataReturns("", err)
+			},
+			shouldErr: true,
+		},
+		{ // CloneCVEData returns empty string
+			prepare: func(mock *changelogfakes.FakeImpl, o *changelog.Options) {
+				o.CloneCVEMaps = true
+				mock.TagStringToSemverReturns(semver.Version{
+					Major: 1,
+					Minor: 19,
+					Patch: 3,
+				}, nil)
+				mock.ReadFileReturns([]byte(changelog.TocEnd), nil)
+				mock.GatherReleaseNotesReturns(&notes.ReleaseNotes{}, nil)
+				mock.CloneCVEDataReturns("", nil)
+			},
+			shouldErr: false,
+		},
 	} {
 		options := &changelog.Options{}
 		sut := changelog.New(options)

--- a/pkg/changelog/changelogfakes/fake_impl.go
+++ b/pkg/changelog/changelogfakes/fake_impl.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -70,6 +70,18 @@ type FakeImpl struct {
 	}
 	checkoutReturnsOnCall map[int]struct {
 		result1 error
+	}
+	CloneCVEDataStub        func() (string, error)
+	cloneCVEDataMutex       sync.RWMutex
+	cloneCVEDataArgsForCall []struct {
+	}
+	cloneCVEDataReturns struct {
+		result1 string
+		result2 error
+	}
+	cloneCVEDataReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
 	}
 	CommitStub        func(*git.Repo, string) error
 	commitMutex       sync.RWMutex
@@ -565,6 +577,62 @@ func (fake *FakeImpl) CheckoutReturnsOnCall(i int, result1 error) {
 	fake.checkoutReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeImpl) CloneCVEData() (string, error) {
+	fake.cloneCVEDataMutex.Lock()
+	ret, specificReturn := fake.cloneCVEDataReturnsOnCall[len(fake.cloneCVEDataArgsForCall)]
+	fake.cloneCVEDataArgsForCall = append(fake.cloneCVEDataArgsForCall, struct {
+	}{})
+	stub := fake.CloneCVEDataStub
+	fakeReturns := fake.cloneCVEDataReturns
+	fake.recordInvocation("CloneCVEData", []interface{}{})
+	fake.cloneCVEDataMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) CloneCVEDataCallCount() int {
+	fake.cloneCVEDataMutex.RLock()
+	defer fake.cloneCVEDataMutex.RUnlock()
+	return len(fake.cloneCVEDataArgsForCall)
+}
+
+func (fake *FakeImpl) CloneCVEDataCalls(stub func() (string, error)) {
+	fake.cloneCVEDataMutex.Lock()
+	defer fake.cloneCVEDataMutex.Unlock()
+	fake.CloneCVEDataStub = stub
+}
+
+func (fake *FakeImpl) CloneCVEDataReturns(result1 string, result2 error) {
+	fake.cloneCVEDataMutex.Lock()
+	defer fake.cloneCVEDataMutex.Unlock()
+	fake.CloneCVEDataStub = nil
+	fake.cloneCVEDataReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) CloneCVEDataReturnsOnCall(i int, result1 string, result2 error) {
+	fake.cloneCVEDataMutex.Lock()
+	defer fake.cloneCVEDataMutex.Unlock()
+	fake.CloneCVEDataStub = nil
+	if fake.cloneCVEDataReturnsOnCall == nil {
+		fake.cloneCVEDataReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.cloneCVEDataReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) Commit(arg1 *git.Repo, arg2 string) error {
@@ -2042,6 +2110,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.addMutex.RUnlock()
 	fake.checkoutMutex.RLock()
 	defer fake.checkoutMutex.RUnlock()
+	fake.cloneCVEDataMutex.RLock()
+	defer fake.cloneCVEDataMutex.RUnlock()
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
 	fake.createDownloadsTableMutex.RLock()

--- a/pkg/changelog/const.go
+++ b/pkg/changelog/const.go
@@ -66,6 +66,24 @@ filename | sha512 hash
 {{- end -}}
 ## Changelog since {{$PreviousRevision}}
 
+{{with .CVEList -}}
+## Important Security Information
+
+This release contains changes that address the following vulnerabilities:
+{{range .}}
+### {{.ID}}: {{.Title}}
+
+{{.Description}}
+
+**CVSS Rating:** {{.CVSSRating}} ({{.CVSSScore}}) [{{.CVSSVector}}]({{.CalcLink}})
+{{- if .TrackingIssue -}}
+<br>
+**Tracking Issue:** {{.TrackingIssue}}
+{{- end }}
+
+{{ end }}
+{{- end -}}
+
 {{with .NotesWithActionRequired -}}
 ## Urgent Upgrade Notes
 

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -217,11 +217,6 @@ func New(
 	for _, pr := range releaseNotes.History() {
 		note := releaseNotes.Get(pr)
 
-		if note.DoNotPublish {
-			logrus.Debugf("skipping PR %d as (marked to not be published)", pr)
-			continue
-		}
-
 		if _, hasCVE := note.DataFields["cve"]; hasCVE {
 			logrus.Infof("Release note for PR #%d has CVE vulnerability info", note.PrNumber)
 
@@ -238,6 +233,11 @@ func New(
 				return nil, errors.Wrapf(err, "checking CVE map file for PR #%d", pr)
 			}
 			doc.CVEList = append(doc.CVEList, newcve)
+		}
+
+		if note.DoNotPublish {
+			logrus.Debugf("skipping PR %d as (marked to not be published)", pr)
+			continue
 		}
 
 		// TODO: Refactor the logic here and add testing.

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -127,7 +127,7 @@ type ReleaseNote struct {
 	DoNotPublish bool `json:"do_not_publish,omitempty"`
 
 	// DataFields a key indexed map of data fields
-	DataFields map[string]ReleaseNotesDataField `json:"data_fields,omitempty"`
+	DataFields map[string]ReleaseNotesDataField `json:"-"`
 }
 
 type Documentation struct {

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -295,13 +295,13 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 						res.pullRequest.GetNumber(),
 					)
 					results = append(results, res)
+				} else {
+					logrus.Debugf(
+						"Skipping PR #%d because it contains no release note",
+						res.pullRequest.GetNumber(),
+					)
 				}
 			}
-			logrus.Debugf(
-				"Skipping PR #%d because it contains no release note",
-				res.pullRequest.GetNumber(),
-			)
-			continue
 		} else {
 			// Append the note as it is
 			results = append(results, res)

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -370,7 +370,7 @@ func TestGatherNotes(t *testing.T) {
 			resultsChecker: func(t *testing.T, results []*Result) {
 				// there is not much we can check on the Result, as all the fields are
 				// unexported
-				expectedResultSize := 7
+				expectedResultSize := 13
 				if e, a := expectedResultSize, len(results); e != a {
 					t.Errorf("Expected the result to be of size %d, got %d", e, a)
 				}

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -146,13 +146,14 @@ const (
 // New creates a new Options instance with the default values
 func New() *Options {
 	return &Options{
-		DiscoverMode: RevisionDiscoveryModeNONE,
-		GithubOrg:    git.DefaultGithubOrg,
-		GithubRepo:   git.DefaultGithubRepo,
-		Format:       FormatMarkdown,
-		GoTemplate:   GoTemplateDefault,
-		Pull:         true,
-		gitCloneFn:   git.CloneOrOpenGitHubRepo,
+		DiscoverMode:       RevisionDiscoveryModeNONE,
+		GithubOrg:          git.DefaultGithubOrg,
+		GithubRepo:         git.DefaultGithubRepo,
+		Format:             FormatMarkdown,
+		GoTemplate:         GoTemplateDefault,
+		Pull:               true,
+		gitCloneFn:         git.CloneOrOpenGitHubRepo,
+		MapProviderStrings: []string{},
 	}
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR modifies the changelog step of anago/stage to add functionality to clone CVE information from a GSC bucket. When running the changelog during staging, krel will now read the cloned data maps and add the CVE information to the changelog.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/release/pull/1995 https://github.com/kubernetes/release/issues/1354

#### Special notes for your reviewer:

The code is ready, I'm just waiting for the latest `k8s-cloud-builder` images to be able to give it a test run. But it is definitely ready for review. Once I give it a test run, I will replace my demo bucket with the real one and remove the `WIP` flag.

#### Does this PR introduce a user-facing change?

```release-note
When cutting a patch release, anago/stage will now read CVE information from a bucket, the CVE information read from the cloned data will be added to the changelog when it is generated.
```
