### PR TITLE
Optimize debian-base image size

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -234,7 +234,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.7.1
+    version: buster-v1.7.2
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.7.1
+IMAGE_VERSION ?= buster-v1.7.2
 CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar
@@ -78,10 +78,6 @@ build: clean
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
 
-	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(CONFIG)
-	# Ensure we don't get surprised by umask settings
-	chmod 0755 $(CONFIG)/qemu-$(QEMUARCH)-static
-
 	docker buildx build \
 		--pull \
 		--load \
@@ -101,7 +97,6 @@ build: clean
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		$(CONFIG)
 	docker buildx rm $$BUILDER
-	rm $(CONFIG)/qemu-$(QEMUARCH)-static
 	rm $(CONFIG)/rootfs.tar
 
 push: build

--- a/images/build/debian-base/buster/Dockerfile.build
+++ b/images/build/debian-base/buster/Dockerfile.build
@@ -16,7 +16,6 @@ ARG BASEIMAGE
 FROM $BASEIMAGE
 
 ARG ARCH
-COPY qemu-$ARCH-static /usr/bin/
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,4 +1,4 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.7.1'
+    IMAGE_VERSION: 'buster-v1.7.2'


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
As discussed in https://github.com/kubernetes/kubernetes/issues/102493 and per wg-k8s-infra as well, we can see the mostly used image is Kube-proxy.

This PR introduces some simple optimizations in debian-base image generation, removing the qemu-static file from it and reducing in 9Mb its size. 

Next PR will be for Kube-proxy generation using the image promoted from thijs PR, and that changes can reduce its image in 30% of size

#### Which issue(s) this PR fixes:

Partially https://github.com/kubernetes/kubernetes/issues/102493

#### Special notes for your reviewer:
Need to verify if the change of tags is also necessary, as this will replace the current images once promoted. 

If this is the case later we can promote the images once both are generated

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
