### PR TITLE
Drop krel cve write command

### DIFF
--- a/pkg/cve/client.go
+++ b/pkg/cve/client.go
@@ -113,3 +113,8 @@ func (c *Client) CopyToTemp(cve string) (file *os.File, err error) {
 func (c *Client) CreateEmptyMap(cve string) (file *os.File, err error) {
 	return c.impl.CreateEmptyFile(cve, &c.options)
 }
+
+// List return a list iof existing CVE entries
+func (c *Client) EntryExists(cveID string) (bool, error) {
+	return c.impl.EntryExists(cveID, &c.options)
+}

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -107,15 +107,8 @@ func (cve *CVE) Validate() error {
 		return errors.New("CVSS score out of range, should be 0.0 - 10.0")
 	}
 
-	// Check that the CVE ID is not empty
-	if cve.ID == "" {
-		return errors.New("ID missing from CVE data")
-	}
-
-	// Verify that the CVE ID is well formed
-	cvsre := regexp.MustCompile(CVEIDRegExp)
-	if !cvsre.MatchString(cve.ID) {
-		return errors.New("CVS ID is not well formed")
+	if err := ValidateID(cve.ID); err != nil {
+		return errors.Wrap(err, "checking CVE ID")
 	}
 
 	// Title and description must not be empty
@@ -125,6 +118,20 @@ func (cve *CVE) Validate() error {
 
 	if cve.Description == "" {
 		return errors.New("CVE description missing from CVE data")
+	}
+
+	return nil
+}
+
+// ValidateID checks if a CVE IS string is valid
+func ValidateID(cveID string) error {
+	if cveID == "" {
+		return errors.New("CVE ID string is empty")
+	}
+
+	// Verify that the CVE ID is well formed
+	if !regexp.MustCompile(CVEIDRegExp).MatchString(cveID) {
+		return errors.New("CVS ID is not well formed")
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Iterating on the `krel cve` command, this command modifies it to remove the `write` subcommand to simplify the interface.

Previously, we used `krel write` to create a new CVE entry, and `krel edit` to modify an existing entry.

This PR combines both into krel edit, which will present the new CVE template if the entry does not exist yet or pull a CVE entry if we already have data for it.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Depends on https://github.com/kubernetes/release/pull/2028

#### Does this PR introduce a user-facing change?

```release-note
`krel cve write` has been eliminated, its functionality now lives in `krel cve edit`
```
