### PR TITLE
Fix image building post-submits: third pass

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,6 +88,8 @@ dependencies:
   - name: "golang: after kubernetes/kubernetes update"
     version: 1.16.1
     refPaths:
+    - path: images/releng/k8s-ci-builder/Dockerfile
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) as builder
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -14,7 +14,10 @@
 
 ARG GO_VERSION
 ARG OLD_BAZEL_VERSION
-FROM golang:${GO_VERSION} as builder
+
+# The Golang version for the builder image should always be explicitly set to
+# the Golang version of the kubernetes/kubernetes active development branch
+FROM golang:1.16.1 as builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,6 +5,12 @@ variants:
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
+  '1.21':
+    CONFIG: default
+    GO_VERSION: '1.16.1'
+    BAZEL_VERSION: '3.4.1'
+    OLD_BAZEL_VERSION: '2.2.0'
+    SKOPEO_VERSION: 'v1.2.0'
   '1.20':
     CONFIG: '1.20'
     GO_VERSION: '1.15.10'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup failing-test regression

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/2002 and https://github.com/kubernetes/release/pull/2001.

- k8s-ci-builder: Add 1.21 branch variant
- k8s-ci-builder: Match go version of the builder image with k/k@dev

  This builder image is responsible for running compile-release-tools and
  copying in tooling like `krel` into the final image.
  
  AFAIK, the compiled RelEng tools have no requirement to exactly match
  the Golang version of all active kubernetes/kubernetes release branches.
  
  In instances where we make changes to releng tooling which are
  backwards-incompatible, we have the possibility to cause image build
  failures for other branch variants (as is currently happening).

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @puerco @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-ci-builder: Add 1.21 branch variant
- k8s-ci-builder: Match go version of the builder image with k/k@dev

  This builder image is responsible for running compile-release-tools and
  copying in tooling like `krel` into the final image.
  
  AFAIK, the compiled RelEng tools have no requirement to exactly match
  the Golang version of all active kubernetes/kubernetes release branches.
  
  In instances where we make changes to releng tooling which are
  backwards-incompatible, we have the possibility to cause image build
  failures for other branch variants (as is currently happening).
```
