### PR TITLE
Fix command for non-interactive debian dockerfiles

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -25,7 +25,7 @@ RUN go build -o . ./cmd/kubepkg/...
 
 FROM debian:buster
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update -y \
     && apt-get -yy -q install --no-install-recommends --no-install-suggests --fix-missing \

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -21,7 +21,6 @@ FROM ${BASEIMAGE}
 ##------------------------------------------------------------
 # global ARGs & ENVs
 ARG TARGETPLATFORM
-ARG DEBIAN_FRONTEND=noninteractive
 
 ENV GOARM 7
 ENV KUBE_DYNAMIC_CROSSPLATFORMS \
@@ -39,6 +38,9 @@ ENV KUBE_CROSSPLATFORMS \
   windows/amd64 windows/386
 
 ##------------------------------------------------------------
+
+# Ensure the debian image is noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Pre-compile the standard go library when cross-compiling. This is much easier now when we have go1.5+
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \

--- a/images/build/cross/legacy/Dockerfile
+++ b/images/build/cross/legacy/Dockerfile
@@ -21,7 +21,6 @@ FROM ${BASEIMAGE}
 ##------------------------------------------------------------
 # global ARGs & ENVs
 
-ARG DEBIAN_FRONTEND=noninteractive
 
 ENV GOARM 7
 ENV KUBE_DYNAMIC_CROSSPLATFORMS \
@@ -39,6 +38,9 @@ ENV KUBE_CROSSPLATFORMS \
   windows/amd64 windows/386
 
 ##------------------------------------------------------------
+
+# Ensure the image is noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Pre-compile the standard go library when cross-compiling. This is much easier now when we have go1.5+
 RUN for platform in ${KUBE_CROSSPLATFORMS}; do GOOS=${platform%/*} GOARCH=${platform##*/} go install std; done \

--- a/images/build/debian-base/buster/Dockerfile.build
+++ b/images/build/debian-base/buster/Dockerfile.build
@@ -18,13 +18,13 @@ FROM $BASEIMAGE
 ARG ARCH
 COPY qemu-$ARCH-static /usr/bin/
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Smaller package install size.
 COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
 
 # Convenience script for building on this base image.
 COPY clean-install /usr/local/bin/clean-install
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # An attempt to fix issues like:
 # ```

--- a/images/build/debian-hyperkube-base/Dockerfile
+++ b/images/build/debian-hyperkube-base/Dockerfile
@@ -36,7 +36,8 @@ RUN clean-install bash
 # The samba-common, cifs-utils, and nfs-common packages depend on
 # ucf, which itself depends on /bin/bash.
 RUN echo "dash dash/sh boolean false" | debconf-set-selections
-RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN dpkg-reconfigure dash
 
 RUN clean-install \
     ca-certificates \

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -15,12 +15,8 @@
 ARG KUBE_CROSS_VERSION
 FROM k8s.gcr.io/build-image/kube-cross:${KUBE_CROSS_VERSION}
 
-##------------------------------------------------------------
-# global ARGs & ENVs
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-##------------------------------------------------------------
+# Non-interactive debian build
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install packages
 RUN apt-get -q update \

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.16.1
 
-RUN export DEBIAN_FRONTEND=noninteractive \
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update -y \
     && apt-get -yy -q install --no-install-recommends --no-install-suggests --fix-missing \
       dpkg-dev \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
in debian-base Dockerfile.build and debian-iptables Dockerfile, the following line:
ENV DEBIAN_FRONTEND=noninteractive

Works ONLY for execution of the make file with a valid tty, but does not work for an automated build environment that runs as a background or disowned process. It hangs at the first instantiation of any apt command requiring stdin input (such as -y).

**Solution:**
To fix this issue, the line is replaced with:
RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

This PR adds this line to all debian dockerfiles
#### Which issue(s) this PR fixes:
https://github.com/kubernetes/release/issues/1699

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
