### PR TITLE
packages/deb: Use ci/latest.txt as canonical cross build marker

### DIFF
--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -289,7 +289,7 @@ func getCRIToolsLatestVersion() (string, error) {
 }
 
 func getLatestKubeCIBuild() (string, error) {
-	return fetchVersion("https://dl.k8s.io/ci-cross/latest.txt")
+	return fetchVersion("https://dl.k8s.io/ci/latest.txt")
 }
 
 func getCIBuildsDownloadLinkBase(_ version) (string, error) {
@@ -298,7 +298,7 @@ func getCIBuildsDownloadLinkBase(_ version) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("https://dl.k8s.io/ci-cross/v%s", latestCiVersion), nil
+	return fmt.Sprintf("https://dl.k8s.io/ci/v%s", latestCiVersion), nil
 }
 
 func getReleaseDownloadLinkBase(v version) (string, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As of https://github.com/kubernetes/k8s.io/pull/1857, https://dl.k8s.io/ci now redirects to Kubernetes Community infra (`gs://k8s-release-dev`) instead of Google-owned infra (`gs://kubernetes-release-dev`).

We also removed `ci-cross` version markers, which are:
1. no longer built
2. redundant, as compared with https://dl.k8s.io/ci/latest.txt

Here we update references to https://dl.k8s.io/ci-cross with https://dl.k8s.io/ci

Part of https://github.com/kubernetes/release/issues/1711 and https://github.com/kubernetes/k8s.io/issues/1569.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato @saschagrunert
cc: @kubernetes/release-engineering @kubernetes/build-admins 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- packages/deb: Use ci/latest.txt as canonical cross build marker
```
