### PR TITLE
krel/announce: ask for confirmation before sending the email

### DIFF
--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -169,8 +169,20 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 
 	logrus.Info("Sending mail")
 	subject := fmt.Sprintf("Kubernetes %s is live!", tag)
-	if err := m.Send(content, subject); err != nil {
-		return errors.Wrap(err, "unable to send mail")
+
+	yes := true
+
+	if rootOpts.nomock {
+		_, yes, err = util.Ask("Send email? (y/N)", "y:Y:yes|n:N:no|N", 10)
+		if err != nil {
+			return err
+		}
+	}
+
+	if yes {
+		if err := m.Send(content, subject); err != nil {
+			return errors.Wrap(err, "unable to send mail")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The changes preserve the existing behaviour when `--nomock` is not passed.
Only when, `--nomock` is passed, a confirmation is seeked.

#### Which issue(s) this PR fixes:

Follow up on kubernetes/sig-release#1734

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
krel/announce: ask for confirmation before sending the email
```

/cc @kubernetes/release-engineering 
/priority important-soon