### PR TITLE
Stop uploading .deb packages to scratch bucket

### DIFF
--- a/packages/deb/jenkins.sh
+++ b/packages/deb/jenkins.sh
@@ -21,10 +21,8 @@ set -o xtrace
 
 declare -r BUILD_TAG="$(date '+%y%m%d%H%M%S')"
 declare -r IMG_NAME="debian-builder:${BUILD_TAG}"
-declare -r DEB_RELEASE_BUCKET="gs://k8s-release-dev/debian"
 
 docker build -t "${IMG_NAME}" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 docker run -it --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}" $@
 
-gsutil -m cp -nrc bin "${DEB_RELEASE_BUCKET}/${BUILD_TAG}"
 printf "%s" "${BUILD_TAG}" | gsutil cp - "${DEB_RELEASE_BUCKET}/latest"


### PR DESCRIPTION
/kind bug
/kind cleanup

#### What this PR does / why we need it:

This commit removes the transient upload of .deb files to a scratch bucket (`k8s-release-dev/`), probably a remnant of an older
process. Currenttly, the google build admins do not have access to write to the bucket.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
None 

#### Special notes for your reviewer:

/assign @amwat 
/cc @kubernetes/release-engineering 

#### Does this PR introduce a user-facing change?


```release-note
When cutting the packages, we no longer upload .deb files to scratch bucket
```
