### PR TITLE
debian-iptables: Stop pinning the iptables version

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -223,15 +223,6 @@ dependencies:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
-  # iptables
-  - name: "iptables"
-    version: 1.8.5
-    refPaths:
-    - path: images/build/debian-iptables/Makefile
-      match: IPTABLES_VERSION \?= (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
-    - path: images/build/debian-iptables/variants.yaml
-      match: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
-
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
     version: buster-v1.7.2

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -245,7 +245,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: buster-v1.6.3
+    version: buster-v1.6.4
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -26,10 +26,10 @@ ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 BASE_REGISTRY?=k8s.gcr.io/build-image
-BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
 
 # Build args
-IPTABLES_VERSION ?= 1.8.5
+BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
+
 QEMUVERSION=5.2.0-2
 
 # This option is for running docker manifest command
@@ -52,7 +52,6 @@ build:
 		-t $(IMAGE)-$(ARCH):$(IMAGE_VERSION) \
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
-		--build-arg=IPTABLES_VERSION=$(IPTABLES_VERSION) \
 		--build-arg=BASEIMAGE=$(BASEIMAGE) \
 		$(CONFIG)
 	docker buildx rm $$BUILDER

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.6.3
+IMAGE_VERSION ?= buster-v1.6.4
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.7.2
 

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -17,11 +17,10 @@ ARG BASEIMAGE
 FROM ${BASEIMAGE} as build
 
 # Install iptables and ebtables packages from buster-backports
-ARG IPTABLES_VERSION
 RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get -t buster-backports -y --no-install-recommends install \
-        iptables=${IPTABLES_VERSION}* \
+        iptables \
         ebtables
 
 # Install other dependencies and then clean up apt caches

--- a/images/build/debian-iptables/cloudbuild.yaml
+++ b/images/build/debian-iptables/cloudbuild.yaml
@@ -16,7 +16,6 @@ steps:
       - IMAGE_VERSION=$_IMAGE_VERSION
       - CONFIG=$_CONFIG
       - DEBIAN_BASE_VERSION=$_DEBIAN_BASE_VERSION
-      - IPTABLES_VERSION=$_IPTABLES_VERSION
       - HOME=/root  # for docker buildx
     args:
     - -c
@@ -32,7 +31,6 @@ substitutions:
   _IMAGE_VERSION: 'v0.0.0'
   _CONFIG: 'codename'
   _DEBIAN_BASE_VERSION: 'v0.0.0'
-  _IPTABLES_VERSION: '0.0.0'
   _REGISTRY: 'fake.repository/registry-name'
 
 tags:
@@ -42,7 +40,6 @@ tags:
 - ${_IMAGE_VERSION}
 - ${_CONFIG}
 - ${_DEBIAN_BASE_VERSION}
-- ${_IPTABLES_VERSION}
 
 images:
   - 'gcr.io/$PROJECT_ID/debian-iptables-amd64:$_IMAGE_VERSION'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -3,4 +3,3 @@ variants:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v1.6.3'
     DEBIAN_BASE_VERSION: 'buster-v1.7.2'
-    IPTABLES_VERSION: '1.8.5'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.6.3'
+    IMAGE_VERSION: 'buster-v1.6.4'
     DEBIAN_BASE_VERSION: 'buster-v1.7.2'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:

This was a request from SIG Network folks the last time we bumped the
image. This makes our lives just a little easier not tracking this
dependency.

(Extracted from https://github.com/kubernetes/release/pull/1622.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian-iptables: Stop pinning the iptables version
- debian-iptables: Build buster-v1.6.4 image
```
