### PR TITLE
Lintlintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -49,6 +48,7 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
@@ -84,7 +84,6 @@ linters:
     # - noctx
     # - nolintlint
     # - paralleltest
-    # - revive
     # - scopelint
     # - tagliatelle
     # - testpackage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,12 @@ issues:
         - gocritic
         - golint
         - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,3 +171,16 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - predeclared
     - promlinter
@@ -82,7 +83,6 @@ linters:
     # - nilerr
     # - nlreturn
     # - noctx
-    # - nolintlint
     # - paralleltest
     # - scopelint
     # - tagliatelle

--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -236,14 +236,14 @@ func (opts *buildAnnounceOptions) saveAnnouncement(announcementSubject string, a
 
 	absOutputPath := filepath.Join(opts.workDir, "announcement.html")
 	logrus.Infof("Writing HTML file to %s", absOutputPath)
-	err := os.WriteFile(absOutputPath, annoucement.Bytes(), os.FileMode(0644))
+	err := os.WriteFile(absOutputPath, annoucement.Bytes(), os.FileMode(0o644))
 	if err != nil {
 		return errors.Wrap(err, "saving announcement.html")
 	}
 
 	absOutputPath = filepath.Join(opts.workDir, "announcement-subject.txt")
 	logrus.Infof("Writing announcement subject to %s", absOutputPath)
-	err = os.WriteFile(absOutputPath, []byte(announcementSubject), os.FileMode(0644))
+	err = os.WriteFile(absOutputPath, []byte(announcementSubject), os.FileMode(0o644))
 	if err != nil {
 		return errors.Wrap(err, "saving announcement-subject.txt")
 	}

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -177,7 +177,7 @@ func TestNewMinorRelease(t *testing.T) { // nolint: dupl
 			os.WriteFile(
 				filepath.Join(s.repo.Dir(), filename),
 				[]byte("Some content"),
-				0644,
+				0o644,
 			),
 		)
 		require.Nil(t, s.repo.Add(filename))

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -51,7 +51,7 @@ func TestChangelogNoArgumentsOrFlags(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestNewPatchRelease(t *testing.T) { // nolint: dupl
+func TestNewPatchRelease(t *testing.T) {
 	// Given
 	s := newSUT(t)
 	defer s.cleanup(t)
@@ -153,7 +153,7 @@ func TestNewAlpha1Release(t *testing.T) {
 	require.Regexp(t, alpha1ReleaseExpectedTOC, string(result))
 }
 
-func TestNewMinorRelease(t *testing.T) { // nolint: dupl
+func TestNewMinorRelease(t *testing.T) {
 	// Given
 	s := newSUT(t)
 	defer s.cleanup(t)

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -450,14 +450,14 @@ func createDraftPR(repoPath, tag string) (err error) {
 	logrus.Debugf("Release notes draft files will be written to %s", releaseDir)
 
 	// Write the markdown draft
-	err = os.WriteFile(filepath.Join(releaseDir, releaseNotesWorkDir, draftMarkdownFile), []byte(result.markdown), 0644)
+	err = os.WriteFile(filepath.Join(releaseDir, releaseNotesWorkDir, draftMarkdownFile), []byte(result.markdown), 0o644)
 	if err != nil {
 		return errors.Wrapf(err, "writing release notes draft")
 	}
 	logrus.Infof("Release Notes Markdown Draft written to %s", filepath.Join(releaseDir, releaseNotesWorkDir, draftMarkdownFile))
 
 	// Write the JSON file of the current notes
-	err = os.WriteFile(filepath.Join(releaseDir, releaseNotesWorkDir, draftJSONFile), []byte(result.json), 0644)
+	err = os.WriteFile(filepath.Join(releaseDir, releaseNotesWorkDir, draftJSONFile), []byte(result.json), 0o644)
 	if err != nil {
 		return errors.Wrapf(err, "writing release notes json file")
 	}

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -369,12 +369,12 @@ func createDraftPR(repoPath, tag string) (err error) {
 	}
 
 	if !isrepo {
-		return errors.New(
-			fmt.Sprintf(
-				"Cannot create PR, %s/%s is not a fork of %s/%s",
-				releaseNotesOpts.githubOrg, releaseNotesOpts.draftRepo,
-				git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
-			),
+		return fmt.Errorf(
+			"cannot create PR, %s/%s is not a fork of %s/%s",
+			releaseNotesOpts.githubOrg,
+			releaseNotesOpts.draftRepo,
+			git.DefaultGithubOrg,
+			git.DefaultGithubReleaseRepo,
 		)
 	}
 

--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -269,9 +269,12 @@ func (o *TestGridOptions) Validate() error {
 		if o.states[i] != stateFailing &&
 			o.states[i] != statePassing &&
 			o.states[i] != stateFlaky {
-			return errors.New(
-				fmt.Sprintf("invalid state %s option. Valid options are: %s, %s, %s",
-					o.states[i], stateFailing, stateFlaky, statePassing),
+			return fmt.Errorf(
+				"invalid state %s option. Valid options are: %s, %s, %s",
+				o.states[i],
+				stateFailing,
+				stateFlaky,
+				statePassing,
 			)
 		}
 	}
@@ -279,9 +282,11 @@ func (o *TestGridOptions) Validate() error {
 	for _, board := range o.boards {
 		if board != boardBlocking &&
 			board != boardInforming {
-			return errors.New(
-				fmt.Sprintf("invalid board %s option. Valid options are: %s, %s",
-					board, boardBlocking, boardInforming),
+			return fmt.Errorf(
+				"invalid board %s option. Valid options are: %s, %s",
+				board,
+				boardBlocking,
+				boardInforming,
 			)
 		}
 	}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -311,7 +311,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 1.40.1
+    version: 1.42.0
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.40.1
+VERSION=v1.42.0
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -231,7 +231,6 @@ func (s *Stage) Submit(stream bool) error {
 
 // Run for the `Stage` struct prepares a release and puts the results on a
 // staging bucket.
-// nolint:dupl
 func (s *Stage) Run() error {
 	s.client.InitState()
 
@@ -363,7 +362,6 @@ func (r *Release) Submit(stream bool) error {
 }
 
 // Run for for `Release` struct finishes a previously staged release.
-// nolint:dupl
 func (r *Release) Run() error {
 	r.client.InitState()
 

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -30,7 +30,7 @@ import (
 
 var err = errors.New("error")
 
-var testVersionTag string = "v1.20.0"
+var testVersionTag = "v1.20.0"
 
 type testStateParameters struct {
 	versionsTag         *string

--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -183,7 +183,7 @@ func UpdateGitHubPage(opts *GitHubPageOptions) (err error) {
 	}
 
 	// Does the release exist yet?
-	var releaseID int64 = 0
+	var releaseID int64
 	commitish := ""
 	for _, release := range releases {
 		if release.GetTagName() == opts.Tag {

--- a/pkg/api/files/validation.go
+++ b/pkg/api/files/validation.go
@@ -101,7 +101,6 @@ func ValidateFiles(files []File) error {
 			return fmt.Errorf("sha256 was not valid (not hex): %q", f.SHA256)
 		}
 
-		// nolint[gomnd]
 		if len(sha256) != 32 {
 			return fmt.Errorf("sha256 was not valid (bad length): %q", f.SHA256)
 		}

--- a/pkg/binary/binary_unit_test.go
+++ b/pkg/binary/binary_unit_test.go
@@ -51,7 +51,7 @@ func TestContainsString(t *testing.T) {
 	require.Nil(t, err)
 }
 
-var kubectlFragment string = `nxsirlx0QAAAAAAA0HZAFANwVyHQekA7vuLSGA57QHEaitUNKXtAY+ef53SofUDqSbATP1Z+QGgo
+var kubectlFragment = `nxsirlx0QAAAAAAA0HZAFANwVyHQekA7vuLSGA57QHEaitUNKXtAY+ef53SofUDqSbATP1Z+QGgo
 7CEZK4RA97PI/X55hUACFbBWgMiFQO85+v5CLoZABGeTp8C4i0D///////+PQBhRnRjrAphA5jvf
 zhnyo0BqJIxot/+oQB7FLgvj9rJAaUuYyn5qtECfyHUuMhK1QAAAAAAAiMNAER3/Jb8Vx0Dhka4+
 lrfNQIWi5Wbutc9AZlLW1XK31ED7KgGmgjnXQHausXxFDtxAvvRkqnwx40AAAAAAAADwQAAAAAAA

--- a/pkg/binary/mach-o.go
+++ b/pkg/binary/mach-o.go
@@ -97,27 +97,28 @@ func (machoh *MachOHeader) MachineType() string {
 
 	// Todo: Perhaps if only one arch is in the file, we could return it here
 
-	// #define CPU_ARCH_ABI64		 0x1000000
+	// CPU_ARCH_ABI64 / 0x1000000
 	switch machoh.CPU {
-	//nolint CPU_TYPE_I386		((cpu_type_t) 7)
+	// CPU_TYPE_I386 / ((cpu_type_t) 7)
 	case 7:
 		return I386
-	//nolint CPU_TYPE_X86_64		((cpu_type_t) (CPU_TYPE_I386 | CPU_ARCH_ABI64))
+	// CPU_TYPE_X86_64 / ((cpu_type_t) (CPU_TYPE_I386 | CPU_ARCH_ABI64))
 	case 16777223:
 		return AMD64
-	//nolint CPU_TYPE_POWERPC		((cpu_type_t) 18)
+	// CPU_TYPE_POWERPC / ((cpu_type_t) 18)
 	case 18:
 		return PPC
-	//nolint CPU_TYPE_POWERPC64	((cpu_type_t)(CPU_TYPE_POWERPC | CPU_ARCH_ABI64))
+	// CPU_TYPE_POWERPC64 / ((cpu_type_t)(CPU_TYPE_POWERPC | CPU_ARCH_ABI64))
 	case 16777234:
 		return PPC64LE
-	//nolint CPU_TYPE_ARM			((cpu_type_t) 12)
+	// CPU_TYPE_ARM / ((cpu_type_t) 12)
 	case 12:
 		return ARM
-	//nolint ARM 64-bits (ARMv8/Aarch64) (not in source)
+	// ARM 64-bits (ARMv8/Aarch64) (not in source)
 	case 16777228:
 		return ARM64
 	}
+
 	logrus.Warnf("Unable to interpret machine type from mach-o header value %d", machoh.CPU)
 	return ""
 }

--- a/pkg/binary/mach-o.go
+++ b/pkg/binary/mach-o.go
@@ -26,7 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//nolint
 const (
 	MachO32Magic   uint32 = 0xfeedface // 32 bit, big endian
 	MachO64Magic   uint32 = 0xfeedfacf // 64 bit, big endian
@@ -48,7 +47,7 @@ type MachOBinary struct {
 	Options *Options
 }
 
-// NewMachOBinary returns a Mach-O binary if the sepciefied file is one
+// NewMachOBinary returns a Mach-O binary if the specified file is one
 func NewMachOBinary(filePath string, opts *Options) (*MachOBinary, error) {
 	header, err := GetMachOHeader(filePath)
 	if err != nil {

--- a/pkg/binary/windows.go
+++ b/pkg/binary/windows.go
@@ -53,7 +53,7 @@ type PEBinary struct {
 	Options *Options
 }
 
-// NewPEBinary Returns a binary implemetation for a windows executable
+// NewPEBinary Returns a binary implementation for a Windows executable
 func NewPEBinary(filePath string, opts *Options) (bin *PEBinary, err error) {
 	header, err := GetPEHeader(filePath)
 	if err != nil {
@@ -76,43 +76,45 @@ func (peh *PEHeader) String() string {
 
 // MachineType returns the moniker of the binary architecture
 func (peh *PEHeader) MachineType() string {
+	//nolint:gocritic
 	switch peh.Machine {
-	//nolint IMAGE_FILE_MACHINE_AMD64     = 0x8664
+	// IMAGE_FILE_MACHINE_AMD64     = 0x8664
 	case 0x8664:
 		return AMD64
-	//nolint IMAGE_FILE_MACHINE_ARM       = 0x1c0
+	// IMAGE_FILE_MACHINE_ARM       = 0x1c0
 	case 0x1c0:
 		return ARM
-	//nolint IMAGE_FILE_MACHINE_ARMNT     = 0x1c4
-	//nolint IMAGE_FILE_MACHINE_ARM64     = 0xaa64
+	// IMAGE_FILE_MACHINE_ARMNT     = 0x1c4
+	// IMAGE_FILE_MACHINE_ARM64     = 0xaa64
 	case 0xaa64:
 		return ARM64
-	//nolint IMAGE_FILE_MACHINE_EBC       = 0xebc
-	//nolint IMAGE_FILE_MACHINE_I386      = 0x14c
+	// IMAGE_FILE_MACHINE_EBC       = 0xebc
+	// IMAGE_FILE_MACHINE_I386      = 0x14c
 	case 0x14c:
 		return I386
-	//nolint IMAGE_FILE_MACHINE_IA64      = 0x200
-	//nolint IMAGE_FILE_MACHINE_M32R      = 0x9041
-	//nolint IMAGE_FILE_MACHINE_MIPS16    = 0x266
-	//nolint IMAGE_FILE_MACHINE_MIPSFPU   = 0x366
-	//nolint IMAGE_FILE_MACHINE_MIPSFPU16 = 0x466
-	//nolint IMAGE_FILE_MACHINE_POWERPC   = 0x1f0
-	//nolint IMAGE_FILE_MACHINE_POWERPCFP = 0x1f1
-	//nolint IMAGE_FILE_MACHINE_R4000     = 0x166
-	//nolint IMAGE_FILE_MACHINE_SH3       = 0x1a2
-	//nolint IMAGE_FILE_MACHINE_SH3DSP    = 0x1a3
-	//nolint IMAGE_FILE_MACHINE_SH4       = 0x1a6
-	//nolint IMAGE_FILE_MACHINE_SH5       = 0x1a8
-	//nolint IMAGE_FILE_MACHINE_THUMB     = 0x1c2
-	//nolint IMAGE_FILE_MACHINE_WCEMIPSV2 = 0x169
+	// IMAGE_FILE_MACHINE_IA64      = 0x200
+	// IMAGE_FILE_MACHINE_M32R      = 0x9041
+	// IMAGE_FILE_MACHINE_MIPS16    = 0x266
+	// IMAGE_FILE_MACHINE_MIPSFPU   = 0x366
+	// IMAGE_FILE_MACHINE_MIPSFPU16 = 0x466
+	// IMAGE_FILE_MACHINE_POWERPC   = 0x1f0
+	// IMAGE_FILE_MACHINE_POWERPCFP = 0x1f1
+	// IMAGE_FILE_MACHINE_R4000     = 0x166
+	// IMAGE_FILE_MACHINE_SH3       = 0x1a2
+	// IMAGE_FILE_MACHINE_SH3DSP    = 0x1a3
+	// IMAGE_FILE_MACHINE_SH4       = 0x1a6
+	// IMAGE_FILE_MACHINE_SH5       = 0x1a8
+	// IMAGE_FILE_MACHINE_THUMB     = 0x1c2
+	// IMAGE_FILE_MACHINE_WCEMIPSV2 = 0x169
 	case 0x1f0:
 		return PPC
 	}
+
 	logrus.Warn("Could not determine architecture type")
 	return ""
 }
 
-// WordLength Returns an intenger indicating if it's a 64 or 32 bit binary
+// WordLength Returns an integer indicating if it's a 64 or 32 bit binary
 func (peh *PEHeader) WordLength() int {
 	// We infer the wordlength from the machine type
 	// https://en.wikibooks.org/wiki/X86_Disassembly/Windows_Executable_Files#PE_Optional_Header

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -537,7 +537,7 @@ func (c *Changelog) adaptChangelogReadmeFile(
 	}
 
 	if err := c.impl.WriteFile(
-		targetFile, []byte(strings.Join(res, nl)+nl), os.FileMode(0644)); err != nil {
+		targetFile, []byte(strings.Join(res, nl)+nl), os.FileMode(0o644)); err != nil {
 		return errors.Wrap(err, "write changelog README.md")
 	}
 	return nil

--- a/pkg/cve/impl.go
+++ b/pkg/cve/impl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
+
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/object"
 )
@@ -199,9 +200,7 @@ func (impl *defaultClientImplementation) ValidateCVEMap(
 	for i, dataMap := range *maps {
 		// Check if map has other the CVE field
 		if _, ok := dataMap.DataFields["cve"]; !ok {
-			return errors.New(
-				fmt.Sprintf("Data map #%d in file %s has no CVE data", i, path),
-			)
+			return fmt.Errorf("data map #%d in file %s has no CVE data", i, path)
 		}
 		// Cast the datafield as CVE data
 		cvedata := CVE{}
@@ -213,10 +212,11 @@ func (impl *defaultClientImplementation) ValidateCVEMap(
 		}
 
 		if cvedata.ID != cveID {
-			return errors.New(
-				fmt.Sprintf(
-					"CVE ID in map #%d in file %s does not match %s", i, path, cveID,
-				),
+			return fmt.Errorf(
+				"CVE ID in map #%d in file %s does not match %s",
+				i,
+				path,
+				cveID,
 			)
 		}
 	}

--- a/pkg/filepromoter/file.go
+++ b/pkg/filepromoter/file.go
@@ -52,7 +52,6 @@ type copyFileOp struct {
 }
 
 // Run implements SyncFileOp.Run
-// nolint[gocyclo]
 func (o *copyFileOp) Run(ctx context.Context) error {
 	// Download to our temp file
 	f, err := os.CreateTemp("", "promoter")

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -102,7 +102,6 @@ func openFilestore(
 }
 
 // computeNeededOperations determines the list of files that need to be copied
-// nolint[funlen]
 func (p *FilestorePromoter) computeNeededOperations(
 	source, dest map[string]*syncFileInfo,
 	destFilestore syncFilestore) ([]SyncFileOp, error) {

--- a/pkg/filepromoter/filestore.go
+++ b/pkg/filepromoter/filestore.go
@@ -106,8 +106,7 @@ func openFilestore(
 func (p *FilestorePromoter) computeNeededOperations(
 	source, dest map[string]*syncFileInfo,
 	destFilestore syncFilestore) ([]SyncFileOp, error) {
-	// nolint[prealloc]
-	var ops []SyncFileOp
+	ops := make([]SyncFileOp, 0)
 
 	for i := range p.Files {
 		f := &p.Files[i]

--- a/pkg/filepromoter/gcs.go
+++ b/pkg/filepromoter/gcs.go
@@ -86,7 +86,6 @@ func (s *gcsSyncFilestore) UploadFile(ctx context.Context, dest, localFile strin
 	w.SendCRC32C = true
 
 	// Much bigger chunk size for faster uploading
-	// nolint[gomnd]
 	w.ChunkSize = 128 * 1024 * 1024
 
 	if _, err := io.Copy(w, in); err != nil {

--- a/pkg/filepromoter/manifest.go
+++ b/pkg/filepromoter/manifest.go
@@ -43,7 +43,6 @@ func (p *ManifestPromoter) BuildOperations(
 		return nil, err
 	}
 
-	// nolint[prealloc]
 	var operations []SyncFileOp
 
 	for i := range p.Manifest.Filestores {

--- a/pkg/git/git_integration_test.go
+++ b/pkg/git/git_integration_test.go
@@ -98,7 +98,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 
 	worktree, err := cloneRepo.Worktree()
@@ -130,7 +130,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	_, err = worktree.Add(branchTestFileName)
 	require.Nil(t, err)
@@ -154,7 +154,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	_, err = worktree.Add(secondBranchTestFileName)
 	require.Nil(t, err)
@@ -178,7 +178,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, thirdBranchTestFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	_, err = worktree.Add(thirdBranchTestFileName)
 	require.Nil(t, err)
@@ -644,7 +644,7 @@ func TestCheckoutSuccess(t *testing.T) {
 	require.Nil(t, os.WriteFile(
 		testRepo.testFileName,
 		[]byte("hello world"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	res, err := command.NewWithWorkDir(
 		testRepo.sut.Dir(), "git", "diff", "--name-only").Run()
@@ -739,7 +739,7 @@ func TestRmSuccessForce(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 	require.Nil(t, os.WriteFile(testRepo.testFileName,
-		[]byte("test"), os.FileMode(0755)),
+		[]byte("test"), os.FileMode(0o755)),
 	)
 
 	require.Nil(t, testRepo.sut.Rm(true, testRepo.testFileName))
@@ -806,7 +806,7 @@ func TestRmFailureModified(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 	require.Nil(t, os.WriteFile(testRepo.testFileName,
-		[]byte("test"), os.FileMode(0755)),
+		[]byte("test"), os.FileMode(0o755)),
 	)
 	require.NotNil(t, testRepo.sut.Rm(false, testRepo.testFileName))
 }
@@ -928,7 +928,7 @@ func TestIsDirtyFailure(t *testing.T) {
 
 	require.Nil(t, os.WriteFile(
 		filepath.Join(testRepo.sut.Dir(), "any-file"),
-		[]byte("test"), os.FileMode(0755)),
+		[]byte("test"), os.FileMode(0o755)),
 	)
 
 	dirty, err := testRepo.sut.IsDirty()

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -114,7 +114,7 @@ func TestGetUserName(t *testing.T) {
 
 func TestGetUserEmail(t *testing.T) {
 	const fakeUserEmail = "kubernetes-test@example.com"
-	currentDir, err := os.Getwd() // nolint: errcheck
+	currentDir, err := os.Getwd()
 	require.Nil(t, err, "error reading the current directory")
 	defer os.Chdir(currentDir) // nolint: errcheck
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -384,7 +384,7 @@ func TestStatus(t *testing.T) {
 	require.True(t, status.IsClean())
 
 	// Create an untracked file
-	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0o644))
 
 	// Status should be modified now
 	status, err = testRepo.Status()
@@ -404,7 +404,7 @@ func TestStatus(t *testing.T) {
 	require.Empty(t, status.String())
 
 	// Modify the file
-	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Bye SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Bye SIG Release"), 0o644))
 	status, err = testRepo.Status()
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf(" M %s\n", testFile), status.String())
@@ -424,7 +424,7 @@ func TestShowLastCommit(t *testing.T) {
 	defer testRepo.Cleanup() // nolint: errcheck
 
 	// Create an untracked file
-	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Hello SIG Release"), 0o644))
 	require.Nil(t, testRepo.Add(testFile))
 	require.Nil(t, testRepo.Commit(fmt.Sprintf("Commit test file at %s", timeNow)))
 
@@ -528,7 +528,7 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, testRepo.Rebase(fmt.Sprintf("origin/%s", branchName)), "cloning synchronizaed repos")
 
 	// Test 2. Rebase should not fail with pulling changes in the remote
-	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello SIG Release"), 0o644))
 	_, err = wtree.Add(testFile)
 	require.Nil(t, err)
 
@@ -554,7 +554,7 @@ func TestRebase(t *testing.T) {
 	require.NotNil(t, testRepo.Rebase("origin/invalidBranch"), "rebasing to invalid branch")
 
 	// Test 4: Rebase must fail on merge conflicts
-	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello again SIG Release"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(rawRepoDir, testFile), []byte("Hello again SIG Release"), 0o644))
 	_, err = wtree.Add(testFile)
 	require.Nil(t, err)
 
@@ -564,7 +564,7 @@ func TestRebase(t *testing.T) {
 	require.Nil(t, err)
 
 	// Commit the same file in the test repo
-	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Conflict me!"), 0644))
+	require.Nil(t, os.WriteFile(filepath.Join(testRepo.Dir(), testFile), []byte("Conflict me!"), 0o644))
 	require.Nil(t, testRepo.Add(filepath.Join(testRepo.Dir(), testFile)))
 	require.Nil(t, testRepo.Commit("Adding file to cause conflict"))
 

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -470,7 +470,7 @@ func TestListBranches(t *testing.T) {
 func TestCreateIssue(t *testing.T) {
 	// Given
 	sut, client := newSUT()
-	var fakeID int = 100000
+	fakeID := 100000
 	title := "Test Issue"
 	body := "Issue body text"
 	opts := &github.NewIssueOptions{

--- a/pkg/github/record.go
+++ b/pkg/github/record.go
@@ -317,7 +317,7 @@ func (c *githubNotesRecordClient) recordAPICall(
 		return err
 	}
 	if err := os.WriteFile(
-		filepath.Join(c.recordDir, fileName), file, os.FileMode(0644),
+		filepath.Join(c.recordDir, fileName), file, os.FileMode(0o644),
 	); err != nil {
 		return err
 	}

--- a/pkg/kubepkg/kubepkg_test.go
+++ b/pkg/kubepkg/kubepkg_test.go
@@ -62,7 +62,7 @@ func sutWithTemplateDir(
 
 	for _, dir := range opts.Packages() {
 		pkgPath := filepath.Join(tempDir, string(buildType), dir)
-		require.Nil(t, os.MkdirAll(pkgPath, 0755))
+		require.Nil(t, os.MkdirAll(pkgPath, 0o755))
 	}
 	return sut, cleanup, mock
 }

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -61,7 +61,7 @@ func TestFileMetadata(t *testing.T) {
 		"kubernetes.tar.gz",
 	} {
 		require.Nil(t, os.WriteFile(
-			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
+			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0o644),
 		))
 	}
 
@@ -145,7 +145,7 @@ func TestDocument_RenderMarkdownTemplateFailure(t *testing.T) {
 			if tt.templateExist {
 				fileName := strings.Split(tt.templateSpec, ":")[1]
 				p := filepath.Join(dir, fileName)
-				require.Nil(t, os.WriteFile(p, []byte(tt.templateContents), 0664))
+				require.Nil(t, os.WriteFile(p, []byte(tt.templateContents), 0o664))
 			}
 
 			doc := Document{}
@@ -251,7 +251,7 @@ func setupTestDir(t *testing.T, dir string) {
 		"kubernetes.tar.gz",
 	} {
 		require.Nil(t, os.WriteFile(
-			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0644),
+			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0o644),
 		))
 	}
 }
@@ -503,7 +503,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 
 					require.NoError(
 						t,
-						os.WriteFile(p, []byte(defaultReleaseNotesTemplate), 0664),
+						os.WriteFile(p, []byte(defaultReleaseNotesTemplate), 0o664),
 						"Writing user specified template.")
 				}
 			}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -389,8 +389,8 @@ func TestApplyMap(t *testing.T) {
 		testcase, ok := testNote.DataFields["testcase"]
 		require.True(t, ok, "found map test without testcase")
 
-		// Read the property this test csae checks
-		//nolint
+		// Read the property this test case checks
+		//nolint:errcheck
 		property := testcase.(map[interface{}]interface{})["property"].(string)
 		require.NotEmpty(t, property)
 		require.NotEmpty(t, property, "testcase found without property")
@@ -401,7 +401,7 @@ func TestApplyMap(t *testing.T) {
 		originalVal := reflect.Indirect(reflectedOriginalNote).FieldByName(property)
 
 		// Factor the test name
-		//nolint
+		//nolint:errcheck
 		testName := testcase.(map[interface{}]interface{})["name"].(string)
 
 		switch expectedValue := testcase.(map[interface{}]interface{})["expected"].(type) {

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -231,7 +231,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	// Create the record dir
 	if o.RecordDir != "" {
 		logrus.Info("Using record mode")
-		if err := os.MkdirAll(o.RecordDir, os.FileMode(0755)); err != nil {
+		if err := os.MkdirAll(o.RecordDir, os.FileMode(0o755)); err != nil {
 			return err
 		}
 	}

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -111,7 +111,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 
 	worktree, err := cloneRepo.Worktree()
@@ -148,7 +148,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	_, err = worktree.Add(branchTestFileName)
 	require.Nil(t, err)
@@ -172,7 +172,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	_, err = worktree.Add(secondBranchTestFileName)
 	require.Nil(t, err)

--- a/pkg/promobot/hash.go
+++ b/pkg/promobot/hash.go
@@ -48,7 +48,6 @@ func (o *GenerateManifestOptions) PopulateDefaults() {
 }
 
 // GenerateManifest generates a manifest containing the files in options.BaseDir
-// nolint[lll]
 func GenerateManifest(ctx context.Context, options GenerateManifestOptions) (*api.Manifest, error) {
 	manifest := &api.Manifest{}
 

--- a/pkg/promobot/hash_test.go
+++ b/pkg/promobot/hash_test.go
@@ -67,7 +67,7 @@ func AssertMatchesFile(t *testing.T, actual, p string) {
 
 	if actual != expected {
 		if os.Getenv("UPDATE_EXPECTED_OUTPUT") != "" {
-			if err := os.WriteFile(p, []byte(actual), 0644); err != nil {
+			if err := os.WriteFile(p, []byte(actual), 0o644); err != nil {
 				t.Fatalf("error writing file %q: %v", p, err)
 			}
 		}

--- a/pkg/promobot/promotefiles.go
+++ b/pkg/promobot/promotefiles.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint[lll]
 package promobot
 
 import (
@@ -59,7 +58,6 @@ func (o *PromoteFilesOptions) PopulateDefaults() {
 }
 
 // RunPromoteFiles executes a file promotion command
-// nolint[gocyclo]
 func RunPromoteFiles(ctx context.Context, options PromoteFilesOptions) error {
 	manifest, err := ReadManifest(options)
 	if err != nil {

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -79,13 +79,13 @@ func TestBuiltWithBazel(t *testing.T) {
 	require.Nil(t, os.WriteFile(
 		baseBazelFile,
 		[]byte("test"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	bazelFile := filepath.Join(bazelTmpDir, "bazel-bin/build/release-tars/kubernetes.tar.gz")
 	require.Nil(t, os.WriteFile(
 		bazelFile,
 		[]byte("test"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 
 	time.Sleep(1 * time.Second)
@@ -96,7 +96,7 @@ func TestBuiltWithBazel(t *testing.T) {
 	require.Nil(t, os.WriteFile(
 		baseDockerFile,
 		[]byte("test"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 	dockerFile := filepath.Join(
 		dockerTmpDir, BuildDir, "release-tars/kubernetes.tar.gz",
@@ -104,7 +104,7 @@ func TestBuiltWithBazel(t *testing.T) {
 	require.Nil(t, os.WriteFile(
 		dockerFile,
 		[]byte("test"),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 
 	defer cleanupTmps(t, baseTmpDir, bazelTmpDir, dockerTmpDir)
@@ -207,7 +207,7 @@ func TestReadBazelVersion(t *testing.T) {
 			require.Nil(t, os.WriteFile(
 				bazelVersionFile,
 				[]byte(version),
-				os.FileMode(0644),
+				os.FileMode(0o644),
 			))
 
 			res, err := ReadBazelVersion(baseTmpDir)
@@ -231,7 +231,7 @@ func TestReadDockerVersion(t *testing.T) {
 	var b bytes.Buffer
 
 	// Create version file
-	err = os.WriteFile(filepath.Join(baseTmpDir, BuildDir, ReleaseTarsPath, "kubernetes", "version"), versionBytes, os.FileMode(0644))
+	err = os.WriteFile(filepath.Join(baseTmpDir, BuildDir, ReleaseTarsPath, "kubernetes", "version"), versionBytes, os.FileMode(0o644))
 	require.Nil(t, err)
 
 	// Create a zip archive.
@@ -250,7 +250,7 @@ func TestReadDockerVersion(t *testing.T) {
 	require.Nil(t, os.WriteFile(
 		filepath.Join(baseTmpDir, BuildDir, ReleaseTarsPath, KubernetesTar),
 		b.Bytes(),
-		os.FileMode(0644),
+		os.FileMode(0o644),
 	))
 
 	defer cleanupTmps(t, baseTmpDir)

--- a/pkg/spdx/relationship.go
+++ b/pkg/spdx/relationship.go
@@ -24,7 +24,7 @@ import (
 
 type RelationshipType string
 
-// nolint
+//nolint:revive,stylecheck
 const (
 	DESCRIBES              RelationshipType = "DESCRIBES"
 	DESCRIBED_BY           RelationshipType = "DESCRIBED_BY"

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -251,7 +251,7 @@ func TestRelationshipRender(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-var testTar string = `H4sICPIFo2AAA2hlbGxvLnRhcgDt1EsKwjAUBdCMXUXcQPuS5rMFwaEraDGgUFpIE3D5puAPRYuD
+var testTar = `H4sICPIFo2AAA2hlbGxvLnRhcgDt1EsKwjAUBdCMXUXcQPuS5rMFwaEraDGgUFpIE3D5puAPRYuD
 VNR7Jm+QQh7c3hQly44Sa/U4hdV0O8+YUKTJkLRCMhKk0zHX+VdjLA6h9pyz6Ju66198N3H+pYpy
 iM1273P+Bm/lX4mUvyQlkP8cLvkHdwhFOIQMd4wBG6Oe5y/1Xf6VNhXjlGGXB3+e/yY2O9e2PV/H
 xvnOBTcsF59eCmZT5Cz+yXT/5bX/pMb3P030fw4rlB8AAAAAAAAAAAAAAAAA4CccAXRRwL4AKAAA

--- a/pkg/vulndash/adapter/adapter.go
+++ b/pkg/vulndash/adapter/adapter.go
@@ -231,7 +231,7 @@ func UpdateVulnerabilityDashboard(
 
 	dashboardJSON := dashboardPath + "dashboard.json"
 	logrus.Infof("writing the vulnerabilities for %s in the file %s", vulnProject, dashboardJSON)
-	err = os.WriteFile(dashboardJSON, jsonFile, 0644)
+	err = os.WriteFile(dashboardJSON, jsonFile, 0o644)
 	if err != nil {
 		return errors.Errorf("Unable to create temporary local"+
 			"JSON file for the dashboard: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- golangci-lint: Update to 1.42.0
- golangci-lint: Enable all issues to display at once
- generated: Run golangci-lint run --fix
- lint: Fixup stylecheck warnings
- lint: Fixup prealloc warnings
- golangci-lint: Replace the now-archived `golint` with `revive`
- lint(revive): Fixup variable declaration warnings
- lint(revive): Replace errors.New(fmt.Sprintf(...)) w/ fmt.Errorf(...)
- golangci-lint: Enable `nolintlint` linter
- lint(nolintlint): Drop unused `nolint` directives
- pkg/binary: Fixup lint warnings
- lint(nolintlint): Enforce stricter settings

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
