### PR TITLE
Bump k8s-cloud-builder version to v1.16.4-2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -141,7 +141,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.16.4-1
+    version: v1.16.4-2
     refPaths:
     - path: images/build/cross/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
@@ -157,7 +157,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.4-1
+    version: v1.16.4-2
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -16,7 +16,7 @@
 SHELL=/bin/bash -o pipefail
 
 IMGNAME = kube-cross
-IMAGE_VERSION ?= v1.16.4-1
+IMAGE_VERSION ?= v1.16.4-2
 CONFIG ?= go1.16
 TYPE ?= default
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -10,7 +10,7 @@ variants:
     TYPE: 'default'
     CONFIG: 'go1.16'
     GO_VERSION: '1.16.4'
-    IMAGE_VERSION: 'v1.16.4-1'
+    IMAGE_VERSION: 'v1.16.4-2'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
   go1.15:

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.16:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.16.4-1'
+    KUBE_CROSS_VERSION: 'v1.16.4-2'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.12-1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng

#### What this PR does / why we need it:

This PR updates the `k8s-cloud-builder` variants file to match the latest kubecross version (v1.16.4-2) to fix the release process.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
- Bump `k8s-cloud-builder` to version v1.16.4-2 
```
