### PR TITLE
setcap image: symlink rm to /usr/sbin/rm

### DIFF
--- a/images/build/setcap/Dockerfile
+++ b/images/build/setcap/Dockerfile
@@ -16,5 +16,6 @@ ARG BASEIMAGE
 
 FROM ${BASEIMAGE}
 
-RUN apt-get update \
+RUN ln -s /bin/rm /usr/sbin/rm \
+    && apt-get update \
     && apt-get -y --no-install-recommends install libcap2-bin


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Building the `setcap` image is failing with the following error:

```
...
#6 24.42  rm command for cleanup subprocess returned error exit status 1
#6 24.45 Error while loading /usr/sbin/rm: No such file or directory
#6 24.45 dpkg: error processing archive /var/cache/apt/archives/libcap2-bin_1%3a2.25-2_arm64.deb (--unpack):
#6 24.45  rm command for cleanup subprocess returned error exit status 1
#6 24.47 Errors were encountered while processing:
#6 24.47  /var/cache/apt/archives/libcap2-bin_1%3a2.25-2_arm64.deb
#6 24.55 E: Sub-process /usr/bin/dpkg returned an error code (1)
#6 ERROR: executor failed running [/dev/.buildkit_qemu_emulator /bin/sh -c apt-get update     && apt-get -y --no-install-recommends install libcap2-bin]: exit code: 100
```

We had the same issue for other images in the past and symlinking the `rm` binary to `/usr/sbin/rm` fixed the issue. I've confirmed that doing this fixes this issue as well.

#### Which issue(s) this PR fixes:

Relevant to https://github.com/kubernetes/kubernetes/issues/102215#issuecomment-849702040

#### Special notes for your reviewer:

h/t to @puerco and @cpanato for discovering and fixing this issue for `debian-iptables`: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1619020291489300

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @justaugustus @cpanato @puerco 
cc @kubernetes/release-engineering 