### PR TITLE
images: Build bullseye variants (part two)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -360,9 +360,8 @@ dependencies:
       match: OS_CODENAME\ \?=\ (bullseye|buster)
     - path: images/build/cross/variants.yaml
       match: "OS_CODENAME: '(bullseye|buster)'"
-    # TODO(codename): Uncomment once bullseye is default
-    #- path: images/build/debian-base/Makefile
-    #  match: CONFIG\ \?=\ (bullseye|buster)
+    - path: images/build/debian-base/Makefile
+      match: CONFIG\ \?=\ (bullseye|buster)
     - path: images/build/debian-base/variants.yaml
       match: "CONFIG: '(bullseye|buster)'"
     - path: images/build/debian-iptables/Makefile
@@ -387,74 +386,75 @@ dependencies:
     - path: packages/deb/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster)
 
-  - name: "Debian: codename (next)"
+  - name: "Debian: codename (next candidate)"
     version: bullseye
     refPaths:
     - path: images/build/debian-base/variants.yaml
       match: "CONFIG: '(bullseye|buster)'"
 
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: bullseye-v1.0.0
+    version: buster-v1.9.0
     refPaths:
     - path: images/build/debian-base/Makefile
-      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+      match: IMAGE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/debian-base/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents"
     version: buster-v1.9.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
-      match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+      match: DEBIAN_BASE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/debian-iptables/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
     - path: images/build/setcap/Makefile
-      match: DEBIAN_BASE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+      match: DEBIAN_BASE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/setcap/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
     version: buster-v1.6.7
     refPaths:
     - path: images/build/debian-iptables/Makefile
-      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+      match: IMAGE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/debian-iptables/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/setcap"
     version: buster-v2.0.4
     refPaths:
     - path: images/build/setcap/Makefile
-      match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+      match: IMAGE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/setcap/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  # Base images (for previous release branches)
-  - name: "k8s.gcr.io/build-image/debian-base (for previous release branches)"
-    version: buster-v1.9.0
+  # Base images (next candidate)
+  - name: "k8s.gcr.io/build-image/debian-base (next candidate)"
+    version: bullseye-v1.0.0
     refPaths:
     - path: images/build/debian-base/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "k8s.gcr.io/build-image/debian-base: dependents (for previous release branches)"
-    version: buster-v1.9.0
+  - name: "k8s.gcr.io/build-image/debian-base: dependents (next candidate)"
+    version: bullseye-v1.0.0
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
-    - path: images/build/setcap/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
+    #- path: images/build/setcap/variants.yaml
+    #  match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "k8s.gcr.io/build-image/debian-iptables (for previous release branches)"
+  - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
     version: buster-v1.6.7
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "k8s.gcr.io/build-image/setcap (for previous release branches)"
+  - name: "k8s.gcr.io/build-image/setcap (next candidate)"
     version: buster-v2.0.4
     refPaths:
     - path: images/build/setcap/variants.yaml
-      match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
+      match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
 # Build environments
   - name: "gcr.io/k8s-testimages/gcb-docker-gcloud"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -445,7 +445,7 @@ dependencies:
     #  match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
-    version: buster-v1.6.7
+    version: bullseye-v1.0.0
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -389,8 +389,18 @@ dependencies:
   - name: "Debian: codename (next candidate)"
     version: bullseye
     refPaths:
+    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
+    #- path: images/build/cross/variants.yaml
+    #  match: "OS_CODENAME: '(bullseye|buster)'"
     - path: images/build/debian-base/variants.yaml
       match: "CONFIG: '(bullseye|buster)'"
+    - path: images/build/go-runner/variants.yaml
+      match: "OS_CODENAME: '(bullseye|buster)'"
+    - path: images/releng/ci/variants.yaml
+      match: "OS_CODENAME: '(bullseye|buster)'"
+    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
+    #- path: images/releng/k8s-ci-builder/variants.yaml
+    #  match: "OS_CODENAME: '(bullseye|buster)'"
 
   - name: "k8s.gcr.io/build-image/debian-base"
     version: buster-v1.9.0

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,8 +19,8 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.0.0
-CONFIG ?= bullseye
+IMAGE_VERSION ?= buster-v1.9.0
+CONFIG ?= buster
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64

