### PR TITLE
Generate TOC after dependencies

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -182,12 +182,6 @@ func (c *Changelog) Run() error {
 		return errors.Wrap(err, "generate release notes")
 	}
 
-	logrus.Info("Generating TOC")
-	toc, err := c.impl.GenerateTOC(markdown)
-	if err != nil {
-		return errors.Wrap(err, "generate table of contents")
-	}
-
 	if c.options.Dependencies {
 		logrus.Info("Generating dependency changes")
 		deps, err := c.impl.DependencyChanges(startRev, endRev)
@@ -195,6 +189,12 @@ func (c *Changelog) Run() error {
 			return errors.Wrap(err, "generate dependency changes")
 		}
 		markdown += strings.Repeat(nl, 2) + deps
+	}
+
+	logrus.Info("Generating TOC")
+	toc, err := c.impl.GenerateTOC(markdown)
+	if err != nil {
+		return errors.Wrap(err, "generate table of contents")
 	}
 
 	// Restore the currently checked out branch


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This fixes the issue that the TOC does not contain the dependency
changes because it has been generated before them.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug that changelog table of contents have been generated before dependency changes.
```
