### PR TITLE
k8s-cloud-builder: Build image using go1.16.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -157,7 +157,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.5-1
+    version: v1.16.6-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.16:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.16.5-1'
+    KUBE_CROSS_VERSION: 'v1.16.6-1'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.13-1'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder: Build image using go1.16.6

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2157

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder: Build image using go1.16.6
```
