### PR TITLE
spdx: Support archives as package src, autonamespace and other improvements

### DIFF
--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -77,7 +77,7 @@ type generateOptions struct {
 	configFile     string
 	license        string
 	images         []string
-	tarballs       []string
+	imageArchives  []string
 	files          []string
 	directories    []string
 	ignorePatterns []string
@@ -88,7 +88,7 @@ func (opts *generateOptions) Validate() error {
 	if opts.configFile == "" &&
 		len(opts.images) == 0 &&
 		len(opts.files) == 0 &&
-		len(opts.tarballs) == 0 &&
+		len(opts.imageArchives) == 0 &&
 		len(opts.directories) == 0 {
 		return errors.New("to generate a SPDX BOM you have to provide at least one image or file")
 	}
@@ -135,9 +135,22 @@ func init() {
 	)
 
 	generateCmd.PersistentFlags().StringSliceVarP(
-		&genOpts.tarballs,
+		&genOpts.imageArchives,
 		"tarball",
 		"t",
+		[]string{},
+		"list of docker archive tarballs to include in the manifest",
+	)
+
+	if err := generateCmd.PersistentFlags().MarkDeprecated(
+		"tarball", "tarball has been renamed to image-archive",
+	); err != nil {
+		logrus.Fatal(errors.Wrap(err, "marking flag as deprecated"))
+	}
+
+	generateCmd.PersistentFlags().StringSliceVar(
+		&genOpts.imageArchives,
+		"image-archive",
 		[]string{},
 		"list of docker archive tarballs to include in the manifest",
 	)
@@ -227,7 +240,7 @@ func generateBOM(opts *generateOptions) error {
 
 	builder := spdx.NewDocBuilder()
 	builderOpts := &spdx.DocGenerateOptions{
-		Tarballs:         opts.tarballs,
+		Tarballs:         opts.imageArchives,
 		Files:            opts.files,
 		Images:           opts.images,
 		Directories:      opts.directories,

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -78,6 +78,7 @@ type generateOptions struct {
 	license        string
 	images         []string
 	imageArchives  []string
+	archives       []string
 	files          []string
 	directories    []string
 	ignorePatterns []string
@@ -89,6 +90,7 @@ func (opts *generateOptions) Validate() error {
 		len(opts.images) == 0 &&
 		len(opts.files) == 0 &&
 		len(opts.imageArchives) == 0 &&
+		len(opts.archives) == 0 &&
 		len(opts.directories) == 0 {
 		return errors.New("to generate a SPDX BOM you have to provide at least one image or file")
 	}
@@ -153,6 +155,13 @@ func init() {
 		"image-archive",
 		[]string{},
 		"list of docker archive tarballs to include in the manifest",
+	)
+
+	generateCmd.PersistentFlags().StringSliceVar(
+		&genOpts.archives,
+		"archive",
+		[]string{},
+		"list of archives to add as packages (supports tar, tar.gz)",
 	)
 
 	generateCmd.PersistentFlags().StringSliceVarP(
@@ -241,6 +250,7 @@ func generateBOM(opts *generateOptions) error {
 	builder := spdx.NewDocBuilder()
 	builderOpts := &spdx.DocGenerateOptions{
 		Tarballs:         opts.imageArchives,
+		Archives:         opts.archives,
 		Files:            opts.files,
 		Images:           opts.images,
 		Directories:      opts.directories,

--- a/cmd/bom/cmd/generate.go
+++ b/cmd/bom/cmd/generate.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 
 	"github.com/pkg/errors"
@@ -93,27 +92,6 @@ func (opts *generateOptions) Validate() error {
 		len(opts.archives) == 0 &&
 		len(opts.directories) == 0 {
 		return errors.New("to generate a SPDX BOM you have to provide at least one image or file")
-	}
-
-	// A namespace URL is required
-	if opts.configFile == "" && opts.namespace == "" {
-		msg := "Error. No namespace defined\n\n"
-		msg += "You did not specify a namespace for your document. This is an error.\n"
-		msg += "To produce a valid SPDX SBOM, the document has to have an URI as its\n"
-		msg += "namespace.\n\nIf you are testing, you can use http://example.com/ for now but your\n"
-		msg += "final document must have a namespace URI pointing to the location where\n"
-		msg += "your SBOM will be referenced in the future.\n\n"
-		msg += "For more details, check the SPDX documentation here:\n"
-		msg += "https://spdx.github.io/spdx-spec/2-document-creation-information/#25-spdx-document-namespace\n\n"
-		msg += "Hint: --namespace is your friend here\n\n"
-		logrus.Info(msg)
-
-		return errors.New("A namespace URI must be defined to have a compliant SPDX BOM")
-	}
-
-	// Check namespace is a valid URL
-	if _, err := url.Parse(opts.namespace); err != nil {
-		return errors.Wrap(err, "parsing the namespace URL")
 	}
 
 	return nil

--- a/pkg/spdx/builder.go
+++ b/pkg/spdx/builder.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -169,13 +170,17 @@ func (builder *defaultDocBuilderImpl) GenerateDoc(
 	// Create the new document
 	doc = NewDocument()
 	doc.Name = genopts.Name
-	doc.Namespace = genopts.Namespace
+
+	// If we do not have a namespace, we generate one
+	// under the public SPDX URL defined in the spec.
+	// (ref https://spdx.github.io/spdx-spec/document-creation-information/#65-spdx-document-namespace-field)
+	if genopts.Namespace == "" {
+		doc.Namespace = "https://spdx.org/spdxdocs/k8s-releng-bom-" + uuid.NewString()
+	} else {
+		doc.Namespace = genopts.Namespace
+	}
 	doc.Creator.Person = genopts.CreatorPerson
 	doc.ExternalDocRefs = genopts.ExternalDocumentRef
-
-	if genopts.Namespace == "" {
-		return nil, errors.New("unable to generate doc, namespace URI is not defined")
-	}
 
 	for _, i := range genopts.Directories {
 		logrus.Infof("Processing directory %s", i)

--- a/pkg/spdx/file.go
+++ b/pkg/spdx/file.go
@@ -86,7 +86,13 @@ func (f *File) Render() (docFragment string, err error) {
 
 // BuildID sets the file ID, optionally from a series of strings
 func (f *File) BuildID(seeds ...string) {
-	f.Entity.BuildID(append([]string{"SPDXRef-File"}, seeds...)...)
+	prefix := ""
+	if f.Options() != nil {
+		if f.Options().Prefix != "" {
+			prefix = "-" + f.Options().Prefix
+		}
+	}
+	f.Entity.BuildID(append([]string{"SPDXRef-File" + prefix}, seeds...)...)
 }
 
 func (f *File) SetEntity(e *Entity) {
@@ -101,4 +107,14 @@ func (f *File) Draw(builder *strings.Builder, o *DrawingOptions, depth int, seen
 		connector = connectorL
 	}
 	fmt.Fprintf(builder, treeLines(o, depth, connector)+"%s (%s)\n", f.SPDXID(), f.Name)
+}
+
+func (f *File) ReadSourceFile(path string) error {
+	if err := f.Entity.ReadSourceFile(path); err != nil {
+		return err
+	}
+	if f.SPDXID() == "" {
+		f.BuildID()
+	}
+	return nil
 }

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -629,14 +629,19 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 	logrus.Infof("Generating SPDX package from image tarball %s", tarPath)
 
 	// Extract all files from tarfile
-	tarOpts := &TarballOptions{
-		AddFiles: true,
+	tarOpts := &TarballOptions{}
+
+	// If specified, add individual files from the tarball to the
+	// spdx package, unless AnalyzeLayers is set because in that
+	// case the individual analyzers decide to do that.
+	if spdxOpts.AddTarFiles && !spdxOpts.AnalyzeLayers {
+		tarOpts.AddFiles = true
 	}
 	tarOpts.ExtractDir, err = di.ExtractTarballTmp(tarPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "extracting tarball to temp dir")
 	}
-	// defer os.RemoveAll(tarOpts.ExtractDir)
+	defer os.RemoveAll(tarOpts.ExtractDir)
 
 	// Read the archive manifest json:
 	manifest, err := di.ReadArchiveManifest(

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -52,7 +52,7 @@ type spdxImplementation interface {
 		OS        string
 	}, error)
 	PackageFromImageTarball(string, *Options) (*Package, error)
-	PackageFromLayerTarball(string, *TarballOptions) (*Package, error)
+	PackageFromTarball(string, *TarballOptions) (*Package, error)
 	GetDirectoryTree(string) ([]string, error)
 	IgnorePatterns(string, []string, bool) ([]gitignore.Pattern, error)
 	ApplyIgnorePatterns([]string, []gitignore.Pattern) []string
@@ -360,12 +360,11 @@ func (di *spdxDefaultImplementation) PullImagesToArchive(
 	return images, nil
 }
 
-// PackageFromLayerTarball builds a SPDX package from an image
-// tarball
-func (di *spdxDefaultImplementation) PackageFromLayerTarball(
+// PackageFromTarball builds a SPDX package from the contents of a tarball
+func (di *spdxDefaultImplementation) PackageFromTarball(
 	layerFile string, opts *TarballOptions,
 ) (*Package, error) {
-	logrus.Infof("Generating SPDX package from layer in %s", layerFile)
+	logrus.Infof("Generating SPDX package from tarball %s", layerFile)
 
 	pkg := NewPackage()
 	pkg.Options().WorkDir = opts.ExtractDir
@@ -640,7 +639,7 @@ func (di *spdxDefaultImplementation) PackageFromImageTarball(
 	// Cycle all the layers from the manifest and add them as packages
 	for _, layerFile := range manifest.LayerFiles {
 		// Generate a package from a layer
-		pkg, err := di.PackageFromLayerTarball(layerFile, tarOpts)
+		pkg, err := di.PackageFromTarball(layerFile, tarOpts)
 		if err != nil {
 			return nil, errors.Wrap(err, "building package from layer")
 		}

--- a/pkg/spdx/implementation.go
+++ b/pkg/spdx/implementation.go
@@ -21,6 +21,7 @@ package spdx
 import (
 	"archive/tar"
 	"bufio"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -79,7 +80,16 @@ func (di *spdxDefaultImplementation) ExtractTarballTmp(tarPath string) (tmpDir s
 	}
 	defer f.Close()
 
-	tr := tar.NewReader(f)
+	var tr *tar.Reader
+	if strings.HasSuffix(tarPath, ".gz") || strings.HasSuffix(tarPath, ".tgz") {
+		gzipReader, err := gzip.NewReader(f)
+		if err != nil {
+			return "", err
+		}
+		tr = tar.NewReader(gzipReader)
+	} else {
+		tr = tar.NewReader(f)
+	}
 	numFiles := 0
 	for {
 		hdr, err := tr.Next()

--- a/pkg/spdx/object.go
+++ b/pkg/spdx/object.go
@@ -59,6 +59,7 @@ type Entity struct {
 }
 
 type ObjectOptions struct {
+	Prefix  string
 	WorkDir string
 }
 

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -68,6 +68,7 @@ type Options struct {
 	ProcessGoModules bool     // If true, spdx will check if dirs are go modules and analize the packages
 	OnlyDirectDeps   bool     // Only include direct dependencies from go.mod
 	ScanLicenses     bool     // Scan licenses from everypossible place unless false
+	AddTarFiles      bool     // Scan and add files inside of tarfiles
 	LicenseCacheDir  string   // Directory to cache SPDX license downloads
 	LicenseData      string   // Directory to store the SPDX licenses
 	IgnorePatterns   []string // Patterns to ignore when scanning file
@@ -162,6 +163,18 @@ func (spdx *SPDX) PackageFromDirectory(dirPath string) (pkg *Package, err error)
 // PackageFromImageTarball returns a SPDX package from a tarball
 func (spdx *SPDX) PackageFromImageTarball(tarPath string) (imagePackage *Package, err error) {
 	return spdx.impl.PackageFromImageTarball(spdx.Options(), tarPath)
+}
+
+// PackageFromArchive returns a SPDX package from a tarball
+func (spdx *SPDX) PackageFromArchive(archivePath string) (imagePackage *Package, err error) {
+	if strings.HasSuffix(archivePath, "tar") || strings.HasSuffix(archivePath, "tar.gz") {
+		return spdx.impl.PackageFromTarball(
+			spdx.Options(), &TarballOptions{
+				AddFiles: true,
+			}, archivePath,
+		)
+	}
+	return nil, errors.Wrap(err, "unable to create spdx package from archive, only tar archives are supported")
 }
 
 // FileFromPath creates a File object from a path

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -109,9 +109,9 @@ func TestPackageFromTarball(t *testing.T) {
 	defer os.Remove(tarFile.Name())
 
 	sut := spdxDefaultImplementation{}
-	_, err := sut.PackageFromTarball("lsdkjflksdjflk", &TarballOptions{})
+	_, err := sut.PackageFromTarball(&Options{}, &TarballOptions{}, "lsdkjflksdjflk")
 	require.NotNil(t, err)
-	pkg, err := sut.PackageFromTarball(tarFile.Name(), &TarballOptions{})
+	pkg, err := sut.PackageFromTarball(&Options{}, &TarballOptions{}, tarFile.Name())
 	require.Nil(t, err)
 	require.NotNil(t, pkg)
 

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -103,15 +103,15 @@ func TestReadArchiveManifest(t *testing.T) {
 	}
 }
 
-func TestPackageFromLayerTarBall(t *testing.T) {
+func TestPackageFromTarball(t *testing.T) {
 	tar := writeTestTarball(t)
 	require.NotNil(t, tar)
 	defer os.Remove(tar.Name())
 
 	sut := spdxDefaultImplementation{}
-	_, err := sut.PackageFromLayerTarball("lsdkjflksdjflk", &TarballOptions{})
+	_, err := sut.PackageFromTarball("lsdkjflksdjflk", &TarballOptions{})
 	require.NotNil(t, err)
-	pkg, err := sut.PackageFromLayerTarball(tar.Name(), &TarballOptions{})
+	pkg, err := sut.PackageFromTarball(tar.Name(), &TarballOptions{})
 	require.Nil(t, err)
 	require.NotNil(t, pkg)
 

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -42,8 +42,8 @@ func TestBuildIDString(t *testing.T) {
 		{[]string{"ABC"}, "ABC"},
 		{[]string{"ABC", "123"}, "ABC-123"},
 		{[]string{"Hello:bye", "123"}, "Hello-bye-123"},
-		{[]string{"Hello^bye", "123"}, "Hellobye-123"},
-		{[]string{"Hello:bye", "123", "&^%&$"}, "Hello-bye-123"},
+		{[]string{"Hello^bye", "123"}, "HelloC94bye-123"},
+		{[]string{"Hello:bye", "123", "&-^%&$"}, "Hello-bye-123-C38-C94C37C38C36"},
 	}
 	for _, tc := range cases {
 		require.Equal(t, tc.expected, buildIDString(tc.seeds...))
@@ -52,9 +52,6 @@ func TestBuildIDString(t *testing.T) {
 	// If we do not pass any seeds, func should return an UUID
 	// which is 36 chars long
 	require.Len(t, buildIDString(), 36)
-
-	// Same thing for only invalid chars
-	require.Len(t, buildIDString("&^$&^%"), 36)
 }
 
 func TestUnitExtractTarballTmp(t *testing.T) {

--- a/pkg/spdx/spdx_unit_test.go
+++ b/pkg/spdx/spdx_unit_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package spdx
 
 import (
+	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -56,22 +58,20 @@ func TestBuildIDString(t *testing.T) {
 }
 
 func TestUnitExtractTarballTmp(t *testing.T) {
-	tar := writeTestTarball(t)
-	require.NotNil(t, tar)
-	defer os.Remove(tar.Name())
+	tarFile := writeTestTarball(t)
+	require.NotNil(t, tarFile)
+	defer os.Remove(tarFile.Name())
 
 	sut := NewSPDX()
 	_, err := sut.ExtractTarballTmp("lsdjkflskdjfl")
 	require.NotNil(t, err)
-	dir, err := sut.ExtractTarballTmp(tar.Name())
+	dir, err := sut.ExtractTarballTmp(tarFile.Name())
 	require.Nil(t, err, "extracting file")
 	defer os.RemoveAll(dir)
 
 	require.True(t, util.Exists(filepath.Join(dir, "/text.txt")), "checking directory")
 	require.True(t, util.Exists(filepath.Join(dir, "/subdir/text.txt")), "checking subdirectory")
 	require.True(t, util.Exists(dir), "checking directory")
-
-	// Check files
 }
 
 func TestReadArchiveManifest(t *testing.T) {
@@ -104,14 +104,14 @@ func TestReadArchiveManifest(t *testing.T) {
 }
 
 func TestPackageFromTarball(t *testing.T) {
-	tar := writeTestTarball(t)
-	require.NotNil(t, tar)
-	defer os.Remove(tar.Name())
+	tarFile := writeTestTarball(t)
+	require.NotNil(t, tarFile)
+	defer os.Remove(tarFile.Name())
 
 	sut := spdxDefaultImplementation{}
 	_, err := sut.PackageFromTarball("lsdkjflksdjflk", &TarballOptions{})
 	require.NotNil(t, err)
-	pkg, err := sut.PackageFromTarball(tar.Name(), &TarballOptions{})
+	pkg, err := sut.PackageFromTarball(tarFile.Name(), &TarballOptions{})
 	require.Nil(t, err)
 	require.NotNil(t, pkg)
 
@@ -162,7 +162,7 @@ func TestExtDocReadSourceFile(t *testing.T) {
 
 func writeTestTarball(t *testing.T) *os.File {
 	// Create a testdir
-	tar, err := os.CreateTemp(os.TempDir(), "test-tar-*.tar.gz")
+	tarFile, err := os.CreateTemp(os.TempDir(), "test-tar-*.tar.gz")
 	require.Nil(t, err)
 
 	tardata, err := base64.StdEncoding.DecodeString(testTar)
@@ -176,9 +176,9 @@ func writeTestTarball(t *testing.T) *os.File {
 	require.Nil(t, err)
 
 	require.Nil(t, os.WriteFile(
-		tar.Name(), bindata, os.FileMode(0o644)), "writing test tar file",
+		tarFile.Name(), bindata, os.FileMode(0o644)), "writing test tar file",
 	)
-	return tar
+	return tarFile
 }
 
 func TestRelationshipRender(t *testing.T) {
@@ -260,3 +260,133 @@ xvnOBTcsF59eCmZT5Cz+yXT/5bX/pMb3P030fw4rlB8AAAAAAAAAAAAAAAAA4CccAXRRwL4AKAAA
 
 var sampleManifest = `[{"Config":"386bcf5c63de46c7066c42d4ae1c38af0689836e88fed37d1dca2d484b343cf5.json","RepoTags":["k8s.gcr.io/kube-apiserver-amd64:v1.22.0-alpha.1"],"Layers":["23e140cb8e03a12cba4ac571d9a7143cf5e2e9b72de3b33ce3243b4f7ad6a188/layer.tar","48dd73ececdf0f52a174ad33a469145824713bd2b73c6257ce1ba8502003ad4e/layer.tar","d397673d78556210baa112013c960cb95a3fd452e5c4a2ead2b26e5a458cd87f/layer.tar"]}]
 `
+
+func TestGetImageReferences(t *testing.T) {
+	references, err := getImageReferences("k8s.gcr.io/kube-apiserver:v1.23.0-alpha.3")
+	images := map[string]struct {
+		arch string
+		os   string
+	}{
+		"k8s.gcr.io/kube-apiserver@sha256:a82ca097e824f99bfb2b5107aa9c427633f9afb82afd002d59204f39ef81ae70": {"amd64", "linux"},
+		"k8s.gcr.io/kube-apiserver@sha256:2a11e07f916b5982d9a6e3bbf5defd66ad50359c00b33862552063beb6981aec": {"arm", "linux"},
+		"k8s.gcr.io/kube-apiserver@sha256:18f97b8c1c9b7b35dea7ba122d86e23066ce347aa8bb75b7346fed3f79d0ea21": {"arm64", "linux"},
+		"k8s.gcr.io/kube-apiserver@sha256:1a61b61491042e2b1e659c4d57d426d01d9467fb381404bff029be4d00ead519": {"ppc64le", "linux"},
+		"k8s.gcr.io/kube-apiserver@sha256:3e98f1591a5052791eec71d3c5f5d0fa913140992cb9e1d19fd80a158305c2ff": {"s390x", "linux"},
+	}
+	require.NoError(t, err)
+	// This image should have 5 architectures
+	require.Len(t, references, 5)
+	for _, refData := range references {
+		_, ok := images[refData.Digest]
+		require.True(t, ok, fmt.Sprintf("Image not found %s", refData.Digest))
+		require.Equal(t, images[refData.Digest].os, refData.OS)
+		require.Equal(t, images[refData.Digest].arch, refData.Arch)
+	}
+
+	// Test a sha reference. This is the linux/ppc64le image
+	singleRef := "k8s.gcr.io/kube-apiserver@sha256:1a61b61491042e2b1e659c4d57d426d01d9467fb381404bff029be4d00ead519"
+	references, err = getImageReferences(singleRef)
+	require.NoError(t, err)
+	require.Len(t, references, 1)
+	require.Equal(t, singleRef, references[0].Digest)
+
+	// Tag with a single image. Image 1.0 is a single image
+	references, err = getImageReferences("k8s.gcr.io/pause:1.0")
+	require.NoError(t, err)
+	require.Len(t, references, 1)
+	require.Equal(t, "k8s.gcr.io/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f", references[0].Digest)
+}
+
+func TestPullImagesToArchive(t *testing.T) {
+	impl := spdxDefaultImplementation{}
+
+	// First. If the tag does not represent an image, expect an error
+	_, err := impl.PullImagesToArchive("k8s.gcr.io/pause:0.0", "/tmp")
+	require.Error(t, err)
+
+	// Create a temp workdir
+	dir, err := os.MkdirTemp("", "extract-image-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// The pause 1.0 image is a single image
+	images, err := impl.PullImagesToArchive("k8s.gcr.io/pause:1.0", dir)
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+	require.FileExists(t, filepath.Join(dir, "a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f.tar"))
+
+	foundFiles := []string{}
+	expectedFiles := []string{
+		"sha256:350b164e7ae1dcddeffadd65c76226c9b6dc5553f5179153fb0e36b78f2a5e06",
+		"a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz",
+		"4964c72cd0245a7f77da38425dc98b472b2699ba6c49d5a9221fb32b972bc06b.tar.gz",
+		"manifest.json",
+	}
+	tarFile, err := os.Open(filepath.Join(dir, "a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f.tar"))
+	require.NoError(t, err)
+	defer tarFile.Close()
+	tarReader := tar.NewReader(tarFile)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+		}
+		if header == nil {
+			break
+		}
+		foundFiles = append(foundFiles, header.Name)
+	}
+	require.Equal(t, expectedFiles, foundFiles)
+}
+
+func TestGetDirectoryTree(t *testing.T) {
+	dir, err := os.MkdirTemp("", "dir-tree-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create a directory. This same array elements should be read back
+	// from the temporary directory.
+	files := []string{"test.txt", "sub1/test2.txt", "sub2/subsub/test3.txt"}
+	path := ""
+	for _, f := range files {
+		path = filepath.Join(dir, f)
+		dir := filepath.Dir(path)
+		require.NoError(t, os.MkdirAll(dir, os.FileMode(0o0755)))
+		require.NoError(t, os.WriteFile(path, []byte("test"), os.FileMode(0o644)))
+	}
+
+	impl := spdxDefaultImplementation{}
+	readFiles, err := impl.GetDirectoryTree(dir)
+	require.NoError(t, err)
+	// Now, compare contents of th array is the same
+	require.ElementsMatch(t, files, readFiles)
+}
+
+func TestIgnorePatterns(t *testing.T) {
+	dir, err := os.MkdirTemp("", "dir-tree-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	impl := spdxDefaultImplementation{}
+
+	// First, a dir without a gitignore should return no patterns, but not err
+	p, err := impl.IgnorePatterns(dir, []string{}, false)
+	require.NoError(t, err)
+	require.Len(t, p, 0)
+
+	// If we pass an extra pattern, we should get it back
+	p, err = impl.IgnorePatterns(dir, []string{".vscode"}, false)
+	require.NoError(t, err)
+	require.Len(t, p, 1)
+
+	// Now put a gitignore and read it back
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".gitignore"),
+		[]byte("# NFS\n.nfs*\n\n# OSX leaves these everywhere on SMB shares\n._*\n\n# OSX trash\n.DS_Store\n"),
+		os.FileMode(0o755),
+	))
+	p, err = impl.IgnorePatterns(dir, nil, false)
+	require.NoError(t, err)
+	require.Len(t, p, 4)
+}

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -161,17 +161,17 @@ type FakeSpdxImplementation struct {
 		result1 *spdx.Package
 		result2 error
 	}
-	PackageFromLayerTarballStub        func(string, *spdx.TarballOptions) (*spdx.Package, error)
-	packageFromLayerTarballMutex       sync.RWMutex
-	packageFromLayerTarballArgsForCall []struct {
+	PackageFromTarballStub        func(string, *spdx.TarballOptions) (*spdx.Package, error)
+	packageFromTarballMutex       sync.RWMutex
+	packageFromTarballArgsForCall []struct {
 		arg1 string
 		arg2 *spdx.TarballOptions
 	}
-	packageFromLayerTarballReturns struct {
+	packageFromTarballReturns struct {
 		result1 *spdx.Package
 		result2 error
 	}
-	packageFromLayerTarballReturnsOnCall map[int]struct {
+	packageFromTarballReturnsOnCall map[int]struct {
 		result1 *spdx.Package
 		result2 error
 	}
@@ -879,17 +879,17 @@ func (fake *FakeSpdxImplementation) PackageFromImageTarballReturnsOnCall(i int, 
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarball(arg1 string, arg2 *spdx.TarballOptions) (*spdx.Package, error) {
-	fake.packageFromLayerTarballMutex.Lock()
-	ret, specificReturn := fake.packageFromLayerTarballReturnsOnCall[len(fake.packageFromLayerTarballArgsForCall)]
-	fake.packageFromLayerTarballArgsForCall = append(fake.packageFromLayerTarballArgsForCall, struct {
+func (fake *FakeSpdxImplementation) PackageFromTarball(arg1 string, arg2 *spdx.TarballOptions) (*spdx.Package, error) {
+	fake.packageFromTarballMutex.Lock()
+	ret, specificReturn := fake.packageFromTarballReturnsOnCall[len(fake.packageFromTarballArgsForCall)]
+	fake.packageFromTarballArgsForCall = append(fake.packageFromTarballArgsForCall, struct {
 		arg1 string
 		arg2 *spdx.TarballOptions
 	}{arg1, arg2})
-	stub := fake.PackageFromLayerTarballStub
-	fakeReturns := fake.packageFromLayerTarballReturns
-	fake.recordInvocation("PackageFromLayerTarball", []interface{}{arg1, arg2})
-	fake.packageFromLayerTarballMutex.Unlock()
+	stub := fake.PackageFromTarballStub
+	fakeReturns := fake.packageFromTarballReturns
+	fake.recordInvocation("PackageFromTarball", []interface{}{arg1, arg2})
+	fake.packageFromTarballMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -899,46 +899,46 @@ func (fake *FakeSpdxImplementation) PackageFromLayerTarball(arg1 string, arg2 *s
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarballCallCount() int {
-	fake.packageFromLayerTarballMutex.RLock()
-	defer fake.packageFromLayerTarballMutex.RUnlock()
-	return len(fake.packageFromLayerTarballArgsForCall)
+func (fake *FakeSpdxImplementation) PackageFromTarballCallCount() int {
+	fake.packageFromTarballMutex.RLock()
+	defer fake.packageFromTarballMutex.RUnlock()
+	return len(fake.packageFromTarballArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarballCalls(stub func(string, *spdx.TarballOptions) (*spdx.Package, error)) {
-	fake.packageFromLayerTarballMutex.Lock()
-	defer fake.packageFromLayerTarballMutex.Unlock()
-	fake.PackageFromLayerTarballStub = stub
+func (fake *FakeSpdxImplementation) PackageFromTarballCalls(stub func(string, *spdx.TarballOptions) (*spdx.Package, error)) {
+	fake.packageFromTarballMutex.Lock()
+	defer fake.packageFromTarballMutex.Unlock()
+	fake.PackageFromTarballStub = stub
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarballArgsForCall(i int) (string, *spdx.TarballOptions) {
-	fake.packageFromLayerTarballMutex.RLock()
-	defer fake.packageFromLayerTarballMutex.RUnlock()
-	argsForCall := fake.packageFromLayerTarballArgsForCall[i]
+func (fake *FakeSpdxImplementation) PackageFromTarballArgsForCall(i int) (string, *spdx.TarballOptions) {
+	fake.packageFromTarballMutex.RLock()
+	defer fake.packageFromTarballMutex.RUnlock()
+	argsForCall := fake.packageFromTarballArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarballReturns(result1 *spdx.Package, result2 error) {
-	fake.packageFromLayerTarballMutex.Lock()
-	defer fake.packageFromLayerTarballMutex.Unlock()
-	fake.PackageFromLayerTarballStub = nil
-	fake.packageFromLayerTarballReturns = struct {
+func (fake *FakeSpdxImplementation) PackageFromTarballReturns(result1 *spdx.Package, result2 error) {
+	fake.packageFromTarballMutex.Lock()
+	defer fake.packageFromTarballMutex.Unlock()
+	fake.PackageFromTarballStub = nil
+	fake.packageFromTarballReturns = struct {
 		result1 *spdx.Package
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PackageFromLayerTarballReturnsOnCall(i int, result1 *spdx.Package, result2 error) {
-	fake.packageFromLayerTarballMutex.Lock()
-	defer fake.packageFromLayerTarballMutex.Unlock()
-	fake.PackageFromLayerTarballStub = nil
-	if fake.packageFromLayerTarballReturnsOnCall == nil {
-		fake.packageFromLayerTarballReturnsOnCall = make(map[int]struct {
+func (fake *FakeSpdxImplementation) PackageFromTarballReturnsOnCall(i int, result1 *spdx.Package, result2 error) {
+	fake.packageFromTarballMutex.Lock()
+	defer fake.packageFromTarballMutex.Unlock()
+	fake.PackageFromTarballStub = nil
+	if fake.packageFromTarballReturnsOnCall == nil {
+		fake.packageFromTarballReturnsOnCall = make(map[int]struct {
 			result1 *spdx.Package
 			result2 error
 		})
 	}
-	fake.packageFromLayerTarballReturnsOnCall[i] = struct {
+	fake.packageFromTarballReturnsOnCall[i] = struct {
 		result1 *spdx.Package
 		result2 error
 	}{result1, result2}
@@ -1131,8 +1131,8 @@ func (fake *FakeSpdxImplementation) Invocations() map[string][][]interface{} {
 	defer fake.licenseReaderMutex.RUnlock()
 	fake.packageFromImageTarballMutex.RLock()
 	defer fake.packageFromImageTarballMutex.RUnlock()
-	fake.packageFromLayerTarballMutex.RLock()
-	defer fake.packageFromLayerTarballMutex.RUnlock()
+	fake.packageFromTarballMutex.RLock()
+	defer fake.packageFromTarballMutex.RUnlock()
 	fake.pullImagesToArchiveMutex.RLock()
 	defer fake.pullImagesToArchiveMutex.RUnlock()
 	fake.readArchiveManifestMutex.RLock()

--- a/pkg/spdx/spdxfakes/fake_spdx_implementation.go
+++ b/pkg/spdx/spdxfakes/fake_spdx_implementation.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -147,11 +147,25 @@ type FakeSpdxImplementation struct {
 		result1 *license.Reader
 		result2 error
 	}
-	PackageFromImageTarballStub        func(string, *spdx.Options) (*spdx.Package, error)
+	PackageFromDirectoryStub        func(*spdx.Options, string) (*spdx.Package, error)
+	packageFromDirectoryMutex       sync.RWMutex
+	packageFromDirectoryArgsForCall []struct {
+		arg1 *spdx.Options
+		arg2 string
+	}
+	packageFromDirectoryReturns struct {
+		result1 *spdx.Package
+		result2 error
+	}
+	packageFromDirectoryReturnsOnCall map[int]struct {
+		result1 *spdx.Package
+		result2 error
+	}
+	PackageFromImageTarballStub        func(*spdx.Options, string) (*spdx.Package, error)
 	packageFromImageTarballMutex       sync.RWMutex
 	packageFromImageTarballArgsForCall []struct {
-		arg1 string
-		arg2 *spdx.Options
+		arg1 *spdx.Options
+		arg2 string
 	}
 	packageFromImageTarballReturns struct {
 		result1 *spdx.Package
@@ -161,11 +175,12 @@ type FakeSpdxImplementation struct {
 		result1 *spdx.Package
 		result2 error
 	}
-	PackageFromTarballStub        func(string, *spdx.TarballOptions) (*spdx.Package, error)
+	PackageFromTarballStub        func(*spdx.Options, *spdx.TarballOptions, string) (*spdx.Package, error)
 	packageFromTarballMutex       sync.RWMutex
 	packageFromTarballArgsForCall []struct {
-		arg1 string
+		arg1 *spdx.Options
 		arg2 *spdx.TarballOptions
+		arg3 string
 	}
 	packageFromTarballReturns struct {
 		result1 *spdx.Package
@@ -814,12 +829,77 @@ func (fake *FakeSpdxImplementation) LicenseReaderReturnsOnCall(i int, result1 *l
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PackageFromImageTarball(arg1 string, arg2 *spdx.Options) (*spdx.Package, error) {
+func (fake *FakeSpdxImplementation) PackageFromDirectory(arg1 *spdx.Options, arg2 string) (*spdx.Package, error) {
+	fake.packageFromDirectoryMutex.Lock()
+	ret, specificReturn := fake.packageFromDirectoryReturnsOnCall[len(fake.packageFromDirectoryArgsForCall)]
+	fake.packageFromDirectoryArgsForCall = append(fake.packageFromDirectoryArgsForCall, struct {
+		arg1 *spdx.Options
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.PackageFromDirectoryStub
+	fakeReturns := fake.packageFromDirectoryReturns
+	fake.recordInvocation("PackageFromDirectory", []interface{}{arg1, arg2})
+	fake.packageFromDirectoryMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSpdxImplementation) PackageFromDirectoryCallCount() int {
+	fake.packageFromDirectoryMutex.RLock()
+	defer fake.packageFromDirectoryMutex.RUnlock()
+	return len(fake.packageFromDirectoryArgsForCall)
+}
+
+func (fake *FakeSpdxImplementation) PackageFromDirectoryCalls(stub func(*spdx.Options, string) (*spdx.Package, error)) {
+	fake.packageFromDirectoryMutex.Lock()
+	defer fake.packageFromDirectoryMutex.Unlock()
+	fake.PackageFromDirectoryStub = stub
+}
+
+func (fake *FakeSpdxImplementation) PackageFromDirectoryArgsForCall(i int) (*spdx.Options, string) {
+	fake.packageFromDirectoryMutex.RLock()
+	defer fake.packageFromDirectoryMutex.RUnlock()
+	argsForCall := fake.packageFromDirectoryArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSpdxImplementation) PackageFromDirectoryReturns(result1 *spdx.Package, result2 error) {
+	fake.packageFromDirectoryMutex.Lock()
+	defer fake.packageFromDirectoryMutex.Unlock()
+	fake.PackageFromDirectoryStub = nil
+	fake.packageFromDirectoryReturns = struct {
+		result1 *spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) PackageFromDirectoryReturnsOnCall(i int, result1 *spdx.Package, result2 error) {
+	fake.packageFromDirectoryMutex.Lock()
+	defer fake.packageFromDirectoryMutex.Unlock()
+	fake.PackageFromDirectoryStub = nil
+	if fake.packageFromDirectoryReturnsOnCall == nil {
+		fake.packageFromDirectoryReturnsOnCall = make(map[int]struct {
+			result1 *spdx.Package
+			result2 error
+		})
+	}
+	fake.packageFromDirectoryReturnsOnCall[i] = struct {
+		result1 *spdx.Package
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSpdxImplementation) PackageFromImageTarball(arg1 *spdx.Options, arg2 string) (*spdx.Package, error) {
 	fake.packageFromImageTarballMutex.Lock()
 	ret, specificReturn := fake.packageFromImageTarballReturnsOnCall[len(fake.packageFromImageTarballArgsForCall)]
 	fake.packageFromImageTarballArgsForCall = append(fake.packageFromImageTarballArgsForCall, struct {
-		arg1 string
-		arg2 *spdx.Options
+		arg1 *spdx.Options
+		arg2 string
 	}{arg1, arg2})
 	stub := fake.PackageFromImageTarballStub
 	fakeReturns := fake.packageFromImageTarballReturns
@@ -840,13 +920,13 @@ func (fake *FakeSpdxImplementation) PackageFromImageTarballCallCount() int {
 	return len(fake.packageFromImageTarballArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) PackageFromImageTarballCalls(stub func(string, *spdx.Options) (*spdx.Package, error)) {
+func (fake *FakeSpdxImplementation) PackageFromImageTarballCalls(stub func(*spdx.Options, string) (*spdx.Package, error)) {
 	fake.packageFromImageTarballMutex.Lock()
 	defer fake.packageFromImageTarballMutex.Unlock()
 	fake.PackageFromImageTarballStub = stub
 }
 
-func (fake *FakeSpdxImplementation) PackageFromImageTarballArgsForCall(i int) (string, *spdx.Options) {
+func (fake *FakeSpdxImplementation) PackageFromImageTarballArgsForCall(i int) (*spdx.Options, string) {
 	fake.packageFromImageTarballMutex.RLock()
 	defer fake.packageFromImageTarballMutex.RUnlock()
 	argsForCall := fake.packageFromImageTarballArgsForCall[i]
@@ -879,19 +959,20 @@ func (fake *FakeSpdxImplementation) PackageFromImageTarballReturnsOnCall(i int, 
 	}{result1, result2}
 }
 
-func (fake *FakeSpdxImplementation) PackageFromTarball(arg1 string, arg2 *spdx.TarballOptions) (*spdx.Package, error) {
+func (fake *FakeSpdxImplementation) PackageFromTarball(arg1 *spdx.Options, arg2 *spdx.TarballOptions, arg3 string) (*spdx.Package, error) {
 	fake.packageFromTarballMutex.Lock()
 	ret, specificReturn := fake.packageFromTarballReturnsOnCall[len(fake.packageFromTarballArgsForCall)]
 	fake.packageFromTarballArgsForCall = append(fake.packageFromTarballArgsForCall, struct {
-		arg1 string
+		arg1 *spdx.Options
 		arg2 *spdx.TarballOptions
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.PackageFromTarballStub
 	fakeReturns := fake.packageFromTarballReturns
-	fake.recordInvocation("PackageFromTarball", []interface{}{arg1, arg2})
+	fake.recordInvocation("PackageFromTarball", []interface{}{arg1, arg2, arg3})
 	fake.packageFromTarballMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -905,17 +986,17 @@ func (fake *FakeSpdxImplementation) PackageFromTarballCallCount() int {
 	return len(fake.packageFromTarballArgsForCall)
 }
 
-func (fake *FakeSpdxImplementation) PackageFromTarballCalls(stub func(string, *spdx.TarballOptions) (*spdx.Package, error)) {
+func (fake *FakeSpdxImplementation) PackageFromTarballCalls(stub func(*spdx.Options, *spdx.TarballOptions, string) (*spdx.Package, error)) {
 	fake.packageFromTarballMutex.Lock()
 	defer fake.packageFromTarballMutex.Unlock()
 	fake.PackageFromTarballStub = stub
 }
 
-func (fake *FakeSpdxImplementation) PackageFromTarballArgsForCall(i int) (string, *spdx.TarballOptions) {
+func (fake *FakeSpdxImplementation) PackageFromTarballArgsForCall(i int) (*spdx.Options, *spdx.TarballOptions, string) {
 	fake.packageFromTarballMutex.RLock()
 	defer fake.packageFromTarballMutex.RUnlock()
 	argsForCall := fake.packageFromTarballArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeSpdxImplementation) PackageFromTarballReturns(result1 *spdx.Package, result2 error) {
@@ -1129,6 +1210,8 @@ func (fake *FakeSpdxImplementation) Invocations() map[string][][]interface{} {
 	defer fake.imageRefToPackageMutex.RUnlock()
 	fake.licenseReaderMutex.RLock()
 	defer fake.licenseReaderMutex.RUnlock()
+	fake.packageFromDirectoryMutex.RLock()
+	defer fake.packageFromDirectoryMutex.RUnlock()
 	fake.packageFromImageTarballMutex.RLock()
 	defer fake.packageFromImageTarballMutex.RUnlock()
 	fake.packageFromTarballMutex.RLock()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/kind feature
/kind deprecation

#### What this PR does / why we need it:

This PR adds a bunch of improvements to the bom tool and the spdx libraries:

* Adds a few more unit tests to the `spdx` package to cover the following functions:
  * `spdx.GetImageReferences`
  * `spdx.TestPullImagesToArchive`
  * `spdx.TestGetDirectoryTree`
  * `spdx.TestIgnorePatterns`
* The `--tarballs` flag is now deprecated. It has been replaced with `--image-archive` during demos and chats, it proved to be confusing (it still works but will print a warning)
* There is a new flag `--archive` that adds archives (currently tars) as packages. Its files are license-scanned and listed in the package
* Passing a flag defining the SPDX document namespace is not required anymore. The generator now defines it using the spdx.org public URL defined in the spec

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @kubernetes/release-engineering  @kubernetes/release-managers 
/milestone v1.23

#### Does this PR introduce a user-facing change?

```release-note
* Added a few more unit tests to the `spdx` package to cover the following functions: `spdx.GetImageReferences` `spdx.TestPullImagesToArchive` `spdx.TestGetDirectoryTree` `spdx.TestIgnorePatterns`
* bom: The `--tarballs` flag is now deprecated. It has been replaced with `--image-archive` during demos and chats, it proved to be confusing (it still works but will print a warning)
* bom: There is a new flag: `--archive`. When enabled, bom adds archives (currently tars) as spdx packages to the doc. Its files are license-scanned and listed in the package
* bom: Passing a flag defining the SPDX document namespace is not required anymore. The generator now defines it using the spdx.org public URL defined in the 2.2+ spec.
* The spdx package now supports reading compressed tars 
```
