### PR TITLE
Add a new ci-reporter tool to generate weekly CI Signal Reports

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,6 +28,13 @@ aliases:
     - BenTheElder
     - MushuEE
     - spiffxp
+  ci-signal-reporter-reviewers:
+    - calvh # 1.23 CI Signal Shadow
+    - encodeflush # 1.23 CI Signal Lead
+    - leonardpahlke # 1.23 CI Signal Shadow
+    - rajula96reddy # 1.23 CI Signal Shadow
+    - RinkiyaKeDad # 1.23 CI Signal Shadow
+    - simrangupta234 # 1.23 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco

--- a/cmd/ci-reporter/OWNERS
+++ b/cmd/ci-reporter/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - ci-signal-reporter-reviewers

--- a/cmd/ci-reporter/README.md
+++ b/cmd/ci-reporter/README.md
@@ -3,7 +3,7 @@
 You can get the current overview for CI signal report by running
 
 ```
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx go run cmd/ci-reporter/report.go
 ```
 
 It needs a GitHub token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
@@ -13,23 +13,23 @@ It needs a GitHub token to be able to query the project board for CI signal. For
 
 ## Run the report
 ```
-git clone git@github.com:alenkacz/ci-signal-report.git <folder>
+git clone git@github.com:kubernetes/release <folder>
 cd <folder>
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx go run cmd/ci-reporter/report.go
 ```
 
 ### Other version statistics
 By adding `RELEASE_VERSION=xxx` where the XXX can be like `1.21`, the report statistics get extended for the choosen version.
 
 ```
-GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run cmd/ci-reporter/report.go
 ```
 
 ### Short report
 You can also output a short version of the report with the flag `-short`. This reduces the report to `New/Not Yet Started` and `In Flight` issues.
 
 ```
-GITHUB_AUTH_TOKEN=xxx go run report.go -short
+GITHUB_AUTH_TOKEN=xxx go run cmd/ci-reporter/report.go -short
 ```
 
 ## Rate limits
