### PR TITLE
Temporarily disable the tag check during staging

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -311,11 +311,6 @@ func (d *defaultStageImpl) VerifyArtifacts(versions []string) error {
 		},
 	)
 
-	// Check that binaries are correctly tagged
-	if err := checker.CheckBinaryTags(); err != nil {
-		return errors.Wrap(err, "checking tags in release binaries")
-	}
-
 	// Ensure binaries are of the correct architecture
 	if err := checker.CheckBinaryArchitectures(); err != nil {
 		return errors.Wrap(err, "checking binary architectures")


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

During the `1.22.0-rc.0` release, we encountered an error where the `kube-apiserver` binary for s390x was reported as not being properly tagged. This commit disables the check temporarily to enable us to download the staged artifacts for verification.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/sig-release/issues/1633

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

This PR temporarily disables the tag check. It will be reverted later.
/priority critical-urgent

```release-note
NONE
```
