### PR TITLE
gcb/stage: Add read-only GITHUB_TOKEN to enable relnotes generation

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -14,6 +14,7 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
+    GITHUB_TOKEN: CiQAIkWjMFgubym04n054BpfS8ED1VAiDVzF2WtEAE9kpXL1HEASUQBLz1D++TFNeowLVAI8MAQ86xJvshtqevcU5lcHEo3K+39HHIZr3uojPto5vm235XkfWWeMM3/VBOwZoelmAyvY2RPHpo7u/Y9kKfCrJu5coA==
     DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
 
 steps:
@@ -49,6 +50,7 @@ steps:
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
   secretEnv:
+  - GITHUB_TOKEN
   - DOCKERHUB_TOKEN
   args:
   - "bin/krel"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to https://github.com/kubernetes/release/pull/2137 and https://github.com/kubernetes/release/pull/2127.
Needed for https://github.com/kubernetes/release/pull/2139 and https://github.com/kubernetes/sig-release/issues/1602.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
gcb/stage: Add read-only GITHUB_TOKEN to enable relnotes generation
```
