### PR TITLE
[go1.15] Update kubernetes/kubernetes dependents to use go1.15.11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -160,7 +160,7 @@ dependencies:
     #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
-    version: 1.15.10
+    version: 1.15.11
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -191,7 +191,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (for previous release branches)"
-    version: v1.15.10-1
+    version: v1.15.11-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -5,9 +5,9 @@ variants:
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.10-1'
+    KUBE_CROSS_VERSION: 'v1.15.11-1'
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15-legacy:
     CONFIG: 'cross1.15-legacy'
-    KUBE_CROSS_VERSION: 'v1.15.10-legacy-1'
+    KUBE_CROSS_VERSION: 'v1.15.11-legacy-1'
     SKOPEO_VERSION: 'v1.2.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -13,13 +13,13 @@ variants:
     SKOPEO_VERSION: 'v1.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.15.10'
+    GO_VERSION: '1.15.11'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.15.10'
+    GO_VERSION: '1.15.11'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
     SKOPEO_VERSION: 'v1.2.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Tracking issue: https://github.com/kubernetes/release/issues/1984

- [go1.15] Update kubernetes/kubernetes dependents to use go1.15.11
- k8s-cloud-builder: Build v1.15.11-1 / v1.15.11-legacy-1 image

/hold for https://github.com/kubernetes/kubernetes/pull/101192
/assign @hasheddan @puerco @justaugustus  
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- [go1.15] Update kubernetes/kubernetes dependents to use go1.15.11
- k8s-cloud-builder: Build v1.15.11-1 / v1.15.11-legacy-1 image
```
