### PR TITLE
Add missing i386 crossbuild toolchain to kube-cross

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -141,7 +141,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.16.4-1
+    version: v1.16.4-2
     refPaths:
     - path: images/build/cross/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,7 +16,7 @@
 SHELL=/bin/bash -o pipefail
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.16.4-1
+IMAGE_VERSION ?= v1.16.4-2
 CONFIG ?= go1.16
 TYPE ?= default
 

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -25,10 +25,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV GOARM 7
 ENV KUBE_DYNAMIC_CROSSPLATFORMS \
-  armhf \
   arm64 \
-  s390x \
-  ppc64el
+  armhf \
+  i386 \
+  ppc64el \
+  s390x
 
 ENV KUBE_CROSSPLATFORMS \
   linux/386 \

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -10,7 +10,7 @@ variants:
     TYPE: 'default'
     CONFIG: 'go1.16'
     GO_VERSION: '1.16.4'
-    IMAGE_VERSION: 'v1.16.4-1'
+    IMAGE_VERSION: 'v1.16.4-2'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We require this toolchain when building via cgo, for example when enabling the PIE buildmode on the `linux/386` platform.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Required for https://github.com/kubernetes/kubernetes/pull/102323
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added i386 crossbuild toolchain to kube-cross.
```
