### PR TITLE
bom: A utility to generate SPDX compliant Bills of Materials

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/release/pkg/spdx"
+)
+
+var genOpts = &generateOptions{}
+
+var generateCmd = &cobra.Command{
+	Short: "bom generate → Create SPDX manifests",
+	Long: `bom → Create SPDX manifests
+
+generate is the bom subcommand to generate SPDX manifests.
+Currently supports creating SBOM for files, images, and docker
+archives (images in tarballs). Supports pulling images from
+registries.
+
+bom can take a deeper look into images using a growing number
+of analyzers designed to add more sense to common base images.
+
+`,
+	Use:               "generate",
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	PersistentPreRunE: initLogging,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return generateBOM(genOpts)
+	},
+}
+
+type generateOptions struct {
+	analyze    bool
+	namespace  string
+	outputFile string
+	images     []string
+	tarballs   []string
+	files      []string
+}
+
+// Validate verify options consistency
+func (opts *generateOptions) Validate() error {
+	if len(opts.images) == 0 && len(opts.files) == 0 && len(opts.tarballs) == 0 {
+		return errors.New("to generate a SPDX BOM you have to provide at least one image or file")
+	}
+
+	// A namespace URL is required
+	if opts.namespace == "" {
+		return errors.New("A namespace (URL) must be defined to have a compliant SPDX BOM")
+	}
+
+	// CHeck namespace is a valid URL
+	if _, err := url.Parse(opts.namespace); err != nil {
+		return errors.Wrap(err, "parsing the namespace URL")
+	}
+
+	return nil
+}
+
+func init() {
+	generateCmd.PersistentFlags().StringSliceVarP(
+		&genOpts.images,
+		"image",
+		"i",
+		[]string{},
+		"list of images",
+	)
+	generateCmd.PersistentFlags().StringSliceVarP(
+		&genOpts.files,
+		"file",
+		"f",
+		[]string{},
+		"list of files to include",
+	)
+
+	generateCmd.PersistentFlags().StringSliceVarP(
+		&genOpts.tarballs,
+		"tarball",
+		"t",
+		[]string{},
+		"list of docker archive tarballs to include in the manifest",
+	)
+
+	generateCmd.PersistentFlags().StringVarP(
+		&genOpts.namespace,
+		"namespace",
+		"n",
+		"",
+		"an URI that servers as namespace for the SPDX doc",
+	)
+
+	generateCmd.PersistentFlags().StringVarP(
+		&genOpts.outputFile,
+		"output",
+		"o",
+		"",
+		"path to the file where the document will be written (defaults to STDOUT)",
+	)
+
+	generateCmd.PersistentFlags().BoolVarP(
+		&genOpts.analyze,
+		"analyze-images",
+		"a",
+		false,
+		"go deeper into images using the available analyzers",
+	)
+}
+
+func generateBOM(opts *generateOptions) error {
+	if err := opts.Validate(); err != nil {
+		return errors.Wrap(err, "validating command line options")
+	}
+	logrus.Info("Generating SPDX Bill of Materials")
+
+	builder := spdx.NewDocBuilder()
+	doc, err := builder.Generate(&spdx.DocGenerateOptions{
+		Tarballs:      opts.tarballs,
+		Files:         opts.files,
+		Images:        opts.images,
+		OutputFile:    opts.outputFile,
+		Namespace:     "",
+		AnalyseLayers: opts.analyze,
+	})
+	if err != nil {
+		return errors.Wrap(err, "generating doc")
+	}
+
+	if opts.outputFile == "" {
+		markup, err := doc.Render()
+		if err != nil {
+			return errors.Wrap(err, "rendering document")
+		}
+		fmt.Println(markup)
+	}
+	return nil
+}

--- a/cmd/bom/cmd/root.go
+++ b/cmd/bom/cmd/root.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/release-utils/log"
+)
+
+var rootCmd = &cobra.Command{
+	Short: "bom: A tool for working with SPDX manifests",
+	Long: `bom (Bill of Materials)
+
+bom is a little utility that lets software authors generate
+SPDX manifests to describe the contents of a release. The
+SPDX manifests provide a way to list and verify all items
+contained in packages, images, and individual files while
+packing the data along with licensing information.
+
+bom is still in its early stages and it is an effort to open
+the libraries developed for the Kubernetes SBOM for other 
+projects to use.
+
+`,
+	Use:               "bom",
+	SilenceUsage:      false,
+	PersistentPreRunE: initLogging,
+}
+
+type commandLineOptions struct {
+	logLevel string
+}
+
+var commandLineOpts = &commandLineOptions{}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(
+		&commandLineOpts.logLevel,
+		"log-level",
+		"info",
+		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
+	)
+
+	rootCmd.AddCommand(generateCmd)
+}
+
+// Execute builds the command
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func initLogging(*cobra.Command, []string) error {
+	return log.SetupGlobalLogger(commandLineOpts.logLevel)
+}

--- a/cmd/bom/main.go
+++ b/cmd/bom/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"k8s.io/release/cmd/bom/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is the initial commit of the `bom` utility. It is a small program to generate SPDX manifest from the code developed for the Kubernetes SBOM effort.

While it is still in the early stages and more of a proof of concept, it is useful as it is to test the output of the SPDX/License code. 

The program's current state already allows software authors to generate SPDX manifests for projects and list images and files in the generated BOM.

Example usage:

`bom generate -f Makefile -i debian:latest -o manifest.spdx`

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/1837

#### Special notes for your reviewer:

Needs https://github.com/kubernetes/release/pull/2064 to run

#### Does this PR introduce a user-facing change?


```release-note
New `bom` utility allows software authors to generate spdx manifests for projects. Allows adding files and images to the manifest.
```
