### PR TITLE
Fix container images provenance data

### DIFF
--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"k8s.io/release/pkg/anago"
 	"k8s.io/release/pkg/build"
 	"k8s.io/release/pkg/changelog"
@@ -42,19 +43,6 @@ type FakeStageImpl struct {
 		result1 error
 	}
 	addBinariesToSBOMReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddProvenanceSubjectStub        func(*provenance.Statement, string, bool) error
-	addProvenanceSubjectMutex       sync.RWMutex
-	addProvenanceSubjectArgsForCall []struct {
-		arg1 *provenance.Statement
-		arg2 string
-		arg3 bool
-	}
-	addProvenanceSubjectReturns struct {
-		result1 error
-	}
-	addProvenanceSubjectReturnsOnCall map[int]struct {
 		result1 error
 	}
 	AddTarfilesToSBOMStub        func(*spdx.Document, string) error
@@ -242,6 +230,35 @@ type FakeStageImpl struct {
 	}
 	generateVersionArtifactsBOMReturnsOnCall map[int]struct {
 		result1 error
+	}
+	GetOutputDirSubjectsStub        func(*anago.StageOptions, string, string) ([]in_toto.Subject, error)
+	getOutputDirSubjectsMutex       sync.RWMutex
+	getOutputDirSubjectsArgsForCall []struct {
+		arg1 *anago.StageOptions
+		arg2 string
+		arg3 string
+	}
+	getOutputDirSubjectsReturns struct {
+		result1 []in_toto.Subject
+		result2 error
+	}
+	getOutputDirSubjectsReturnsOnCall map[int]struct {
+		result1 []in_toto.Subject
+		result2 error
+	}
+	GetProvenanceSubjectsStub        func(*anago.StageOptions, string) ([]in_toto.Subject, error)
+	getProvenanceSubjectsMutex       sync.RWMutex
+	getProvenanceSubjectsArgsForCall []struct {
+		arg1 *anago.StageOptions
+		arg2 string
+	}
+	getProvenanceSubjectsReturns struct {
+		result1 []in_toto.Subject
+		result2 error
+	}
+	getProvenanceSubjectsReturnsOnCall map[int]struct {
+		result1 []in_toto.Subject
+		result2 error
 	}
 	ListBinariesStub func(string) ([]struct {
 		Path     string
@@ -549,69 +566,6 @@ func (fake *FakeStageImpl) AddBinariesToSBOMReturnsOnCall(i int, result1 error) 
 		})
 	}
 	fake.addBinariesToSBOMReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubject(arg1 *provenance.Statement, arg2 string, arg3 bool) error {
-	fake.addProvenanceSubjectMutex.Lock()
-	ret, specificReturn := fake.addProvenanceSubjectReturnsOnCall[len(fake.addProvenanceSubjectArgsForCall)]
-	fake.addProvenanceSubjectArgsForCall = append(fake.addProvenanceSubjectArgsForCall, struct {
-		arg1 *provenance.Statement
-		arg2 string
-		arg3 bool
-	}{arg1, arg2, arg3})
-	stub := fake.AddProvenanceSubjectStub
-	fakeReturns := fake.addProvenanceSubjectReturns
-	fake.recordInvocation("AddProvenanceSubject", []interface{}{arg1, arg2, arg3})
-	fake.addProvenanceSubjectMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubjectCallCount() int {
-	fake.addProvenanceSubjectMutex.RLock()
-	defer fake.addProvenanceSubjectMutex.RUnlock()
-	return len(fake.addProvenanceSubjectArgsForCall)
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubjectCalls(stub func(*provenance.Statement, string, bool) error) {
-	fake.addProvenanceSubjectMutex.Lock()
-	defer fake.addProvenanceSubjectMutex.Unlock()
-	fake.AddProvenanceSubjectStub = stub
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubjectArgsForCall(i int) (*provenance.Statement, string, bool) {
-	fake.addProvenanceSubjectMutex.RLock()
-	defer fake.addProvenanceSubjectMutex.RUnlock()
-	argsForCall := fake.addProvenanceSubjectArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubjectReturns(result1 error) {
-	fake.addProvenanceSubjectMutex.Lock()
-	defer fake.addProvenanceSubjectMutex.Unlock()
-	fake.AddProvenanceSubjectStub = nil
-	fake.addProvenanceSubjectReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeStageImpl) AddProvenanceSubjectReturnsOnCall(i int, result1 error) {
-	fake.addProvenanceSubjectMutex.Lock()
-	defer fake.addProvenanceSubjectMutex.Unlock()
-	fake.AddProvenanceSubjectStub = nil
-	if fake.addProvenanceSubjectReturnsOnCall == nil {
-		fake.addProvenanceSubjectReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addProvenanceSubjectReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1542,6 +1496,137 @@ func (fake *FakeStageImpl) GenerateVersionArtifactsBOMReturnsOnCall(i int, resul
 	fake.generateVersionArtifactsBOMReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjects(arg1 *anago.StageOptions, arg2 string, arg3 string) ([]in_toto.Subject, error) {
+	fake.getOutputDirSubjectsMutex.Lock()
+	ret, specificReturn := fake.getOutputDirSubjectsReturnsOnCall[len(fake.getOutputDirSubjectsArgsForCall)]
+	fake.getOutputDirSubjectsArgsForCall = append(fake.getOutputDirSubjectsArgsForCall, struct {
+		arg1 *anago.StageOptions
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetOutputDirSubjectsStub
+	fakeReturns := fake.getOutputDirSubjectsReturns
+	fake.recordInvocation("GetOutputDirSubjects", []interface{}{arg1, arg2, arg3})
+	fake.getOutputDirSubjectsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjectsCallCount() int {
+	fake.getOutputDirSubjectsMutex.RLock()
+	defer fake.getOutputDirSubjectsMutex.RUnlock()
+	return len(fake.getOutputDirSubjectsArgsForCall)
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjectsCalls(stub func(*anago.StageOptions, string, string) ([]in_toto.Subject, error)) {
+	fake.getOutputDirSubjectsMutex.Lock()
+	defer fake.getOutputDirSubjectsMutex.Unlock()
+	fake.GetOutputDirSubjectsStub = stub
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjectsArgsForCall(i int) (*anago.StageOptions, string, string) {
+	fake.getOutputDirSubjectsMutex.RLock()
+	defer fake.getOutputDirSubjectsMutex.RUnlock()
+	argsForCall := fake.getOutputDirSubjectsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjectsReturns(result1 []in_toto.Subject, result2 error) {
+	fake.getOutputDirSubjectsMutex.Lock()
+	defer fake.getOutputDirSubjectsMutex.Unlock()
+	fake.GetOutputDirSubjectsStub = nil
+	fake.getOutputDirSubjectsReturns = struct {
+		result1 []in_toto.Subject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GetOutputDirSubjectsReturnsOnCall(i int, result1 []in_toto.Subject, result2 error) {
+	fake.getOutputDirSubjectsMutex.Lock()
+	defer fake.getOutputDirSubjectsMutex.Unlock()
+	fake.GetOutputDirSubjectsStub = nil
+	if fake.getOutputDirSubjectsReturnsOnCall == nil {
+		fake.getOutputDirSubjectsReturnsOnCall = make(map[int]struct {
+			result1 []in_toto.Subject
+			result2 error
+		})
+	}
+	fake.getOutputDirSubjectsReturnsOnCall[i] = struct {
+		result1 []in_toto.Subject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjects(arg1 *anago.StageOptions, arg2 string) ([]in_toto.Subject, error) {
+	fake.getProvenanceSubjectsMutex.Lock()
+	ret, specificReturn := fake.getProvenanceSubjectsReturnsOnCall[len(fake.getProvenanceSubjectsArgsForCall)]
+	fake.getProvenanceSubjectsArgsForCall = append(fake.getProvenanceSubjectsArgsForCall, struct {
+		arg1 *anago.StageOptions
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetProvenanceSubjectsStub
+	fakeReturns := fake.getProvenanceSubjectsReturns
+	fake.recordInvocation("GetProvenanceSubjects", []interface{}{arg1, arg2})
+	fake.getProvenanceSubjectsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjectsCallCount() int {
+	fake.getProvenanceSubjectsMutex.RLock()
+	defer fake.getProvenanceSubjectsMutex.RUnlock()
+	return len(fake.getProvenanceSubjectsArgsForCall)
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjectsCalls(stub func(*anago.StageOptions, string) ([]in_toto.Subject, error)) {
+	fake.getProvenanceSubjectsMutex.Lock()
+	defer fake.getProvenanceSubjectsMutex.Unlock()
+	fake.GetProvenanceSubjectsStub = stub
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjectsArgsForCall(i int) (*anago.StageOptions, string) {
+	fake.getProvenanceSubjectsMutex.RLock()
+	defer fake.getProvenanceSubjectsMutex.RUnlock()
+	argsForCall := fake.getProvenanceSubjectsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjectsReturns(result1 []in_toto.Subject, result2 error) {
+	fake.getProvenanceSubjectsMutex.Lock()
+	defer fake.getProvenanceSubjectsMutex.Unlock()
+	fake.GetProvenanceSubjectsStub = nil
+	fake.getProvenanceSubjectsReturns = struct {
+		result1 []in_toto.Subject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GetProvenanceSubjectsReturnsOnCall(i int, result1 []in_toto.Subject, result2 error) {
+	fake.getProvenanceSubjectsMutex.Lock()
+	defer fake.getProvenanceSubjectsMutex.Unlock()
+	fake.GetProvenanceSubjectsStub = nil
+	if fake.getProvenanceSubjectsReturnsOnCall == nil {
+		fake.getProvenanceSubjectsReturnsOnCall = make(map[int]struct {
+			result1 []in_toto.Subject
+			result2 error
+		})
+	}
+	fake.getProvenanceSubjectsReturnsOnCall[i] = struct {
+		result1 []in_toto.Subject
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeStageImpl) ListBinaries(arg1 string) ([]struct {
@@ -2770,8 +2855,6 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.addBinariesToSBOMMutex.RLock()
 	defer fake.addBinariesToSBOMMutex.RUnlock()
-	fake.addProvenanceSubjectMutex.RLock()
-	defer fake.addProvenanceSubjectMutex.RUnlock()
 	fake.addTarfilesToSBOMMutex.RLock()
 	defer fake.addTarfilesToSBOMMutex.RUnlock()
 	fake.branchNeedsCreationMutex.RLock()
@@ -2802,6 +2885,10 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.generateSourceTreeBOMMutex.RUnlock()
 	fake.generateVersionArtifactsBOMMutex.RLock()
 	defer fake.generateVersionArtifactsBOMMutex.RUnlock()
+	fake.getOutputDirSubjectsMutex.RLock()
+	defer fake.getOutputDirSubjectsMutex.RUnlock()
+	fake.getProvenanceSubjectsMutex.RLock()
+	defer fake.getProvenanceSubjectsMutex.RUnlock()
 	fake.listBinariesMutex.RLock()
 	defer fake.listBinariesMutex.RUnlock()
 	fake.listImageArchivesMutex.RLock()

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -20,9 +20,11 @@ package anago_test
 import (
 	"testing"
 
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/stretchr/testify/require"
 	"k8s.io/release/pkg/anago"
 	"k8s.io/release/pkg/anago/anagofakes"
+	"k8s.io/release/pkg/provenance"
 	"k8s.io/release/pkg/release"
 	"k8s.io/release/pkg/spdx"
 	"sigs.k8s.io/release-sdk/git"
@@ -530,9 +532,15 @@ func TestStageArtifacts(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // Add AddProvenanceSubject fails
+		{ // GetProvenanceSubjects fails
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.AddProvenanceSubjectReturns(err)
+				mock.GetProvenanceSubjectsReturns(nil, err)
+			},
+			shouldError: true,
+		},
+		{ // GetOutputDirSubjects fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.GetOutputDirSubjectsReturns(nil, err)
 			},
 			shouldError: true,
 		},
@@ -540,6 +548,9 @@ func TestStageArtifacts(t *testing.T) {
 		opts := anago.DefaultStageOptions()
 		sut := anago.NewDefaultStage(opts)
 		mock := &anagofakes.FakeStageImpl{}
+		mock.GenerateAttestationReturns(provenance.NewSLSAStatement(), nil)
+		mock.GetProvenanceSubjectsReturns([]intoto.Subject{}, nil)
+		mock.GetOutputDirSubjectsReturns([]intoto.Subject{}, nil)
 		tc.prepare(mock)
 		sut.SetImpl(mock)
 

--- a/pkg/release/provenance.go
+++ b/pkg/release/provenance.go
@@ -143,3 +143,111 @@ func (di *defaultProvenanceCheckerImpl) checkProvenance(
 	opts *ProvenanceCheckerOptions, s *provenance.Statement) error {
 	return errors.Wrap(s.VerifySubjects(opts.StageDirectory), "checking subjects in attestation")
 }
+
+func NewProvenanceReader(opts *ProvenanceReaderOptions) *ProvenanceReader {
+	return &ProvenanceReader{
+		options: opts,
+		impl:    &defaultProvenanceReaderImpl{},
+	}
+}
+
+type ProvenanceReader struct {
+	options *ProvenanceReaderOptions
+	impl    provenanceReaderImplementation
+}
+
+type provenanceReaderImplementation interface {
+	GetStagingSubjects(*ProvenanceReaderOptions, string) ([]intoto.Subject, error)
+	GetBuildSubjects(*ProvenanceReaderOptions, string, string) ([]intoto.Subject, error)
+}
+
+type ProvenanceReaderOptions struct {
+	Bucket       string
+	BuildVersion string
+	WorkspaceDir string
+}
+
+// GetBuildSubjects returns all artifacts in the output directory
+// as intoto subjects, ready to add to the attestation
+func (pr *ProvenanceReader) GetBuildSubjects(path, version string) ([]intoto.Subject, error) {
+	return pr.impl.GetBuildSubjects(pr.options, path, version)
+}
+
+// GetStagingSubjects reads artifacts from the GCB workspace and returns them
+// as in-toto subjects, with their paths normalized to their final locations
+// in the staging bucket.
+func (pr *ProvenanceReader) GetStagingSubjects(path string) ([]intoto.Subject, error) {
+	return pr.impl.GetStagingSubjects(pr.options, path)
+}
+
+type defaultProvenanceReaderImpl struct{}
+
+func (di *defaultProvenanceReaderImpl) GetStagingSubjects(
+	opts *ProvenanceReaderOptions, path string) ([]intoto.Subject, error) {
+	// Create the dummy statement to read artifacts
+	dummy := provenance.NewSLSAStatement()
+
+	// The path in the bucket were built artifacts will be staged
+	gcsPath := filepath.Join(opts.Bucket, StagePath, opts.BuildVersion)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "checking artifact path to generate provenance subjects")
+	}
+
+	if info.IsDir() {
+		if err := dummy.ReadSubjectsFromDir(path); err != nil {
+			return nil, errors.Wrapf(err, "generating provenance subject from file %s", path)
+		}
+	} else {
+		if err := dummy.AddSubjectFromFile(path); err != nil {
+			return nil, errors.Wrapf(err, "generating provenance subject from file %s", path)
+		}
+	}
+
+	// Check if we are dealing with the sources tar and translate to the top
+	if dummy.Subject[0].Name == filepath.Join(opts.WorkspaceDir, SourcesTar) {
+		dummy.Subject[0].Name = SourcesTar
+	}
+
+	for i, s := range dummy.Subject {
+		dummy.Subject[i].Name = object.GcsPrefix + filepath.Join(gcsPath, s.Name)
+	}
+
+	return dummy.Subject, nil
+}
+
+func (di *defaultProvenanceReaderImpl) GetBuildSubjects(
+	opts *ProvenanceReaderOptions, path, version string) ([]intoto.Subject, error) {
+	// The path in the bucket were built artifacts will be staged
+	gcsPath := filepath.Join(opts.Bucket, StagePath, opts.BuildVersion)
+
+	// When adding the output directory for a specific version, we need
+	// to modiy the paths in the attestation to match the bucket names.
+	// In order to do that, we create a dummy statement. Use that to read
+	// the files and translate those to the final attestation with the paths
+	// translated.
+	dummy := provenance.NewSLSAStatement()
+	if err := dummy.ReadSubjectsFromDir(path); err != nil {
+		return nil, errors.Wrap(err, "reading output directory provenance subjects")
+	}
+
+	// Cycle the subjects, translate the paths and copy them to the
+	// real attestation:
+	newSubjects := []intoto.Subject{}
+	for _, subject := range dummy.Subject {
+		// If the artifact is not in the images or gcs-stage dir, skip
+		if !strings.HasPrefix(subject.Name, ImagesPath) &&
+			!strings.HasPrefix(subject.Name, GCSStagePath) {
+			continue
+		}
+
+		// Now the tricky part. We need to re-append the version tag. Eg
+		// gcs-stage/v1.23.0-alpha.4/file.txt shoud be
+		// v1.23.0-alpha.4/gcs-stage/v1.23.0-alpha.4/file.txt shoud be
+		subject.Name = object.GcsPrefix + filepath.Join(gcsPath, version, subject.Name)
+
+		newSubjects = append(newSubjects, subject)
+	}
+	return newSubjects, nil
+}

--- a/pkg/release/provenance_test.go
+++ b/pkg/release/provenance_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/release-sdk/object"
+)
+
+func TestGetBuildSubjects(t *testing.T) {
+	// create a test dir with stuff
+	dir, err := os.MkdirTemp("", "provenance-test-")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	require.Nil(t, os.Mkdir(filepath.Join(dir, ImagesPath), os.FileMode(0o755)))
+
+	testFiles := map[string]struct {
+		data     string
+		checksum string
+	}{
+		"README.md": {
+			data:     "123",
+			checksum: "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+		},
+		"LICENSE": {
+			data:     "Copyright © 2000",
+			checksum: "c8377d9ac397f096eb81aa8b409945b8f228976bc8eb7f4de32d222018163534",
+		},
+	}
+
+	for filename, testData := range testFiles {
+		require.Nil(t, os.WriteFile(filepath.Join(dir, ImagesPath, filename), []byte(testData.data), os.FileMode(0o644)))
+	}
+
+	impl := defaultProvenanceReaderImpl{}
+	opts := ProvenanceReaderOptions{
+		Bucket:       "test-bucket",
+		BuildVersion: "v0.0158987987",
+		WorkspaceDir: dir,
+	}
+	version := "v1.0"
+	subjects, err := impl.GetBuildSubjects(&opts, dir, version)
+	require.Nil(t, err)
+	require.Equal(t, len(testFiles), len(subjects))
+
+	// Check the files have the bucket prefix:
+	gcsPath := filepath.Join(opts.Bucket, StagePath, opts.BuildVersion)
+
+	// Check subjects match in their data and rewritten path
+	for _, sub := range subjects {
+		filename := filepath.Base(sub.Name)
+		require.NotEmpty(t, filename)
+		_, ok := testFiles[filename]
+		require.True(t, ok)
+		require.Equal(t, testFiles[filename].checksum, sub.Digest["sha256"])
+		require.True(t, strings.HasPrefix(sub.Name, object.GcsPrefix+gcsPath), filename)
+		require.True(t, strings.HasPrefix(sub.Name, object.GcsPrefix+filepath.Join(gcsPath, version)), filename)
+	}
+}
+
+func TestGetStagingSubjects(t *testing.T) {
+	// create a test dir with stuff
+	dir, err := os.MkdirTemp("", "provenance-test-")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	require.Nil(t, os.Mkdir(filepath.Join(dir, "second"), os.FileMode(0o755)))
+
+	testFiles := map[string]struct {
+		data     string
+		checksum string
+	}{
+		SourcesTar: {
+			data:     "123",
+			checksum: "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+		},
+		"second/LICENSE": {
+			data:     "Copyright © 2000",
+			checksum: "c8377d9ac397f096eb81aa8b409945b8f228976bc8eb7f4de32d222018163534",
+		},
+	}
+
+	for filename, testData := range testFiles {
+		require.Nil(t, os.WriteFile(filepath.Join(dir, filename), []byte(testData.data), os.FileMode(0o644)))
+	}
+
+	impl := defaultProvenanceReaderImpl{}
+	opts := ProvenanceReaderOptions{
+		Bucket:       "test-bucket",
+		BuildVersion: "v0.0158987987",
+		WorkspaceDir: dir,
+	}
+	subjects, err := impl.GetStagingSubjects(&opts, dir)
+	require.Nil(t, err)
+	require.Equal(t, len(testFiles), len(subjects))
+
+	// Check the files have the bucket prefix:
+	gcsPath := filepath.Join(opts.Bucket, StagePath, opts.BuildVersion)
+
+	// Al subjects should appear in the provenance data, we have an exception
+	// with the sources tar which always goes to the top of the staging dir
+	for _, sub := range subjects {
+		filename := filepath.Base(sub.Name)
+		require.NotEmpty(t, filename)
+		_, ok := testFiles[filepath.Join("second", filename)]
+		if filename == SourcesTar {
+			require.False(t, ok)
+			require.Equal(t, sub.Name, object.GcsPrefix+filepath.Join(gcsPath, SourcesTar))
+		} else {
+			require.True(t, ok)
+			require.True(t, strings.HasPrefix(sub.Name, object.GcsPrefix+gcsPath), filename)
+		}
+	}
+}

--- a/pkg/spdx/gomod.go
+++ b/pkg/spdx/gomod.go
@@ -358,7 +358,11 @@ func (di *GoModDefaultImpl) DownloadPackage(pkg *GoPackage, opts *GoModuleOption
 	logrus.WithField("package", pkg.ImportPath).Infof("Downloading package %s@%s", pkg.ImportPath, pkg.Revision)
 	repo, err := vcs.RepoRootForImportPath(pkg.ImportPath, true)
 	if err != nil {
-		return errors.Wrapf(err, "Fetching package %s from %s", pkg.ImportPath, repo.Repo)
+		repoName := "[unknown repo]"
+		if repo != nil {
+			repoName = repo.Repo
+		}
+		return errors.Wrapf(err, "Fetching package %s from %s", pkg.ImportPath, repoName)
 	}
 
 	if !util.Exists(filepath.Join(os.TempDir(), downloadDir)) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

During the first iteration of the provenance data, the attested data produced during stage for the container image tarballs was wrong. This PR introduces a complete refactor of  the provenance generation code. It shifts all the provenance code to a new `ProvenanceReader` object that takes care of generating the necessary information for 1) everything in the build output directory  and 2) other artifacts (such as the source code tarball).

#### Which issue(s) this PR fixes:

Fixes a bug in the provenance data generation (no issue was opened for this) 
Part of https://github.com/kubernetes/release/issues/2267


#### Special notes for your reviewer:

Test run: https://console.cloud.google.com/cloud-build/builds;region=global/d1bd16f2-3701-4f27-94ac-30c54e1b1a58?project=kubernetes-release-test

#### Does this PR introduce a user-facing change?

```release-note
New `release.ProvenanceReade` object handles the generation of provenance subjects during staging. Written in response to a bug found in the intoto subjects included in the attestation, this new object is now more testable.
```
