### PR TITLE
Revert "Use default KUBE_PARALLEL_BUILD_MEMORY"

### DIFF
--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -84,6 +84,7 @@ func (m *Make) MakeCross(version string) error {
 	}
 
 	// Unset the build memory requirement for parallel builds
+	// TODO: Remove this once the 1.20 release reaches EOL.
 	const buildMemoryKey = "KUBE_PARALLEL_BUILD_MEMORY"
 	logrus.Infof("Unsetting %s to force parallel build", buildMemoryKey)
 	os.Setenv(buildMemoryKey, "0")

--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -83,6 +83,11 @@ func (m *Make) MakeCross(version string) error {
 		return errors.Wrapf(err, "checking out version %s", version)
 	}
 
+	// Unset the build memory requirement for parallel builds
+	const buildMemoryKey = "KUBE_PARALLEL_BUILD_MEMORY"
+	logrus.Infof("Unsetting %s to force parallel build", buildMemoryKey)
+	os.Setenv(buildMemoryKey, "0")
+
 	logrus.Info("Building binaries")
 	if err := m.impl.Command(
 		"make",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR reverts #1939 because the release branches up to 1.21 still have the 40G limit. As per #1795, this should speed up the release process for those branches by about 10 minutes.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/hold
until the patch releases are not until and to be manually tested

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @saschagrunert @puerco 