### PR TITLE
Add notice if release note gets excluded because of mismatched authors

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -313,6 +313,10 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 	for _, result := range results {
 		if g.options.RequiredAuthor != "" {
 			if result.commit.GetAuthor().GetLogin() != g.options.RequiredAuthor {
+				logrus.Infof(
+					"Skipping release note for PR #%d because required author %q does not match with %q",
+					result.pullRequest.GetNumber(), g.options.RequiredAuthor, result.commit.GetAuthor().GetLogin(),
+				)
 				continue
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
If an author does not match then we now log the reason for a better
debug ability.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added info log notice if a release note got excluded because of required author mismatch
```
