### PR TITLE
Close release notes maps after reading

### DIFF
--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -61,6 +61,7 @@ func ParseReleaseNotesMap(mapPath string) (*[]ReleaseNotesMap, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "opening maps")
 	}
+	defer yamlReader.Close()
 
 	decoder := yaml.NewDecoder(yamlReader)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

While parsing the release notes map files, the open files were not closed, causing __too many open files__ errors on some systems. This PR fixes the bug.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Thanks for reporting Pavel!
/assign @pmmalinov01 

#### Does this PR introduce a user-facing change?


```release-note
Fixed a bug where creating a PR would fail with a __too many open files__ error.
```
