### PR TITLE
Use -trimpath for builds

### DIFF
--- a/compile-release-tools
+++ b/compile-release-tools
@@ -76,7 +76,7 @@ compile_with_flags() {
     git_tree_state=clean
   fi
 
-  go build -v -ldflags "-s -w \
+  go build -v -trimpath -ldflags "-s -w \
     -X $pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     -X $pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
     -X $pkg.gitTreeState=$git_tree_state \


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The flag removes all file system paths from the resulting executable.
Instead of absolute file system paths, the recorded file names will
begin with either "go" (for the standard library), or a module
path@version (when using modules), or a plain import path (when using
GOPATH).

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
