### PR TITLE
git logAdd cve.ValidateID and Client.EntryExists functions

### DIFF
--- a/pkg/cve/client.go
+++ b/pkg/cve/client.go
@@ -113,3 +113,8 @@ func (c *Client) CopyToTemp(cve string) (file *os.File, err error) {
 func (c *Client) CreateEmptyMap(cve string) (file *os.File, err error) {
 	return c.impl.CreateEmptyFile(cve, &c.options)
 }
+
+// List return a list iof existing CVE entries
+func (c *Client) EntryExists(cveID string) (bool, error) {
+	return c.impl.EntryExists(cveID, &c.options)
+}

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -107,15 +107,8 @@ func (cve *CVE) Validate() error {
 		return errors.New("CVSS score out of range, should be 0.0 - 10.0")
 	}
 
-	// Check that the CVE ID is not empty
-	if cve.ID == "" {
-		return errors.New("ID missing from CVE data")
-	}
-
-	// Verify that the CVE ID is well formed
-	cvsre := regexp.MustCompile(CVEIDRegExp)
-	if !cvsre.MatchString(cve.ID) {
-		return errors.New("CVS ID is not well formed")
+	if err := ValidateID(cve.ID); err != nil {
+		return errors.Wrap(err, "checking CVE ID")
 	}
 
 	// Title and description must not be empty
@@ -125,6 +118,20 @@ func (cve *CVE) Validate() error {
 
 	if cve.Description == "" {
 		return errors.New("CVE description missing from CVE data")
+	}
+
+	return nil
+}
+
+// ValidateID checks if a CVE IS string is valid
+func ValidateID(cveID string) error {
+	if cveID == "" {
+		return errors.New("CVE ID string is empty")
+	}
+
+	// Verify that the CVE ID is well formed
+	if !regexp.MustCompile(CVEIDRegExp).MatchString(cveID) {
+		return errors.New("CVS ID is not well formed")
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds two functions to the CVE package:
`cve.ValidateID` checks CVE ids externally
Client.EntryExists checks if we already have an entry for a specific CVE

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
