### PR TITLE
Update golangci-lint to v1.40.1 and fix lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
     - goconst
     - gocritic
@@ -29,16 +30,19 @@ linters:
     - goheader
     - goimports
     - golint
+    - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosimple
     - govet
+    - importas
     - ineffassign
-    - interfacer
-    - maligned
+    - makezero
     - misspell
     - nakedret
     - prealloc
+    - predeclared
+    - promlinter
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
@@ -50,8 +54,13 @@ linters:
     - unused
     - varcheck
     - whitespace
+    # - cyclop
+    # - errorlint
     # - exhaustive
+    # - exhaustivestruct
     # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
     # - funlen
     # - gci
     # - gochecknoglobals
@@ -61,13 +70,22 @@ linters:
     # - goerr113
     # - gomnd
     # - gosec
+    # - ifshort
     # - lll
     # - nestif
+    # - nilerr
     # - nlreturn
     # - noctx
     # - nolintlint
+    # - paralleltest
+    # - revive
     # - scopelint
+    # - tagliatelle
     # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
     # - wsl
 linters-settings:
   godox:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -213,7 +213,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 1.31.0
+    version: 1.40.1
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.31.0
+VERSION=v1.40.1
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -46,8 +46,7 @@ type Binary struct {
 }
 
 // Options to control the binary checker
-type Options struct {
-}
+type Options struct{}
 
 // DefaultOptions set of options
 var DefaultOptions = &Options{}

--- a/pkg/release/archive_unit_test.go
+++ b/pkg/release/archive_unit_test.go
@@ -133,7 +133,8 @@ func TestGetLogFiles(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	goodFiles := []string{"anago.log", "anago-stage.log", "anago.log.1", "anago-stage.log.1"}
-	allFiles := append(goodFiles, []string{"test1.txt", "other.log", "anago.txt"}...)
+	allFiles := goodFiles
+	allFiles = append(allFiles, "test1.txt", "other.log", "anago.txt")
 	for _, fileName := range allFiles {
 		require.Nil(t, os.WriteFile(filepath.Join(dir, fileName), []byte("test"), os.FileMode(0o644)))
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This updates golangci-lint to the latest release and fixes new lints. It
also enables linters which do not report any issue.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
