### PR TITLE
config: Add configs for copying GitHub releases to GCS buckets

### DIFF
--- a/config/kpromo-gh.yaml
+++ b/config/kpromo-gh.yaml
@@ -1,0 +1,11 @@
+# Configurations for copying GitHub releases to GCS buckets
+# Used by https://sigs.k8s.io/promo-tools/cmd/kpromo
+releaseConfigs:
+- org: containernetworking
+  repo: plugins
+  gcsBucket: k8s-staging-cni-plugins
+  releaseDir: releases
+- org: kubernetes-sigs
+  repo: cri-tools
+  gcsBucket: k8s-staging-cri-tools
+  releaseDir: releases


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes-sigs/promo-tools/pull/441.
Used by https://sigs.k8s.io/promo-tools/cmd/kpromo.
Referenced in today's SIG Release [meeting](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit#bookmark=id.v3stikoq1v45).

Part of release improvements for CRI tools (https://github.com/kubernetes-sigs/cri-tools/issues/616) + CNI plugins (https://github.com/kubernetes/sig-release/issues/245).

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

/hold for local testing

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
config: Add configs for copying GitHub releases to GCS buckets
```