@@ -45,7 +45,7 @@ curl \
 
 ## Example output
 ```
-GITHUB_AUTH_TOKEN=yourFavouriteGitHubTokenLivesHere RELEASE_VERSION=1.21 go run report.go -short
+GITHUB_AUTH_TOKEN=yourFavouriteGitHubTokenLivesHere RELEASE_VERSION=1.21 go run cmd/ci-reporter/report.go -short
 
 New/Not Yet Started
 SIG network

--- a/cmd/ci-reporter/README.md
+++ b/cmd/ci-reporter/README.md
@@ -1,0 +1,105 @@
+# CI signal report
+
+You can get the current overview for CI signal report by running
+
+```
+GITHUB_AUTH_TOKEN=xxx go run report.go
+```
+
+It needs a GitHub token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
+
+## Prerequisites
+- GoLang >=1.16
+
+## Run the report
+```
+git clone git@github.com:alenkacz/ci-signal-report.git <folder>
+cd <folder>
+GITHUB_AUTH_TOKEN=xxx go run report.go
+```
+
+### Other version statistics
+By adding `RELEASE_VERSION=xxx` where the XXX can be like `1.21`, the report statistics get extended for the choosen version.
+
+```
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
+```
+
+### Short report
+You can also output a short version of the report with the flag `-short`. This reduces the report to `New/Not Yet Started` and `In Flight` issues.
+
+```
+GITHUB_AUTH_TOKEN=xxx go run report.go -short
+```
+
+## Rate limits
+GitHub API has rate limits, to see how much you have used you can query like this (replace User with your GH user and Token with your Auth Token):
+```
+curl \
+  -u GIT_HUB-USER:GIT_HUB_TOKEN -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit & curl \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit
+```
+
+
+## Example output
+```
+GITHUB_AUTH_TOKEN=yourFavouriteGitHubTokenLivesHere RELEASE_VERSION=1.21 go run report.go -short
+
+New/Not Yet Started
+SIG network
+#80719 https://api.github.com/repos/kubernetes/kubernetes/issues/80719 [sig-network] Services should only allow access from service loadbalancer source ranges [Slow]
+
+SIG storage
+#80717 https://api.github.com/repos/kubernetes/kubernetes/issues/80717  [sig-storage] CSI Volumes [Driver: csi-hostpath] Snapshot Tests
+
+In flight
+SIG testing
+#79662 https://api.github.com/repos/kubernetes/kubernetes/issues/79662   Nodes resize test failing in master-blocking
+
+SIG cluster-lifecycle
+#78907 https://api.github.com/repos/kubernetes/kubernetes/issues/78907 [Flaky Tests] task-06-upgrade is failing on master-informing
+
+SIG scheduling
+#74931 https://api.github.com/repos/kubernetes/kubernetes/issues/74931 Scheduler TestPreemptionRaces is flaky
+
+Observing
+SIG apps
+#79740 https://api.github.com/repos/kubernetes/kubernetes/issues/79740  Test Deployment deployment should support rollback is failing on master informing
+
+SIG cli
+#79533 https://api.github.com/repos/kubernetes/kubernetes/issues/79533  Kubectl client Conformance test failing
+
+Resolved
+SIG cluster-lifecycle
+#80434 https://api.github.com/repos/kubernetes/kubernetes/issues/80434  Errors bringing up kube-proxy in CI
+
+Failures in Master-Blocking
+    14 jobs total
+    9 are passing
+    2 are flaking
+    3 are failing
+    0 are stale
+
+Failures in Master-Informing
+    14 jobs total
+    7 are passing
+    4 are flaking
+    3 are failing
+    0 are stale
+
+Failures in 1.21-Blocking
+    14 jobs total
+    9 are passing
+    2 are flaking
+    3 are failing
+    0 are stale
+
+Failures in 1.21-Informing
+    14 jobs total
+    7 are passing
+    4 are flaking
+    3 are failing
+    0 are stale
+ ```

--- a/cmd/ci-reporter/report.go
+++ b/cmd/ci-reporter/report.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/google/go-github/v34/github"
+	"golang.org/x/oauth2"
+)
+
+type requiredJob struct {
+	OutputName string
+	URLName    string
+}
+
+func main() {
+	boolPtr := flag.Bool("short", false, "a short report for mails and slack")
+	flag.Parse()
+
+	githubAPIToken := os.Getenv("GITHUB_AUTH_TOKEN")
+	if githubAPIToken == "" {
+		fmt.Printf("Please provide GITHUB_AUTH_TOKEN env variable to be able to pull cards from the github board")
+		os.Exit(1)
+	}
+
+	releaseVersion := os.Getenv("RELEASE_VERSION")
+
+	err := printCardsOverview(githubAPIToken, *boolPtr)
+	if err != nil {
+		fmt.Printf("error when querying cards overview, exiting: %v\n", err)
+		os.Exit(1)
+	}
+
+	printJobsStatistics(releaseVersion)
+}
+
+const (
+	newCards                = 4212817
+	underInvestigationCards = 4212819
+	observingCards          = 4212821
+	ciSignalBoardProjectID  = 2093513
+)
+
+type issueOverview struct {
+	url   string
+	id    int64
+	title string
+	sig   string
+}
+
+func printCardsOverview(token string, setShort bool) error {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	newCardsOverview, err := getCardsFromColumn(newCards, client, token)
+	if err != nil {
+		return err
+	}
+
+	investigationCardsOverview, err := getCardsFromColumn(underInvestigationCards, client, token)
+	if err != nil {
+		return err
+	}
+
+	observingCardsOverview, err := getCardsFromColumn(observingCards, client, token)
+	if err != nil {
+		return err
+	}
+
+	resolvedCards, err := findResolvedCardsColumns(client)
+	if err != nil {
+		return err
+	}
+
+	resolvedCardsOverview, err := getCardsFromColumn(resolvedCards, client, token)
+	if err != nil {
+		return err
+	}
+
+	printCards(setShort, groupByCards(newCardsOverview), groupByCards(investigationCardsOverview), groupByCards(observingCardsOverview), groupByCards(resolvedCardsOverview))
+
+	return nil
+}
+
+func findResolvedCardsColumns(client *github.Client) (int64, error) {
+	opt := &github.ListOptions{}
+	columns, _, err := client.Projects.ListProjectColumns(context.Background(), ciSignalBoardProjectID, opt)
+	if err != nil {
+		return 0, err
+	}
+
+	resolvedColumns := make([]*github.ProjectColumn, 0)
+	for _, v := range columns {
+		if v.Name != nil && *v.Name == "Resolved" {
+			resolvedColumns = append(resolvedColumns, v)
+		}
+	}
+
+	sort.Slice(resolvedColumns, func(i, j int) bool {
+		return resolvedColumns[i].GetID() < resolvedColumns[j].GetID()
+	})
+	return resolvedColumns[0].GetID(), err
+}
+
+func printCards(shortReport bool, newCards, investigation, observing, resolved map[string][]*issueOverview) {
+	fmt.Println("New/Not Yet Started")
+	for k, v := range newCards {
+		fmt.Printf("SIG %s\n", k)
+		for _, i := range v {
+			fmt.Printf("#%d %s %s\n", i.id, i.url, i.title)
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("In flight")
+	for k, v := range investigation {
+		fmt.Printf("SIG %s\n", k)
+		for _, i := range v {
+			fmt.Printf("#%d %s %s\n", i.id, i.url, i.title)
+		}
+		fmt.Println()
+	}
+
+	if !shortReport {
+		fmt.Println("Observing")
+		for k, v := range observing {
+			fmt.Printf("SIG %s\n", k)
+			for _, i := range v {
+				fmt.Printf("#%d %s %s\n", i.id, i.url, i.title)
+			}
+			fmt.Println()
+		}
+
+		fmt.Println("Resolved")
+		for k, v := range resolved {
+			fmt.Printf("SIG %s\n", k)
+			for _, i := range v {
+				fmt.Printf("#%d %s %s\n", i.id, i.url, i.title)
+			}
+			fmt.Println()
+		}
+	}
+}
+
+func groupByCards(issues []*issueOverview) map[string][]*issueOverview {
+	result := make(map[string][]*issueOverview)
+	for _, i := range issues {
+		_, ok := result[i.sig]
+		if !ok {
+			result[i.sig] = make([]*issueOverview, 0)
+		}
+		result[i.sig] = append(result[i.sig], i)
+	}
+	return result
+}
+
+func getCardsFromColumn(cardsID int64, client *github.Client, token string) ([]*issueOverview, error) {
+	opt := &github.ProjectCardListOptions{}
+	cards, _, err := client.Projects.ListProjectCards(context.Background(), cardsID, opt)
+	if err != nil {
+		fmt.Printf("error when querying cards %v", err)
+		return nil, err
+	}
+
+	issues := make([]*issueOverview, 0)
+	for _, c := range cards {
+		if c.ContentURL == nil {
+			continue
+		}
+
+		issueURL := *c.ContentURL
+		issueDetail, err := getIssueDetail(issueURL, token)
+		if err != nil {
+			return nil, err
+		}
+
+		overview := issueOverview{
+			url:   issueDetail.HTMLURL,
+			id:    issueDetail.Number,
+			title: cleanTitle(issueDetail.Title),
+		}
+		for _, v := range issueDetail.Labels {
+			if strings.Contains(*v.Name, "sig/") {
+				overview.sig = strings.Title(strings.ReplaceAll(*v.Name, "sig/", ""))
+				if strings.EqualFold(overview.sig, "cli") {
+					overview.sig = strings.ToUpper(overview.sig)
+				}
+				if strings.EqualFold(overview.sig, "cluster-lifecycle") {
+					overview.sig = strings.ToLower(overview.sig)
+				}
+				break
+			}
+		}
+		issues = append(issues, &overview)
+	}
+
+	return issues, nil
+}
+
+type IssueDetail struct {
+	Number  int64          `json:"number"`
+	HTMLURL string         `json:"html_url"`
+	Title   string         `json:"title"`
+	Labels  []github.Label `json:"labels,omitempty"`
+}
+
+func getIssueDetail(url, authToken string) (*IssueDetail, error) {
+	// Create a Bearer string by appending string access token
+	bearer := "Bearer " + authToken
+
+	// Create a new request using http
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	// add authorization header to the req
+	req.Header.Add("Authorization", bearer)
+
+	// Send req using http Client
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("Error on response.\n[ERROR] -", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("%v", err)
+		return nil, err
+	}
+	var result IssueDetail
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func cleanTitle(title string) string {
+	return strings.ReplaceAll(title, "[Failing Test]", "")
+}
+
+func printJobsStatistics(version string) {
+	requiredJobs := []requiredJob{
+		{OutputName: "Master-Blocking", URLName: "sig-release-master-blocking"},
+		{OutputName: "Master-Informing", URLName: "sig-release-master-informing"},
+	}
+
+	if version != "" {
+		requiredJobs = append(requiredJobs, []requiredJob{
+			{OutputName: version + "-blocking", URLName: "sig-release-" + version + "-blocking"},
+			{OutputName: version + "-informing", URLName: "sig-release-" + version + "-informing"},
+		}...)
+	}
+
+	result := make([]statistics, 0)
+	for _, kubeJob := range requiredJobs {
+		resp, err := http.Get(fmt.Sprintf("https://testgrid.k8s.io/%s/summary", kubeJob.URLName))
+		if err != nil {
+			fmt.Printf("%v", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf("%v", err)
+			return
+		}
+
+		jobs, err := getStatsFromJSON(body)
+		if err != nil {
+			fmt.Printf("%v", err)
+			return
+		}
+
+		statistics := getStatistics(jobs)
+		statistics.name = kubeJob.OutputName
+		result = append(result, statistics)
+	}
+
+	prettyPrint(result)
+}
+
+func prettyPrint(stats []statistics) {
+	for _, stat := range stats {
+		fmt.Printf("Failures in %s\n", stat.name)
+		fmt.Printf("\t%d jobs total\n", stat.total)
+		fmt.Printf("\t%d are passing\n", stat.passing)
+		fmt.Printf("\t%d are flaking\n", stat.flaking)
+		fmt.Printf("\t%d are failing\n", stat.failing)
+		fmt.Printf("\t%d are stale\n", stat.stale)
+		fmt.Print("\n\n")
+	}
+}
+
+func getStatistics(jobs map[string]overview) statistics {
+	result := statistics{}
+	for _, v := range jobs {
+		if v.OverallStatus == "PASSING" {
+			result.passing++
+		} else if v.OverallStatus == "FAILING" {
+			result.failing++
+		} else if v.OverallStatus == "FLAKY" {
+			result.flaking++
+		} else {
+			result.stale++
+		}
+		result.total++
+	}
+	return result
+}
+
+type statistics struct {
+	name    string
+	total   int
+	passing int
+	flaking int
+	failing int
+	stale   int
+}
+
+type overview struct {
+	OverallStatus string `json:"overall_status"`
+}
+
+func getStatsFromJSON(body []byte) (map[string]overview, error) {
+	result := make(map[string]overview)
+	err := json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github/v33 v33.0.0 // indirect
+	github.com/google/go-github/v34 v34.0.0
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -104,7 +105,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/go.sum
+++ b/go.sum
@@ -486,6 +486,8 @@ github.com/google/go-containerregistry v0.6.0 h1:niQ+8XD//kKgArIFwDVBXsWVWbde16L
 github.com/google/go-containerregistry v0.6.0/go.mod h1:euCCtNbZ6tKqi1E72vwDj2xZcN5ttKpZLfa/wSo5iLw=
 github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
+github.com/google/go-github/v34 v34.0.0 h1:/siYFImY8KwGc5QD1gaPf+f8QX6tLwxNIco2RkYxoFA=
+github.com/google/go-github/v34 v34.0.0/go.mod h1:w/2qlrXUfty+lbyO6tatnzIw97v1CM+/jZcwXMDiPQQ=
 github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-github/v39 v39.1.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature

#### What this PR does / why we need it:

There have been discussions around porting the existing CI Signal Report tooling (https://github.com/alenkacz/ci-signal-report) to this repository. This PR attempts to unblock the CI Signal team and move the same to k/release as a new program for now with further plans as discussed in https://kubernetes.slack.com/archives/C2C40FMNF/p1622718810193000 and how the CI Signal Team would want to develop the tooling.

### Open Questions

- **[RESOLVED - Stephen's comment below answers the question]** Who are the OWNERS of the `cmd/ci-reporter` directory? I have added the 1.23 CI Signal Team as approvers/reviewers for now. We may need folks who are around irrespective of the release cycles.
- Some new dependencies also got added with the code
  - `github.com/google/go-github/v34`
    - `github.com/google/go-github/v33` is being used in this repo already as an indirect dependency. We need to figure out if we really need both and see if we can use just one version. 
  - **[RESOLVED - We are not pulling that dependency anymore]** `github.com/kelseyhightower/envconfig`
    - This is being used only once to read the `GITHUB_AUTH_TOKEN` environment variable. I guess this can be removed since we are just reading one environment variable and `os.Getenv` can be used instead. 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/sig-release/issues/1586
Fixes https://github.com/kubernetes/org/issues/3044
Progresses on https://kubernetes.slack.com/archives/C2C40FMNF/p1622718810193000
Unblocks https://kubernetes.slack.com/archives/CN0K3TE2C/p1636398789023800?thread_ts=1636389405.015600&cid=CN0K3TE2C

#### Special notes for your reviewer:

Please have a look at the commits for attribution to the Authors who contributed to https://github.com/alenkacz/ci-signal-report. 

#### Does this PR introduce a user-facing change?

```release-note
Add a new ci-reporter tool to generate weekly CI Signal Reports
```

/area release-team
/priority critical-urgent 
/cc @encodeflush @calvh @leonardpahlke @rajula96reddy @RinkiyaKeDad @simrangupta234
/cc @kubernetes/release-engineering
cc: @kubernetes/release-team-leads 