### PR TITLE
License Catalog: Ignore deprecated license IDs

### DIFF
--- a/pkg/license/catalog.go
+++ b/pkg/license/catalog.go
@@ -93,6 +93,9 @@ func (catalog *Catalog) WriteLicensesAsText(targetDir string) error {
 		wg.Add(1)
 		go func(l *License) {
 			defer wg.Done()
+			if l.IsDeprecatedLicenseID {
+				return
+			}
 			if lerr := l.WriteText(filepath.Join(targetDir, l.LicenseID+".txt")); err != nil {
 				if err == nil {
 					err = lerr


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit changes the license package to avoid using any
deprecated SPDX IDs from the SPDX catalog when training the
classifier. When scanning a file with those licenses, we will
now use the new labels exclusively.

Signed-off-by: Adolfo Garcia Veytia (puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/1837

#### Special notes for your reviewer:

Minor cleanup

#### Does this PR introduce a user-facing change?

```release-note
When training the license classifier, the `license` package will now ignore deprecated license IDs from the SPDX catalog.
```
