### PR TITLE
go-runner: get source from k8s.io/component-base

### DIFF
--- a/images/build/go-runner/Dockerfile
+++ b/images/build/go-runner/Dockerfile
@@ -18,9 +18,9 @@ ARG BUILDER_IMAGE
 FROM ${BUILDER_IMAGE} as builder
 WORKDIR /workspace
 
-# Copy the sources
-COPY ./go-runner.go ./
-COPY ./go.* ./
+# Copy the module files which define the dependency for
+# the external kube-log-runner binary.
+COPY ./go.* ./*.go ./
 
 # Allow fallback to 'direct' for GOPROXY
 #
@@ -36,23 +36,38 @@ COPY ./go.* ./
 # ref: https://golang.org/doc/go1.15#go-command
 ENV GOPROXY="https://proxy.golang.org|direct"
 
+RUN go env
+RUN go version
+
+# Fix up the go.mod and go.sum for the current version of Go.
+# This is necessary because the source code only works with
+# recent Go, but the release repo wants to build also with
+# older Go.
+RUN set -x && \
+    go_version=$(go version | sed -e 's/go version go\([^ ]*\).*/\1/' -e 's/\([0-9]*\)\.\([0-9]*\)\.[0-9]*/\1.\2/') && \
+    echo Major Go version: ${go_version} && \
+    sed -i -e "s/^go .*/go ${go_version}/" go.mod
+RUN cat go.mod
+RUN go mod tidy
+
 # Build
-ARG package=.
+ARG package=k8s.io/component-base/logs/kube-log-runner
 ARG ARCH
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=${ARCH}
 
-RUN go env
-
-RUN go build -ldflags '-s -w -buildid= -extldflags "-static"' \
-    -o go-runner ${package}
+RUN GOBIN=`pwd` go install -ldflags '-s -w -buildid= -extldflags "-static"' \
+    ${package}
 
 # Production image
 FROM ${DISTROLESS_IMAGE}
 LABEL maintainers="Kubernetes Authors"
 LABEL description="go based runner for distroless scenarios"
 WORKDIR /
-COPY --from=builder /workspace/go-runner .
+
+# The image uses the traditional "go-runner" name because that is part of its
+# API.
+COPY --from=builder /workspace/kube-log-runner go-runner
 ENTRYPOINT ["/go-runner"]

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -37,7 +37,7 @@ PLATFORMS ?= linux/amd64 linux/arm64 linux/arm linux/ppc64le linux/s390x
 
 HOST_GOOS ?= $(shell go env GOOS)
 HOST_GOARCH ?= $(shell go env GOARCH)
-GO_BUILD ?= go build
+GO_BUILD ?= GOBIN=$(shell pwd) go install k8s.io/component-base/logs/kube-log-runner
 
 .PHONY: all build clean
 
@@ -50,7 +50,7 @@ build:
 
 .PHONY: clean
 clean:
-	rm go-runner
+	rm -f kube-log-runner
 
 BUILD_ARGS = --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) \
              --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_REGISTRY)/$(DISTROLESS_IMAGE)

--- a/images/build/go-runner/README.md
+++ b/images/build/go-runner/README.md
@@ -28,3 +28,8 @@ we would use go-runner like so:
 The go-runner would then ensure that we run the `/usr/local/bin/kube-apiserver` with the 
 specified parameters and redirect stdout ONLY to the log file specified and ensure anything 
 logged to stderr also ends up in the log file.
+
+# Source code
+
+The source code of go-runner is maintained in
+https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/component-base/logs/kube-log-runner

--- a/images/build/go-runner/go-runner.go
+++ b/images/build/go-runner/go-runner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,110 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+// +build tools
+
+package gorunner
 
 import (
-	"flag"
-	"fmt"
-	"io"
-	"log"
-	"os"
-	"os/exec"
-	"os/signal"
-	"strings"
-	"syscall"
+	_ "k8s.io/component-base/logs/kube-log-runner"
 )
