### PR TITLE
Use native `errors` methods instead of `fmt.Sprintf`

### DIFF
--- a/cmd/krel/cmd/cve.go
+++ b/cmd/krel/cmd/cve.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"strings"
 
@@ -88,7 +87,7 @@ var argFunc = func(cmd *cobra.Command, args []string) error {
 	}
 	cveOpts.CVE = strings.ToUpper(args[0])
 	if err := cve.NewClient().CheckID(cveOpts.CVE); err != nil {
-		return errors.New(fmt.Sprintf("Invalid CVE ID. Format must match %s", cve.CVEIDRegExp))
+		return errors.Errorf("invalid CVE ID. Format must match %s", cve.CVEIDRegExp)
 	}
 	return nil
 }

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -410,7 +410,7 @@ func createDraftPR(repoPath, tag string) (err error) {
 	// Check if the directory exists
 	releaseDir := filepath.Join(sigReleaseRepo.Dir(), releasePath)
 	if !util.Exists(releaseDir) {
-		return errors.New(fmt.Sprintf("could not find release directory %s", releaseDir))
+		return errors.Errorf("could not find release directory %s", releaseDir)
 	}
 
 	// If we got the --fix flag, start the fix flow

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -17,7 +17,6 @@ limitations under the License.
 package build
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -95,7 +94,7 @@ func (bi *Instance) Build() error {
 		"make",
 		releaseType,
 	).RunSuccess(); buildErr != nil {
-		return errors.Wrapf(buildErr, fmt.Sprintf("running make %s", releaseType))
+		return errors.Wrapf(buildErr, "running make %s", releaseType)
 	}
 
 	// Pushing the build

--- a/pkg/license/implementation.go
+++ b/pkg/license/implementation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package license
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -77,7 +76,7 @@ func (d *ReaderDefaultImpl) ClassifyLicenseFiles(paths []string) (
 		license := d.catalog.GetLicense(label)
 		if license == nil {
 			return nil, unrecognizedPaths,
-				errors.New(fmt.Sprintf("ID does not correspond to a valid license: '%s'", label))
+				errors.Errorf("ID does not correspond to a valid license: '%s'", label)
 		}
 		licenseText, err := os.ReadFile(f)
 		if err != nil {
@@ -116,7 +115,7 @@ func (d *ReaderDefaultImpl) LicenseFromFile(path string) (license *License, err 
 	// Get the license corresponding to the ID label
 	license = d.catalog.GetLicense(label)
 	if license == nil {
-		return nil, errors.New(fmt.Sprintf("ID does not correspond to a valid license: %s", label))
+		return nil, errors.Errorf("ID does not correspond to a valid license: %s", label)
 	}
 
 	return license, nil

--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -99,7 +99,7 @@ func (gp *GitObjectPusher) PushBranch(branchName string) error {
 		return errors.Wrap(err, "checking if branch already exists locally")
 	}
 	if !branchExists {
-		return errors.New(fmt.Sprintf("Unable to push branch %s, it does not exist in the local repo", branchName))
+		return errors.Errorf("unable to push branch %s, it does not exist in the local repo", branchName)
 	}
 
 	logrus.Infof("Pushing%s %s branch:", dryRunLabel[gp.opts.DryRun], branchName)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This cleanup makes the usage of `fmt.Sprintf()` obsolete while sticking
to the native methods of the `errors` package.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold for the patches
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
