### PR TITLE
add go-runner to debian-iptables image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -427,7 +427,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: buster-v1.6.7
+    version: buster-v1.7.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ (bullseye|buster)-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -435,7 +435,7 @@ dependencies:
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.17.2-buster.0
+    version: v2.3.1-go1.17.3-buster.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-(bullseye|buster)\.\d+

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -434,6 +434,12 @@ dependencies:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  - name: "k8s.gcr.io/build-image/go-runner: dependents"
+    version: v2.3.1-go1.17.2-buster.0
+    refPaths:
+    - path: images/build/debian-iptables/Makefile
+      match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-(bullseye|buster)\.\d+
+
   - name: "k8s.gcr.io/build-image/setcap"
     version: buster-v2.0.4
     refPaths:

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -21,6 +21,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= buster-v1.6.7
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
+GORUNNER_VERSION ?= v2.3.1-go1.17.2-buster.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
@@ -29,6 +30,7 @@ BASE_REGISTRY?=k8s.gcr.io/build-image
 
 # Build args
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
+GORUNNERIMAGE?=$(BASE_REGISTRY)/go-runner:$(GORUNNER_VERSION)
 
 QEMUVERSION=5.2.0-2
 
@@ -53,6 +55,7 @@ build:
 		-t $(IMAGE)-$(ARCH):$(TAG)-$(CONFIG) \
 		-t $(IMAGE)-$(ARCH):latest-$(CONFIG) \
 		--build-arg=BASEIMAGE=$(BASEIMAGE) \
+		--build-arg=GORUNNERIMAGE=$(GORUNNERIMAGE) \
 		$(CONFIG)
 	docker buildx rm $$BUILDER
 

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -21,7 +21,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= buster-v1.7.0
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
-GORUNNER_VERSION ?= v2.3.1-go1.17.2-buster.0
+GORUNNER_VERSION ?= v2.3.1-go1.17.3-buster.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= buster-v1.6.7
+IMAGE_VERSION ?= buster-v1.7.0
 CONFIG ?= buster
 DEBIAN_BASE_VERSION ?= buster-v1.9.0
 GORUNNER_VERSION ?= v2.3.1-go1.17.2-buster.0

--- a/images/build/debian-iptables/buster/Dockerfile
+++ b/images/build/debian-iptables/buster/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG BASEIMAGE
+ARG GORUNNERIMAGE
 
 FROM ${BASEIMAGE} as build
 
@@ -43,5 +44,10 @@ RUN update-alternatives \
 	--slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
 	--slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
 
+# we're going to borrow the /go-runner binary in the final image
+# dedupe this binary by just copying it from the go-runner image
+FROM ${GORUNNERIMAGE} as gorunner
+
 FROM scratch
 COPY --from=build / /
+COPY --from=gorunner /go-runner /go-runner

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -7,5 +7,5 @@ variants:
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.6.7'
+    IMAGE_VERSION: 'buster-v1.7.0'
     DEBIAN_BASE_VERSION: 'buster-v1.9.0'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Adds the go-runner binary from the go-runner image to debian-iptables.

See background: https://github.com/kubernetes/kubernetes/issues/106086

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
debian-iptables image now contains /go-runner binary
```
