### PR TITLE
Update  k8s-ci-builder/k8s-cloud-builder to go 1.15.14

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -224,7 +224,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
-    version: 1.15.13
+    version: 1.15.14
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -261,7 +261,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (for previous release branches)"
-    version: v1.15.13-1
+    version: v1.15.14-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -7,7 +7,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.16.6-1'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.13-1'
+    KUBE_CROSS_VERSION: 'v1.15.14-1'
   cross1.15-legacy:
     CONFIG: 'cross1.15-legacy'
-    KUBE_CROSS_VERSION: 'v1.15.13-legacy-1'
+    KUBE_CROSS_VERSION: 'v1.15.14-legacy-1'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -21,11 +21,11 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.15.13'
+    GO_VERSION: '1.15.14'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.15.13'
+    GO_VERSION: '1.15.14'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:
Tracking issue: https://github.com/kubernetes/release/issues/2157
/assign @xmudrii  @Verolop  @justaugustus
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2157

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Update `dependencies.yaml` 1.15 to use Go 1.15.14
- k8s-cloud-builder: Build v1.15.14-legacy-1/v1.15.14-1 image
- k8s-ci-builder: Build 1.15 image variants using Go 1.15.14
```
