### PR TITLE
k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.7

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.6
+    version: 1.16.7
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -157,7 +157,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.6-1
+    version: v1.16.7-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,7 +4,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.17.0-rc.2-1'
   cross1.16:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.16.6-1'
+    KUBE_CROSS_VERSION: 'v1.16.7-1'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.14-1'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OLD_BAZEL_VERSION
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.16.6 AS builder
+FROM golang:1.16.7 AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.6
+GO_VERSION ?= 1.16.7
 BAZEL_VERSION ?= 3.4.1
 OLD_BAZEL_VERSION ?= 2.2.0
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.6'
+    GO_VERSION: '1.16.7'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.23':
@@ -11,12 +11,12 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: '1.16.6'
+    GO_VERSION: '1.16.7'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.6'
+    GO_VERSION: '1.16.7'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.7

PRs in k/k that uses go 1.16 are merged: https://github.com/kubernetes/kubernetes/pull/104199 / https://github.com/kubernetes/kubernetes/pull/104201 / https://github.com/kubernetes/kubernetes/pull/104200

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2196

/assign @puerco @saschagrunert @xmudrii @justaugustus 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.7
```
