### PR TITLE
debian-base: Build buster-v1.7.0 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -229,7 +229,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.6.0
+    version: buster-v1.7.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.6.0
+IMAGE_VERSION ?= buster-v1.7.0
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,4 +1,4 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.6.0'
+    IMAGE_VERSION: 'buster-v1.7.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Periodic image build to address security updates.
Should address https://github.com/kubernetes/kubernetes/issues/102215.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @puerco 
cc: @kubernetes/release-engineering @destijl @dims 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
debian-base: Build buster-v1.7.0 image
```
