### PR TITLE
Make feature flag `--list-v2`  of `krel release-notes` as the default behavior

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -126,7 +126,7 @@ type releaseNotesOptions struct {
 	createDraftPR      bool
 	createWebsitePR    bool
 	fixNotes           bool
-	listReleaseNotesV2 bool
+	listReleaseNotesV1 bool
 	websiteRepo        string
 	mapProviders       []string
 	githubOrg          string
@@ -206,10 +206,10 @@ func init() {
 	)
 
 	releaseNotesCmd.PersistentFlags().BoolVar(
-		&releaseNotesOpts.listReleaseNotesV2,
-		"list-v2",
-		true,
-		"enable experimental implementation to list commits (ListReleaseNotesV2)",
+		&releaseNotesOpts.listReleaseNotesV1,
+		"list-v1",
+		false,
+		"enable previous implementation to list commits",
 	)
 
 	releaseNotesCmd.PersistentFlags().BoolVar(
@@ -966,7 +966,7 @@ func gatherNotesFrom(repoPath, startTag string) (*notes.ReleaseNotes, error) {
 	notesOptions.EndRev = releaseNotesOpts.tag
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
-	notesOptions.ListReleaseNotesV2 = releaseNotesOpts.listReleaseNotesV2
+	notesOptions.ListReleaseNotesV1 = releaseNotesOpts.listReleaseNotesV1
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -208,7 +208,7 @@ func init() {
 	releaseNotesCmd.PersistentFlags().BoolVar(
 		&releaseNotesOpts.listReleaseNotesV2,
 		"list-v2",
-		false,
+		true,
 		"enable experimental implementation to list commits (ListReleaseNotesV2)",
 	)
 

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -260,7 +260,7 @@ func init() {
 	cmd.PersistentFlags().BoolVar(
 		&opts.ListReleaseNotesV2,
 		"list-v2",
-		false,
+		true,
 		"enable experimental implementation to list commits (ListReleaseNotesV2)",
 	)
 }

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -258,10 +258,10 @@ func init() {
 		"specify a location to recursively look for release notes *.y[a]ml file mappings",
 	)
 	cmd.PersistentFlags().BoolVar(
-		&opts.ListReleaseNotesV2,
-		"list-v2",
-		true,
-		"enable experimental implementation to list commits (ListReleaseNotesV2)",
+		&opts.ListReleaseNotesV1,
+		"list-v1",
+		false,
+		"enable previous implementation to list commits",
 	)
 }
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -238,11 +238,11 @@ func GatherReleaseNotes(opts *options.Options) (*ReleaseNotes, error) {
 
 	var releaseNotes *ReleaseNotes
 	startTime := time.Now()
-	if gatherer.options.ListReleaseNotesV2 {
-		logrus.Warn("EXPERIMENTAL IMPLEMENTATION ListReleaseNotesV2 ENABLED")
-		releaseNotes, err = gatherer.ListReleaseNotesV2()
-	} else {
+	if gatherer.options.ListReleaseNotesV1 {
+		logrus.Warn("Previous implementation of listing commits ENABLED")
 		releaseNotes, err = gatherer.ListReleaseNotes()
+	} else {
+		releaseNotes, err = gatherer.ListReleaseNotesV2()
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "listing release notes")

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -105,8 +105,8 @@ type Options struct {
 	// log level
 	Debug bool
 
-	// EXPERIMENTAL: Feature flag for using v2 implementation to list commits
-	ListReleaseNotesV2 bool
+	// Feature flag for using v1 implementation to list commits
+	ListReleaseNotesV1 bool
 
 	// RecordDir specifies the directory for API call recordings. Cannot be
 	// used together with ReplayDir.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make feature flag `--list-v2`  of `krel release-notes` as the default behavior.
 
@wilsonehusin  's [experimental code](https://github.com/kubernetes/release/pull/1888) to list release notes locally behind a feature flag `--list-v2` has been out for a while. And release notes team have been trying with this flag since release 1.22 and it has been working fine. This is to make it as the default behavior.

#### Which issue(s) this PR fixes:
Fixes #2241 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make feature flag `--list-v2`  of `krel release-notes` as the default behavior.
```
