### PR TITLE
relnotes: Sleep when hitting the secondary GH limit

### DIFF
--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -518,6 +518,7 @@ func checkErrMsg(t *testing.T, err error, expectedMsg string) {
 func response(statusCode, lastPage int) *github.Response {
 	res := &github.Response{
 		LastPage: lastPage,
+		NextPage: 0,
 		Response: &http.Response{
 			StatusCode: statusCode,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The last couple of releases have been hitting a new secondary rate limit
in the GitHub API. This PR makes some changes to play a bit more fair with
the API.

Now, the notes gatherer interprets the GitHub API response. If the
secondary rate limit was hit, the functions that make a lot of calls
will now sleep for a minute+random before respawning.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
Fixes #2225
Fixes #2302

/priority critical-urgent
/assign @justaugustus @Verolop @palnabarun @saschagrunert 
/cc @kubernetes/release-engineering 
/milestone v1.23

#### Special notes for your reviewer:

**Note:** this functionality should go into the `github` package in release-sdk <!--, ~but the notes gatherer is older and is not using the module. So for now it's in the notes package~ --> (looking into this)

#### Does this PR introduce a user-facing change?

```release-note
The release notes gatherer will now sleep for a minute+random secs when hitting the GitHub API secondary rate limit. 
```
