### PR TITLE
[WIP] images/releng/ko-builder: Initial commit

### DIFF
--- a/images/releng/ko-builder/Dockerfile
+++ b/images/releng/ko-builder/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Consider parameterizing Google Cloud SDK version
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+# Install golang
+# TODO: Consider parameterizing Golang version outside of Dockerfile
+ARG GO_VERSION=1.16.4
+RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.tar.gz
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOROOT /usr/local/go
+
+# Install ko
+# TODO: Consider parameterizing ko version outside of Dockerfile
+ARG KO_VERSION=0.8.3
+RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
+RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
+
+WORKDIR /workspace
+
+ENTRYPOINT [ "ko" ]


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is inspired by the Tekton ko build image (h/t @priyawadhwa): https://github.com/tektoncd/plumbing/blob/fe57aef52b996fa58ca2ff5529819c8706f2ac4b/tekton/images/ko-gcloud/Dockerfile

Here we attempt to provide a simpler means of building container images for the Golang applications we maintain via [ko](https://github.com/google/ko).

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

This is likely missing a few things, but just getting it off of my local and in public early.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Initial build of ko-builder image
```
