### PR TITLE
Fix image building post-submits: first pass

### DIFF
--- a/cloudbuild-kubepkg.yaml
+++ b/cloudbuild-kubepkg.yaml
@@ -25,6 +25,8 @@ substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
   _REGISTRY: 'fake.repository/registry-name'
+  # TODO(images): Remove once CI failures are resolved.
+  _CI_FAILURES: 'https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-releng-ci/1380321161841217536'
 images:
   - 'gcr.io/$PROJECT_ID/kubepkg:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/kubepkg:latest'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -145,6 +145,57 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
 
+  # Golang (for previous release branches)
+  - name: "golang (for previous release branches)"
+    version: 1.15.11
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    # TODO(images): Uncomment once releng-ci uses variants
+    #- path: images/releng/ci/cloudbuild.yaml
+    #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
+    version: 1.15.10
+    refPaths:
+    # TODO(images): Uncomment once k8s-ci-builder is using the correct Golang
+    #               versions for all branches
+    #- path: images/releng/k8s-ci-builder/variants.yaml
+    #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  # Golang images (for previous release branches)
+  - name: "k8s.gcr.io/build-image/go-runner (for previous release branches)"
+    version: v2.3.1-go1.15.11-buster.0
+    refPaths:
+    - path: images/build/go-runner/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
+  - name: "k8s.gcr.io/build-image/go-runner: image revision (for previous release branches)"
+    version: 0
+    refPaths:
+    - path: images/build/go-runner/variants.yaml
+      match: REVISION:\ '\d+'
+
+  - name: "k8s.gcr.io/build-image/kube-cross (for previous release branches)"
+    version: v1.15.11-1
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
+
+  - name: "k8s.gcr.io/build-image/kube-cross: config variant (for previous release branches)"
+    version: go1.15
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: go\d+.\d+
+
+  - name: "k8s.gcr.io/build-image/kube-cross: dependents (for previous release branches)"
+    version: v1.15.10-1
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+
+
   # golangci-lint
   - name: "golangci-lint"
     version: 1.31.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -160,10 +160,8 @@ dependencies:
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
     version: 1.15.10
     refPaths:
-    # TODO(images): Uncomment once k8s-ci-builder is using the correct Golang
-    #               versions for all branches
-    #- path: images/releng/k8s-ci-builder/variants.yaml
-    #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang images (for previous release branches)
   - name: "k8s.gcr.io/build-image/go-runner (for previous release branches)"

--- a/images/k8s-cloud-builder/ci-failures
+++ b/images/k8s-cloud-builder/ci-failures
@@ -1,0 +1,1 @@
+https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1380321161795080192

--- a/images/releng/ci/ci-failures
+++ b/images/releng/ci/ci-failures
@@ -1,0 +1,1 @@
+https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-releng-ci/1380321161841217536

--- a/images/releng/k8s-ci-builder/ci-failures
+++ b/images/releng/k8s-ci-builder/ci-failures
@@ -1,0 +1,1 @@
+https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-k8s-ci-builder/1382488810838822912

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -7,19 +7,19 @@ variants:
     SKOPEO_VERSION: 'v1.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.16.1'
+    GO_VERSION: '1.15.10'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.16.1'
+    GO_VERSION: '1.15.10'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: '1.16.1'
+    GO_VERSION: '1.13.15'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup failing-test regression

#### What this PR does / why we need it:

The following post-submit jobs are failing:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-k8s-ci-builder/1382488810838822912:

```
denied: Token exchange failed for project 'k8s-staging-build-image'. Caller does not have permission 'storage.buckets.get'. To configure permissions, follow instructions at: https://cloud.google.com/container-registry/docs/access-control
make: *** [Makefile:61: push] Error 1
ERROR: (gcloud.builds.submit) build a9a85c0c-1f57-48dd-95f3-04b02c69c0b0 completed with status "FAILURE"
ERROR
ERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f" failed: step exited with non-zero status: 2 
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1380321161795080192:

```
ERROR: (gcloud.builds.submit) build 1b81b04c-408d-41a6-a1b9-e8dc5ffe9014 completed with status "FAILURE"
Finished Step #1 - "test"
ERROR
ERROR: failed to find one or more images after execution of build steps: ["gcr.io/k8s-staging-releng/k8s-cloud-builder:v20210409-v0.8.0-14-g0539f9b7-cross1.16" "gcr.io/k8s-staging-releng/k8s-cloud-builder:latest-cross1.16" "gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.16.1-1"] 
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-kubepkg/1382488810868183040:

```
Finished Step #1
ERROR
ERROR: failed to find one or more images after execution of build steps: ["gcr.io/k8s-staging-releng/kubepkg:v20210415-v0.8.0-36-g9d8604e1" "gcr.io/k8s-staging-releng/kubepkg:latest" "gcr.io/k8s-staging-releng/kubepkg-rpm:v20210415-v0.8.0-36-g9d8604e1" "gcr.io/k8s-staging-releng/kubepkg-rpm:latest"] 
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-releng-ci/1380321161841217536:

```
Finished Step #1
ERROR
ERROR: failed to find one or more images after execution of build steps: ["gcr.io/k8s-staging-releng/releng-ci:v20210409-v0.8.0-14-g0539f9b7" "gcr.io/k8s-staging-releng/releng-ci:v0.5.0" "gcr.io/k8s-staging-releng/releng-ci:latest"]
ERROR: (gcloud.builds.submit) build e8f891da-cb23-4a0a-af28-ff9061127aa5 completed with status "FAILURE" 
```

Let's fix them!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
dependencies: Add Golang entries for previous release branches
```
