### PR TITLE
Fix krel cve -f flag description

### DIFF
--- a/cmd/krel/cmd/cve.go
+++ b/cmd/krel/cmd/cve.go
@@ -100,7 +100,7 @@ func init() {
 		"file",
 		"f",
 		[]string{},
-		"version tag for the notes",
+		"update vulnerability data from a local map file",
 	)
 
 	cveCmd.AddCommand(cveEditCmd, cveDeleteCmd)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The help text for krel cve -f was wrong. This commit updates to read:

> update vulnerability data from a local map file

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
NONE
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
FIxed the help text for `krel cve -f`. It now reads _"update vulnerability data from a local map file"_
```
