### PR TITLE
Mark SPDX manifest as not required during push to stage

### DIFF
--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -347,7 +347,7 @@ func (bi *Instance) StageLocalArtifacts() error {
 		"kubernetes-release.spdx": filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", bi.opts.Version)),
 	} {
 		if err := util.CopyFileLocal(
-			sbom, filepath.Join(stageDir, filename), true,
+			sbom, filepath.Join(stageDir, filename), false,
 		); err != nil {
 			return errors.Wrapf(err, "copying SBOM manifests")
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

This commit marks the push of the SPDX manifests as not required
to fix failing tests that make use of the push code but do not
generate the SPDX documents.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/2110

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
