### PR TITLE
BOM: Include full list of transient go dependencies

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -71,6 +71,7 @@ type generateOptions struct {
 	analyze        bool
 	noGitignore    bool
 	noGoModules    bool
+	noGoTransient  bool
 	namespace      string
 	outputFile     string
 	images         []string
@@ -161,6 +162,12 @@ func init() {
 		false,
 		"don't perform go.mod analysis, sbom will not include data about go packages",
 	)
+	generateCmd.PersistentFlags().BoolVar(
+		&genOpts.noGoTransient,
+		"no-transient",
+		false,
+		"don't include transient go dependencies, only direct deps from go.mod",
+	)
 
 	generateCmd.PersistentFlags().StringVarP(
 		&genOpts.namespace,
@@ -203,6 +210,7 @@ func generateBOM(opts *generateOptions) error {
 		Namespace:        opts.namespace,
 		AnalyseLayers:    opts.analyze,
 		ProcessGoModules: !opts.noGoModules,
+		OnlyDirectDeps:   !opts.noGoTransient,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/pkg/license/download.go
+++ b/pkg/license/download.go
@@ -67,19 +67,23 @@ type DownloaderOptions struct {
 func (do *DownloaderOptions) Validate() error {
 	// If we are using a cache
 	if do.EnableCache {
-		// Is we have a cache dir, check if it exists
-		if do.CacheDir != "" {
-			if !util.Exists(do.CacheDir) {
-				return errors.New("the specified cache directory does not exist: " + do.CacheDir)
-			}
-		}
-		// And no cache dir was specified
+		// and no cache dir was specified
 		if do.CacheDir == "" {
+			// use a temporary dir
 			dir, err := os.MkdirTemp(os.TempDir(), "license-cache-")
+			do.CacheDir = dir
 			if err != nil {
 				return errors.Wrap(err, "creating temporary directory")
 			}
-			do.CacheDir = dir
+		} else if !util.Exists(do.CacheDir) {
+			if err := os.MkdirAll(do.CacheDir, os.FileMode(0o755)); err != nil {
+				return errors.Wrap(err, "creating license downloader cache")
+			}
+		}
+
+		// Is we have a cache dir, check if it exists
+		if !util.Exists(do.CacheDir) {
+			return errors.New("the specified cache directory does not exist: " + do.CacheDir)
 		}
 	}
 	return nil

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -45,7 +45,7 @@ func (d *ReaderDefaultImpl) ClassifyFile(path string) (licenseTag string, moreTa
 	// Get the classsification
 	matches, err := d.Classifier().MatchFrom(file)
 	if len(matches) == 0 {
-		logrus.Warn("File does not match a known license: " + path)
+		logrus.Debugf("File does not match a known license: %s", path)
 	}
 	var highestConf float64
 	moreTags = []string{}
@@ -81,10 +81,12 @@ func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
 		// Apend to the return results
 		licenseList = append(licenseList, ClassifyResult{f, license})
 	}
-	logrus.Infof(
-		"License classifier recognized %d/%d (%d%%) os the files",
-		len(licenseList), len(paths), (len(licenseList)/len(paths))*100,
-	)
+	if len(paths) > 0 {
+		logrus.Infof(
+			"License classifier recognized %d/%d (%d%%) os the files",
+			len(licenseList), len(paths), (len(licenseList)/len(paths))*100,
+		)
+	}
 	return licenseList, unrecognizedPaths, nil
 }
 
@@ -102,7 +104,7 @@ func (d *ReaderDefaultImpl) LicenseFromFile(path string) (license *License, err 
 	}
 
 	if label == "" {
-		logrus.Info("File does not contain a known license: " + path)
+		logrus.Debugf("File does not contain a known license: %s", path)
 		return nil, nil
 	}
 
@@ -170,7 +172,7 @@ func (d *ReaderDefaultImpl) Initialize(opts *ReaderOptions) error {
 	logrus.Infof("Writing license data to %s", opts.CachePath())
 
 	// Write the licenses to disk as th classifier will need them
-	if err := catalog.WriteLicensesAsText(opts.LicensesPath()); err != nil {
+	if err := catalog.WriteLicensesAsText(opts.CachePath()); err != nil {
 		return errors.Wrap(err, "writing license data to disk")
 	}
 

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -64,8 +64,10 @@ type DocGenerateOptions struct {
 	AnalyseLayers    bool     // A flag that controls if deep layer analysis should be performed
 	NoGitignore      bool     // Do not read exclusions from gitignore file
 	ProcessGoModules bool     // Analyze go.mod to include data about packages
+	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
 	OutputFile       string   // Output location
 	Namespace        string   // Namespace for the document (a unique URI)
+	ScanLicenses     bool     // Try to llok into files to determine their license
 	Tarballs         []string // A slice of tar paths
 	Files            []string // A slice of naked files to include in the bom
 	Images           []string // A slice of docker images

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -36,6 +36,10 @@ const (
 	spdxLicenseDlCache      = spdxTempDir + "/downloadCache"
 	gitIgnoreFile           = ".gitignore"
 	validNameCharsRe        = `[^a-zA-Z0-9-]+`
+
+	// Consts of some SPDX expressions
+	NONE        = "NONE"
+	NOASSERTION = "NOASSERTION"
 )
 
 type SPDX struct {
@@ -144,7 +148,7 @@ func (spdx *SPDX) PackageFromDirectory(dirPath string) (pkg *Package, err error)
 		if lic != nil {
 			f.LicenseInfoInFile = lic.LicenseID
 		} else {
-			f.LicenseInfoInFile = "NONE"
+			f.LicenseInfoInFile = NONE
 		}
 		f.LicenseConcluded = licenseTag
 		if err := f.ReadSourceFile(filepath.Join(dirPath, path)); err != nil {

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -63,11 +63,11 @@ type FakeSpdxImplementation struct {
 		result1 []string
 		result2 error
 	}
-	GetGoDependenciesStub        func(string, bool) ([]*spdx.Package, error)
+	GetGoDependenciesStub        func(string, *spdx.Options) ([]*spdx.Package, error)
 	getGoDependenciesMutex       sync.RWMutex
 	getGoDependenciesArgsForCall []struct {
 		arg1 string
-		arg2 bool
+		arg2 *spdx.Options
 	}
 	getGoDependenciesReturns struct {
 		result1 []*spdx.Package
@@ -414,12 +414,12 @@ func (fake *FakeSpdxImplementation) GetDirectoryTreeReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) GetGoDependencies(arg1 string, arg2 bool) ([]*spdx.Package, error) {
+func (fake *FakeSpdxImplementation) GetGoDependencies(arg1 string, arg2 *spdx.Options) ([]*spdx.Package, error) {
 	fake.getGoDependenciesMutex.Lock()
 	ret, specificReturn := fake.getGoDependenciesReturnsOnCall[len(fake.getGoDependenciesArgsForCall)]
 	fake.getGoDependenciesArgsForCall = append(fake.getGoDependenciesArgsForCall, struct {
 		arg1 string
-		arg2 bool
+		arg2 *spdx.Options
 	}{arg1, arg2})
 	stub := fake.GetGoDependenciesStub
 	fakeReturns := fake.getGoDependenciesReturns
@@ -440,13 +440,13 @@ func (fake *FakeSpdxImplementation) GetGoDependenciesCallCount() int {
 	return len(fake.getGoDependenciesArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) GetGoDependenciesCalls(stub func(string, bool) ([]*spdx.Package, error)) {
+func (fake *FakeSpdxImplementation) GetGoDependenciesCalls(stub func(string, *spdx.Options) ([]*spdx.Package, error)) {
 	fake.getGoDependenciesMutex.Lock()
 	defer fake.getGoDependenciesMutex.Unlock()
 	fake.GetGoDependenciesStub = stub
 }
 
-func (fake *FakeSpdxImplementation) GetGoDependenciesArgsForCall(i int) (string, bool) {
+func (fake *FakeSpdxImplementation) GetGoDependenciesArgsForCall(i int) (string, *spdx.Options) {
 	fake.getGoDependenciesMutex.RLock()
 	defer fake.getGoDependenciesMutex.RUnlock()
 	argsForCall := fake.getGoDependenciesArgsForCall[i]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind feature
/kind design

#### What this PR does / why we need it:

**Full List of Dependencies is now the Default**
Based on the discussion on https://github.com/kubernetes/release/pull/2077 this PR modifies the way we determine dependencies when scanning directories that contain go modules. All modules pulled by go as transient dependencies will now be included in the SBOM. The dependencies are determined by running `go -list --deps`.

This PR also includes code to take advantage of the local go
    module cache. When scanning go package licenses, `bom` will use any
    packages already downloaded and determine the licensing information
    from there before attempting to download the modules. This results in a considerable performance improvement.
    
A new flag is introduced to `bom generate`: `--no-transient`
When set, this flag will revert to the original behvaior where only direct go dependencies are included in the Bill of Materials.

**Parallel Downloads**
When `bom` has to download go dependencies, all downloads will now be done in parallel, also resulting in a considerable performance improvement.

**License package bugfix**
Finally, a bug in the license package has been fixed, avoiding an edge case where a division by zero would crash the program under certain cases. Also, the license output has been improved by shifting some of the output to log level debug. 

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/1837
Follow up to:  https://github.com/kubernetes/release/pull/2077

#### Special notes for your reviewer:

Only the last 4 commits are relevant, needs a rebase once https://github.com/kubernetes/release/pull/2077 merges.

Hold until 2077 merged
/hold

#### Does this PR introduce a user-facing change?
```release-note
- `bom generate` will now perform go package downloads in parallel
- When generating an sbom from a go module directory, `bom` will now list all transient dependencies by default. A new flag `--no-transient` can be used to only include direct dependencies in the document.
- Reduced the output of the license package by moving some of the output to Debug.
- FIxed a bug where the license package would sometimes crash due to a division by zero.  
```
