### PR TITLE
Revert not checking GH token in stage

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -169,9 +169,7 @@ func (d *defaultStageImpl) ToFile(fileName string) error {
 }
 
 func (d *defaultStageImpl) CheckPrerequisites() error {
-	preReqChecker := release.NewPrerequisitesChecker()
-	preReqChecker.Options().CheckGitHubToken = false
-	return preReqChecker.Run(workspaceDir)
+	return release.NewPrerequisitesChecker().Run(workspaceDir)
 }
 
 func (d *defaultStageImpl) BranchNeedsCreation(


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it:

We need a GitHub token for release notes generation. This PR restores
checking the token before stage. The options for PrerequisitesChecker
are left in case we want to build a "fast stage" later.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:

/assign @justaugustus @xmudrii 


#### Does this PR introduce a user-facing change?


```release-note
None
```
