### PR TITLE
Fix gcs.PathExists() bug

### DIFF
--- a/pkg/object/gcs.go
+++ b/pkg/object/gcs.go
@@ -369,11 +369,17 @@ func (g *GCS) PathExists(gcsPath string) (bool, error) {
 		)
 	}
 
-	err := gcp.GSUtil(
+	// Do an ls with gsutil to check if the file exists:
+	if err := gcp.GSUtil(
 		"ls",
 		gcsPath,
-	)
-	if err != nil {
+	); err != nil {
+		// .. but check the message because if not found
+		// it will exit with an error
+		if strings.Contains(err.Error(), "One or more URLs matched no objects") {
+			return false, nil
+		}
+		// Anything else we treat as error
 		return false, err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This commit fixes a bug where calls to `gcs.PathExists()` would return an
error (instead of false) when a path does not exist.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

At the core, `gsutil` exits non-zero when a path is not found, eg:
```bash
gsutil ls gs://some-bucket/some/file.yaml || echo "Error"
CommandException: One or more URLs matched no objects.
Error
```
The original function did not have the logic to return false on non-existing paths so, until now, could not be used to check for nonexistent paths.

#### Does this PR introduce a user-facing change?
```release-note
Fix a bug in `gcs.PathExists()` where nonexisting paths would always return an error (instead of false). Now the function can actually be used to check for the non existence of a file.
```
