### PR TITLE
Bump k8s-ci-builder to golang 1.16.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.5
+    version: 1.16.6
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OLD_BAZEL_VERSION
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.16.5 AS builder
+FROM golang:1.16.6 AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.5
+GO_VERSION ?= 1.16.6
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.5'
+    GO_VERSION: '1.16.6'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.5'
+    GO_VERSION: '1.16.6'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area dependency release-eng/security

cc: @kubernetes/release-engineering

#### What this PR does / why we need it:

Tracking issue: https://github.com/kubernetes/release/issues/2157

This PR modifies the k8s-ci-builder files and dependencies.yaml manifest to golang 1.16.6

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2157

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Bump 1.16 variant of `k8s-ci-builder` to 1.16.6
```
