### PR TITLE
update ci-signal reporter OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,13 +28,6 @@ aliases:
     - BenTheElder
     - MushuEE
     - spiffxp
-  ci-signal-reporter-reviewers:
-    - calvh # 1.23 CI Signal Shadow
-    - encodeflush # 1.23 CI Signal Lead
-    - leonardpahlke # 1.23 CI Signal Shadow
-    - rajula96reddy # 1.23 CI Signal Shadow
-    - RinkiyaKeDad # 1.23 CI Signal Shadow
-    - simrangupta234 # 1.23 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco

--- a/cmd/ci-reporter/OWNERS
+++ b/cmd/ci-reporter/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-  - ci-signal-reporter-reviewers


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the OWNERS file in the ci-signal report tool. It also deletes the OWNERS_ALIAS reference which has been created for that. 

The entire ci-signal team has been added as reviewer to the sub-project (k/release/cmd/ci-reporter). From my perspective, nobody on that lists fulfills the requirements that be a reviewer for this sub-project ([requirements to be a reviewer](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer)). I thinks this has been mistakenly added initially [see PR](https://github.com/kubernetes/release/pull/2309)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/cc @encodeflush @rajula96reddy @simrangupta234 @RinkiyaKeDad @calvh 

/assign @justaugustus @puerco 
