### PR TITLE
un-emeritus BenTheElder per https://github.com/kubernetes/release/pul…

### DIFF
--- a/images/build/OWNERS
+++ b/images/build/OWNERS
@@ -2,5 +2,6 @@
 
 approvers:
   - release-engineering-approvers
+  - BenTheElder
 reviewers:
   - release-engineering-reviewers

--- a/images/build/debian-base/OWNERS
+++ b/images/build/debian-base/OWNERS
@@ -2,10 +2,10 @@
 
 approvers:
   - release-engineering-approvers
+  - BenTheElder
 reviewers:
   - release-engineering-reviewers
 
 emeritus_approvers:
-  - BenTheElder
   - mkumatag
   - tallclair

--- a/images/build/debian-iptables/OWNERS
+++ b/images/build/debian-iptables/OWNERS
@@ -2,11 +2,11 @@
 
 approvers:
   - release-engineering-approvers
+  - BenTheElder
 reviewers:
   - release-engineering-reviewers
 
 emeritus_approvers:
-  - BenTheElder
   - bowei
   - freehan
   - jingax10

--- a/images/build/go-runner/OWNERS
+++ b/images/build/go-runner/OWNERS
@@ -2,5 +2,6 @@
 
 approvers:
   - release-engineering-approvers
+  - BenTheElder
 reviewers:
   - release-engineering-reviewers


### PR DESCRIPTION
…l/2214

Undoing either directly emeritused or by way of removing build-image-approvers. See discussion on #2214.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

See previous linked PR diff + discussion.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
