### PR TITLE
k8s-ci-builder: Fix `CONFIG` substitution for `1.21` variant

### DIFF
--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -6,7 +6,7 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
   '1.21':
-    CONFIG: default
+    CONFIG: '1.21'
     GO_VERSION: '1.16.1'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup failing-test regression

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/2003.
k8s-ci-builder: Fix `CONFIG` substitution for `1.21` variant

/assign @hasheddan @puerco @cpanato 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
k8s-ci-builder: Fix `CONFIG` substitution for `1.21` variant
```
