### PR TITLE
Do not check GitHub token during stage

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -169,7 +169,9 @@ func (d *defaultStageImpl) ToFile(fileName string) error {
 }
 
 func (d *defaultStageImpl) CheckPrerequisites() error {
-	return release.NewPrerequisitesChecker().Run(workspaceDir)
+	preReqChecker := release.NewPrerequisitesChecker()
+	preReqChecker.Options().CheckGitHubToken = false
+	return preReqChecker.Run(workspaceDir)
 }
 
 func (d *defaultStageImpl) BranchNeedsCreation(

--- a/pkg/release/prerequisites.go
+++ b/pkg/release/prerequisites.go
@@ -34,11 +34,29 @@ import (
 // release.
 type PrerequisitesChecker struct {
 	impl prerequisitesCheckerImpl
+	opts *PrerequisitesCheckerOptions
+}
+
+// Type prerequisites checker
+type PrerequisitesCheckerOptions struct {
+	CheckGitHubToken bool
+}
+
+var DefaultPrerequisitesCheckerOptions = &PrerequisitesCheckerOptions{
+	CheckGitHubToken: true,
 }
 
 // NewPrerequisitesChecker creates a new PrerequisitesChecker instance.
 func NewPrerequisitesChecker() *PrerequisitesChecker {
-	return &PrerequisitesChecker{&defaultPrerequisitesChecker{}}
+	return &PrerequisitesChecker{
+		&defaultPrerequisitesChecker{},
+		DefaultPrerequisitesCheckerOptions,
+	}
+}
+
+// Options return the options from the prereq checker
+func (p *PrerequisitesChecker) Options() *PrerequisitesCheckerOptions {
+	return p.opts
 }
 
 // SetImpl can be used to set the internal PrerequisitesChecker implementation.
@@ -129,11 +147,13 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 	}
 
 	// GitHub checks
-	logrus.Infof(
-		"Verifying that %s environemt variable is set", github.TokenEnvKey,
-	)
-	if !p.impl.IsEnvSet(github.TokenEnvKey) {
-		return errors.Errorf("no %s env variable set", github.TokenEnvKey)
+	if p.opts.CheckGitHubToken {
+		logrus.Infof(
+			"Verifying that %s environemt variable is set", github.TokenEnvKey,
+		)
+		if !p.impl.IsEnvSet(github.TokenEnvKey) {
+			return errors.Errorf("no %s env variable set", github.TokenEnvKey)
+		}
 	}
 
 	// Disk space check


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR adds a new options set to `PrerequisitesChecker`. Right now it has only one option: `CheckGitHubToken`. When true, the checker will ensure the GitHub token is set. So during stage we can choose to run without it.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

Follow up to: https://github.com/kubernetes/release/pull/2137

#### Special notes for your reviewer:

/assign @justaugustus 
/priority critical-urgent
/milestone v1.22

#### Does this PR introduce a user-facing change?

```release-note
`PrerequisitesChecker` nos has options, currently the only one is `CheckGitHubToken`.  This bool allows us to run without setting the GITHUB_TOKEN variable when not needed
```
