### PR TITLE
Don't generate dependency report for release notes draft

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -125,7 +125,6 @@ type releaseNotesOptions struct {
 	userFork           string
 	createDraftPR      bool
 	createWebsitePR    bool
-	dependencies       bool
 	fixNotes           bool
 	listReleaseNotesV2 bool
 	websiteRepo        string
@@ -182,13 +181,6 @@ func init() {
 		"create-website-pr",
 		false,
 		"patch the relnotes.k8s.io sources and generate a PR with the changes",
-	)
-
-	releaseNotesCmd.PersistentFlags().BoolVar(
-		&releaseNotesOpts.dependencies,
-		"dependencies",
-		true,
-		"add dependency report",
 	)
 
 	releaseNotesCmd.PersistentFlags().StringSliceVarP(
@@ -1010,18 +1002,6 @@ func buildNotesResult(startTag string, releaseNotes *notes.ReleaseNotes) (*relea
 		return nil, errors.Wrapf(
 			err, "rendering release notes to markdown",
 		)
-	}
-
-	// Add the dependency report if necessary
-	if releaseNotesOpts.dependencies {
-		logrus.Info("Generating dependency changes")
-		deps, err := notes.NewDependencies().Changes(
-			startTag, releaseNotesOpts.tag,
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "creating dependency report")
-		}
-		markdown += strings.Repeat(nl, 2) + deps
 	}
 
 	// Create the JSON


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
The report will be added during the release cut, which then contains the
most recent version of changed dependencies. This way we can avoid
having the report twice in the notes, too.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/kubernetes/pull/104146

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `--dependencies` flag from `krel release-notes`, because they will be added during release cut.
```
