### PR TITLE
k8s-cloud-builder: Update to v1.23.0-go1.17-buster.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -191,10 +191,10 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.16.7-1
+    version: v1.23.0-go1.17-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
-      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)-\\d+'"
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
@@ -242,10 +242,10 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-(bullseye|buster)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.17.0-rc.2-1
+    version: v1.23.0-go1.17-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
-      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)-\\d+'"
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   # Golang (for previous release branches)
   - name: "golang (for previous release branches)"

--- a/images/k8s-cloud-builder/cloudbuild.yaml
+++ b/images/k8s-cloud-builder/cloudbuild.yaml
@@ -25,7 +25,7 @@ substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
   _CONFIG: 'cross0.0'
-  _KUBE_CROSS_VERSION: 'v0.0.0-0'
+  _KUBE_CROSS_VERSION: 'v0.0.0-go0.0.0-codename.0'
   _REGISTRY: 'fake.repository/registry-name'
 
 images:

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.17:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.17.0-rc.2-1'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17-buster.0'
   cross1.16:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.16.7-1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

k8s-cloud-builder: Update to v1.23.0-go1.17-buster.0
/hold for https://github.com/kubernetes/kubernetes/pull/103692.
go1.17 tracking: https://github.com/kubernetes/release/issues/2169

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @cpanato @puerco @jeremyrickard 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
k8s-cloud-builder: Update to v1.23.0-go1.17-buster.0
```
