### PR TITLE
kube-cross: Build v1.16.3-canary-2 image

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -3,7 +3,7 @@ variants:
     TYPE: 'default'
     CONFIG: 'canary'
     GO_VERSION: '1.16.3'
-    IMAGE_VERSION: 'v1.16.3-canary-1'
+    IMAGE_VERSION: 'v1.16.3-canary-2'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.16:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dependency

#### What this PR does / why we need it:

This is a no-op to retrigger [previous GCB builds which failed](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-kube-cross/1382958539042983936) due to
resource quota exhaustion.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://github.com/kubernetes/release/issues/2005, https://github.com/kubernetes/release/pull/2006
Blocks https://github.com/kubernetes/k8s.io/pull/1936.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- kube-cross: Build v1.16.3-canary-2 image
```
