### PR TITLE
cross: install ip looks like it is not there for bullseye

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -56,7 +56,8 @@ RUN apt-get -q update \
         jq \
         patch \
         rsync \
-        unzip
+        unzip \
+        iproute2
 
 # Use dynamic cgo linking for architectures other than amd64 for the server platforms
 # To install crossbuild essential for other architectures add the following repository.
@@ -102,8 +103,8 @@ RUN mkdir $TMPDIR \
   && chmod o+t $TMPDIR
 
 # Get the code coverage tool and goimports
-RUN go get golang.org/x/tools/cmd/cover \
-           golang.org/x/tools/cmd/goimports \
+RUN for i in {1..5}; do GOPROXY="direct" go install golang.org/x/tools/cmd/cover@latest && break || sleep 15; done  \
+    && for i in {1..5}; do GOPROXY="direct" go install golang.org/x/tools/cmd/goimports@latest && break || sleep 15; done  \
     && go clean -cache
 
 # Cleanup a bit

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,12 +2,12 @@ variants:
   v1.23-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.23.0-go1.17.1-bullseye.0'
+    IMAGE_VERSION: 'v1.23.0-go1.17.1-bullseye.1'
     KUBERNETES_VERSION: 'v1.23.0'
     GO_VERSION: '1.17.1'
     GO_MAJOR_VERSION: '1.17'
     OS_CODENAME: 'bullseye'
-    REVISION: '0'
+    REVISION: '1'
     PROTOBUF_VERSION: '3.7.0'
   v1.23-go1.17-buster:
     CONFIG: 'go1.17-buster'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Looks like the bullseye does not include the tool `ip` in our configuration, adding that to not break the building in k/k

for more context see: https://github.com/kubernetes/kubernetes/pull/105158

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
cross: install ip looks like it is not there for bullseye
```
