### PR TITLE
Pass branch without remote to HasRemoteBranch()

### DIFF
--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -241,6 +241,7 @@ func (gp *GitObjectPusher) PushMain() error {
 
 func (gp *GitObjectPusher) mergeRemoteIfRequired(branch string) error {
 	branch = git.Remotify(branch)
+	branchParts := strings.Split(branch, "/")
 	logrus.Infof("Merging %s branch if required", branch)
 
 	logrus.Infof("Fetching from %s", git.DefaultRemote)
@@ -248,7 +249,7 @@ func (gp *GitObjectPusher) mergeRemoteIfRequired(branch string) error {
 		return errors.Wrap(err, "fetch remote")
 	}
 
-	branchExists, err := gp.repo.HasRemoteBranch(branch)
+	branchExists, err := gp.repo.HasRemoteBranch(branchParts[1])
 	if err != nil {
 		return errors.Wrapf(
 			err, "checking if branch %s exists in repo remote", branch,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`git.HasRemoteBranch()` takes a branch without the remote. So we modify
`mergeRemoteIfRequired()` to pass only the branch name.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

Follow up to: #2177 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
