### PR TITLE
[go1.17] Default to go1.17

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.7-buster AS builder
+FROM golang:1.17-buster AS builder
 
 ENV GO111MODULE=on
 

--- a/Dockerfile-kubepkg-rpm
+++ b/Dockerfile-kubepkg-rpm
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.7-buster AS builder
+FROM golang:1.17-buster AS builder
 
 ENV GO111MODULE=on
 

--- a/cmd/vulndash/Makefile
+++ b/cmd/vulndash/Makefile
@@ -20,14 +20,14 @@ SHELL=/bin/bash -o pipefail
 
 REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
 IMGNAME = vulndash
-IMAGE_VERSION ?= v0.4.3-7
+IMAGE_VERSION ?= v0.4.3-8
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.7
+GO_VERSION ?= 1.17
 OS_CODENAME ?= buster
 DISTROLESS_IMAGE ?= static-debian10
 

--- a/cmd/vulndash/variants.yaml
+++ b/cmd/vulndash/variants.yaml
@@ -1,6 +1,6 @@
 variants:
   default:
-    IMAGE_VERSION: 'v0.4.3-7'
-    GO_VERSION: '1.16.7'
+    IMAGE_VERSION: 'v0.4.3-8'
+    GO_VERSION: '1.17'
     OS_CODENAME: 'buster'
     DISTROLESS_IMAGE: 'static-debian10'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,6 +100,16 @@ dependencies:
     - path: images/build/go-runner/variants.yaml
       match: "GO_MAJOR_VERSION: '\\d+.\\d+'"
 
+  - name: "golang: go.mod"
+    version: 1.17
+    refPaths:
+    - path: go.mod
+      match: go \d+.\d+
+    - path: images/build/go-runner/go.mod
+      match: go \d+.\d+
+    - path: packages/deb/go.mod
+      match: go \d+.\d+
+
   - name: "golang: after kubernetes/kubernetes update"
     version: 1.17
     refPaths:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.16.7
+    version: 1.17
     refPaths:
     - path: Dockerfile-kubepkg
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
@@ -84,12 +84,12 @@ dependencies:
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster)
 
   # Golang pre-releases are denoted as `1.y<pre-release stage>.z`
-  # Example: go1.16rc1
+  # Example: go1.17rc1
   #
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.16
+    version: 1.17
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_MAJOR_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -101,7 +101,7 @@ dependencies:
       match: "GO_MAJOR_VERSION: '\\d+.\\d+'"
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.16.7
+    version: 1.17
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -118,15 +118,15 @@ dependencies:
   # Golang images
 
   # Represents the targeted Kubernetes version at the time the images
-  # are to be created e.g., 'v1.22.0'
+  # are to be created e.g., 'v1.100.0'
   #
   # Note: There is no need to increment the patch version of this variable.
   #       The reason for the inclusion of the patch version here is to satisfy
   #       a SemVer regex on the IMAGE_VERSION.
   #
   # Example:
-  # - v1.22.0-go1.16-buster.0 satisfies SemVer regex, while:
-  # - v1.22-go1.16-buster.0 does not
+  # - v1.100.0-go1.17-buster.0 satisfies SemVer regex, while:
+  # - v1.100-go1.17-buster.0 does not
   - name: "Kubernetes version (stable.0)"
     version: v1.22.0
     refPaths:
@@ -156,7 +156,7 @@ dependencies:
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/build-image/go-runner"
-    version: v2.3.1-go1.16.7-buster.0
+    version: v2.3.1-go1.17-buster.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -170,14 +170,13 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.22.0-go1.16.7-buster.0
+    version: v1.23.0-go1.17-buster.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  # TODO: Consider capturing this in "golang: 1.<major>" instead
   - name: "k8s.gcr.io/build-image/kube-cross: config variant"
-    version: go1.16-buster
+    version: go1.17-buster
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-(bullseye|buster)'"
@@ -234,7 +233,6 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  # TODO: Consider capturing this in "golang: 1.<major>" instead
   - name: "k8s.gcr.io/build-image/kube-cross: config variant (next candidate)"
     version: go1.17-buster
     refPaths:
@@ -289,7 +287,6 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  # TODO: Consider capturing this in "golang: 1.<major>" instead
   - name: "k8s.gcr.io/build-image/kube-cross: config variant (for previous release branches)"
     version: go1.15-buster
     refPaths:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -148,7 +148,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
