### PR TITLE
comment fix

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -39,7 +39,7 @@ dependencies:
   #- name: "crictl"
   #  version: 1.18.0
 
-  # distroless
+  # cosign
   - name: "gcr.io/projectsigstore/cosign"
     version: v0.4.0@sha256:7e9a6ca62c3b502a125754fbeb4cde2d37d4261a9c905359585bfc0a63ff17f4
     refPaths:


### PR DESCRIPTION
The dependency on https://github.com/sigstore/cosign project's
images is labelled as "distroless", which is confusing.  Cosign
relates to distroless (eg: for verifying distroless's signatures),
but it's able to do more too.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
