### PR TITLE
k8s-cloud-builder/k8s-ci-builder: Build image using go1.15.15

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -224,7 +224,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (for previous release branches)"
-    version: 1.15.14
+    version: 1.15.15
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -261,7 +261,7 @@ dependencies:
       match: go\d+.\d+
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (for previous release branches)"
-    version: v1.15.14-1
+    version: v1.15.15-1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-\d+

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -7,7 +7,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.16.7-1'
   cross1.15:
     CONFIG: 'cross1.15'
-    KUBE_CROSS_VERSION: 'v1.15.14-1'
+    KUBE_CROSS_VERSION: 'v1.15.15-1'
   cross1.15-legacy:
     CONFIG: 'cross1.15-legacy'
-    KUBE_CROSS_VERSION: 'v1.15.14-legacy-1'
+    KUBE_CROSS_VERSION: 'v1.15.15-legacy-1'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -21,11 +21,11 @@ variants:
     OLD_BAZEL_VERSION: '2.2.0'
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: '1.15.14'
+    GO_VERSION: '1.15.15'
     BAZEL_VERSION: '3.4.1'
     OLD_BAZEL_VERSION: '2.2.0'
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: '1.15.14'
+    GO_VERSION: '1.15.15'
     BAZEL_VERSION: '2.2.0'
     OLD_BAZEL_VERSION: '0.23.2'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: Build image using go1.15.15

PRs in k/k that uses go 1.15 are merged: https://github.com/kubernetes/kubernetes/pull/104215 / https://github.com/kubernetes/kubernetes/pull/104216

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2196

/assign @puerco @saschagrunert @xmudrii @justaugustus 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: Build image using go1.15.15
```
