### PR TITLE
feat: adds release cycle support to schedule-builder

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -60,6 +60,51 @@ func parseSchedule(patchSchedule PatchSchedule) string {
 	return scheduleOut
 }
 
+func parseReleaseSchedule(releaseSchedule ReleaseSchedule) string {
+	output := []string{}
+	output = append(output, fmt.Sprintf("# Kubernetes %s\n", releaseSchedule.Releases[0].Version))
+
+	output = append(output, fmt.Sprintf("#### Links\n"))
+	for _, link := range releaseSchedule.Releases[0].Links {
+		output = append(output, fmt.Sprintf("* [%s](%s)\n", link.Text, link.Href))
+	}
+	output = append(output, fmt.Sprintf("#### Tracking docs\n"))
+	for _, trackingDocs := range releaseSchedule.Releases[0].TrackingDocs {
+		output = append(output, fmt.Sprintf("* [%s](%s)\n", trackingDocs.Text, trackingDocs.Href))
+	}
+
+	output = append(output, fmt.Sprintf("#### Guides\n"))
+	for _, guide := range releaseSchedule.Releases[0].Guides {
+		output = append(output, fmt.Sprintf("* [%s](%s)\n", guide.Text, guide.Href))
+	}
+
+	output = append(output, fmt.Sprintf("## Timeline\n"))
+	for _, releaseSchedule := range releaseSchedule.Releases {
+		tableString := &strings.Builder{}
+		table := tablewriter.NewWriter(tableString)
+		table.SetAutoWrapText(false)
+		table.SetHeader([]string{"**What**", "**Who**", "**When**", "**WEEK**", "**CI Signal**"})
+
+		for _, timeline := range releaseSchedule.Timeline {
+			table.Append([]string{strings.TrimSpace(timeline.What), strings.TrimSpace(timeline.Who), strings.TrimSpace(timeline.When), strings.TrimSpace(timeline.Week), strings.TrimSpace(timeline.CISignal), ""})
+
+		}
+
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		table.SetCenterSeparator("|")
+		table.Render()
+
+		output = append(output, tableString.String())
+	}
+
+	scheduleOut := strings.Join(output, "\n")
+
+	logrus.Info("Release Schedule parsed")
+	println(scheduleOut)
+
+	return scheduleOut
+}
+
 func patchReleaseInPreviousList(a string, previousPatches []PreviousPatches) bool {
 	for _, b := range previousPatches {
 		if b.Release == a {

--- a/cmd/schedule-builder/cmd/model.go
+++ b/cmd/schedule-builder/cmd/model.go
@@ -38,3 +38,38 @@ type Schedule struct {
 	EndOfLifeDate      string            `yaml:"endOfLifeDate"`
 	PreviousPatches    []PreviousPatches `yaml:"previousPatches"`
 }
+
+type ReleaseSchedule struct {
+	Releases []Release `yaml:"releases"`
+}
+
+type Release struct {
+	Version      string        `yaml:"version"`
+	Links        []Link        `yaml:"links"`
+	TrackingDocs []TrackingDoc `yaml:"trackingDocs"`
+	Guides       []Guide       `yaml:"guides"`
+	Timeline     []Timeline    `yaml:"timeline"`
+}
+
+type Link struct {
+	Href string `yaml:"href"`
+	Text string `yaml:"text"`
+}
+
+type TrackingDoc struct {
+	Href string `yaml:"href"`
+	Text string `yaml:"text"`
+}
+
+type Guide struct {
+	Href string `yaml:"href"`
+	Text string `yaml:"text"`
+}
+
+type Timeline struct {
+	What     string `yaml:"what"`
+	Who      string `yaml:"who"`
+	When     string `yaml:"when"`
+	Week     string `yaml:"week"`
+	CISignal string `yaml:"ciSignal"`
+}


### PR DESCRIPTION
Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is adds a new functionality to the schedule-builder, which allows us to create new release cycles somewhat like [1.23](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/README.md)
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #2207 

or

None
-->

#### Special notes for your reviewer:
The sample `release-cycle.yaml` is below:
```yaml
releases:
- version: 1.23
  links:
    - href: https://git.k8s.io/sig-release/releases/release-1.23/README.md
      text: This document
    - href: https://groups.google.com/a/kubernetes.io/g/release-team
      text: Release Team
    - href: http://bit.ly/k8s123-releasemtg
      text: Meeting Minutes
  trackingDocs:
    - href: https://bit.ly/k8s123-enhancements
      text: Enhancements Tracking Sheet
    - href: TBD
      text: Feature blog Tracking Sheet
    - href: https://github.com/kubernetes/kubernetes/milestone/56
      text: kubernetes/sig-release v1.23 milestone
  guides:
    - href: https://git.k8s.io/community/contributors/devel/sig-release/release.md
      text: Targeting Issues and PRs to This Milestone
    - href: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md#troubleshooting-a-failure
      text: Triaging and Escalating Test Failures
  timeline:
    - what: Start of Release Cycle
      who: Lead
      when: Mon August 23, 2021
      week: week 1
      ciSignal: master-blocking
    - what:  Start Enhancements Tracking
      who: Enhancements Lead
      when: Mon August 23, 2021
      week: week 1
      ciSignal:
    - what: 1.23.0-alpha.1 released
      who: Branch Manager
      when: Wed August 25, 2021
      week: week 1
      ciSignal:
    - what: Schedule finalized
      who: Lead
      when: Thu August 26, 2021
      week: week 1
      ciSignal:
   ```
   
   It was parsed with the below command:
   `./schedule-builder --config-path release-cycle.yaml--output-file release-cycle-schedule.md --type-file release`
   
 The output `release-cycle-schedule.md` looked like below, if the below-generated template looks fine to the reviewers, I will add test for both `root_test.go` and `markdown_test.go`: 
# Kubernetes 1.23

#### Links

* [This document](https://git.k8s.io/sig-release/releases/release-1.23/README.md)

* [Release Team](https://groups.google.com/a/kubernetes.io/g/release-team)

* [Meeting Minutes](http://bit.ly/k8s123-releasemtg)

#### Tracking docs

* [Enhancements Tracking Sheet](https://bit.ly/k8s123-enhancements)

* [Feature blog Tracking Sheet](TBD)

* [kubernetes/sig-release v1.23 milestone](https://github.com/kubernetes/kubernetes/milestone/56)

#### Guides

* [Targeting Issues and PRs to This Milestone](https://git.k8s.io/community/contributors/devel/sig-release/release.md)

* [Triaging and Escalating Test Failures](https://git.k8s.io/community/contributors/devel/sig-testing/testing.md#troubleshooting-a-failure)

## Timeline

|          **WHAT**           |      **WHO**      |      **WHEN**       | **WEEK** |  **CI SIGNAL**  |  |
|-----------------------------|-------------------|---------------------|----------|-----------------|--|
| Start of Release Cycle      | Lead              | Mon August 23, 2021 | week 1   | master-blocking |  |
| Start Enhancements Tracking | Enhancements Lead | Mon August 23, 2021 | week 1   |                 |  |
| 1.23.0-alpha.1 released     | Branch Manager    | Wed August 25, 2021 | week 1   |                 |  |
| Schedule finalized          | Lead              | Thu August 26, 2021 | week 1   |                 |  |

     
 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
