### PR TITLE
debian-iptables: Build buster-v1.6.7 image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -400,7 +400,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: buster-v1.6.6
+    version: buster-v1.6.7
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ [a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -431,7 +431,7 @@ dependencies:
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'
 
   - name: "k8s.gcr.io/build-image/debian-iptables (for previous release branches)"
-    version: buster-v1.6.6
+    version: buster-v1.6.7
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: '[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)'

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.6.6
+IMAGE_VERSION ?= buster-v1.6.7
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
 

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.6.6'
+    IMAGE_VERSION: 'buster-v1.6.7'
     DEBIAN_BASE_VERSION: 'buster-v1.9.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Bumping the debian-iptables version to remediate some new vulnerabilities in openssl:

- CVE-2021-3711
- CVE-2021-3712

/assign @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- debian-iptables: Build buster-v1.6.7 image
```
