### PR TITLE
debian-base: Build bullseye-v1.0.0 images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -309,3 +309,30 @@ dependencies:
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/setcap/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+
+  # Base images (for previous release branches)
+  - name: "k8s.gcr.io/build-image/debian-base (for previous release branches)"
+    version: buster-v1.9.0
+    refPaths:
+    - path: images/build/debian-base/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+
+  - name: "k8s.gcr.io/build-image/debian-base: dependents (for previous release branches)"
+    version: buster-v1.9.0
+    refPaths:
+    - path: images/build/debian-iptables/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+    - path: images/build/setcap/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+
+  - name: "k8s.gcr.io/build-image/debian-iptables (for previous release branches)"
+    version: buster-v1.6.6
+    refPaths:
+    - path: images/build/debian-iptables/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+
+  - name: "k8s.gcr.io/build-image/setcap (for previous release branches)"
+    version: buster-v2.0.4
+    refPaths:
+    - path: images/build/setcap/variants.yaml
+      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -275,7 +275,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: buster-v1.9.0
+    version: bullseye-v1.0.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,8 +19,8 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.9.0
-CONFIG ?= buster
+IMAGE_VERSION ?= bullseye-v1.0.0
+CONFIG ?= bullseye
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64

--- a/images/build/debian-base/bullseye/Dockerfile
+++ b/images/build/debian-base/bullseye/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/images/build/debian-base/bullseye/Dockerfile.build
+++ b/images/build/debian-base/bullseye/Dockerfile.build
@@ -1,0 +1,97 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+FROM $BASEIMAGE
+
+ARG ARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Smaller package install size.
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+# Convenience script for building on this base image.
+COPY clean-install /usr/local/bin/clean-install
+
+# An attempt to fix issues like:
+# ```
+# Error while loading /usr/sbin/dpkg-split: No such file or directory
+# Error while loading /usr/sbin/dpkg-deb: No such file or directory
+# ```
+# See: https://github.com/docker/buildx/issues/495
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    ln -s /bin/tar /usr/sbin/tar && \
+    ln -s /bin/rm /usr/sbin/rm
+
+# Update system packages.
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+# Hold required packages to avoid breaking the installation of packages
+RUN apt-mark hold apt gnupg adduser passwd libsemanage1 libcap2
+
+# Remove unnecessary packages.
+# This list was generated manually by listing the installed packages (`apt list --installed`),
+# then running `apt-cache rdepends --installed --no-recommends` to find the "root" packages.
+# The root packages were evaluated based on whether they were needed in the container image.
+# Several utilities (e.g. ping) were kept for usefulness, but may be removed in later versions.
+RUN echo "Yes, do as I say!" | apt-get purge \
+    bash \
+    e2fsprogs \
+    libcap2-bin \
+    libmount1 \
+    libsmartcols1 \
+    libblkid1 \
+    libss2 \
+    ncurses-base \
+    ncurses-bin \
+    tzdata
+
+# No-op stubs replace some unnecessary binaries that may be depended on in the install process (in
+# particular we don't run an init process).
+WORKDIR /usr/local/bin
+RUN touch noop && \
+    chmod 555 noop && \
+    ln -s noop runlevel && \
+    ln -s noop invoke-rc.d && \
+    ln -s noop update-rc.d
+WORKDIR /
+
+# Cleanup cached and unnecessary files.
+RUN apt-get autoremove -y && \
+    apt-get clean -y && \
+    tar -czf /usr/share/copyrights.tar.gz /usr/share/common-licenses /usr/share/doc/*/copyright && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /usr/share/common-licenses* \
+        /usr/share/bash-completion \
+        ~/.bashrc \
+        ~/.profile \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    mkdir -p /usr/share/man/man1 /usr/share/man/man2 \
+        /usr/share/man/man3 /usr/share/man/man4 \
+        /usr/share/man/man5 /usr/share/man/man6 \
+        /usr/share/man/man7 /usr/share/man/man8

--- a/images/build/debian-base/bullseye/clean-install
+++ b/images/build/debian-base/bullseye/clean-install
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/images/build/debian-base/bullseye/excludes
+++ b/images/build/debian-base/bullseye/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/man/*

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  # Debian 11 - Kubernetes 1.23 and newer
+  bullseye:
+    CONFIG: 'bullseye'
+    IMAGE_VERSION: 'bullseye-v1.0.0'
+  # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v1.9.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

debian-base: Build bullseye-v1.0.0 images

Debian 11 (Bullseye) is [now out](https://www.debian.org/News/2021/20210814).
Let's build some new base images!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
debian-base: Build bullseye-v1.0.0 images
```
