### PR TITLE
Improve BuildVersion verification and local checks in krel build

### DIFF
--- a/cmd/krel/cmd/release.go
+++ b/cmd/krel/cmd/release.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -132,7 +133,13 @@ func init() {
 func runRelease(options *anago.ReleaseOptions) error {
 	options.NoMock = rootOpts.nomock
 	rel := anago.NewRelease(options)
+
 	if submitJob {
+		// Perform a local check of the specified options
+		// before launching a Cloud Build job:
+		if err := options.Validate(&anago.State{}); err != nil {
+			return errors.Wrap(err, "prechecking release options")
+		}
 		return rel.Submit(stream)
 	}
 	return rel.Run()

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -99,6 +99,15 @@ func (o *Options) Validate(state *State) error {
 		return errors.Errorf("invalid release branch: %s", o.ReleaseBranch)
 	}
 
+	// Verify the build version is correct:
+	correct, err := release.IsValidReleaseBuild(o.BuildVersion)
+	if err != nil {
+		return errors.Wrap(err, "checking for a valid build version")
+	}
+	if !correct {
+		return errors.New("invalid BuildVersion specified")
+	}
+
 	semverBuildVersion, err := util.TagStringToSemver(o.BuildVersion)
 	if err != nil {
 		return errors.Wrapf(err, "invalid build version: %s", o.BuildVersion)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -210,6 +210,10 @@ func ReadDockerizedVersion(workDir string) (string, error) {
 
 // IsValidReleaseBuild checks if build version is valid for release.
 func IsValidReleaseBuild(build string) (bool, error) {
+	// If the tag has a plus sign, then we force the versionBuildRe to match
+	if strings.Contains(build, "+") {
+		return regexp.MatchString("("+versionReleaseRE+`(\.`+versionBuildRE+")"+versionDirtyRE+"?)", build)
+	}
 	return regexp.MatchString("("+versionReleaseRE+`(\.`+versionBuildRE+")?"+versionDirtyRE+"?)", build)
 }
 

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -331,6 +331,23 @@ func TestIsValidReleaseBuild(t *testing.T) {
 				rErr: false,
 			},
 		},
+		"InvalidCopiedBuild": {
+			// This trimmed tag often gets copied when double clicking
+			// on the CloudBuild console:
+			build: "v1.22.0-alpha.0.787+e6",
+			want: want{
+				r:    false,
+				rErr: false,
+			},
+		},
+		"ValidCopiedBuild": {
+			// Full tag from previous test case:
+			build: "v1.22.0-alpha.0.787+e6b4fa381152d6",
+			want: want{
+				r:    true,
+				rErr: false,
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR improves the input validation in `krel release` by introducing the following changes:

1. The `release.IsValidReleaseBuild()` function now enforces the `versionBuildRE` regexp to check the build version when it contains a plus sign.
2. This same function is now used in the options validation in anago in addition to the SemVer parsing check.
3. Finally, when invoking a command that would result in a cloud build Job, `krel release` will now perform a local validation of the options before running.

While the options are checked during the release process, double-checking them saves the release manager time in case of an error and resources by avoiding the execution of a job destined to fail.

#### Which issue(s) this PR fixes:

Stops a recurring problem with input encountered again during the `v1.22.0-alpha.1` cut (https://github.com/kubernetes/sig-release/issues/1547)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- `krel release` will now check its inputs locally before submitting a GCB job.
- The `release.IsValidReleaseBuild()` function will now do a better validation of the BuildVersion option.
- Options in krel now perform a better check of the BuildVersion string in addition to parsing it as SemVer
```