--- a/images/build/debian-iptables/bullseye/Dockerfile
+++ b/images/build/debian-iptables/bullseye/Dockerfile
@@ -16,17 +16,12 @@ ARG BASEIMAGE
 
 FROM ${BASEIMAGE} as build
 
-# Install iptables and ebtables packages from bullseye-backports
-RUN echo deb http://deb.debian.org/debian bullseye-backports main >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -t bullseye-backports -y --no-install-recommends install \
-        iptables \
-        ebtables
-
 # Install other dependencies and then clean up apt caches
 RUN clean-install \
     conntrack \
+    ebtables \
     ipset \
+    iptables \
     kmod \
     netbase
 

--- a/images/build/debian-iptables/bullseye/Dockerfile
+++ b/images/build/debian-iptables/bullseye/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+
+FROM ${BASEIMAGE} as build
+
+# Install iptables and ebtables packages from bullseye-backports
+RUN echo deb http://deb.debian.org/debian bullseye-backports main >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get -t bullseye-backports -y --no-install-recommends install \
+        iptables \
+        ebtables
+
+# Install other dependencies and then clean up apt caches
+RUN clean-install \
+    conntrack \
+    ipset \
+    kmod \
+    netbase
+
+# Install iptables wrapper scripts to detect the correct iptables mode
+# the first time any of them is run
+COPY iptables-wrapper /usr/sbin/iptables-wrapper
+
+RUN update-alternatives \
+	--install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+RUN update-alternatives \
+	--install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+
+FROM scratch
+COPY --from=build / /

--- a/images/build/debian-iptables/bullseye/iptables-wrapper
+++ b/images/build/debian-iptables/bullseye/iptables-wrapper
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+
+# Bugs in iptables-nft 1.8.3 may cause it to get stuck in a loop in
+# some circumstances, so we have to run the nft check in a timeout. To
+# avoid hitting that timeout, we only bother to even check nft if
+# legacy iptables was empty / mostly empty.
+
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l || true)
+num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l || true)
+if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+    mode=legacy
+  else
+    mode=nft
+fi
+
+update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
+
+# Now re-exec the original command with the newly-selected alternative
+exec "$0" "$@"

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,4 +1,10 @@
 variants:
+  # Debian 11 - Kubernetes 1.23 and newer
+  bullseye:
+    CONFIG: 'bullseye'
+    IMAGE_VERSION: 'bullseye-v1.0.0'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.0.0'
+  # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v1.6.7'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,4 +1,12 @@
 variants:
+  go1.17-bullseye:
+    CONFIG: 'go1.17-bullseye'
+    IMAGE_VERSION: 'v2.3.1-go1.17.1-bullseye.0'
+    GO_MAJOR_VERSION: '1.17'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    GO_VERSION: '1.17.1'
+    DISTROLESS_IMAGE: 'static-debian11'
   go1.17-buster:
     CONFIG: 'go1.17-buster'
     IMAGE_VERSION: 'v2.3.1-go1.17.1-buster.0'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  go1.17-bullseye:
+    CONFIG: 'go1.17-bullseye'
+    GO_VERSION: '1.17.1'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   go1.17-buster:
     CONFIG: 'go1.17-buster'
     GO_VERSION: '1.17.1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/release/pull/2209, https://github.com/kubernetes/release/pull/2211, and https://github.com/kubernetes/release/pull/2223.

- debian-iptables: Build bullseye-v1.0.0 images
- images: Build go1.17-bullseye variants
  - go-runner:v2.3.1-go1.17.1-bullseye.0
  - releng-ci

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian-iptables: Build bullseye-v1.0.0 images
- images: Build go1.17-bullseye variants
  - go-runner:v2.3.1-go1.17.1-bullseye.0
  - releng-ci
```
