### PR TITLE
kpromo: Initial image building configuration

### DIFF
--- a/cmd/kpromo/Dockerfile
+++ b/cmd/kpromo/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the manager binary
+ARG GO_VERSION
+ARG OS_CODENAME
+# TODO(codename): Consider parameterizing in Makefile based on codename
+ARG DISTROLESS_IMAGE
+FROM golang:${GO_VERSION}-${OS_CODENAME} as builder
+
+WORKDIR /go/src/k8s.io/release
+
+# Copy the sources
+ENV package="./cmd/kpromo"
+COPY ../../go.mod ../../go.sum ./
+COPY ../../pkg ./pkg/
+COPY ../../cmd/kpromo ${package}/
+
+RUN go mod download
+
+# Build
+ARG ARCH
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=${ARCH}
+
+RUN go build -trimpath -ldflags '-s -w -buildid= -extldflags "-static"' \
+    -o kpromo ${package}
+
+# Production image
+FROM gcr.io/distroless/${DISTROLESS_IMAGE}:latest
+
+LABEL maintainers="Kubernetes Authors"
+LABEL description="kpromo: The Kubernetes project artifact promoter"
+
+WORKDIR /
+COPY --from=builder /go/src/k8s.io/release/kpromo .
+
+ENTRYPOINT ["/kpromo"]

