### PR TITLE
[GO1.15] Update k8s-cloud-builder/k8s-ci-builder

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -177,7 +177,7 @@ dependencies:
     #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
-    version: 1.15.11
+    version: 1.15.12
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -208,7 +208,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (for previous release branches)"
-    version: v1.15.11-1
+    version: v1.15.12-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,7 +4,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.16.4-1'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.11-1'
+    KUBE_CROSS_VERSION: 'v1.15.12-1'
   cross1.15-legacy:
     CONFIG: 'cross1.15-legacy'
-    KUBE_CROSS_VERSION: 'v1.15.11-legacy-1'
+    KUBE_CROSS_VERSION: 'v1.15.12-legacy-1'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -11,12 +11,12 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.15.11'
+    GO_VERSION: '1.15.12'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.15.11'
+    GO_VERSION: '1.15.12'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'
   '1.18':


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Tracking issue: https://github.com/kubernetes/release/issues/2060

- k8s-cloud-builder: Build v1.15.12-legacy-1/v1.15.12-1 image
- k8s-ci-builder: Build image variants using go1.15.12

/assign @hasheddan @puerco @saschagrunert @justaugustus 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-cloud-builder: Build v1.15.12-legacy-1/v1.15.12-1 image
- k8s-ci-builder: Build image variants using go1.15.12
```
