### PR TITLE
Stop updating /debian/latest marker in scratch bucket

### DIFF
--- a/packages/deb/jenkins.sh
+++ b/packages/deb/jenkins.sh
@@ -24,5 +24,3 @@ declare -r IMG_NAME="debian-builder:${BUILD_TAG}"
 
 docker build -t "${IMG_NAME}" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 docker run -it --rm -v "${PWD}/bin:/src/bin" "${IMG_NAME}" $@
-
-printf "%s" "${BUILD_TAG}" | gsutil cp - "${DEB_RELEASE_BUCKET}/latest"


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

This commit stops updating the `/debian/latest` marker in the `k8s-release-dev/` when cutting the packages

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:
Follow up to #2216 

#### Special notes for your reviewer:

/assign @amwat 
/cc @kubernetes/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
When generating the packages for a release, we no longer update the /debian/latest marker in k8s-release-dev
```