--- a/cmd/kpromo/Makefile
+++ b/cmd/kpromo/Makefile
@@ -1,0 +1,98 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set default shell
+SHELL=/bin/bash -o pipefail
+
+REGISTRY ?= gcr.io/k8s-staging-artifact-promoter
+IMGNAME = kpromo
+IMAGE_VERSION ?= v0.1.0-1
+
+IMAGE = $(REGISTRY)/$(IMGNAME)
+
+TAG ?= $(shell git describe --tags --always --dirty)
+
+# Build args
+GO_VERSION ?= 1.17
+OS_CODENAME ?= buster
+DISTROLESS_IMAGE ?= static-debian10
+
+# Configuration
+CONFIG = $(OS_CODENAME)
+
+PLATFORMS ?= linux/amd64
+
+HOST_GOOS ?= $(shell go env GOOS)
+HOST_GOARCH ?= $(shell go env GOARCH)
+GO_BUILD ?= go build
+
+BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
+             --build-arg=OS_CODENAME=$(OS_CODENAME) \
+             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE)
+
+# Ensure support for 'docker buildx' and 'docker manifest' commands
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+.PHONY: all build clean
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	$(GO_BUILD)
+
+.PHONY: clean
+clean:
+	rm kpromo
+
+# build with buildx
+# https://github.com/docker/buildx/issues/59
+.PHONY: container
+container: init-docker-buildx
+	echo "Building $(IMGNAME) for the following platforms: $(PLATFORMS)"
+	@for platform in $(PLATFORMS); do \
+		echo "Starting build for $${platform} platform"; \
+		docker buildx build \
+			--load \
+			--progress plain \
+			--platform $${platform} \
+			--tag $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION) \
+			--tag $(IMAGE)-$${platform##*/}:$(TAG) \
+			--tag $(IMAGE)-$${platform##*/}:latest \
+			$(BUILD_ARGS) \
+			-f $(CURDIR)/Dockerfile \
+			../../.; \
+	done
+
+.PHONY: push
+push: container
+	echo "Pushing $(IMGNAME) tags"
+	@for platform in $(PLATFORMS); do \
+		echo "Pushing tags for $${platform} platform"; \
+		docker push $(IMAGE)-$${platform##*/}:$(IMAGE_VERSION); \
+		docker push $(IMAGE)-$${platform##*/}:$(TAG); \
+		docker push $(IMAGE)-$${platform##*/}:latest; \
+	done
+
+.PHONY: manifest
+manifest: push
+	docker manifest create --amend $(IMAGE):$(IMAGE_VERSION) $(IMAGE)-$(subst linux/,,$(firstword $(PLATFORMS))):$(IMAGE_VERSION)
+	@for platform in $(PLATFORMS); do docker manifest annotate --arch "$${platform##*/}" ${IMAGE}:${IMAGE_VERSION} ${IMAGE}-$${platform##*/}:${IMAGE_VERSION}; done
+	docker manifest push --purge $(IMAGE):$(IMAGE_VERSION)
+
+# enable buildx
+.PHONY: init-docker-buildx
+init-docker-buildx:
+	./../../hack/init-buildx.sh

--- a/cmd/kpromo/README.md
+++ b/cmd/kpromo/README.md
@@ -111,4 +111,4 @@ Global Flags:
 
 - [`kOps`][kops-release-process]
 
-[kops-release-process]: https://kops.sigs.k8s.io/development/release/
+[kops-release-process]: https://kops.sigs.k8s.io/contributing/release-process/

--- a/cmd/kpromo/cloudbuild.yaml
+++ b/cmd/kpromo/cloudbuild.yaml
@@ -1,0 +1,55 @@
+# See https://git.k8s.io/test-infra/config/jobs/image-pushing/README.md for
+# more details on image pushing process
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
+    entrypoint: 'bash'
+    dir: ./cmd/kpromo
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - REGISTRY=gcr.io/$PROJECT_ID
+    - HOME=/root
+    - TAG=$_GIT_TAG
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    - IMAGE_VERSION=$_IMAGE_VERSION
+    - GO_VERSION=$_GO_VERSION
+    - OS_CODENAME=$_OS_CODENAME
+    - DISTROLESS_IMAGE=$_DISTROLESS_IMAGE
+    args:
+    - '-c'
+    - |
+      gcloud auth configure-docker \
+      && make manifest
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _IMAGE_VERSION: 'v0.0.0'
+  _GO_VERSION: '0.0.0'
+  _OS_CODENAME: 'codename'
+  _DISTROLESS_IMAGE: 'static-debian00'
+
+tags:
+- 'kpromo'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_IMAGE_VERSION}
+- ${_GO_VERSION}
+- ${_OS_CODENAME}
+- ${_DISTROLESS_IMAGE}
+
+images:
+  - 'gcr.io/$PROJECT_ID/kpromo-amd64:$_IMAGE_VERSION'
+  - 'gcr.io/$PROJECT_ID/kpromo-amd64:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/kpromo-amd64:latest'

--- a/cmd/kpromo/variants.yaml
+++ b/cmd/kpromo/variants.yaml
@@ -1,0 +1,6 @@
+variants:
+  default:
+    IMAGE_VERSION: 'v0.1.0-1'
+    GO_VERSION: '1.17'
+    OS_CODENAME: 'buster'
+    DISTROLESS_IMAGE: 'static-debian10'

--- a/cmd/vulndash/Dockerfile
+++ b/cmd/vulndash/Dockerfile
@@ -36,7 +36,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=${ARCH}
 
-RUN go build -ldflags '-s -w -buildid= -extldflags "-static"' \
+RUN go build -trimpath -ldflags '-s -w -buildid= -extldflags "-static"' \
     -o vulndash ${package}
 
 # Production image

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,6 +66,10 @@ dependencies:
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
     - path: Dockerfile-kubepkg-rpm
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
+    - path: cmd/kpromo/Makefile
+      match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: cmd/kpromo/variants.yaml
+      match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
     - path: cmd/vulndash/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: cmd/vulndash/variants.yaml
@@ -156,6 +160,14 @@ dependencies:
     refPaths:
     - path: images/releng/ci/variants.yaml
       match: REVISION:\ '\d+'
+
+  - name: "k8s.gcr.io/artifact-promoter/kpromo"
+    version: v0.1.0-1
+    refPaths:
+    - path: cmd/kpromo/Makefile
+      match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
+    - path: cmd/kpromo/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)-([0-9]+)
 
   - name: "k8s.gcr.io/artifact-promoter/vulndash"
     version: v0.4.3-8
@@ -320,6 +332,11 @@ dependencies:
   - name: "Debian: codename (default)"
     version: buster
     refPaths:
+    # Must match distroless Debian version as well
+    - path: cmd/kpromo/Makefile
+      match: OS_CODENAME\ \?=\ (bullseye|buster)
+    - path: cmd/kpromo/variants.yaml
+      match: "OS_CODENAME: '(bullseye|buster)'"
     # Must match distroless Debian version as well
     - path: cmd/vulndash/Makefile
       match: OS_CODENAME\ \?=\ (bullseye|buster)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

kpromo: Initial image building configuration

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref:
- https://github.com/kubernetes/test-infra/pull/23416
- https://github.com/kubernetes/k8s.io/issues/2624#issuecomment-907557954
- https://github.com/kubernetes/k8s.io/pull/2272
- https://kubernetes.slack.com/archives/CCK68P2Q2/p1630361275004300

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kpromo: Initial image building configuration
```
