### PR TITLE
debian-builder: use golang:1.16.7-buster as the base image

### DIFF
--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.7
+FROM golang:1.16.7-buster
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1629401120230000?thread_ts=1629353341.198900&cid=CJH2GBF7Y

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
