### PR TITLE
Update `cosign` image to v0.4.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -43,7 +43,7 @@ dependencies:
 
   # distroless
   - name: "gcr.io/projectsigstore/cosign"
-    version: v0.3.1@sha256:c581a4f0f6dd158220fa05d2351d8015f969b68de5c61d52c41478fae84e7064
+    version: v0.4.0@sha256:7e9a6ca62c3b502a125754fbeb4cde2d37d4261a9c905359585bfc0a63ff17f4
     refPaths:
     - path: images/build/go-runner/cloudbuild.yaml
       match: gcr.io/projectsigstore/cosign:v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)@sha256:[a-f0-9]{64}

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/projectsigstore/cosign:v0.3.1@sha256:c581a4f0f6dd158220fa05d2351d8015f969b68de5c61d52c41478fae84e7064'
+  - name: 'gcr.io/projectsigstore/cosign:v0.4.0@sha256:7e9a6ca62c3b502a125754fbeb4cde2d37d4261a9c905359585bfc0a63ff17f4'
     dir: ./images/build/go-runner
     args:
     - 'verify'


### PR DESCRIPTION
Signatures created before and after v0.4.0 are incompatible. We're creating both sets of signatures for now, but the v0.4.0 format is what will be supported going forward 

/kind feature
/area dependency security

```release-note
NONE
```
