### PR TITLE
images: Build debian-iptables / setcap from debian-base:buster-v1.9.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -303,7 +303,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/setcap"
-    version: buster-v2.0.3
+    version: buster-v2.0.4
     refPaths:
     - path: images/build/setcap/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -283,7 +283,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents"
-    version: buster-v1.8.0
+    version: buster-v1.9.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -295,7 +295,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: buster-v1.6.5
+    version: buster-v1.6.6
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.6.5
+IMAGE_VERSION ?= buster-v1.6.6
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
 

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -20,7 +20,7 @@ IMAGE=$(REGISTRY)/debian-iptables
 TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= buster-v1.6.5
 CONFIG ?= buster
-DEBIAN_BASE_VERSION ?= buster-v1.8.0
+DEBIAN_BASE_VERSION ?= buster-v1.9.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.6.5'
+    IMAGE_VERSION: 'buster-v1.6.6'
     DEBIAN_BASE_VERSION: 'buster-v1.9.0'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,4 +2,4 @@ variants:
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v1.6.5'
-    DEBIAN_BASE_VERSION: 'buster-v1.8.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.9.0'

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/setcap
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v2.0.3
+IMAGE_VERSION ?= buster-v2.0.4
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
 

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -20,7 +20,7 @@ IMAGE=$(REGISTRY)/setcap
 TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= buster-v2.0.3
 CONFIG ?= buster
-DEBIAN_BASE_VERSION ?= buster-v1.8.0
+DEBIAN_BASE_VERSION ?= buster-v1.9.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -2,4 +2,4 @@ variants:
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v2.0.3'
-    DEBIAN_BASE_VERSION: 'buster-v1.8.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.9.0'

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.0.3'
+    IMAGE_VERSION: 'buster-v2.0.4'
     DEBIAN_BASE_VERSION: 'buster-v1.9.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/2189.
Part of https://github.com/kubernetes/kubernetes/issues/104083.

- debian-iptables: Build buster-v1.6.6 image
- setcap: Build buster-v2.0.4 image

/assign @puerco @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian-iptables: Build buster-v1.6.6 image
- setcap: Build buster-v2.0.4 image
```
