### PR TITLE
Merge remote branch only if required

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -478,8 +478,14 @@ func TestFetchRemote(t *testing.T) {
 	require.Nil(t, err)
 
 	// Now, call fetch
-	err = testRepo.FetchRemote("origin")
+	newContent, err := testRepo.FetchRemote("origin")
 	require.Nil(t, err, "Calling fetch to get a test tag")
+	require.True(t, newContent)
+
+	// Fetching again should provide no updates
+	newContent, err = testRepo.FetchRemote("origin")
+	require.Nil(t, err, "Calling fetch to get a test tag again")
+	require.False(t, newContent)
 
 	// And now we can verify the tags was successfully transferred via FetchRemote()
 	testTags, err = testRepo.TagsForBranch(branchName)
@@ -532,7 +538,9 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, err)
 
 	// Pull the changes to the test repo
-	require.Nil(t, testRepo.FetchRemote("origin"))
+	newContent, err := testRepo.FetchRemote("origin")
+	require.Nil(t, err)
+	require.True(t, newContent)
 
 	// Do the Rebase
 	require.Nil(t, testRepo.Rebase(fmt.Sprintf("origin/%s", branchName)), "rebasing changes from origin")
@@ -561,7 +569,10 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, testRepo.Commit("Adding file to cause conflict"))
 
 	// Now, fetch and rebase
-	require.Nil(t, testRepo.FetchRemote("origin"))
+	newContent, err = testRepo.FetchRemote("origin")
+	require.Nil(t, err)
+	require.True(t, newContent)
+
 	err = testRepo.Rebase(fmt.Sprintf("origin/%s", branchName))
 	require.NotNil(t, err, "testing for merge conflicts")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Enhancing the `git.FetchRemote()` API to return `true` if something got
fetched. This is being used by `push_git_objects.go` to increase the
debugging capabilities.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold for the patches
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
