### PR TITLE
kube-cross: Build v1.22-dev-1 image using etcd v3.5.0

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,11 @@
 variants:
+  dev:
+    TYPE: 'default'
+    CONFIG: 'dev'
+    GO_VERSION: '1.16.5'
+    IMAGE_VERSION: 'v1.22-dev-1'
+    PROTOBUF_VERSION: '3.7.0'
+    ETCD_VERSION: 'v3.5.0'
   canary:
     TYPE: 'default'
     CONFIG: 'canary'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -6,6 +6,13 @@ variants:
     IMAGE_VERSION: 'v1.16.5-canary-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
+  '1.22':
+    TYPE: 'default'
+    CONFIG: '1.22'
+    GO_VERSION: '1.16.5'
+    IMAGE_VERSION: 'v1.22-go1.16.5-1'
+    PROTOBUF_VERSION: '3.7.0'
+    ETCD_VERSION: 'v3.4.13'
   '1.21':
     TYPE: 'default'
     CONFIG: '1.21'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -6,20 +6,16 @@ variants:
     IMAGE_VERSION: 'v1.16.5-canary-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
-  go1.16:
+  '1.21':
     TYPE: 'default'
-    CONFIG: 'go1.16'
+    CONFIG: '1.21'
     GO_VERSION: '1.16.5'
-    IMAGE_VERSION: 'v1.16.5-1'
+    IMAGE_VERSION: 'v1.21-go1.16.5-1'
     PROTOBUF_VERSION: '3.7.0'
     ETCD_VERSION: 'v3.4.13'
-  go1.15:
-    TYPE: 'default'
-    CONFIG: 'go1.15'
-    GO_VERSION: '1.15.13'
-    IMAGE_VERSION: 'v1.15.13-1'
-    PROTOBUF_VERSION: '3.7.0'
-    ETCD_VERSION: 'v3.4.13'
+
+# For 1.20 and 1.19 release branches
+# TODO: Remove once 1.20 and 1.19 are EOL
   go1.15-legacy:
     TYPE: 'legacy'
     CONFIG: 'go1.15'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/kubernetes/issues/102294.
(cc: @serathius @pacoxu)

- kube-cross: Build v1.21-go1.16.5-1 image
- kube-cross: Build v1.22-go1.16.5-1 image
- kube-cross: Build v1.22-dev-1 image using etcd v3.5.0 

This PR includes a version pattern change to encode more information into the
image tag:

`v<kubernetes-release>-<config-identifier>-<revision>`

The v1.22-go1.16.5-1 and v1.21-go1.16.5-1 image should be roughly equivalent to v1.16.5-1.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @hasheddan @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold I'm not married to this tag change, so open to suggestions.
Ideally, I'd like to accomplish the following:
- at a glance, understand what branch the image should be used for
- have an image variant (`dev`) that allows us to test when we change dependencies that are not Golang

I'll make changes to the `canary` variant as part of https://github.com/kubernetes/release/pull/2117.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- kube-cross: Build v1.21-go1.16.5-1 image
- kube-cross: Build v1.22-go1.16.5-1 image
- kube-cross: Build v1.22-dev-1 image using etcd v3.5.0 
```
