### PR TITLE
bom: fix panic when LICENSE file is not found

### DIFF
--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -506,6 +506,10 @@ func (di *spdxDefaultImplementation) GetDirectoryLicense(
 	if err != nil {
 		return nil, errors.Wrap(err, "getting directory license")
 	}
+	if licenseResult == nil {
+		logrus.Warnf("License classifier could not find a license for directory: %v", err)
+		return nil, nil
+	}
 	return licenseResult.License, nil
 }
 

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -151,9 +151,7 @@ func (spdx *SPDX) PackageFromDirectory(dirPath string) (pkg *Package, err error)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning directory for licenses")
 	}
-	if lic == nil {
-		logrus.Warnf("License classifier could not find a license for directory: %v", err)
-	} else {
+	if lic != nil {
 		licenseTag = lic.LicenseID
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When using `bom` to generate a SPDX file for my repositories, I faced a panic error when the license file is not available yet.

```
WARN Could not find any licensing information in /Users/hectorj2f/yada/project
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1450166]

goroutine 1 [running]:
k8s.io/release/pkg/spdx.(*spdxDefaultImplementation).GetDirectoryLicense(0x189dc98, 0xc00000f650, 0xc00002e720, 0x20, 0x1863340, 0x100, 0x0, 0x0)
	k8s.io/release/pkg/spdx/implementation.go:509 +0xa6
k8s.io/release/pkg/spdx.(*SPDX).PackageFromDirectory(0xc0000c3bc0, 0x7ffeefbffb87, 0x1, 0x17, 0xc0000d7bb0, 0x1)
	k8s.io/release/pkg/spdx/spdx.go:150 +0x208
k8s.io/release/pkg/spdx.(*defaultDocBuilderImpl).GenerateDoc(0x189dc98, 0x186d6d0, 0xc0000bf100, 0x100, 0xc0000bf100, 0x0)
	k8s.io/release/pkg/spdx/builder.go:177 +0x2e5
k8s.io/release/pkg/spdx.(*DocBuilder).Generate(0xc0000c3cc8, 0xc0000bf100, 0xc0000d7cb8, 0x1, 0x1)
	k8s.io/release/pkg/spdx/builder.go:71 +0x62
k8s.io/release/cmd/bom/cmd.generateBOM(0x186f1a0, 0x189dc98, 0x0)
	k8s.io/release/cmd/bom/cmd/generate.go:237 +0x26f
k8s.io/release/cmd/bom/cmd.glob..func1(0x1865d00, 0xc000200cf0, 0x1, 0x3, 0x0, 0x0)
	k8s.io/release/cmd/bom/cmd/generate.go:66 +0xb5
github.com/spf13/cobra.(*Command).execute(0x1865d00, 0xc000200cc0, 0x3, 0x3, 0x1865d00, 0xc000200cc0)
	github.com/spf13/cobra@v1.2.1/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x1865f80, 0x1007a05, 0xc000094058, 0x10016d0)
	github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.2.1/command.go:902
k8s.io/release/cmd/bom/cmd.Execute()
	k8s.io/release/cmd/bom/cmd/root.go:67 +0x31
main.main()
	k8s.io/release/cmd/bom/main.go:24 +0x25
```
The code should WARN or ERROR when they don't find the License but it should not throw a panic error.

#### Which issue(s) this PR fixes:

Fixes the mentioned issue in the previous section. The current code prompts a warning message without throwing a panic error.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bom: fix panic when LICENSE file is not found
```
