### PR TITLE
OWNERS updates

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@
 
 aliases:
   sig-release-leads:
-    - alejandrox1 # SIG Technical Lead
     - hasheddan # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
@@ -16,7 +15,6 @@ aliases:
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
-    - gianarb # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,12 +33,6 @@ aliases:
     - dims
     - justaugustus
     - listx
-  build-image-reviewers:
-    - BenTheElder
-    - cblecker
-    - dims
-    - justaugustus
-    - listx
   krel-approvers:
     - cpanato
     - hasheddan

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,13 +9,10 @@ aliases:
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
-    - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager
-    - idealhack # Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
-    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
@@ -56,25 +53,17 @@ aliases:
     - xmudrii
   promo-tools-approvers:
     - justaugustus
-    - justinsb
-    - listx
   promo-tools-reviewers:
     - justaugustus
-    - justinsb
-    - listx
   release-notes-approvers:
-    - jeefy
     - puerco
     - saschagrunert
   release-notes-reviewers:
-    - jeefy
     - puerco
     - saschagrunert
   vulndash-approvers:
     - cpanato
     - justaugustus
-    - listx
   vulndash-reviewers:
     - cpanato
     - justaugustus
-    - listx

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -54,6 +54,7 @@ aliases:
   release-notes-reviewers:
     - puerco
     - saschagrunert
+    - wilsonehusin
   vulndash-approvers:
     - cpanato
     - justaugustus

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
     - onlydole # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - verolop # Release Manager Associate
+    - wilsonehusin # Release Manager Associate
   build-admins:
     - amwat
     - BenTheElder

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -38,6 +38,7 @@ aliases:
     - hasheddan
     - puerco
     - saschagrunert
+    - xmudrii
   krel-reviewers:
     - cpanato
     - hasheddan

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,7 +48,9 @@ aliases:
   promo-tools-approvers:
     - justaugustus
   promo-tools-reviewers:
+    - hasheddan
     - justaugustus
+    - saschagrunert
   release-notes-approvers:
     - puerco
     - saschagrunert

--- a/images/build/OWNERS
+++ b/images/build/OWNERS
@@ -6,5 +6,4 @@ approvers:
   - build-image-approvers
   - release-engineering-approvers
 reviewers:
-  - build-image-reviewers
   - release-engineering-approvers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Periodic cleanup and building some more coverage into the review roster.

- Remove inactive reviewers/approvers
- Offboard Jorge and Gianluca
- Add @wilsonehusin as Release Manager Associate
- Use release-engineering-approvers alias as build image reviewers
- Add Wilson to release-notes-reviewers
- Add Marko to krel-approvers
- Add Dan and Sascha to promo-tools-reviewers

/assign @saschagrunert @hasheddan @jeremyrickard 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
