### PR TITLE
Final fixes for initial 2-SBOM release

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -45,6 +45,9 @@ const (
 
 	// releaseNotesJSONFile is the file containing the release notes in json format
 	releaseNotesJSONFile = workspaceDir + "/src/release-notes.json"
+
+	// The default license for all artifacts
+	LicenseIdentifier = "Apache-2.0"
 )
 
 // Options are settings which will be used by `StageOptions` as well as

--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -30,6 +30,30 @@ import (
 )
 
 type FakeStageImpl struct {
+	AddBinariesToSBOMStub        func(*spdx.Document, string) error
+	addBinariesToSBOMMutex       sync.RWMutex
+	addBinariesToSBOMArgsForCall []struct {
+		arg1 *spdx.Document
+		arg2 string
+	}
+	addBinariesToSBOMReturns struct {
+		result1 error
+	}
+	addBinariesToSBOMReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddTarfilesToSBOMStub        func(*spdx.Document, string) error
+	addTarfilesToSBOMMutex       sync.RWMutex
+	addTarfilesToSBOMArgsForCall []struct {
+		arg1 *spdx.Document
+		arg2 string
+	}
+	addTarfilesToSBOMReturns struct {
+		result1 error
+	}
+	addTarfilesToSBOMReturnsOnCall map[int]struct {
+		result1 error
+	}
 	BranchNeedsCreationStub        func(string, string, semver.Version) (bool, error)
 	branchNeedsCreationMutex       sync.RWMutex
 	branchNeedsCreationArgsForCall []struct {
@@ -43,6 +67,19 @@ type FakeStageImpl struct {
 	}
 	branchNeedsCreationReturnsOnCall map[int]struct {
 		result1 bool
+		result2 error
+	}
+	BuildBaseArtifactsSBOMStub        func(*spdx.DocGenerateOptions) (*spdx.Document, error)
+	buildBaseArtifactsSBOMMutex       sync.RWMutex
+	buildBaseArtifactsSBOMArgsForCall []struct {
+		arg1 *spdx.DocGenerateOptions
+	}
+	buildBaseArtifactsSBOMReturns struct {
+		result1 *spdx.Document
+		result2 error
+	}
+	buildBaseArtifactsSBOMReturnsOnCall map[int]struct {
+		result1 *spdx.Document
 		result2 error
 	}
 	CheckPrerequisitesStub        func() error
@@ -154,10 +191,10 @@ type FakeStageImpl struct {
 		result1 *spdx.Document
 		result2 error
 	}
-	GenerateVersionArtifactsBOMStub        func(*spdx.DocGenerateOptions) error
+	GenerateVersionArtifactsBOMStub        func(string) error
 	generateVersionArtifactsBOMMutex       sync.RWMutex
 	generateVersionArtifactsBOMArgsForCall []struct {
-		arg1 *spdx.DocGenerateOptions
+		arg1 string
 	}
 	generateVersionArtifactsBOMReturns struct {
 		result1 error
@@ -165,17 +202,55 @@ type FakeStageImpl struct {
 	generateVersionArtifactsBOMReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ListArtifactsStub        func(string) (map[string][]string, error)
-	listArtifactsMutex       sync.RWMutex
-	listArtifactsArgsForCall []struct {
+	ListBinariesStub func(string) ([]struct {
+		Path     string
+		Platform string
+		Arch     string
+	}, error)
+	listBinariesMutex       sync.RWMutex
+	listBinariesArgsForCall []struct {
 		arg1 string
 	}
-	listArtifactsReturns struct {
-		result1 map[string][]string
+	listBinariesReturns struct {
+		result1 []struct {
+			Path     string
+			Platform string
+			Arch     string
+		}
 		result2 error
 	}
-	listArtifactsReturnsOnCall map[int]struct {
-		result1 map[string][]string
+	listBinariesReturnsOnCall map[int]struct {
+		result1 []struct {
+			Path     string
+			Platform string
+			Arch     string
+		}
+		result2 error
+	}
+	ListImageArchivesStub        func(string) ([]string, error)
+	listImageArchivesMutex       sync.RWMutex
+	listImageArchivesArgsForCall []struct {
+		arg1 string
+	}
+	listImageArchivesReturns struct {
+		result1 []string
+		result2 error
+	}
+	listImageArchivesReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
+	ListTarballsStub        func(string) ([]string, error)
+	listTarballsMutex       sync.RWMutex
+	listTarballsArgsForCall []struct {
+		arg1 string
+	}
+	listTarballsReturns struct {
+		result1 []string
+		result2 error
+	}
+	listTarballsReturnsOnCall map[int]struct {
+		result1 []string
 		result2 error
 	}
 	MakeCrossStub        func(string) error
@@ -339,6 +414,130 @@ type FakeStageImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
+func (fake *FakeStageImpl) AddBinariesToSBOM(arg1 *spdx.Document, arg2 string) error {
+	fake.addBinariesToSBOMMutex.Lock()
+	ret, specificReturn := fake.addBinariesToSBOMReturnsOnCall[len(fake.addBinariesToSBOMArgsForCall)]
+	fake.addBinariesToSBOMArgsForCall = append(fake.addBinariesToSBOMArgsForCall, struct {
+		arg1 *spdx.Document
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.AddBinariesToSBOMStub
+	fakeReturns := fake.addBinariesToSBOMReturns
+	fake.recordInvocation("AddBinariesToSBOM", []interface{}{arg1, arg2})
+	fake.addBinariesToSBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) AddBinariesToSBOMCallCount() int {
+	fake.addBinariesToSBOMMutex.RLock()
+	defer fake.addBinariesToSBOMMutex.RUnlock()
+	return len(fake.addBinariesToSBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) AddBinariesToSBOMCalls(stub func(*spdx.Document, string) error) {
+	fake.addBinariesToSBOMMutex.Lock()
+	defer fake.addBinariesToSBOMMutex.Unlock()
+	fake.AddBinariesToSBOMStub = stub
+}
+
+func (fake *FakeStageImpl) AddBinariesToSBOMArgsForCall(i int) (*spdx.Document, string) {
+	fake.addBinariesToSBOMMutex.RLock()
+	defer fake.addBinariesToSBOMMutex.RUnlock()
+	argsForCall := fake.addBinariesToSBOMArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) AddBinariesToSBOMReturns(result1 error) {
+	fake.addBinariesToSBOMMutex.Lock()
+	defer fake.addBinariesToSBOMMutex.Unlock()
+	fake.AddBinariesToSBOMStub = nil
+	fake.addBinariesToSBOMReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) AddBinariesToSBOMReturnsOnCall(i int, result1 error) {
+	fake.addBinariesToSBOMMutex.Lock()
+	defer fake.addBinariesToSBOMMutex.Unlock()
+	fake.AddBinariesToSBOMStub = nil
+	if fake.addBinariesToSBOMReturnsOnCall == nil {
+		fake.addBinariesToSBOMReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addBinariesToSBOMReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOM(arg1 *spdx.Document, arg2 string) error {
+	fake.addTarfilesToSBOMMutex.Lock()
+	ret, specificReturn := fake.addTarfilesToSBOMReturnsOnCall[len(fake.addTarfilesToSBOMArgsForCall)]
+	fake.addTarfilesToSBOMArgsForCall = append(fake.addTarfilesToSBOMArgsForCall, struct {
+		arg1 *spdx.Document
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.AddTarfilesToSBOMStub
+	fakeReturns := fake.addTarfilesToSBOMReturns
+	fake.recordInvocation("AddTarfilesToSBOM", []interface{}{arg1, arg2})
+	fake.addTarfilesToSBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOMCallCount() int {
+	fake.addTarfilesToSBOMMutex.RLock()
+	defer fake.addTarfilesToSBOMMutex.RUnlock()
+	return len(fake.addTarfilesToSBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOMCalls(stub func(*spdx.Document, string) error) {
+	fake.addTarfilesToSBOMMutex.Lock()
+	defer fake.addTarfilesToSBOMMutex.Unlock()
+	fake.AddTarfilesToSBOMStub = stub
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOMArgsForCall(i int) (*spdx.Document, string) {
+	fake.addTarfilesToSBOMMutex.RLock()
+	defer fake.addTarfilesToSBOMMutex.RUnlock()
+	argsForCall := fake.addTarfilesToSBOMArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOMReturns(result1 error) {
+	fake.addTarfilesToSBOMMutex.Lock()
+	defer fake.addTarfilesToSBOMMutex.Unlock()
+	fake.AddTarfilesToSBOMStub = nil
+	fake.addTarfilesToSBOMReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) AddTarfilesToSBOMReturnsOnCall(i int, result1 error) {
+	fake.addTarfilesToSBOMMutex.Lock()
+	defer fake.addTarfilesToSBOMMutex.Unlock()
+	fake.AddTarfilesToSBOMStub = nil
+	if fake.addTarfilesToSBOMReturnsOnCall == nil {
+		fake.addTarfilesToSBOMReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addTarfilesToSBOMReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageImpl) BranchNeedsCreation(arg1 string, arg2 string, arg3 semver.Version) (bool, error) {
 	fake.branchNeedsCreationMutex.Lock()
 	ret, specificReturn := fake.branchNeedsCreationReturnsOnCall[len(fake.branchNeedsCreationArgsForCall)]
@@ -401,6 +600,70 @@ func (fake *FakeStageImpl) BranchNeedsCreationReturnsOnCall(i int, result1 bool,
 	}
 	fake.branchNeedsCreationReturnsOnCall[i] = struct {
 		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOM(arg1 *spdx.DocGenerateOptions) (*spdx.Document, error) {
+	fake.buildBaseArtifactsSBOMMutex.Lock()
+	ret, specificReturn := fake.buildBaseArtifactsSBOMReturnsOnCall[len(fake.buildBaseArtifactsSBOMArgsForCall)]
+	fake.buildBaseArtifactsSBOMArgsForCall = append(fake.buildBaseArtifactsSBOMArgsForCall, struct {
+		arg1 *spdx.DocGenerateOptions
+	}{arg1})
+	stub := fake.BuildBaseArtifactsSBOMStub
+	fakeReturns := fake.buildBaseArtifactsSBOMReturns
+	fake.recordInvocation("BuildBaseArtifactsSBOM", []interface{}{arg1})
+	fake.buildBaseArtifactsSBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOMCallCount() int {
+	fake.buildBaseArtifactsSBOMMutex.RLock()
+	defer fake.buildBaseArtifactsSBOMMutex.RUnlock()
+	return len(fake.buildBaseArtifactsSBOMArgsForCall)
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOMCalls(stub func(*spdx.DocGenerateOptions) (*spdx.Document, error)) {
+	fake.buildBaseArtifactsSBOMMutex.Lock()
+	defer fake.buildBaseArtifactsSBOMMutex.Unlock()
+	fake.BuildBaseArtifactsSBOMStub = stub
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOMArgsForCall(i int) *spdx.DocGenerateOptions {
+	fake.buildBaseArtifactsSBOMMutex.RLock()
+	defer fake.buildBaseArtifactsSBOMMutex.RUnlock()
+	argsForCall := fake.buildBaseArtifactsSBOMArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOMReturns(result1 *spdx.Document, result2 error) {
+	fake.buildBaseArtifactsSBOMMutex.Lock()
+	defer fake.buildBaseArtifactsSBOMMutex.Unlock()
+	fake.BuildBaseArtifactsSBOMStub = nil
+	fake.buildBaseArtifactsSBOMReturns = struct {
+		result1 *spdx.Document
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) BuildBaseArtifactsSBOMReturnsOnCall(i int, result1 *spdx.Document, result2 error) {
+	fake.buildBaseArtifactsSBOMMutex.Lock()
+	defer fake.buildBaseArtifactsSBOMMutex.Unlock()
+	fake.BuildBaseArtifactsSBOMStub = nil
+	if fake.buildBaseArtifactsSBOMReturnsOnCall == nil {
+		fake.buildBaseArtifactsSBOMReturnsOnCall = make(map[int]struct {
+			result1 *spdx.Document
+			result2 error
+		})
+	}
+	fake.buildBaseArtifactsSBOMReturnsOnCall[i] = struct {
+		result1 *spdx.Document
 		result2 error
 	}{result1, result2}
 }
@@ -953,11 +1216,11 @@ func (fake *FakeStageImpl) GenerateSourceTreeBOMReturnsOnCall(i int, result1 *sp
 	}{result1, result2}
 }
 
-func (fake *FakeStageImpl) GenerateVersionArtifactsBOM(arg1 *spdx.DocGenerateOptions) error {
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOM(arg1 string) error {
 	fake.generateVersionArtifactsBOMMutex.Lock()
 	ret, specificReturn := fake.generateVersionArtifactsBOMReturnsOnCall[len(fake.generateVersionArtifactsBOMArgsForCall)]
 	fake.generateVersionArtifactsBOMArgsForCall = append(fake.generateVersionArtifactsBOMArgsForCall, struct {
-		arg1 *spdx.DocGenerateOptions
+		arg1 string
 	}{arg1})
 	stub := fake.GenerateVersionArtifactsBOMStub
 	fakeReturns := fake.generateVersionArtifactsBOMReturns
@@ -978,13 +1241,13 @@ func (fake *FakeStageImpl) GenerateVersionArtifactsBOMCallCount() int {
 	return len(fake.generateVersionArtifactsBOMArgsForCall)
 }
 
-func (fake *FakeStageImpl) GenerateVersionArtifactsBOMCalls(stub func(*spdx.DocGenerateOptions) error) {
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMCalls(stub func(string) error) {
 	fake.generateVersionArtifactsBOMMutex.Lock()
 	defer fake.generateVersionArtifactsBOMMutex.Unlock()
 	fake.GenerateVersionArtifactsBOMStub = stub
 }
 
-func (fake *FakeStageImpl) GenerateVersionArtifactsBOMArgsForCall(i int) *spdx.DocGenerateOptions {
+func (fake *FakeStageImpl) GenerateVersionArtifactsBOMArgsForCall(i int) string {
 	fake.generateVersionArtifactsBOMMutex.RLock()
 	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
 	argsForCall := fake.generateVersionArtifactsBOMArgsForCall[i]
@@ -1014,16 +1277,20 @@ func (fake *FakeStageImpl) GenerateVersionArtifactsBOMReturnsOnCall(i int, resul
 	}{result1}
 }
 
-func (fake *FakeStageImpl) ListArtifacts(arg1 string) (map[string][]string, error) {
-	fake.listArtifactsMutex.Lock()
-	ret, specificReturn := fake.listArtifactsReturnsOnCall[len(fake.listArtifactsArgsForCall)]
-	fake.listArtifactsArgsForCall = append(fake.listArtifactsArgsForCall, struct {
+func (fake *FakeStageImpl) ListBinaries(arg1 string) ([]struct {
+	Path     string
+	Platform string
+	Arch     string
+}, error) {
+	fake.listBinariesMutex.Lock()
+	ret, specificReturn := fake.listBinariesReturnsOnCall[len(fake.listBinariesArgsForCall)]
+	fake.listBinariesArgsForCall = append(fake.listBinariesArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListArtifactsStub
-	fakeReturns := fake.listArtifactsReturns
-	fake.recordInvocation("ListArtifacts", []interface{}{arg1})
-	fake.listArtifactsMutex.Unlock()
+	stub := fake.ListBinariesStub
+	fakeReturns := fake.listBinariesReturns
+	fake.recordInvocation("ListBinaries", []interface{}{arg1})
+	fake.listBinariesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
 	}
@@ -1033,47 +1300,199 @@ func (fake *FakeStageImpl) ListArtifacts(arg1 string) (map[string][]string, erro
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeStageImpl) ListArtifactsCallCount() int {
-	fake.listArtifactsMutex.RLock()
-	defer fake.listArtifactsMutex.RUnlock()
-	return len(fake.listArtifactsArgsForCall)
+func (fake *FakeStageImpl) ListBinariesCallCount() int {
+	fake.listBinariesMutex.RLock()
+	defer fake.listBinariesMutex.RUnlock()
+	return len(fake.listBinariesArgsForCall)
 }
 
-func (fake *FakeStageImpl) ListArtifactsCalls(stub func(string) (map[string][]string, error)) {
-	fake.listArtifactsMutex.Lock()
-	defer fake.listArtifactsMutex.Unlock()
-	fake.ListArtifactsStub = stub
+func (fake *FakeStageImpl) ListBinariesCalls(stub func(string) ([]struct {
+	Path     string
+	Platform string
+	Arch     string
+}, error)) {
+	fake.listBinariesMutex.Lock()
+	defer fake.listBinariesMutex.Unlock()
+	fake.ListBinariesStub = stub
 }
 
-func (fake *FakeStageImpl) ListArtifactsArgsForCall(i int) string {
-	fake.listArtifactsMutex.RLock()
-	defer fake.listArtifactsMutex.RUnlock()
-	argsForCall := fake.listArtifactsArgsForCall[i]
+func (fake *FakeStageImpl) ListBinariesArgsForCall(i int) string {
+	fake.listBinariesMutex.RLock()
+	defer fake.listBinariesMutex.RUnlock()
+	argsForCall := fake.listBinariesArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeStageImpl) ListArtifactsReturns(result1 map[string][]string, result2 error) {
-	fake.listArtifactsMutex.Lock()
-	defer fake.listArtifactsMutex.Unlock()
-	fake.ListArtifactsStub = nil
-	fake.listArtifactsReturns = struct {
-		result1 map[string][]string
+func (fake *FakeStageImpl) ListBinariesReturns(result1 []struct {
+	Path     string
+	Platform string
+	Arch     string
+}, result2 error) {
+	fake.listBinariesMutex.Lock()
+	defer fake.listBinariesMutex.Unlock()
+	fake.ListBinariesStub = nil
+	fake.listBinariesReturns = struct {
+		result1 []struct {
+			Path     string
+			Platform string
+			Arch     string
+		}
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeStageImpl) ListArtifactsReturnsOnCall(i int, result1 map[string][]string, result2 error) {
-	fake.listArtifactsMutex.Lock()
-	defer fake.listArtifactsMutex.Unlock()
-	fake.ListArtifactsStub = nil
-	if fake.listArtifactsReturnsOnCall == nil {
-		fake.listArtifactsReturnsOnCall = make(map[int]struct {
-			result1 map[string][]string
+func (fake *FakeStageImpl) ListBinariesReturnsOnCall(i int, result1 []struct {
+	Path     string
+	Platform string
+	Arch     string
+}, result2 error) {
+	fake.listBinariesMutex.Lock()
+	defer fake.listBinariesMutex.Unlock()
+	fake.ListBinariesStub = nil
+	if fake.listBinariesReturnsOnCall == nil {
+		fake.listBinariesReturnsOnCall = make(map[int]struct {
+			result1 []struct {
+				Path     string
+				Platform string
+				Arch     string
+			}
 			result2 error
 		})
 	}
-	fake.listArtifactsReturnsOnCall[i] = struct {
-		result1 map[string][]string
+	fake.listBinariesReturnsOnCall[i] = struct {
+		result1 []struct {
+			Path     string
+			Platform string
+			Arch     string
+		}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) ListImageArchives(arg1 string) ([]string, error) {
+	fake.listImageArchivesMutex.Lock()
+	ret, specificReturn := fake.listImageArchivesReturnsOnCall[len(fake.listImageArchivesArgsForCall)]
+	fake.listImageArchivesArgsForCall = append(fake.listImageArchivesArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListImageArchivesStub
+	fakeReturns := fake.listImageArchivesReturns
+	fake.recordInvocation("ListImageArchives", []interface{}{arg1})
+	fake.listImageArchivesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) ListImageArchivesCallCount() int {
+	fake.listImageArchivesMutex.RLock()
+	defer fake.listImageArchivesMutex.RUnlock()
+	return len(fake.listImageArchivesArgsForCall)
+}
+
+func (fake *FakeStageImpl) ListImageArchivesCalls(stub func(string) ([]string, error)) {
+	fake.listImageArchivesMutex.Lock()
+	defer fake.listImageArchivesMutex.Unlock()
+	fake.ListImageArchivesStub = stub
+}
+
+func (fake *FakeStageImpl) ListImageArchivesArgsForCall(i int) string {
+	fake.listImageArchivesMutex.RLock()
+	defer fake.listImageArchivesMutex.RUnlock()
+	argsForCall := fake.listImageArchivesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) ListImageArchivesReturns(result1 []string, result2 error) {
+	fake.listImageArchivesMutex.Lock()
+	defer fake.listImageArchivesMutex.Unlock()
+	fake.ListImageArchivesStub = nil
+	fake.listImageArchivesReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) ListImageArchivesReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listImageArchivesMutex.Lock()
+	defer fake.listImageArchivesMutex.Unlock()
+	fake.ListImageArchivesStub = nil
+	if fake.listImageArchivesReturnsOnCall == nil {
+		fake.listImageArchivesReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listImageArchivesReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) ListTarballs(arg1 string) ([]string, error) {
+	fake.listTarballsMutex.Lock()
+	ret, specificReturn := fake.listTarballsReturnsOnCall[len(fake.listTarballsArgsForCall)]
+	fake.listTarballsArgsForCall = append(fake.listTarballsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListTarballsStub
+	fakeReturns := fake.listTarballsReturns
+	fake.recordInvocation("ListTarballs", []interface{}{arg1})
+	fake.listTarballsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) ListTarballsCallCount() int {
+	fake.listTarballsMutex.RLock()
+	defer fake.listTarballsMutex.RUnlock()
+	return len(fake.listTarballsArgsForCall)
+}
+
+func (fake *FakeStageImpl) ListTarballsCalls(stub func(string) ([]string, error)) {
+	fake.listTarballsMutex.Lock()
+	defer fake.listTarballsMutex.Unlock()
+	fake.ListTarballsStub = stub
+}
+
+func (fake *FakeStageImpl) ListTarballsArgsForCall(i int) string {
+	fake.listTarballsMutex.RLock()
+	defer fake.listTarballsMutex.RUnlock()
+	argsForCall := fake.listTarballsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) ListTarballsReturns(result1 []string, result2 error) {
+	fake.listTarballsMutex.Lock()
+	defer fake.listTarballsMutex.Unlock()
+	fake.ListTarballsStub = nil
+	fake.listTarballsReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) ListTarballsReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listTarballsMutex.Lock()
+	defer fake.listTarballsMutex.Unlock()
+	fake.ListTarballsStub = nil
+	if fake.listTarballsReturnsOnCall == nil {
+		fake.listTarballsReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listTarballsReturnsOnCall[i] = struct {
+		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -1884,8 +2303,14 @@ func (fake *FakeStageImpl) WriteSourceBOMReturnsOnCall(i int, result1 error) {
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.addBinariesToSBOMMutex.RLock()
+	defer fake.addBinariesToSBOMMutex.RUnlock()
+	fake.addTarfilesToSBOMMutex.RLock()
+	defer fake.addTarfilesToSBOMMutex.RUnlock()
 	fake.branchNeedsCreationMutex.RLock()
 	defer fake.branchNeedsCreationMutex.RUnlock()
+	fake.buildBaseArtifactsSBOMMutex.RLock()
+	defer fake.buildBaseArtifactsSBOMMutex.RUnlock()
 	fake.checkPrerequisitesMutex.RLock()
 	defer fake.checkPrerequisitesMutex.RUnlock()
 	fake.checkReleaseBucketMutex.RLock()
@@ -1906,8 +2331,12 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.generateSourceTreeBOMMutex.RUnlock()
 	fake.generateVersionArtifactsBOMMutex.RLock()
 	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
-	fake.listArtifactsMutex.RLock()
-	defer fake.listArtifactsMutex.RUnlock()
+	fake.listBinariesMutex.RLock()
+	defer fake.listBinariesMutex.RUnlock()
+	fake.listImageArchivesMutex.RLock()
+	defer fake.listImageArchivesMutex.RUnlock()
+	fake.listTarballsMutex.RLock()
+	defer fake.listTarballsMutex.RUnlock()
 	fake.makeCrossMutex.RLock()
 	defer fake.makeCrossMutex.RUnlock()
 	fake.openRepoMutex.RLock()

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -662,6 +662,7 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 	// in WriteSourceBOM() before writing the actual files.
 	spdxDOC, err := d.impl.GenerateSourceTreeBOM(&spdx.DocGenerateOptions{
 		ProcessGoModules: true,
+		License:          "Apache-2.0",
 		OutputFile:       "/tmp/kubernetes-source.spdx",
 		Namespace:        "http://k8s.io/sbom/source/REPLACE",
 		ScanLicenses:     true,
@@ -681,11 +682,11 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 		if err := d.impl.GenerateVersionArtifactsBOM(&spdx.DocGenerateOptions{
 			AnalyseLayers:  false,
 			OnlyDirectDeps: false,
-			// License:          "Apache-2.0", // Needs https://github.com/kubernetes/release/pull/2096
-			Namespace:    fmt.Sprintf("https://k8s.io/sbom/release/%s", version),
-			ScanLicenses: false,
-			Tarballs:     artifactsList["images"],
-			Files:        artifactsList["binaries"],
+			License:        "Apache-2.0",
+			Namespace:      fmt.Sprintf("https://k8s.io/sbom/release/%s", version),
+			ScanLicenses:   false,
+			Tarballs:       artifactsList["images"],
+			Files:          artifactsList["binaries"],
 			OutputFile: filepath.Join(
 				os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", version),
 			),

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -551,10 +551,11 @@ func (d *defaultStageImpl) AddBinariesToSBOM(sbom *spdx.Document, version string
 			return errors.Wrap(err, "adding file to artifacts sbom")
 		}
 		file.AddRelationship(&spdx.Relationship{
-			FullRender:    false,
-			PeerReference: fmt.Sprintf("DocumentRef-kubernetes-%s", version),
-			Comment:       "Source code",
-			Type:          spdx.GENERATED_FROM,
+			FullRender:       false,
+			PeerReference:    "SPDXRef-Package-kubernetes",
+			PeerExtReference: fmt.Sprintf("kubernetes-%s", version),
+			Comment:          "Source code",
+			Type:             spdx.GENERATED_FROM,
 		})
 	}
 	return nil
@@ -580,10 +581,11 @@ func (d *defaultStageImpl) AddTarfilesToSBOM(sbom *spdx.Document, version string
 			return errors.Wrap(err, "adding file to artifacts sbom")
 		}
 		file.AddRelationship(&spdx.Relationship{
-			FullRender:    false,
-			PeerReference: fmt.Sprintf("DocumentRef-kubernetes-%s", version),
-			Comment:       "Source code",
-			Type:          spdx.GENERATED_FROM,
+			FullRender:       false,
+			PeerReference:    "SPDXRef-Package-kubernetes",
+			PeerExtReference: fmt.Sprintf("kubernetes-%s", version),
+			Comment:          "Source code",
+			Type:             spdx.GENERATED_FROM,
 		})
 	}
 	return nil
@@ -639,10 +641,11 @@ func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
 	// Stamp all packages. We do this here because it includes both images and
 	for _, pkg := range doc.Packages {
 		pkg.AddRelationship(&spdx.Relationship{
-			FullRender:    false,
-			PeerReference: fmt.Sprintf("DocumentRef-kubernetes-%s", version),
-			Comment:       "Source code",
-			Type:          spdx.GENERATED_FROM,
+			FullRender:       false,
+			PeerReference:    "SPDXRef-Package-kubernetes",
+			PeerExtReference: fmt.Sprintf("kubernetes-%s", version),
+			Comment:          "Source code",
+			Type:             spdx.GENERATED_FROM,
 		})
 	}
 

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/spdx"
 	"sigs.k8s.io/release-utils/log"
-	"sigs.k8s.io/release-utils/util"
 )
 
 // stageClient is a client for staging releases.
@@ -154,10 +153,15 @@ type stageImpl interface {
 		options *build.Options, srcPath, gcsPath string,
 	) error
 	PushContainerImages(options *build.Options) error
-	GenerateVersionArtifactsBOM(options *spdx.DocGenerateOptions) error
+	GenerateVersionArtifactsBOM(string) error
 	GenerateSourceTreeBOM(options *spdx.DocGenerateOptions) (*spdx.Document, error)
 	WriteSourceBOM(spdxDoc *spdx.Document, version string) error
-	ListArtifacts(version string) (map[string][]string, error)
+	ListBinaries(version string) ([]struct{ Path, Platform, Arch string }, error)
+	ListImageArchives(string) ([]string, error)
+	ListTarballs(version string) ([]string, error)
+	BuildBaseArtifactsSBOM(*spdx.DocGenerateOptions) (*spdx.Document, error)
+	AddBinariesToSBOM(*spdx.Document, string) error
+	AddTarfilesToSBOM(*spdx.Document, string) error
 }
 
 func (d *defaultStageImpl) Submit(options *gcb.Options) error {
@@ -275,122 +279,21 @@ func (d *DefaultStage) Submit(stream bool) error {
 	return d.impl.Submit(options)
 }
 
-// ListArtifacts is a function lists the release artifacts, will be
-// replaced once the supported platforms code is ready
-func (d *defaultStageImpl) ListArtifacts(version string) (list map[string][]string, err error) {
-	list = map[string][]string{
-		"images":   {},
-		"binaries": {},
-	}
-	buildDir := filepath.Join(
-		gitRoot, fmt.Sprintf("%s-%s", release.BuildDir, version),
-	)
+// ListBinaries returns a list of all the binaries obtained
+// from the build with platform and arch details
+func (d *defaultStageImpl) ListBinaries(version string) (list []struct{ Path, Platform, Arch string }, err error) {
+	return release.ListBuildBinaries(gitRoot, version)
+}
 
-	// Stage 1: add all image archives:
-	arches, err := os.ReadDir(filepath.Join(buildDir, release.ImagesPath))
-	if err != nil {
-		return nil, errors.Wrap(err, "opening images directory")
-	}
-	for _, arch := range arches {
-		if !arch.IsDir() {
-			continue
-		}
-		images, err := os.ReadDir(filepath.Join(buildDir, release.ImagesPath, arch.Name()))
-		if err != nil {
-			return nil, errors.Wrapf(err, "opening %s images directory", arch.Name())
-		}
-		for _, tarball := range images {
-			list["images"] = append(list["images"],
-				filepath.Join(buildDir, release.ImagesPath, arch.Name(), tarball.Name()),
-			)
-		}
-	}
+// ListImageArchives returns a list of the image archives produced
+// fior the specified version
+func (d *defaultStageImpl) ListImageArchives(version string) ([]string, error) {
+	return release.ListBuildImages(gitRoot, version)
+}
 
-	// Stage 2: add the naked binaries:
-	rootPath := filepath.Join(buildDir, release.ReleaseStagePath)
-	platformsPath := filepath.Join(rootPath, "client")
-	if !util.Exists(platformsPath) {
-		logrus.Infof("Not adding binaries as %s was not found", platformsPath)
-		return list, nil
-	}
-	platformsAndArches, err := os.ReadDir(platformsPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "retrieve platforms from %s", platformsPath)
-	}
-
-	for _, platformArch := range platformsAndArches {
-		if !platformArch.IsDir() {
-			logrus.Warnf(
-				"Skipping platform and arch %q because it's not a directory",
-				platformArch.Name(),
-			)
-			continue
-		}
-
-		split := strings.Split(platformArch.Name(), "-")
-		if len(split) != 2 {
-			return nil, errors.Errorf(
-				"expected `platform-arch` format for %s", platformArch.Name(),
-			)
-		}
-
-		platform := split[0]
-		arch := split[1]
-		logrus.Infof(
-			"Copying binaries for %s platform on %s arch", platform, arch,
-		)
-
-		src := filepath.Join(
-			rootPath, "client", platformArch.Name(), "kubernetes", "client", "bin",
-		)
-
-		// We assume here the "server package" is a superset of the "client
-		// package"
-		serverSrc := filepath.Join(rootPath, "server", platformArch.Name())
-		if util.Exists(serverSrc) {
-			logrus.Infof("Server source found in %s, copying them", serverSrc)
-			src = filepath.Join(serverSrc, "kubernetes", "server", "bin")
-		}
-
-		if err := filepath.Walk(src,
-			func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				if info.IsDir() {
-					return nil
-				}
-
-				list["binaries"] = append(list["binaries"], path)
-				return nil
-			},
-		); err != nil {
-			return nil, errors.Wrapf(err, "gathering binaries from %s", src)
-		}
-
-		// ADD node binaries
-		// Copy node binaries if they exist and this isn't a 'server' platform
-		nodeSrc := filepath.Join(rootPath, "node", platformArch.Name())
-		if !util.Exists(serverSrc) && util.Exists(nodeSrc) {
-			src = filepath.Join(nodeSrc, "kubernetes", "node", "bin")
-			if err := filepath.Walk(src,
-				func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if info.IsDir() {
-						return nil
-					}
-
-					list["binaries"] = append(list["binaries"], path)
-					return nil
-				},
-			); err != nil {
-				return nil, errors.Wrapf(err, "gathering node binaries from %s", src)
-			}
-		}
-	}
-	return list, nil
+// ListTarballs returns the produced tarballs produced for this version
+func (d *defaultStageImpl) ListTarballs(version string) ([]string, error) {
+	return release.ListBuildTarballs(gitRoot, version)
 }
 
 func (d *DefaultStage) InitLogFile() error {
@@ -628,10 +531,91 @@ func (d *DefaultStage) GenerateChangelog() error {
 	})
 }
 
-func (d *defaultStageImpl) GenerateVersionArtifactsBOM(options *spdx.DocGenerateOptions) error {
+// AddBinariesToSBOM reads the produced "naked" binaries and adds them to the sbom
+func (d *defaultStageImpl) AddBinariesToSBOM(sbom *spdx.Document, version string) error {
+	binaries, err := d.ListBinaries(version)
+	if err != nil {
+		return errors.Wrapf(err, "Getting binaries list for %s", version)
+	}
+
+	// Add the binaries, taking care of their docs
+	for _, bin := range binaries {
+		file := spdx.NewFile()
+		if err := file.ReadSourceFile(bin.Path); err != nil {
+			return errors.Wrapf(err, "reading binary sourcefile from %s", bin.Path)
+		}
+		file.Name = filepath.Join("bin", bin.Platform, bin.Arch, filepath.Base(bin.Path))
+		file.FileName = file.Name
+		file.LicenseConcluded = LicenseIdentifier
+		if err := sbom.AddFile(file); err != nil {
+			return errors.Wrap(err, "adding file to artifacts sbom")
+		}
+	}
+	return nil
+}
+
+// AddImagesToSBOM reads the image archives from disk and adds them to the sbom
+func (d *defaultStageImpl) AddTarfilesToSBOM(sbom *spdx.Document, version string) error {
+	tarballs, err := d.ListTarballs(version)
+	if err != nil {
+		return errors.Wrapf(err, "listing release tarballs for %s", version)
+	}
+
+	// Once the initial doc is generated, add the tarfiles
+	for _, tar := range tarballs {
+		file := spdx.NewFile()
+		if err := file.ReadSourceFile(tar); err != nil {
+			return errors.Wrapf(err, "reading tarball sourcefile from %s", tar)
+		}
+		file.Name = filepath.Base(tar)
+		file.LicenseConcluded = LicenseIdentifier
+		file.FileName = filepath.Base(tar)
+		if err := sbom.AddFile(file); err != nil {
+			return errors.Wrap(err, "adding file to artifacts sbom")
+		}
+	}
+	return nil
+}
+
+func (d *defaultStageImpl) BuildBaseArtifactsSBOM(options *spdx.DocGenerateOptions) (*spdx.Document, error) {
 	logrus.Info("Generating release artifacts SBOM")
-	_, err := spdx.NewDocBuilder().Generate(options)
-	return errors.Wrap(err, "generating bill of materials")
+	return spdx.NewDocBuilder().Generate(options)
+}
+
+func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
+	images, err := d.ListImageArchives(version)
+	if err != nil {
+		return errors.Wrap(err, "getting artifacts list")
+	}
+
+	// Build the base artifacts sbom. We only pass it the images for
+	// now as the binaries and tarballs need more processing
+	doc, err := d.BuildBaseArtifactsSBOM(&spdx.DocGenerateOptions{
+		Name:           fmt.Sprintf("Kubernetes Release %s", version),
+		AnalyseLayers:  false,
+		OnlyDirectDeps: false,
+		License:        LicenseIdentifier,
+		Namespace:      fmt.Sprintf("https://k8s.io/sbom/release/%s", version),
+		ScanLicenses:   false,
+		Tarballs:       images,
+		OutputFile:     filepath.Join(),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "generating base artifacts sbom for %s", version)
+	}
+
+	// Add the binaries and tarballs
+	if err := d.AddBinariesToSBOM(doc, version); err != nil {
+		return errors.Wrapf(err, "adding binaries to %s SBOM", version)
+	}
+	if err := d.AddTarfilesToSBOM(doc, version); err != nil {
+		return errors.Wrapf(err, "adding tarballs to %s SBOM", version)
+	}
+
+	if err := doc.Write(filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", version))); err != nil {
+		return errors.Wrapf(err, "writing artifacts SBOM for %s", version)
+	}
+	return nil
 }
 
 func (d *defaultStageImpl) GenerateSourceTreeBOM(
@@ -662,7 +646,7 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 	// in WriteSourceBOM() before writing the actual files.
 	spdxDOC, err := d.impl.GenerateSourceTreeBOM(&spdx.DocGenerateOptions{
 		ProcessGoModules: true,
-		License:          "Apache-2.0",
+		License:          LicenseIdentifier,
 		OutputFile:       "/tmp/kubernetes-source.spdx",
 		Namespace:        "http://k8s.io/sbom/source/REPLACE",
 		ScanLicenses:     true,
@@ -675,22 +659,7 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 	// We generate an artifacts sbom for each of the versions
 	// we are building
 	for _, version := range d.state.versions.Ordered() {
-		artifactsList, err := d.impl.ListArtifacts(version)
-		if err != nil {
-			return errors.Wrap(err, "getting artifacts list")
-		}
-		if err := d.impl.GenerateVersionArtifactsBOM(&spdx.DocGenerateOptions{
-			AnalyseLayers:  false,
-			OnlyDirectDeps: false,
-			License:        "Apache-2.0",
-			Namespace:      fmt.Sprintf("https://k8s.io/sbom/release/%s", version),
-			ScanLicenses:   false,
-			Tarballs:       artifactsList["images"],
-			Files:          artifactsList["binaries"],
-			OutputFile: filepath.Join(
-				os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", version),
-			),
-		}); err != nil {
+		if err := d.impl.GenerateVersionArtifactsBOM(version); err != nil {
 			return errors.Wrapf(err, "generating SBOM for version %s", version)
 		}
 

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -42,7 +42,8 @@ type YamlBOMConfiguration struct {
 		Person string `yaml:"person"`
 		Tool   string `yaml:"tool"`
 	} `yaml:"creator"`
-	Artifacts []*YamlBuildArtifact `yaml:"artifacts"`
+	ExternalDocRefs []ExternalDocumentRef `yaml:"external-docs"`
+	Artifacts       []*YamlBuildArtifact  `yaml:"artifacts"`
 }
 
 func NewDocBuilder() *DocBuilder {
@@ -84,22 +85,23 @@ func (db *DocBuilder) Generate(genopts *DocGenerateOptions) (*Document, error) {
 }
 
 type DocGenerateOptions struct {
-	AnalyseLayers    bool     // A flag that controls if deep layer analysis should be performed
-	NoGitignore      bool     // Do not read exclusions from gitignore file
-	ProcessGoModules bool     // Analyze go.mod to include data about packages
-	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
-	ScanLicenses     bool     // Try to llok into files to determine their license
-	ConfigFile       string   // Path to SBOM configuration file
-	OutputFile       string   // Output location
-	Name             string   // Name to us ein the resulting document
-	Namespace        string   // Namespace for the document (a unique URI)
-	CreatorPerson    string   // Document creator information
-	License          string   // Main license of the document
-	Tarballs         []string // A slice of tar paths
-	Files            []string // A slice of naked files to include in the bom
-	Images           []string // A slice of docker images
-	Directories      []string // A slice of directories to convert into packages
-	IgnorePatterns   []string // a slice of regexp patterns to ignore when scanning dirs
+	AnalyseLayers       bool                  // A flag that controls if deep layer analysis should be performed
+	NoGitignore         bool                  // Do not read exclusions from gitignore file
+	ProcessGoModules    bool                  // Analyze go.mod to include data about packages
+	OnlyDirectDeps      bool                  // Only include direct dependencies from go.mod
+	ScanLicenses        bool                  // Try to llok into files to determine their license
+	ConfigFile          string                // Path to SBOM configuration file
+	OutputFile          string                // Output location
+	Name                string                // Name to us ein the resulting document
+	Namespace           string                // Namespace for the document (a unique URI)
+	CreatorPerson       string                // Document creator information
+	License             string                // Main license of the document
+	Tarballs            []string              // A slice of tar paths
+	Files               []string              // A slice of naked files to include in the bom
+	Images              []string              // A slice of docker images
+	Directories         []string              // A slice of directories to convert into packages
+	IgnorePatterns      []string              // a slice of regexp patterns to ignore when scanning dirs
+	ExternalDocumentRef []ExternalDocumentRef // List of external documents related to the bom
 }
 
 func (o *DocGenerateOptions) Validate() error {
@@ -164,6 +166,7 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	doc.Name = genopts.Name
 	doc.Namespace = genopts.Namespace
 	doc.Creator.Person = genopts.CreatorPerson
+	doc.ExternalDocRefs = genopts.ExternalDocumentRef
 
 	if genopts.Namespace == "" {
 		return nil, errors.New("unable to generate doc, namespace URI is not defined")
@@ -261,6 +264,8 @@ func (builder *defaultDocBuilderImpl) ReadYamlConfiguration(
 	if conf.License != "" {
 		opts.License = conf.License
 	}
+
+	opts.ExternalDocumentRef = conf.ExternalDocRefs
 
 	// Add all the artifacts
 	for _, artifact := range conf.Artifacts {

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -571,7 +571,6 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 	tarOpts := &TarballOptions{}
 	tarOpts.ExtractDir, err = di.ExtractTarballTmp(tarPath)
 	if err != nil {
-		logrus.Info("Nononono")
 		return nil, errors.Wrap(err, "extracting tarball to temp dir")
 	}
 	defer os.RemoveAll(tarOpts.ExtractDir)
@@ -598,7 +597,6 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 
 	// Create the new SPDX package
 	imagePackage = NewPackage()
-	logrus.Infof("%+v", imagePackage.Options())
 	imagePackage.Options().WorkDir = tarOpts.ExtractDir
 	imagePackage.Name = manifest.RepoTags[0]
 	imagePackage.BuildID(imagePackage.Name)
@@ -612,6 +610,9 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 		if err != nil {
 			return nil, errors.Wrap(err, "building package from layer")
 		}
+		// Regenerate the BuildID to avoid clashes when handling multiple
+		// images at the same time.
+		pkg.BuildID(manifest.RepoTags[0], layerFile)
 
 		// If the option is enabled, scan the container layers
 		if spdxOpts.AnalyzeLayers {

--- a/pkg/spdx/relationship.go
+++ b/pkg/spdx/relationship.go
@@ -80,10 +80,26 @@ type Relationship struct {
 }
 
 func (ro *Relationship) Render(hostObject Object) (string, error) {
-	if ro.Peer.SPDXID() == "" {
+	// We can render the relationship from an object or from a
+	// predefined entity reference. But we have to have on of them
+	if ro.Peer == nil && ro.PeerReference == "" {
+		return "", errors.New(
+			"unable to render reference no peer or peer reference defined",
+		)
+	}
+	if ro.Peer != nil && ro.Peer.SPDXID() == "" {
 		return "", errors.New("unable to render relationship, peer object has no SPDX ID")
 	}
 
+	if ro.FullRender && ro.Peer == nil {
+		return "", errors.New("unable to render relationship. perr object has to be set")
+	}
+
+	if ro.Type == "" {
+		return "", errors.New("unable to render relationship, type is not set")
+	}
+
+	// The host object must have an ID defined in all cases
 	if hostObject.SPDXID() == "" {
 		return "", errors.New("Unable to rennder relationship, hostObject has no ID")
 	}
@@ -96,6 +112,10 @@ func (ro *Relationship) Render(hostObject Object) (string, error) {
 		}
 		docFragment += objDoc
 	}
-	docFragment += fmt.Sprintf("Relationship: %s %s %s\n", hostObject.SPDXID(), ro.Type, ro.Peer.SPDXID())
+	if ro.Peer != nil {
+		docFragment += fmt.Sprintf("Relationship: %s %s %s\n", hostObject.SPDXID(), ro.Type, ro.Peer.SPDXID())
+	} else {
+		docFragment += fmt.Sprintf("Relationship: %s %s %s\n", hostObject.SPDXID(), ro.Type, ro.PeerReference)
+	}
 	return docFragment, nil
 }

--- a/pkg/spdx/relationship.go
+++ b/pkg/spdx/relationship.go
@@ -72,11 +72,12 @@ const (
 )
 
 type Relationship struct {
-	FullRender    bool             // Flag, then true the package will be rendered in the doc
-	PeerReference string           // SPDX Ref of the peer object. Will override the ID of provided package if set
-	Comment       string           // Relationship ship commnet
-	Type          RelationshipType // Relationship of the specified package
-	Peer          Object           //
+	FullRender       bool             // Flag, then true the package will be rendered in the doc
+	PeerReference    string           // SPDX Ref of the peer object. Will override the ID of provided package if set
+	PeerExtReference string           // External doc reference if peer is a different doc
+	Comment          string           // Relationship ship commnet
+	Type             RelationshipType // Relationship of the specified package
+	Peer             Object           // SPDX object that acts as peer
 }
 
 func (ro *Relationship) Render(hostObject Object) (string, error) {
@@ -112,10 +113,18 @@ func (ro *Relationship) Render(hostObject Object) (string, error) {
 		}
 		docFragment += objDoc
 	}
+	peerExtRef := ""
+	if ro.PeerExtReference != "" {
+		peerExtRef = fmt.Sprintf("DocumentRef-%s:", ro.PeerExtReference)
+	}
 	if ro.Peer != nil {
-		docFragment += fmt.Sprintf("Relationship: %s %s %s\n", hostObject.SPDXID(), ro.Type, ro.Peer.SPDXID())
+		docFragment += fmt.Sprintf(
+			"Relationship: %s %s %s%s\n", hostObject.SPDXID(), ro.Type, peerExtRef, ro.Peer.SPDXID(),
+		)
 	} else {
-		docFragment += fmt.Sprintf("Relationship: %s %s %s\n", hostObject.SPDXID(), ro.Type, ro.PeerReference)
+		docFragment += fmt.Sprintf(
+			"Relationship: %s %s %s%s\n", hostObject.SPDXID(), ro.Type, peerExtRef, ro.PeerReference,
+		)
 	}
 	return docFragment, nil
 }

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -198,6 +198,11 @@ func TestRelationshipRender(t *testing.T) {
 			false, fmt.Sprintf("Relationship: %s DEPENDS_ON %s\n", host.SPDXID(), peer.SPDXID()),
 		},
 		{
+			// Relationships with a remote reference
+			Relationship{FullRender: false, Type: DEPENDS_ON, Peer: peer, PeerExtReference: "Remote"},
+			false, fmt.Sprintf("Relationship: %s DEPENDS_ON DocumentRef-Remote:%s\n", host.SPDXID(), peer.SPDXID()),
+		},
+		{
 			// Relationships without a full object, but
 			// with a set reference must render
 			Relationship{FullRender: false, PeerReference: dummyref, Type: DEPENDS_ON},

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -143,6 +143,20 @@ func TestExternalDocRef(t *testing.T) {
 	}
 }
 
+func TestExtDocReadSourceFile(t *testing.T) {
+	// Create a known testfile
+	f, err := os.CreateTemp("", "")
+	require.Nil(t, err)
+	require.Nil(t, os.WriteFile(f.Name(), []byte("Hellow World"), os.FileMode(0o644)))
+
+	ed := ExternalDocumentRef{}
+	require.NotNil(t, ed.ReadSourceFile("/kjfhg/skjdfkjh"))
+	require.Nil(t, ed.ReadSourceFile(f.Name()))
+	require.NotNil(t, ed.Checksums)
+	require.Equal(t, len(ed.Checksums), 1)
+	require.Equal(t, "5f341d31f6b6a8b15bc4e6704830bf37f99511d1", ed.Checksums["SHA1"])
+}
+
 func writeTestTarball(t *testing.T) *os.File {
 	// Create a testdire
 	tar, err := os.CreateTemp(os.TempDir(), "test-tar-*.tar.gz")

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -122,6 +122,27 @@ func TestPackageFromLayerTarBall(t *testing.T) {
 	require.Equal(t, "f3b48a64a3d9db36fff10a9752dea6271725ddf125baf7026cdf09a2c352d9ff4effadb75da31e4310bc1b2513be441c86488b69d689353128f703563846c97e", pkg.Checksum["SHA512"])
 }
 
+func TestExternalDocRef(t *testing.T) {
+	cases := []struct {
+		DocRef    ExternalDocumentRef
+		StringVal string
+	}{
+		{ExternalDocumentRef{ID: "", URI: "", Checksums: map[string]string{}}, ""},
+		{ExternalDocumentRef{ID: "", URI: "http://example.com/", Checksums: map[string]string{"SHA256": "d3b53860aa08e5c7ea868629800eaf78856f6ef3bcd4a2f8c5c865b75f6837c8"}}, ""},
+		{ExternalDocumentRef{ID: "test-id", URI: "", Checksums: map[string]string{"SHA256": "d3b53860aa08e5c7ea868629800eaf78856f6ef3bcd4a2f8c5c865b75f6837c8"}}, ""},
+		{ExternalDocumentRef{ID: "test-id", URI: "http://example.com/", Checksums: map[string]string{}}, ""},
+		{
+			ExternalDocumentRef{
+				ID: "test-id", URI: "http://example.com/", Checksums: map[string]string{"SHA256": "d3b53860aa08e5c7ea868629800eaf78856f6ef3bcd4a2f8c5c865b75f6837c8"},
+			},
+			"DocumentRef-test-id http://example.com/ SHA256:d3b53860aa08e5c7ea868629800eaf78856f6ef3bcd4a2f8c5c865b75f6837c8",
+		},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.StringVal, tc.DocRef.String())
+	}
+}
+
 func writeTestTarball(t *testing.T) *os.File {
 	// Create a testdire
 	tar, err := os.CreateTemp(os.TempDir(), "test-tar-*.tar.gz")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/kind feature

#### What this PR does / why we need it:

In preparation for the v1.22.0-beta.1 prerelease, this PR adds the final touches for the 2 SBOM structure. The main focus of these changes is stability, adding detail to the SBOMs and linking the two produces documents together.

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/1837

#### Special notes for your reviewer:

Changes are listed in the release notes, more details about each modification can be found in the commit messages.

A stage test run of these commits can be seen here: https://console.cloud.google.com/cloud-build/builds;region=global/57e940cb-c65c-4a8a-a3f2-e6e33043b512?project=kubernetes-release-test

#### Does this PR introduce a user-facing change?


```release-note
* Apache-2.0 is now defined as the default and expressed license in packages
* The SPDX package now supports ExternalDocRef making it possible to define external documents related to an SBOM
* Added functions to the `release` package to get the produced artifacts (ListBuildImages, ListBuildTarballs, ListBuildBinaries)
* Added release tarballs (client, server, node) to artifacts SBOM
* Binaries are now listed with their correct relative paths in the artifacts SBOM
* FIxed a bug where SPDX Ids would clash when two packages shared the same base image
* The source code SBOM is now referenced by the artifacts sbom packages as GENERATED_FROM
* Added tests to ensure SPDX Relationships render correctly 
```
