### PR TITLE
debian-iptables: add go-runner to bullseye image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -464,7 +464,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: '(bullseye|buster)-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-iptables/bullseye/Dockerfile
+++ b/images/build/debian-iptables/bullseye/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG BASEIMAGE
+ARG GORUNNERIMAGE
 
 FROM ${BASEIMAGE} as build
 
@@ -38,5 +39,10 @@ RUN update-alternatives \
 	--slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
 	--slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
 
+# we're going to borrow the /go-runner binary in the final image
+# dedupe this binary by just copying it from the go-runner image
+FROM ${GORUNNERIMAGE} as gorunner
+
 FROM scratch
 COPY --from=build / /
+COPY --from=gorunner /go-runner /go-runner

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,7 +2,7 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.0.0'
+    IMAGE_VERSION: 'bullseye-v1.1.0'
     DEBIAN_BASE_VERSION: 'bullseye-v1.0.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

https://github.com/kubernetes/release/pull/2301 did the same for the buster
image, but Kubernetes master (= 1.23) uses the debian-iptables:bullseye-v1.0.0
image, so the same change is also needed there.

See https://github.com/kubernetes/kubernetes/issues/106086

#### Does this PR introduce a user-facing change?

```release-note
debian-iptables:bullseye image now contains /go-runner binary
```
