### PR TITLE
Reduce handling of Github during stage and release

### DIFF
--- a/pkg/release/archive.go
+++ b/pkg/release/archive.go
@@ -218,6 +218,17 @@ func (a *defaultArchiverImpl) DeleteStalePasswordFiles(releaseBuildDir string) e
 	).RunSuccess(); err != nil {
 		return errors.Wrap(err, "deleting temporary password files")
 	}
+
+	// Delete the git remote config to avoid it ending in the stage bucket
+	gitConf := filepath.Join(releaseBuildDir, "k8s.io/kubernetes/.git/config")
+	if util.Exists(gitConf) {
+		if err := os.Remove(gitConf); err != nil {
+			return errors.Wrap(err, "deleting git remote config")
+		}
+	} else {
+		logrus.Warn("git configuration file not found, nothing to remove")
+	}
+
 	return nil
 }
 

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -37,25 +37,11 @@ import (
 func PrepareWorkspaceStage(directory string) error {
 	logrus.Infof("Preparing workspace for staging in %s", directory)
 	logrus.Infof("Cloning repository to %s", directory)
-	repo, err := git.CloneOrOpenGitHubRepo(
+	_, err := git.CloneOrOpenGitHubRepo(
 		directory, git.DefaultGithubOrg, git.DefaultGithubRepo, false,
 	)
 	if err != nil {
 		return errors.Wrap(err, "clone k/k repository")
-	}
-
-	token, ok := os.LookupEnv(github.TokenEnvKey)
-	if !ok {
-		return errors.Errorf("%s env variable is not set", github.TokenEnvKey)
-	}
-
-	if err := repo.SetURL(git.DefaultRemote, (&url.URL{
-		Scheme: "https",
-		User:   url.UserPassword("git", token),
-		Host:   "github.com",
-		Path:   filepath.Join(git.DefaultGithubOrg, git.DefaultGithubRepo),
-	}).String()); err != nil {
-		return errors.Wrap(err, "changing git remote of repository")
 	}
 
 	// Prewarm the SPDX licenses cache. As it is one of the main


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces the following changes:

* krel now resets the origin remote on the staged clone of kubernetes/kubernetes.  If for some reason we need to change the Github token between staging and release, krel will now reset it in the staged sources.

* Since all git operations in kubernetes/kubernetes during stage only involve the local clone of the repository, we do not set the authenticated git remote to avoid the risk of the token ending in the stage bucket.

* During the release stage, to avoid having the github token archived in the release bucket, we now destroy the git remote configuration before archiving the release.
    


Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
Fixes #1645

#### Special notes for your reviewer:

/priority critical-urgent
/assign @justaugustus @jeremyrickard @saschagrunert 
/milestone v1.22

#### Does this PR introduce a user-facing change?


```release-note
* stage now runs completely without setting the github token in the k/k clone remote configuration
* krel now resets the git origin remote in the staged clone of kubernetes/kubernetes to pickup a new `GITHUB_TOKEN` if we change it.
* before archiving the release, we now delete the git remote config
```
