### PR TITLE
debian-base: symlink rm to /usr/sbin/rm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -234,7 +234,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.7.0
+    version: buster-v1.7.1
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.7.0
+IMAGE_VERSION ?= buster-v1.7.1
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/buster/Dockerfile.build
+++ b/images/build/debian-base/buster/Dockerfile.build
@@ -32,9 +32,10 @@ COPY clean-install /usr/local/bin/clean-install
 # Error while loading /usr/sbin/dpkg-deb: No such file or directory
 # ```
 # See: https://github.com/docker/buildx/issues/495
-RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split
-RUN ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb
-RUN ln -s /bin/tar /usr/sbin/tar
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    ln -s /bin/tar /usr/sbin/tar && \
+    ln -s /bin/rm /usr/sbin/rm
 
 # Update system packages.
 RUN apt-get update \

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,4 +1,4 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.7.0'
+    IMAGE_VERSION: 'buster-v1.7.1'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Image building for images that are using `debian-base` as the base image can fail with the following error:

```
#6 24.45 Error while loading /usr/sbin/rm: No such file or directory
```

We had that problem for `debian-iptables` and `setcap` -- both images based on `debian-base`. Symlinking the `rm` binary to `/usr/sbin/rm` fixes the problem (for example see #2090).

We've discussed on Slack and decided that it might make sense to symlink the `rm` binary in the base image. That way, we don't have to do this in each image that uses `debian-base` as the base image. Also, @puerco and @justaugustus proposed that we replace multiple `RUN ln` with single `RUN ln ... &&` to reduce the number of layers.

Reference: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1622127940168900

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I have a question about this PR -- do we need to bump the `debian-base` image version somewhere?

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @justaugustus @cpanato @puerco @saschagrunert 
cc @kubernetes/release-engineering 