### PR TITLE
remove dh-systemd package which no longer exists 

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -34,7 +34,6 @@ RUN apt-get update -y \
         ca-certificates \
         curl \
         debhelper \
-        dh-systemd \
         fakeroot \
     && apt-get upgrade -y \
     && apt-get autoremove -y \

--- a/cmd/kubepkg/templates/latest/deb/kubelet/debian/control
+++ b/cmd/kubepkg/templates/latest/deb/kubelet/debian/control
@@ -2,7 +2,7 @@ Source: kubelet
 Section: misc
 Priority: optional
 Maintainer: Kubernetes Authors <kubernetes-dev+release@googlegroups.com>
-Build-Depends: curl, ca-certificates, debhelper (>= 8.0.0), dh-systemd (>= 1.5)
+Build-Depends: curl, ca-certificates, debhelper (>= 9.20160709)
 Standards-Version: 3.9.4
 Homepage: https://kubernetes.io
 Vcs-Git: https://github.com/kubernetes/kubernetes.git

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -20,7 +20,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       dpkg-dev \
       build-essential \
       debhelper \
-      dh-systemd \
     && apt-get upgrade -y \
     && apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/packages/deb/bionic/kubelet/debian/control
+++ b/packages/deb/bionic/kubelet/debian/control
@@ -2,7 +2,7 @@ Source: kubelet
 Section: misc
 Priority: optional
 Maintainer: Kubernetes Authors <kubernetes-dev+release@googlegroups.com>
-Build-Depends: curl, ca-certificates, debhelper (>= 8.0.0), dh-systemd (>= 1.5)
+Build-Depends: curl, ca-certificates, debhelper (>= 9.20160709)
 Standards-Version: 3.9.4
 Homepage: https://kubernetes.io
 Vcs-Git: https://github.com/kubernetes/kubernetes.git


### PR DESCRIPTION
(folded into debhelper https://bugs.debian.org/822670)

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

we can't build without this, the package doesn't exist

Slack convo: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1637185646162100?thread_ts=1637138428.119300&cid=CJH2GBF7Y

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian packaging: remove dependency on dh-systemd, which is now part of debhelper, update debhelper requirements to minimum version with dh-systemd included (>= 9.20160709)
```
