### PR TITLE
k8s-cloud-builder: bump kube-cross image tag to v1.23.0-go1.17.1-buster.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -199,7 +199,13 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: REVISION:\ '\d+'
 
-  - name: "k8s.gcr.io/build-image/kube-cross: dependents"
+  - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
+    version: v1.23.0-go1.17.1-bullseye.1
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "k8s.gcr.io/build-image/kube-cross: dependents buster"
     version: v1.23.0-go1.17.1-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,10 +1,16 @@
 variants:
-  cross1.17:
+  v1.23-cross1.17-bullseye:
+    CONFIG: 'cross1.17'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.1-bullseye.1'
+  v1.23-cross1.17-buster:
     CONFIG: 'cross1.17'
     KUBE_CROSS_VERSION: 'v1.23.0-go1.17.1-buster.0'
-  cross1.16:
+  v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.8-buster.0'
+  v1.21-cross1.16-buster:
+    CONFIG: 'cross1.16'
+    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.8-buster.0'
   cross1.15:
     CONFIG: 'cross1.15'
     KUBE_CROSS_VERSION: 'v1.15.15-1'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

in this PR we fix the kube-cross image https://github.com/kubernetes/release/pull/2260 and I forgot to bump the k8s-cloud-build, this PR fix that

needed by: https://github.com/kubernetes/sig-release/issues/1715

/assign @puerco @xmudrii @Verolop @ameukam 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
