### PR TITLE
Fix list manipulation of release notes

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -697,7 +697,7 @@ we're pulling the correct go-runner arch from the manifest list.</p>
 </ul>
 <h3>Other (Cleanup or Flake)</h3>
 <ul>
-<li>Adds a bootstrapping ClusterRole, ClusterRoleBinding and group for /metrics, /livez/<em>, /readyz/</em>, &amp; /healthz/- endpoints. (<a href="https://github.com/kubernetes/kubernetes/pull/93311">#93311</a>, <a href="https://github.com/logicalhan">@logicalhan</a>) [SIG API Machinery, Auth, Cloud Provider and Instrumentation]</li>
+<li>Adds a bootstrapping ClusterRole, ClusterRoleBinding and group for /metrics, /livez/<em>, /readyz/</em>, &amp; /healthz/* endpoints. (<a href="https://github.com/kubernetes/kubernetes/pull/93311">#93311</a>, <a href="https://github.com/logicalhan">@logicalhan</a>) [SIG API Machinery, Auth, Cloud Provider and Instrumentation]</li>
 <li>Base-images: Update to debian-iptables:buster-v1.3.0
 <ul>
 <li>Uses iptables 1.8.5</li>

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -806,7 +806,8 @@ func stripDash(note string) string {
 const listPrefix = "- "
 
 func dashify(note string) string {
-	return strings.ReplaceAll(note, "* ", listPrefix)
+	re := regexp.MustCompile(`(?m)(^\s*)\*\s`)
+	return re.ReplaceAllString(note, "$1- ")
 }
 
 // unlist transforms a single markdown list entry to a flat note entry

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -430,3 +430,41 @@ func TestApplyMap(t *testing.T) {
 		}
 	}
 }
+
+func TestDashify(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		input, expected string
+	}{
+		{ // modify list
+			input:    "* test",
+			expected: "- test",
+		},
+		{ // modify list
+			input: `
+				* list item
+				  * sub list item
+				  * sub list item
+			`,
+			expected: `
+				- list item
+				  - sub list item
+				  - sub list item
+			`,
+		},
+		{ // no substitution
+			input: `
+				This is some plain **bold** text.
+				**And bold at the beginning of a line**.
+			`,
+			expected: `
+				This is some plain **bold** text.
+				**And bold at the beginning of a line**.
+			`,
+		},
+	} {
+		result := dashify(tc.input)
+		require.Equal(t, tc.expected, result)
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The `strings.ReplaceAll` would also change bold (`**`) markdown, which
is not intended. We now use a more complex regex to ensure that we only
manipulate list entries.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/2055
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed release notes list manipulation (`*` → `-`) which falsely replaced bold markdown text.
```