-
-var (
-	logFilePath    = flag.String("log-file", "", "If non-empty, save stdout to this file")
-	alsoToStdOut   = flag.Bool("also-stdout", false, "useful with log-file, log to standard output as well as the log file")
-	redirectStderr = flag.Bool("redirect-stderr", true, "treat stderr same as stdout")
-)
-
-func main() {
-	flag.Parse()
-
-	if err := configureAndRun(); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func configureAndRun() error {
-	var (
-		outputStream io.Writer = os.Stdout
-		errStream    io.Writer = os.Stderr
-	)
-
-	args := flag.Args()
-	if len(args) == 0 {
-		return fmt.Errorf("not enough arguments to run")
-	}
-
-	if logFilePath != nil && *logFilePath != "" {
-		logFile, err := os.OpenFile(*logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return fmt.Errorf("failed to create log file %v: %w", *logFilePath, err)
-		}
-		if *alsoToStdOut {
-			outputStream = io.MultiWriter(os.Stdout, logFile)
-		} else {
-			outputStream = logFile
-		}
-	}
-
-	if *redirectStderr {
-		errStream = outputStream
-	}
-
-	exe := args[0]
-	var exeArgs []string
-	if len(args) > 1 {
-		exeArgs = args[1:]
-	}
-	cmd := exec.Command(exe, exeArgs...)
-	cmd.Stdout = outputStream
-	cmd.Stderr = errStream
-
-	log.Printf("Running command:\n%v", cmdInfo(cmd))
-	err := cmd.Start()
-	if err != nil {
-		return fmt.Errorf("starting command: %w", err)
-	}
-
-	// Handle signals and shutdown process gracefully.
-	go setupSigHandler(cmd.Process)
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("running command: %w", err)
-	}
-	return nil
-}
-
-// cmdInfo generates a useful look at what the command is for printing/debug.
-func cmdInfo(cmd *exec.Cmd) string {
-	return fmt.Sprintf(
-		`Command env: (log-file=%v, also-stdout=%v, redirect-stderr=%v)
-Run from directory: %v
-Executable path: %v
-Args (comma-delimited): %v`, *logFilePath, *alsoToStdOut, *redirectStderr,
-		cmd.Dir, cmd.Path, strings.Join(cmd.Args, ","),
-	)
-}
-
-// setupSigHandler will forward any termination signals to the process
-func setupSigHandler(process *os.Process) {
-	// terminationSignals are signals that cause the program to exit in the
-	// supported platforms (linux, darwin, windows).
-	terminationSignals := []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
-
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, terminationSignals...)
-
-	// Block until a signal is received.
-	log.Println("Now listening for interrupts")
-	s := <-c
-	log.Printf("Got signal: %v. Sending down to process (PID: %v)", s, process.Pid)
-	if err := process.Signal(s); err != nil {
-		log.Fatalf("Failed to signal process: %v", err)
-	}
-	log.Printf("Signalled process %v successfully.", process.Pid)
-}

--- a/images/build/go-runner/go.mod
+++ b/images/build/go-runner/go.mod
@@ -1,3 +1,5 @@
 module k8s.io/release/images/build/go-runner
 
 go 1.19
+
+require k8s.io/component-base v0.25.4

--- a/images/build/go-runner/go.sum
+++ b/images/build/go-runner/go.sum
@@ -1,0 +1,2 @@
+k8s.io/component-base v0.25.4 h1:n1bjg9Yt+G1C0WnIDJmg2fo6wbEU1UGMRiQSjmj7hNQ=
+k8s.io/component-base v0.25.4/go.mod h1:nnZJU8OP13PJEm6/p5V2ztgX2oyteIaAGKGMYb2L2cY=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The source code is now maintained by WG structured logging under
k/k/staging/src/k8s.io/component-base/logs/kube-log-runner.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
