### PR TITLE
pkg/cip: Revert os/io go1.16 changes

### DIFF
--- a/pkg/cip/audit/auditor.go
+++ b/pkg/cip/audit/auditor.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -99,7 +100,7 @@ func (s *ServerContext) RunAuditor() {
 // ParsePubSubMessage parses an HTTP request body into a reg.GCRPubSubPayload.
 func ParsePubSubMessage(body io.Reader) (*reg.GCRPubSubPayload, error) {
 	// Handle basic errors (malformed requests).
-	bodyBytes, err := io.ReadAll(body)
+	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		return nil, fmt.Errorf("iotuil.ReadAll: %v", err)
 	}

--- a/pkg/cip/dockerregistry/grow_manifest.go
+++ b/pkg/cip/dockerregistry/grow_manifest.go
@@ -18,7 +18,7 @@ package inventory
 
 import (
 	"context"
-	"os"
+	"io/ioutil"
 	"path"
 	"path/filepath"
 
@@ -138,7 +138,7 @@ func WriteImages(manifest Manifest, rii RegInvImage) error {
 	logrus.Infoln("RENDER", imagesPath)
 
 	// Write the file.
-	err := os.WriteFile(
+	err := ioutil.WriteFile(
 		imagesPath, []byte(rii.ToYAML(YamlMarshalingOpts{})), 0644)
 	return err
 }

--- a/pkg/cip/dockerregistry/inventory.go
+++ b/pkg/cip/dockerregistry/inventory.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -131,7 +132,7 @@ func ParseManifestFromFile(filePath string) (Manifest, error) {
 	var mfest Manifest
 	var empty Manifest
 
-	b, err := os.ReadFile(filePath)
+	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -158,7 +159,7 @@ func ParseThinManifestFromFile(filePath string) (Manifest, error) {
 	var mfest Manifest
 	var empty Manifest
 
-	b, err := os.ReadFile(filePath)
+	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -196,7 +197,7 @@ func ParseImagesFromFile(filePath string) (Images, error) {
 	var images Images
 	var empty Images
 
-	b, err := os.ReadFile(filePath)
+	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return empty, err
 	}
@@ -318,7 +319,7 @@ func ValidateThinManifestDirectoryStructure(
 	// For every subfolder in <dir>/manifests, ensure that a
 	// "promoter-manifest.yaml" file exists, and also that a corresponding file
 	// exists in the "images" folder.
-	files, err := os.ReadDir(manifestDir)
+	files, err := ioutil.ReadDir(manifestDir)
 	if err != nil {
 		return err
 	}
@@ -1094,7 +1095,7 @@ func getJSONSFromProcess(req stream.ExternalRequest) (cipJson.Objects, Errors) {
 		)
 	}
 
-	be, err := io.ReadAll(stderrReader)
+	be, err := ioutil.ReadAll(stderrReader)
 	if err != nil {
 		streamErrs = append(
 			streamErrs,

--- a/pkg/cip/remotemanifest/git.go
+++ b/pkg/cip/remotemanifest/git.go
@@ -18,6 +18,7 @@ package remotemanifest
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -86,7 +87,7 @@ func cloneToTempDir(
 	repoURL fmt.Stringer,
 	branch string,
 ) (string, error) {
-	tdir, err := os.MkdirTemp("", "k8s.io-")
+	tdir, err := ioutil.TempDir("", "k8s.io-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup regression

#### What this PR does / why we need it:

sigs.k8s.io/k8s-container-image-promoter is currently stuck on go1.15
due to a variety of bazel dependency updates that are not straightforward
to untangle.

Due to the incompatibility of the updated os/io packages with go1.15, we're
no longer able to update k/release in k-sigs/cip.

This commit reverts the go1.16 os/io usage to the go1.15-compatible ioutil
methods.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold going to quickly check if this is now importable from k-sigs/cip using my fork

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- pkg/cip: Revert os/io go1.16 changes

  sigs.k8s.io/k8s-container-image-promoter is currently stuck on go1.15
  due to a variety of bazel dependency updates that are not straightforward
  to untangle.
  
  Due to the incompatibility of the updated os/io packages with go1.15, we're
  no longer able to update k/release in k-sigs/cip.
  
  This commit reverts the go1.16 os/io usage to the go1.15-compatible ioutil
  methods.
```
