### PR TITLE
Update/build Golang 1.17rc1 and 1.16.6 images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -172,10 +172,6 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/releng/ci/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  - name: "golang: after kubernetes/kubernetes update (next candidate)"
-    version: 1.16.5
-    refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -207,7 +207,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.16.6-1
+    version: v1.17.0-rc.1-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.5
+    version: 1.16.6
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,7 @@
 variants:
+  cross1.17:
+    CONFIG: 'cross1.17'
+    KUBE_CROSS_VERSION: 'v1.17.0-rc.1-1'
   cross1.16:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.16.6-1'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OLD_BAZEL_VERSION
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.16.5 AS builder
+FROM golang:1.16.6 AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.5
+GO_VERSION ?= 1.16.6
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.5'
+    GO_VERSION: '1.16.6'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.23':
@@ -11,12 +11,12 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: '1.16.5'
+    GO_VERSION: '1.16.6'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.5'
+    GO_VERSION: '1.16.6'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -4,6 +4,11 @@ variants:
     GO_VERSION: '1.16.5'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
+  '1.23':
+    CONFIG: '1.23'
+    GO_VERSION: '1.17rc1'
+    BAZEL_VERSION: '3.4.1'
+    OLD_BAZEL_VERSION: '2.2.0'
   '1.22':
     CONFIG: '1.22'
     GO_VERSION: '1.16.5'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -4,6 +4,11 @@ variants:
     GO_VERSION: '1.16.5'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
+  '1.22':
+    CONFIG: '1.22'
+    GO_VERSION: '1.16.5'
+    BAZEL_VERSION: '3.4.1'
+    OLD_BAZEL_VERSION: '2.2.0'
   '1.21':
     CONFIG: '1.21'
     GO_VERSION: '1.16.5'
@@ -17,10 +22,5 @@ variants:
   '1.19':
     CONFIG: '1.19'
     GO_VERSION: '1.15.13'
-    BAZEL_VERSION: '2.2.0'
-    OLD_BAZEL_VERSION: '0.23.2'
-  '1.18':
-    CONFIG: '1.18'
-    GO_VERSION: '1.13.15'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'


### PR DESCRIPTION
/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Tracking issue: https://github.com/kubernetes/release/issues/2157

- k8s-ci-builder: Add 1.22 variant, drop 1.18 variant
- k8s-ci-builder: Add 1.23 variant
- k8s-ci-builder: Build go1.16.6 images
- k8s-cloud-builder: Build v1.17.0-rc.1-1 image

Supersedes https://github.com/kubernetes/release/pull/2166 to fix a [verify failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/release/2166/pull-release-verify/1415217609908948992) created by the "next candidate" (go1.17rc1) images.

/assign @puerco @saschagrunert @cpanato @xmudrii 
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- k8s-ci-builder: Add 1.22 variant, drop 1.18 variant
- k8s-ci-builder: Add 1.23 variant
- k8s-ci-builder: Build go1.16.6 images
- k8s-cloud-builder: Build v1.17.0-rc.1-1 image
```