-    version: v0.4.3-7
+    version: v0.4.3-8
     refPaths:
     - path: cmd/vulndash/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/release
 
-go 1.16
+go 1.17
 
 require (
 	cloud.google.com/go/containeranalysis v0.1.0
@@ -45,4 +45,73 @@ require (
 	sigs.k8s.io/release-utils v0.3.0
 	sigs.k8s.io/yaml v1.2.0
 	sigs.k8s.io/zeitgeist v0.3.0
+)
+
+require (
+	cloud.google.com/go v0.92.1 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aws/aws-sdk-go v1.37.6 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/cli v20.10.7+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v20.10.7+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/color v1.10.0 // indirect
+	github.com/fvbommel/sortorder v1.0.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-ole/go-ole v1.2.5 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20200824053859-8c8b3816f167 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-github/v33 v33.0.0 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/klauspost/compress v1.13.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-runewidth v0.0.12 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mmarkdown/mmark v2.0.40+incompatible // indirect
+	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.2-0.20200206005212-79b036d80240 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/spiegel-im-spiegel/errs v1.0.2 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/xanzy/go-gitlab v0.43.0 // indirect
+	github.com/xanzy/ssh-agent v0.3.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/grpc v1.39.1 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -18,18 +18,18 @@ SHELL=/bin/bash -o pipefail
 IMGNAME = kube-cross
 
 # Represents the targeted Kubernetes version at the time the images
-# are to be created e.g., 'v1.22.0'
+# are to be created e.g., 'v1.100.0'
 #
 # Note: There is no need to increment the patch version of this variable.
 #       The reason for the inclusion of the patch version here is to satisfy
 #       a SemVer regex on the IMAGE_VERSION.
 #
 # Example:
-# - v1.22.0-go1.16-buster.0 satisfies SemVer regex, while:
-# - v1.22-go1.16-buster.0 does not
+# - v1.100.0-go1.17-buster.0 satisfies SemVer regex, while:
+# - v1.100-go1.17-buster.0 does not
 KUBERNETES_VERSION ?= v1.22.0
-GO_VERSION ?= 1.16.7
-GO_MAJOR_VERSION ?= 1.16
+GO_VERSION ?= 1.17
+GO_MAJOR_VERSION ?= 1.17
 OS_CODENAME ?= buster
 REVISION ?= 0
 TYPE ?= default

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -17,11 +17,11 @@ include $(CURDIR)/../../Makefile.common-image
 
 IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)
-GO_MAJOR_VERSION ?= 1.16
+GO_MAJOR_VERSION ?= 1.17
 REVISION ?= 0
 
 # Build args
-GO_VERSION ?= 1.16.7
+GO_VERSION ?= 1.17
 OS_CODENAME ?= buster
 DISTROLESS_IMAGE ?= static-debian10
 

--- a/images/build/go-runner/go.mod
+++ b/images/build/go-runner/go.mod
@@ -1,3 +1,3 @@
 module k8s.io/release/images/build/go-runner
 
-go 1.16
+go 1.17

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.16.7-${OS_CODENAME} AS builder
+FROM golang:1.17-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.16.7
+GO_VERSION ?= 1.17
 OS_CODENAME ?= buster
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.7-buster
+FROM golang:1.17-buster
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \

--- a/packages/deb/go.mod
+++ b/packages/deb/go.mod
@@ -1,5 +1,5 @@
 module k8s.io/release/packages/deb
 
-go 1.16
+go 1.17
 
 require github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup feature
/area dependency

#### What this PR does / why we need it:

/hold for https://github.com/kubernetes/release/pull/2222
- dependencies.yaml: Default to go1.17 for image builds
- vulndash: Build v0.4.3-8 image
- dependencies.yaml: Add entry for go.mod
- packages/deb: Update module to go1.17
- images/build/go-runner: Update module to go1.17
- go.mod: Update module to go1.17

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

I expect some failures here, either in image building or verify tests; just putting it up for early signal.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- [go1.17] Default to go1.17
  - dependencies.yaml: Default to go1.17 for image builds
  - vulndash: Build v0.4.3-8 image
  - dependencies.yaml: Add entry for go.mod
  - packages/deb: Update module to go1.17
  - images/build/go-runner: Update module to go1.17
  - go.mod: Update module to go1.17
```
