### PR TITLE
Update go-git to v5.4.2 to fix repo cloning bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/GoogleCloudPlatform/testgrid v0.0.38
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheggaaa/pb/v3 v3.0.8
-	github.com/go-git/go-git/v5 v5.4.1
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-containerregistry v0.5.1
 	github.com/google/go-github/v33 v33.0.0

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12/go.mod
 github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.2.0/go.mod h1:kh02eMX+wdqqxgNMEyq8YgwlIOsDOa9homkUq1PoTMs=
-github.com/go-git/go-git/v5 v5.4.1 h1:2RJXJuTMac944e419pJJJ3mOJBcr3A3M6SN6wQKZ/Gs=
-github.com/go-git/go-git/v5 v5.4.1/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR bumps the `go-git` package to version v5.4.2 which fixes a bug that was preventing us from cloning kubernetes/kubernetes

/priority critical-urgent
/milestone v1.22

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
Fixes #2094

#### Special notes for your reviewer:
The go-git team has disabled the feature that caused the bug: https://github.com/go-git/go-git/pull/326

I have confirmed the release process runs again from my branch: https://console.cloud.google.com/cloud-build/builds;region=global/951c177e-eaea-4d0f-a943-2849b78ffd3d?project=kubernetes-release-test
```
Step #3: INFO[2021-06-02T14:12:58Z] Preparing workspace for staging in /workspace/src/k8s.io/kubernetes 
Step #3: INFO[2021-06-02T14:12:58Z] Cloning repository to /workspace/src/k8s.io/kubernetes 
Step #3: INFO[2021-06-02T14:16:33Z] Tagging repository                            step=6/9
Step #3: INFO[2021-06-02T14:16:33Z] Preparing version v1.22.0-alpha.3            
Step #3: INFO[2021-06-02T14:16:33Z] Checking out branch master                   
Step #3: INFO[2021-06-02T14:16:33Z] Current branch is master                     
Step #3: INFO[2021-06-02T14:16:33Z] Detaching HEAD at commit 1795a98eebe58f to create tag v1.22.0-alpha.3 
```


#### Does this PR introduce a user-facing change?

```release-note
Update `go-git` to v5.4.2 to fix a bug that prevented the release process to clone repositories
```
