### PR TITLE
Check branch existence before merge

### DIFF
--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -248,6 +248,19 @@ func (gp *GitObjectPusher) mergeRemoteIfRequired(branch string) error {
 		return errors.Wrap(err, "fetch remote")
 	}
 
+	branchExists, err := gp.repo.HasRemoteBranch(branch)
+	if err != nil {
+		return errors.Wrapf(
+			err, "checking if branch %s exists in repo remote", branch,
+		)
+	}
+	if !branchExists {
+		logrus.Infof(
+			"Git repository does not have remote branch %s, not attempting merge", branch,
+		)
+		return nil
+	}
+
 	logrus.Infof("Merging %s branch", branch)
 	if err := gp.repo.Merge(branch); err != nil {
 		return errors.Wrapf(


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

We now support merges happening between stage and release. But the code
for this does not currently check to see if the remote branch exists
before attempting to fetch and merge.

This commit modifies the git pusher to check if the remote branch exists
before merging.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
```release-note
Git Pusher will now check for a remote branch before attempting to fetch + merge
```
