### PR TITLE
images: Build bullseye variants (part three)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -450,9 +450,8 @@ dependencies:
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
-    #- path: images/build/setcap/variants.yaml
-    #  match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+    - path: images/build/setcap/variants.yaml
+      match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
     version: bullseye-v1.0.0
@@ -461,7 +460,7 @@ dependencies:
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/setcap (next candidate)"
-    version: buster-v2.0.4
+    version: bullseye-v1.0.0
     refPaths:
     - path: images/build/setcap/variants.yaml
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -389,18 +389,16 @@ dependencies:
   - name: "Debian: codename (next candidate)"
     version: bullseye
     refPaths:
-    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
-    #- path: images/build/cross/variants.yaml
-    #  match: "OS_CODENAME: '(bullseye|buster)'"
+    - path: images/build/cross/variants.yaml
+      match: "OS_CODENAME: '(bullseye|buster)'"
     - path: images/build/debian-base/variants.yaml
       match: "CONFIG: '(bullseye|buster)'"
     - path: images/build/go-runner/variants.yaml
       match: "OS_CODENAME: '(bullseye|buster)'"
     - path: images/releng/ci/variants.yaml
       match: "OS_CODENAME: '(bullseye|buster)'"
-    # TODO(bullseye): Uncomment as part of https://github.com/kubernetes/release/pull/2249
-    #- path: images/releng/k8s-ci-builder/variants.yaml
-    #  match: "OS_CODENAME: '(bullseye|buster)'"
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "OS_CODENAME: '(bullseye|buster)'"
 
   - name: "k8s.gcr.io/build-image/debian-base"
     version: buster-v1.9.0

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -60,9 +60,9 @@ fi
 
 # Ensure qemu is in binfmt_misc
 # NOTE: Please always pin this to a digest for predictability/auditability
-# Last updated: 08/21/2020
+# Last updated: 09/18/2021
 if [ "$(uname)" == 'Linux' ]; then
-  docker run --rm --privileged multiarch/qemu-user-static@sha256:c772ee1965aa0be9915ee1b018a0dd92ea361b4fa1bcab5bbc033517749b2af4 --reset -p yes
+  docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2@sha256:14ef836763dd8a1d69927699811f89338b129faa3bd9eb52cd696bc3d84aa81a --reset -p yes
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3600s
+timeout: 5400s
 
 options:
   substitution_option: ALLOW_LOOSE

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.23-go1.17-bullseye:
+    CONFIG: 'go1.17-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.23.0-go1.17.1-bullseye.0'
+    KUBERNETES_VERSION: 'v1.23.0'
+    GO_VERSION: '1.17.1'
+    GO_MAJOR_VERSION: '1.17'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.7.0'
   v1.23-go1.17-buster:
     CONFIG: 'go1.17-buster'
     TYPE: 'default'

--- a/images/build/setcap/Dockerfile
+++ b/images/build/setcap/Dockerfile
@@ -16,5 +16,9 @@ ARG BASEIMAGE
 
 FROM ${BASEIMAGE}
 
+ARG BASEIMAGE
+
 RUN apt-get update \
+    && CODENAME=$(. /etc/os-release; echo $VERSION_CODENAME) && \
+    if [ "bullseye" = "$CODENAME" ]; then apt-get -y --allow-change-held-packages install libcap2; fi \
     && apt-get -y --no-install-recommends install libcap2-bin

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -1,4 +1,10 @@
 variants:
+  # Debian 11 - Kubernetes 1.23 and newer
+  bullseye:
+    CONFIG: 'bullseye'
+    IMAGE_VERSION: 'bullseye-v1.0.0'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.0.0'
+  # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v2.0.4'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -75,9 +75,9 @@ RUN echo "Installing Packages ..." \
             mercurial \
             pkg-config \
             procps \
-            python \
-            python-dev \
-            python-pip \
+            python3 \
+            python3-dev \
+            python3-pip \
             rsync \
             software-properties-common \
             unzip \

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -3,6 +3,10 @@ variants:
     CONFIG: default
     GO_VERSION: '1.16.8'
     OS_CODENAME: 'buster'
+  next:
+    CONFIG: next
+    GO_VERSION: '1.17.1'
+    OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
     GO_VERSION: '1.17.1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Builds on top of https://github.com/kubernetes/release/pull/2210.
~/hold for rebase magic~

- setcap: Build bullseye-v1.0.0 images
- images: Build go1.17-bullseye variants (part two)
  - kube-cross:v1.23.0-go1.17.1-bullseye.0
  - k8s-ci-builder

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- setcap: Build bullseye-v1.0.0 images
- images: Build go1.17-bullseye variants (part two)
  - kube-cross:v1.23.0-go1.17.1-bullseye.0
  - k8s-ci-builder
```
