### PR TITLE
gcb: Update GITHUB_TOKEN to use new authentication token format

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -14,7 +14,7 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAIkWjMMb2OjCHCt1hHer4ZBqqD1Mj7+dfTpvkkuzS64nrGm0SUQBLz1D+4Zwp6te6JByO/zvGpHMhW6/i3BJMRYXtNTkyBGMnZuH+J3gQfhcGL2HXjr75lHaCxF4bxPr45xen5D/Kk1+paL+XpOU3KJIADy7uGQ==
+    GITHUB_TOKEN: CiQAIkWjMImwKwjbMsGh/N6QPg/AgdFo8f/6kNTBESxQLfTtWuMSUQBLz1D+ff3d7WKkopX86uyuO2xZH1k6KZRo2dXv6X5SbEkMoV5l6Bzm2owbIqJUMqWIyrMPJvNGi30iOERBOfbJ6IISMK81RDV+JmWzLCcANA==
 
 steps:
 - name: gcr.io/cloud-builders/git

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -14,7 +14,7 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAIkWjMMb2OjCHCt1hHer4ZBqqD1Mj7+dfTpvkkuzS64nrGm0SUQBLz1D+4Zwp6te6JByO/zvGpHMhW6/i3BJMRYXtNTkyBGMnZuH+J3gQfhcGL2HXjr75lHaCxF4bxPr45xen5D/Kk1+paL+XpOU3KJIADy7uGQ==
+    GITHUB_TOKEN: CiQAIkWjMImwKwjbMsGh/N6QPg/AgdFo8f/6kNTBESxQLfTtWuMSUQBLz1D+ff3d7WKkopX86uyuO2xZH1k6KZRo2dXv6X5SbEkMoV5l6Bzm2owbIqJUMqWIyrMPJvNGi30iOERBOfbJ6IISMK81RDV+JmWzLCcANA==
     DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
 
 steps:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area release-eng/security
/priority critical-urgent

#### What this PR does / why we need it:

ref: https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

Command invocation (assumes you are a member of `k8s-infra-release-admins`, with access to the [`k8s-releng-prod` GCP project](https://github.com/kubernetes/sig-release/blob/master/release-engineering/gcp.md#iam))

```console
gcloud config configurations create releng-prod
gcloud config set project k8s-releng-prod
gcloud config set account <email-address>
```

On macOS:

```console
gcloud kms encrypt --location global --keyring release --key encrypt-0 --ciphertext-file=- --plaintext-file=<(echo -n '<GITHUB_TOKEN>') | base64
```

On Linux:

```console
gcloud kms encrypt --location global --keyring release --key encrypt-0 --ciphertext-file=- --plaintext-file=<(echo -n '<GITHUB_TOKEN>') | base64 -w 0
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcb: Update GITHUB_TOKEN to use new authentication token format
```
