### PR TITLE
k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -111,7 +111,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.17
+    version: 1.17.1
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -200,14 +200,14 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents"
-    version: v1.23.0-go1.17-buster.0
+    version: v1.23.0-go1.17.1-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.17
+    version: 1.17.1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -250,7 +250,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-(bullseye|buster)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.23.0-go1.17-buster.0
+    version: v1.23.0-go1.17.1-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   cross1.17:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17-buster.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.1-buster.0'
   cross1.16:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.16.7-1'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.17-${OS_CODENAME} AS builder
+FROM golang:1.17.1-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.17
+GO_VERSION ?= 1.17.1
 OS_CODENAME ?= buster
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,7 +5,7 @@ variants:
     OS_CODENAME: 'buster'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17'
+    GO_VERSION: '1.17.1'
     OS_CODENAME: 'buster'
   '1.22':
     CONFIG: '1.22'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.1

PRs in k/k that uses go 1.17.1 are merged: https://github.com/kubernetes/kubernetes/pull/104904

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2238

/assign @puerco @Verolop  @xmudrii @justaugustus 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.1
```
