### PR TITLE
releng-ci: Enable building multiple image variants

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/releng/ci/cloudbuild.yaml
+    - path: images/releng/ci/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -112,11 +112,11 @@ dependencies:
     - path: images/build/go-runner/VERSION
 
   # Golang images
-  - name: "gcr.io/k8s-staging-releng/releng-ci"
-    version: v0.5.2
+  - name: "gcr.io/k8s-staging-releng/releng-ci: image revision"
+    version: 1
     refPaths:
-    - path: images/releng/ci/cloudbuild.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: images/releng/ci/variants.yaml
+      match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
     version: v0.4.3-7
@@ -170,9 +170,8 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    # TODO(images): Uncomment once releng-ci uses variants
-    #- path: images/releng/ci/cloudbuild.yaml
-    #  match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
     version: 1.15.12
@@ -181,6 +180,12 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang images (for previous release branches)
+  - name: "gcr.io/k8s-staging-releng/releng-ci: image revision (for previous release branches)"
+    version: 1
+    refPaths:
+    - path: images/releng/ci/variants.yaml
+      match: REVISION:\ '\d+'
+
   - name: "k8s.gcr.io/build-image/go-runner (for previous release branches)"
     version: v2.3.1-go1.15.12-buster.0
     refPaths:

--- a/images/releng/ci/ci-failures
+++ b/images/releng/ci/ci-failures
@@ -1,2 +1,0 @@
-https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-releng-ci/1382830189288886272
-https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-releng-ci/1380321161841217536

--- a/images/releng/ci/cloudbuild.yaml
+++ b/images/releng/ci/cloudbuild.yaml
@@ -8,29 +8,37 @@ steps:
     dir: ./images/releng/ci
     args:
       - build
-      - --tag=$_REGISTRY/releng-ci:$_GIT_TAG
-      - --tag=$_REGISTRY/releng-ci:$_IMAGE_VERSION
-      - --tag=$_REGISTRY/releng-ci:latest
+      - --tag=$_REGISTRY/releng-ci:${_GO_VERSION}-${_REVISION}
+      - --tag=$_REGISTRY/releng-ci:${_GIT_TAG}-${_CONFIG}
+      - --tag=$_REGISTRY/releng-ci:latest-${_CONFIG}
       - --build-arg=GO_VERSION=${_GO_VERSION}
       - .
   - name: gcr.io/gcp-runtimes/container-structure-test
     dir: ./images/releng/ci
     args:
       - test
-      - --image=$_REGISTRY/releng-ci:latest
+      - --image=$_REGISTRY/releng-ci:latest-${_CONFIG}
       - --config=test.yaml
+
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMAGE_VERSION: 'v0.5.2'
-  _GO_VERSION: '1.16.4'
+  _CONFIG: 'go0.0'
+  _GO_VERSION: '0.0.0'
+  _REVISION: '0'
   _REGISTRY: 'fake.repository/registry-name'
-images:
-  - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}'
-  - 'gcr.io/$PROJECT_ID/releng-ci:${_IMAGE_VERSION}'
-  - 'gcr.io/$PROJECT_ID/releng-ci:latest'
 
 tags:
 - 'releng-ci'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_CONFIG}
+- ${_GO_VERSION}
+- ${_REVISION}
+
+images:
+  - 'gcr.io/$PROJECT_ID/releng-ci:${_GO_VERSION}-${_REVISION}'
+  - 'gcr.io/$PROJECT_ID/releng-ci:${_GIT_TAG}-${_CONFIG}'
+  - 'gcr.io/$PROJECT_ID/releng-ci:latest-${_CONFIG}'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,0 +1,9 @@
+variants:
+  go1.16:
+    CONFIG: 'go1.16'
+    GO_VERSION: '1.16.4'
+    REVISION: '1'
+  go1.15:
+    CONFIG: 'go1.15'
+    GO_VERSION: '1.15.12'
+    REVISION: '1'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup feature failing-test

#### What this PR does / why we need it:

We have a few repos, like sigs.k8s.io/k8s-container-image-promoter, which
use the releng-ci image to run Prow jobs.

In certain instances, the repos may trail on Golang versions e.g., CIP is
currently using go1.15, which cause CI failures due to changes in how in
go.sum is calculated in go1.16.

This change allows us to build releng-ci images for multiple versions of
Golang.

Example: [pull-cip-verify](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_k8s-container-image-promoter/291/pull-cip-verify/1397884129428639744) / https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/291 (FYI @listx @tylerferrara)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- releng-ci: Enable building multiple image variants
```
