### PR TITLE
Perform provenance verification in dedicated scratch dir

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -635,7 +635,8 @@ func (d *DefaultRelease) CheckProvenance() error {
 
 func (d *defaultReleaseImpl) CheckStageProvenance(bucket, buildVersion string) error {
 	checker := release.NewProvenanceChecker(&release.ProvenanceCheckerOptions{
-		StageBucket: bucket,
+		ScratchDirectory: filepath.Join(workspaceDir, "provenance-workdir"),
+		StageBucket:      bucket,
 	})
 
 	return checker.CheckStageProvenance(buildVersion)

--- a/pkg/release/provenance.go
+++ b/pkg/release/provenance.go
@@ -80,7 +80,14 @@ func (pc *ProvenanceChecker) CheckStageProvenance(buildVersion string) error {
 	}
 
 	// Run the check of the artifacts
-	return pc.impl.checkProvenance(pc.options, statement)
+	if err := pc.impl.checkProvenance(pc.options, statement); err != nil {
+		return errors.Wrap(err, "verifying provenance of staged artifacts")
+	}
+	logrus.Infof(
+		"Successfully verified provenance information of %d staged artifacts",
+		len(statement.Subject),
+	)
+	return nil
 }
 
 type ProvenanceCheckerOptions struct {
@@ -103,7 +110,7 @@ func (di *defaultProvenanceCheckerImpl) downloadStagedArtifacts(
 ) error {
 	logrus.Infof("Synching stage from %s to %s", path, opts.StageDirectory)
 	if !util.Exists(opts.StageDirectory) {
-		if err := os.Mkdir(opts.StageDirectory, os.FileMode(0o755)); err != nil {
+		if err := os.MkdirAll(opts.StageDirectory, os.FileMode(0o755)); err != nil {
 			return errors.Wrap(err, "creating local working directory")
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR modifies the provenance code to perform the staged artifact verification in a dedicated scratch directory inside the  Cloud Build workspace.

Before, the scratch directory was created without control in the current directory, resulting in the bucket copy being performed in the git tree.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Part of: https://github.com/kubernetes/release/issues/2267
Follow-up to #2283

#### Special notes for your reviewer:
/assign @Verolop @justaugustus @cpanato
/cc @kubernetes/release-engineering 
/priority important-soon

#### Does this PR introduce a user-facing change?

```release-note
During `anago.release`, krel will now download and perform the staged artifact verification in a dedicated directory in the Cloud Build workspace. 
```
