### PR TITLE
Determine SPDX license from command line (+bug fix)

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -75,6 +75,7 @@ type generateOptions struct {
 	namespace      string
 	outputFile     string
 	configFile     string
+	license        string
 	images         []string
 	tarballs       []string
 	files          []string
@@ -156,6 +157,14 @@ func init() {
 		"list of regexp patterns to ignore when scanning directories",
 	)
 
+	generateCmd.PersistentFlags().StringVarP(
+		&genOpts.license,
+		"license",
+		"l",
+		"",
+		"SPDX license identifier to declare in the SBOM",
+	)
+
 	generateCmd.PersistentFlags().BoolVar(
 		&genOpts.noGitignore,
 		"no-gitignore",
@@ -228,6 +237,7 @@ func generateBOM(opts *generateOptions) error {
 		ProcessGoModules: !opts.noGoModules,
 		OnlyDirectDeps:   !opts.noGoTransient,
 		ConfigFile:       opts.configFile,
+		License:          opts.license,
 	}
 
 	// We only replace the ignore patterns one or more where defined

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -565,8 +565,8 @@ func (di *spdxDefaultImplementation) ImageRefToPackage(ref string, opts *Options
 			FullRender: true,
 			Comment:    "Container image lager",
 		})
-		pkg.AddRelationship(&Relationship{
-			Peer:    subpkg,
+		subpkg.AddRelationship(&Relationship{
+			Peer:    pkg,
 			Type:    VARIANT_OF,
 			Comment: "Image index",
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR adds a feature and fixes a bug in the SBOM generator:

1. Fixes a bug where the SPDX relationships in multiarch images where expressed backwards in the document.
2. Adds a new flag `--license` to specify the project license from the command line, this was already possible using a config file.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- SPDX: Fixed a bug where the `VARIANT_OF` relationship in multiarch container images was expressed backwards
- New `-l` | `--license` flag to define the project's license from the command line
```
