### PR TITLE
[go1.16] Update kubernetes/kubernetes dependents to use go1.16.4

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.3 AS builder
+FROM golang:1.16.4 AS builder
 
 ENV GO111MODULE=on
 

--- a/Dockerfile-kubepkg-rpm
+++ b/Dockerfile-kubepkg-rpm
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.3 AS builder
+FROM golang:1.16.4 AS builder
 
 ENV GO111MODULE=on
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
     version: 1.16.4
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) as builder
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) AS builder
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,6 +66,10 @@ dependencies:
   - name: "golang"
     version: 1.16.4
     refPaths:
+    - path: Dockerfile-kubepkg
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) AS builder
+    - path: Dockerfile-kubepkg-rpm
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) AS builder
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: cmd/vulndash/variants.yaml
@@ -80,6 +84,10 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/releng/ci/cloudbuild.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: packages/deb/Dockerfile
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)
 
   # Golang pre-releases are denoted as `1.y<pre-release stage>.z`
   # Example: go1.16rc1
@@ -93,7 +101,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.3
+    version: 1.16.4
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+) as builder
@@ -151,7 +159,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.3-1
+    version: v1.16.4-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.16:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.16.3-1'
+    KUBE_CROSS_VERSION: 'v1.16.4-1'
     SKOPEO_VERSION: 'v1.2.0'
   cross1.15:
     CONFIG: 'cross1.15'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OLD_BAZEL_VERSION
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.16.3 as builder
+FROM golang:1.16.4 AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.0
+GO_VERSION ?= 1.16.4
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.3'
+    GO_VERSION: '1.16.4'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.3'
+    GO_VERSION: '1.16.4'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
     SKOPEO_VERSION: 'v1.2.0'

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.3
+FROM golang:1.16.4
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Tracking issue: https://github.com/kubernetes/release/issues/2060

- [go1.16] Update kubernetes/kubernetes dependents to use go1.16.4
- k8s-cloud-builder: Build v1.16.4-1 image
- k8s-ci-builder: Build image variants using go1.16.4

/assign @hasheddan @puerco @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- [go1.16] Update kubernetes/kubernetes dependents to use go1.16.4
- k8s-cloud-builder: Build v1.16.4-1 image
- k8s-ci-builder: Build image variants using go1.16.4
```
