### PR TITLE
gcb/stage: Remove extraneous GITHUB_TOKEN from config

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -14,7 +14,6 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAIkWjMImwKwjbMsGh/N6QPg/AgdFo8f/6kNTBESxQLfTtWuMSUQBLz1D+ff3d7WKkopX86uyuO2xZH1k6KZRo2dXv6X5SbEkMoV5l6Bzm2owbIqJUMqWIyrMPJvNGi30iOERBOfbJ6IISMK81RDV+JmWzLCcANA==
     DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
 
 steps:
@@ -50,7 +49,6 @@ steps:
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
   secretEnv:
-  - GITHUB_TOKEN
   - DOCKERHUB_TOKEN
   args:
   - "bin/krel"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to https://github.com/kubernetes/release/pull/2127.

Given we no longer set an authenticated git environment in the staging
phase of the release, we no longer need to include the GitHub token in
the secrets environment.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- gcb/stage: Remove extraneous GITHUB_TOKEN from config

  Given we no longer set an authenticated git environment in the staging
  phase of the release, we no longer need to include the GitHub token in
  the secrets environment.
```
