### PR TITLE
Generate the first SBOM protoype from the Kubernetes release process

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -236,7 +236,7 @@ func (s *Stage) Run() error {
 		return errors.Wrap(err, "init log file")
 	}
 
-	logger := log.NewStepLogger(9)
+	logger := log.NewStepLogger(10)
 	logger.Infof("Using krel version:\n%s", version.Get().String())
 
 	logger.WithStep().Info("Validating options")
@@ -277,6 +277,11 @@ func (s *Stage) Run() error {
 	logger.WithStep().Info("Generating changelog")
 	if err := s.client.GenerateChangelog(); err != nil {
 		return errors.Wrap(err, "generate changelog")
+	}
+
+	logger.WithStep().Info("Generating bill of materials")
+	if err := s.client.GenerateBillOfMaterials(); err != nil {
+		return errors.Wrap(err, "generating sbom")
 	}
 
 	logger.WithStep().Info("Staging artifacts")

--- a/pkg/anago/anagofakes/fake_stage_client.go
+++ b/pkg/anago/anagofakes/fake_stage_client.go
@@ -52,6 +52,16 @@ type FakeStageClient struct {
 	checkReleaseBranchStateReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GenerateBillOfMaterialsStub        func() error
+	generateBillOfMaterialsMutex       sync.RWMutex
+	generateBillOfMaterialsArgsForCall []struct {
+	}
+	generateBillOfMaterialsReturns struct {
+		result1 error
+	}
+	generateBillOfMaterialsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GenerateChangelogStub        func() error
 	generateChangelogMutex       sync.RWMutex
 	generateChangelogArgsForCall []struct {
@@ -296,6 +306,59 @@ func (fake *FakeStageClient) CheckReleaseBranchStateReturnsOnCall(i int, result1
 		})
 	}
 	fake.checkReleaseBranchStateReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) GenerateBillOfMaterials() error {
+	fake.generateBillOfMaterialsMutex.Lock()
+	ret, specificReturn := fake.generateBillOfMaterialsReturnsOnCall[len(fake.generateBillOfMaterialsArgsForCall)]
+	fake.generateBillOfMaterialsArgsForCall = append(fake.generateBillOfMaterialsArgsForCall, struct {
+	}{})
+	stub := fake.GenerateBillOfMaterialsStub
+	fakeReturns := fake.generateBillOfMaterialsReturns
+	fake.recordInvocation("GenerateBillOfMaterials", []interface{}{})
+	fake.generateBillOfMaterialsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageClient) GenerateBillOfMaterialsCallCount() int {
+	fake.generateBillOfMaterialsMutex.RLock()
+	defer fake.generateBillOfMaterialsMutex.RUnlock()
+	return len(fake.generateBillOfMaterialsArgsForCall)
+}
+
+func (fake *FakeStageClient) GenerateBillOfMaterialsCalls(stub func() error) {
+	fake.generateBillOfMaterialsMutex.Lock()
+	defer fake.generateBillOfMaterialsMutex.Unlock()
+	fake.GenerateBillOfMaterialsStub = stub
+}
+
+func (fake *FakeStageClient) GenerateBillOfMaterialsReturns(result1 error) {
+	fake.generateBillOfMaterialsMutex.Lock()
+	defer fake.generateBillOfMaterialsMutex.Unlock()
+	fake.GenerateBillOfMaterialsStub = nil
+	fake.generateBillOfMaterialsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) GenerateBillOfMaterialsReturnsOnCall(i int, result1 error) {
+	fake.generateBillOfMaterialsMutex.Lock()
+	defer fake.generateBillOfMaterialsMutex.Unlock()
+	fake.GenerateBillOfMaterialsStub = nil
+	if fake.generateBillOfMaterialsReturnsOnCall == nil {
+		fake.generateBillOfMaterialsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateBillOfMaterialsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -765,6 +828,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.checkPrerequisitesMutex.RUnlock()
 	fake.checkReleaseBranchStateMutex.RLock()
 	defer fake.checkReleaseBranchStateMutex.RUnlock()
+	fake.generateBillOfMaterialsMutex.RLock()
+	defer fake.generateBillOfMaterialsMutex.RUnlock()
 	fake.generateChangelogMutex.RLock()
 	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/release/pkg/gcp/gcb"
 	"k8s.io/release/pkg/git"
 	"k8s.io/release/pkg/release"
+	"k8s.io/release/pkg/spdx"
 )
 
 type FakeStageImpl struct {
@@ -138,6 +139,43 @@ type FakeStageImpl struct {
 	}
 	generateReleaseVersionReturnsOnCall map[int]struct {
 		result1 *release.Versions
+		result2 error
+	}
+	GenerateSourceTreeBOMStub        func(*spdx.DocGenerateOptions) (*spdx.Document, error)
+	generateSourceTreeBOMMutex       sync.RWMutex
+	generateSourceTreeBOMArgsForCall []struct {
+		arg1 *spdx.DocGenerateOptions
+	}
+	generateSourceTreeBOMReturns struct {
+		result1 *spdx.Document
+		result2 error
+	}
+	generateSourceTreeBOMReturnsOnCall map[int]struct {
+		result1 *spdx.Document
+		result2 error
+	}
+	GenerateVersionArtifactsBOMStub        func(*spdx.DocGenerateOptions) error
+	generateVersionArtifactsBOMMutex       sync.RWMutex
+	generateVersionArtifactsBOMArgsForCall []struct {
+		arg1 *spdx.DocGenerateOptions
+	}
+	generateVersionArtifactsBOMReturns struct {
+		result1 error
+	}
+	generateVersionArtifactsBOMReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ListArtifactsStub        func(string) (map[string][]string, error)
+	listArtifactsMutex       sync.RWMutex
+	listArtifactsArgsForCall []struct {
+		arg1 string
+	}
+	listArtifactsReturns struct {
+		result1 map[string][]string
+		result2 error
+	}
+	listArtifactsReturnsOnCall map[int]struct {
+		result1 map[string][]string
 		result2 error
 	}
 	MakeCrossStub        func(string) error
@@ -283,6 +321,18 @@ type FakeStageImpl struct {
 		result1 error
 	}
 	toFileReturnsOnCall map[int]struct {
+		result1 error
+	}
+	WriteSourceBOMStub        func(*spdx.Document, string) error
+	writeSourceBOMMutex       sync.RWMutex
+	writeSourceBOMArgsForCall []struct {
+		arg1 *spdx.Document
+		arg2 string
+	}
+	writeSourceBOMReturns struct {
+		result1 error
+	}
+	writeSourceBOMReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -835,6 +885,195 @@ func (fake *FakeStageImpl) GenerateReleaseVersionReturnsOnCall(i int, result1 *r
 	}
 	fake.generateReleaseVersionReturnsOnCall[i] = struct {
 		result1 *release.Versions
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOM(arg1 *spdx.DocGenerateOptions) (*spdx.Document, error) {
+	fake.generateSourceTreeBOMMutex.Lock()
+	ret, specificReturn := fake.generateSourceTreeBOMReturnsOnCall[len(fake.generateSourceTreeBOMArgsForCall)]
+	fake.generateSourceTreeBOMArgsForCall = append(fake.generateSourceTreeBOMArgsForCall, struct {
+		arg1 *spdx.DocGenerateOptions
+	}{arg1})
+	stub := fake.GenerateSourceTreeBOMStub
+	fakeReturns := fake.generateSourceTreeBOMReturns
+	fake.recordInvocation("GenerateSourceTreeBOM", []interface{}{arg1})
+	fake.generateSourceTreeBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOMCallCount() int {
+	fake.generateSourceTreeBOMMutex.RLock()
+	defer fake.generateSourceTreeBOMMutex.RUnlock()
+	return len(fake.generateSourceTreeBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOMCalls(stub func(*spdx.DocGenerateOptions) (*spdx.Document, error)) {
+	fake.generateSourceTreeBOMMutex.Lock()
+	defer fake.generateSourceTreeBOMMutex.Unlock()
+	fake.GenerateSourceTreeBOMStub = stub
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOMArgsForCall(i int) *spdx.DocGenerateOptions {
+	fake.generateSourceTreeBOMMutex.RLock()
+	defer fake.generateSourceTreeBOMMutex.RUnlock()
+	argsForCall := fake.generateSourceTreeBOMArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOMReturns(result1 *spdx.Document, result2 error) {
+	fake.generateSourceTreeBOMMutex.Lock()
+	defer fake.generateSourceTreeBOMMutex.Unlock()
+	fake.GenerateSourceTreeBOMStub = nil
+	fake.generateSourceTreeBOMReturns = struct {
+		result1 *spdx.Document
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GenerateSourceTreeBOMReturnsOnCall(i int, result1 *spdx.Document, result2 error) {
+	fake.generateSourceTreeBOMMutex.Lock()
+	defer fake.generateSourceTreeBOMMutex.Unlock()
+	fake.GenerateSourceTreeBOMStub = nil
+	if fake.generateSourceTreeBOMReturnsOnCall == nil {
+		fake.generateSourceTreeBOMReturnsOnCall = make(map[int]struct {
+			result1 *spdx.Document
+			result2 error
+		})
+	}
+	fake.generateSourceTreeBOMReturnsOnCall[i] = struct {
+		result1 *spdx.Document
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOM(arg1 *spdx.DocGenerateOptions) error {
+	fake.generateVersionArtifactsBOMMutex.Lock()
+	ret, specificReturn := fake.generateVersionArtifactsBOMReturnsOnCall[len(fake.generateVersionArtifactsBOMArgsForCall)]
+	fake.generateVersionArtifactsBOMArgsForCall = append(fake.generateVersionArtifactsBOMArgsForCall, struct {
+		arg1 *spdx.DocGenerateOptions
+	}{arg1})
+	stub := fake.GenerateVersionArtifactsBOMStub
+	fakeReturns := fake.generateVersionArtifactsBOMReturns
+	fake.recordInvocation("GenerateVersionArtifactsBOM", []interface{}{arg1})
+	fake.generateVersionArtifactsBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMCallCount() int {
+	fake.generateVersionArtifactsBOMMutex.RLock()
+	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
+	return len(fake.generateVersionArtifactsBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMCalls(stub func(*spdx.DocGenerateOptions) error) {
+	fake.generateVersionArtifactsBOMMutex.Lock()
+	defer fake.generateVersionArtifactsBOMMutex.Unlock()
+	fake.GenerateVersionArtifactsBOMStub = stub
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMArgsForCall(i int) *spdx.DocGenerateOptions {
+	fake.generateVersionArtifactsBOMMutex.RLock()
+	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
+	argsForCall := fake.generateVersionArtifactsBOMArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMReturns(result1 error) {
+	fake.generateVersionArtifactsBOMMutex.Lock()
+	defer fake.generateVersionArtifactsBOMMutex.Unlock()
+	fake.GenerateVersionArtifactsBOMStub = nil
+	fake.generateVersionArtifactsBOMReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMReturnsOnCall(i int, result1 error) {
+	fake.generateVersionArtifactsBOMMutex.Lock()
+	defer fake.generateVersionArtifactsBOMMutex.Unlock()
+	fake.GenerateVersionArtifactsBOMStub = nil
+	if fake.generateVersionArtifactsBOMReturnsOnCall == nil {
+		fake.generateVersionArtifactsBOMReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateVersionArtifactsBOMReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) ListArtifacts(arg1 string) (map[string][]string, error) {
+	fake.listArtifactsMutex.Lock()
+	ret, specificReturn := fake.listArtifactsReturnsOnCall[len(fake.listArtifactsArgsForCall)]
+	fake.listArtifactsArgsForCall = append(fake.listArtifactsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListArtifactsStub
+	fakeReturns := fake.listArtifactsReturns
+	fake.recordInvocation("ListArtifacts", []interface{}{arg1})
+	fake.listArtifactsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) ListArtifactsCallCount() int {
+	fake.listArtifactsMutex.RLock()
+	defer fake.listArtifactsMutex.RUnlock()
+	return len(fake.listArtifactsArgsForCall)
+}
+
+func (fake *FakeStageImpl) ListArtifactsCalls(stub func(string) (map[string][]string, error)) {
+	fake.listArtifactsMutex.Lock()
+	defer fake.listArtifactsMutex.Unlock()
+	fake.ListArtifactsStub = stub
+}
+
+func (fake *FakeStageImpl) ListArtifactsArgsForCall(i int) string {
+	fake.listArtifactsMutex.RLock()
+	defer fake.listArtifactsMutex.RUnlock()
+	argsForCall := fake.listArtifactsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) ListArtifactsReturns(result1 map[string][]string, result2 error) {
+	fake.listArtifactsMutex.Lock()
+	defer fake.listArtifactsMutex.Unlock()
+	fake.ListArtifactsStub = nil
+	fake.listArtifactsReturns = struct {
+		result1 map[string][]string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) ListArtifactsReturnsOnCall(i int, result1 map[string][]string, result2 error) {
+	fake.listArtifactsMutex.Lock()
+	defer fake.listArtifactsMutex.Unlock()
+	fake.ListArtifactsStub = nil
+	if fake.listArtifactsReturnsOnCall == nil {
+		fake.listArtifactsReturnsOnCall = make(map[int]struct {
+			result1 map[string][]string
+			result2 error
+		})
+	}
+	fake.listArtifactsReturnsOnCall[i] = struct {
+		result1 map[string][]string
 		result2 error
 	}{result1, result2}
 }
@@ -1580,6 +1819,68 @@ func (fake *FakeStageImpl) ToFileReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeStageImpl) WriteSourceBOM(arg1 *spdx.Document, arg2 string) error {
+	fake.writeSourceBOMMutex.Lock()
+	ret, specificReturn := fake.writeSourceBOMReturnsOnCall[len(fake.writeSourceBOMArgsForCall)]
+	fake.writeSourceBOMArgsForCall = append(fake.writeSourceBOMArgsForCall, struct {
+		arg1 *spdx.Document
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.WriteSourceBOMStub
+	fakeReturns := fake.writeSourceBOMReturns
+	fake.recordInvocation("WriteSourceBOM", []interface{}{arg1, arg2})
+	fake.writeSourceBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) WriteSourceBOMCallCount() int {
+	fake.writeSourceBOMMutex.RLock()
+	defer fake.writeSourceBOMMutex.RUnlock()
+	return len(fake.writeSourceBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) WriteSourceBOMCalls(stub func(*spdx.Document, string) error) {
+	fake.writeSourceBOMMutex.Lock()
+	defer fake.writeSourceBOMMutex.Unlock()
+	fake.WriteSourceBOMStub = stub
+}
+
+func (fake *FakeStageImpl) WriteSourceBOMArgsForCall(i int) (*spdx.Document, string) {
+	fake.writeSourceBOMMutex.RLock()
+	defer fake.writeSourceBOMMutex.RUnlock()
+	argsForCall := fake.writeSourceBOMArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) WriteSourceBOMReturns(result1 error) {
+	fake.writeSourceBOMMutex.Lock()
+	defer fake.writeSourceBOMMutex.Unlock()
+	fake.WriteSourceBOMStub = nil
+	fake.writeSourceBOMReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) WriteSourceBOMReturnsOnCall(i int, result1 error) {
+	fake.writeSourceBOMMutex.Lock()
+	defer fake.writeSourceBOMMutex.Unlock()
+	fake.WriteSourceBOMStub = nil
+	if fake.writeSourceBOMReturnsOnCall == nil {
+		fake.writeSourceBOMReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.writeSourceBOMReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1601,6 +1902,12 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.generateChangelogMutex.RUnlock()
 	fake.generateReleaseVersionMutex.RLock()
 	defer fake.generateReleaseVersionMutex.RUnlock()
+	fake.generateSourceTreeBOMMutex.RLock()
+	defer fake.generateSourceTreeBOMMutex.RUnlock()
+	fake.generateVersionArtifactsBOMMutex.RLock()
+	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
+	fake.listArtifactsMutex.RLock()
+	defer fake.listArtifactsMutex.RUnlock()
 	fake.makeCrossMutex.RLock()
 	defer fake.makeCrossMutex.RUnlock()
 	fake.openRepoMutex.RLock()
@@ -1625,6 +1932,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.tagMutex.RUnlock()
 	fake.toFileMutex.RLock()
 	defer fake.toFileMutex.RUnlock()
+	fake.writeSourceBOMMutex.RLock()
+	defer fake.writeSourceBOMMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -81,6 +81,10 @@ type stageClient interface {
 	// into the local repository.
 	GenerateChangelog() error
 
+	// GenerateBillOfMaterials generates the SBOM documents for the Kubernetes
+	// source code and the release artifacts.
+	GenerateBillOfMaterials() error
+
 	// StageArtifacts copies the build artifacts to a Google Cloud Bucket.
 	StageArtifacts() error
 }

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -341,6 +341,14 @@ func (bi *Instance) StageLocalArtifacts() error {
 		)
 	}
 
+	// Write the bill of materials manifests
+	if err := util.CopyFileLocal(
+		filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", bi.opts.Version)),
+		filepath.Join(stageDir, "kubernetes-release.spdx"), true,
+	); err != nil {
+		return errors.Wrapf(err, "copying SBOM manifests")
+	}
+
 	// Write the release checksums
 	logrus.Info("Writing checksums")
 	if err := release.WriteChecksums(stageDir); err != nil {

--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -342,11 +342,15 @@ func (bi *Instance) StageLocalArtifacts() error {
 	}
 
 	// Write the bill of materials manifests
-	if err := util.CopyFileLocal(
-		filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", bi.opts.Version)),
-		filepath.Join(stageDir, "kubernetes-release.spdx"), true,
-	); err != nil {
-		return errors.Wrapf(err, "copying SBOM manifests")
+	for filename, sbom := range map[string]string{
+		"kubernetes-source.spdx":  filepath.Join(os.TempDir(), fmt.Sprintf("source-bom-%s.spdx", bi.opts.Version)),
+		"kubernetes-release.spdx": filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", bi.opts.Version)),
+	} {
+		if err := util.CopyFileLocal(
+			sbom, filepath.Join(stageDir, filename), true,
+		); err != nil {
+			return errors.Wrapf(err, "copying SBOM manifests")
+		}
 	}
 
 	// Write the release checksums

--- a/pkg/license/license_unit_test.go
+++ b/pkg/license/license_unit_test.go
@@ -51,13 +51,11 @@ func TestCacheData(t *testing.T) {
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.RemoveAll(tempdir)) }()
 
-	impl := DefaultDownloaderImpl{
-		Options: &DownloaderOptions{
-			EnableCache:       true,
-			CacheDir:          tempdir,
-			parallelDownloads: 0,
-		},
-	}
+	opts := DefaultDownloaderOpts
+	opts.CacheDir = tempdir
+
+	impl := DefaultDownloaderImpl{Options: opts}
+
 	// Get some testing data
 	testData := []byte("Testing 1,2,3")
 	testURL := "http://example.com/"
@@ -106,14 +104,11 @@ func TestGetLicenseFromURL(t *testing.T) {
 
 	testURL := "http://www.example.com"
 
+	opts := DefaultDownloaderOpts
+	opts.CacheDir = tempdir
+
 	// Create a default implementation with caching enabled
-	impl := DefaultDownloaderImpl{
-		Options: &DownloaderOptions{
-			EnableCache:       true,
-			CacheDir:          tempdir,
-			parallelDownloads: 1,
-		},
-	}
+	impl := DefaultDownloaderImpl{Options: opts}
 
 	// First, cache the data artificially
 	require.Nil(t, impl.cacheData(testURL, []byte(testFullLicense)))

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -156,6 +156,5 @@ func (f *File) ReadSourceFile(path string) error {
 		path, f.Options().WorkDir+string(filepath.Separator),
 	)
 	f.ID = "SPDXRef-File-" + f.Checksum["SHA256"][0:15]
-	logrus.Infof("Added file %s as %s", f.Name, f.ID)
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR integrates the Bill of Materials code Into the release process. This generates the first SBOM prototypes that describe a Kubernetes release. We are generating one SBOM for the source code and one for the release artifacts. The proposed namespaces for these are the following:

* http://k8s.io/sbom/source/v1.22.0-alpha.3
* http://k8s.io/sbom/release/v1.22.0-alpha.3

This PR aims to test the integration of the BOM code with the Kubernetes Release process. The resulting SBOM documents will describe the release source and artifacts, but will not include yet all the features of the SPDX libraries. They will do most of the work of creating the BOM however, enabling us to look for bugs and polish the documents to their final state in beta.0.

This PR is broken into several commits, I've attempted to add meaningful descriptions to each one. The most important changes are:

* Prewarming the license cache during release.PrepareWorkspaceStage() to avoid downloading the license files later
* The release process staging phase now has a `GenerateBillOfMaterials()` step that builds the SPDX documents.
* We now create an SPDX SBOM describing the Kubernetes source during staging
* Each version in a release now features an SPDX bill of materials listing its binaries and images
* stage.GenerateBillOfMaterials() now has an integration test


#### Which issue(s) this PR fixes:
Part of: https://github.com/kubernetes/release/issues/1837

#### Special notes for your reviewer:

The SBOM generation has been tested in several test runs of the release process. I've verified that both stage and release work as expected. For details see:

* Mock stage run: https://console.cloud.google.com/cloud-build/builds/c95c4cde-bfa6-470f-ab35-540399f90a0c?project=648026197307
* Mock release run: https://console.cloud.google.com/cloud-build/builds/82f86e12-7a0c-492d-93ef-d1a8b64f9f41?project=648026197307

One of the commits features a temporary function: `ListArtifacts()`. This function will be replaced with the Supported Platforms framework once we finish it  (ref: https://github.com/kubernetes/release/pull/1926 )

#### Does this PR introduce a user-facing change?

```release-note
* When staging a new kubernetes build, `krel` will now prewarm the license cache to have the classifier data ready when generating the bill of materials.
* The release process staging phase now has a `GenerateBillOfMaterials()` step that builds the SPDX documents.
* We now create an SPDX SBOM describing the Kubernetes source during staging
* Each version in a release now features an SPDX bill of materials listing its binaries and images
* stage.GenerateBillOfMaterials() now has an integration test

```
