### PR TITLE
Fix tag sorting for recent git versions

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -930,13 +930,16 @@ func (r *Repo) TagsForBranch(branch string) (res []string, err error) {
 	defer func() { err = r.Checkout(previousBranch) }()
 
 	status, err := command.NewWithWorkDir(
-		r.Dir(), gitExecutable, "tag", "--sort=-creatordate", "--merged",
+		r.Dir(), gitExecutable, "tag", "--sort=creatordate", "--merged",
 	).RunSilentSuccessOutput()
 	if err != nil {
 		return nil, errors.Wrapf(safeError(err), "retrieving merged tags for branch %s", branch)
 	}
 
-	return strings.Fields(status.Output()), nil
+	tags := strings.Fields(status.Output())
+	sort.Sort(sort.Reverse(sort.StringSlice(tags)))
+
+	return tags, nil
 }
 
 // Tags returns a list of tags for the repository.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We now manually sort the tags because the behavior seems to have changed
with recent git versions.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed tag sorting in `git.TagsForBranch()` for recent versions of git
```
