### PR TITLE
CI-Reporter testgrid logic into pkg/testgrid

### DIFF
--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -89,7 +89,10 @@ func RunReport(cfg ReporterConfig) error {
 	if err != nil {
 		return err
 	}
-	PrintTestgridReportData(testgridReportData)
+	err = PrintTestgridReportData(cfg, &testgridReportData)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -66,7 +66,8 @@ func PrintTestgridReportData(cfg ReporterConfig, stats *testgrid.DashboardData) 
 				fmt.Printf("%s: %s\n", jobData.OverallStatus, jobName)
 				fmt.Printf("- %s\n", jobData.GetJobURL(jobName))
 				fmt.Printf("- %s\n", jobData.Status)
-			} else if jobData.OverallStatus == testgrid.Failing {
+			}
+			if jobData.OverallStatus == testgrid.Failing {
 				// Filter sigs
 				sigRegex := regexp.MustCompile(`sig-[a-zA-Z]+`)
 				sigsInvolved := map[string]int{}

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -17,97 +17,83 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"reflect"
+	"regexp"
+
+	"github.com/pkg/errors"
+	"k8s.io/release/pkg/testgrid"
 )
 
-// RequiredTestgridJob specifies a testgrid job like 'Master-Blocking'
-type RequiredTestgridJob struct {
-	OutputName string
-	URLName    string
-}
-
 // GetTestgridReportData used to request the raw report data from testgrid
-func GetTestgridReportData(cfg ReporterConfig) ([]TestgridStatistics, error) {
-	requiredJobs := []RequiredTestgridJob{
-		{OutputName: "Master-Blocking", URLName: "sig-release-master-blocking"},
-		{OutputName: "Master-Informing", URLName: "sig-release-master-informing"},
-	}
+func GetTestgridReportData(cfg ReporterConfig) (testgrid.DashboardData, error) {
+	testgridURLs := []testgrid.DashboardName{"sig-release-master-blocking", "sig-release-master-informing"}
 
 	if cfg.ReleaseVersion != "" {
-		requiredJobs = append(requiredJobs, []RequiredTestgridJob{
-			{OutputName: cfg.ReleaseVersion + "-blocking", URLName: "sig-release-" + cfg.ReleaseVersion + "-blocking"},
-			{OutputName: cfg.ReleaseVersion + "-informing", URLName: "sig-release-" + cfg.ReleaseVersion + "-informing"},
+		testgridURLs = append(testgridURLs, []testgrid.DashboardName{
+			testgrid.DashboardName(fmt.Sprintf("sig-release-%s-blocking", cfg.ReleaseVersion)),
+			testgrid.DashboardName(fmt.Sprintf("sig-release-%s-informing", cfg.ReleaseVersion)),
 		}...)
 	}
-	result := make([]TestgridStatistics, 0)
-	for _, job := range requiredJobs {
-		resp, err := http.Get(fmt.Sprintf("https://testgrid.k8s.io/%s/summary", job.URLName))
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		jobs := make(map[string]overview)
-		err = json.Unmarshal(body, &jobs)
-		if err != nil {
-			return nil, err
-		}
-
-		statistics := getStatistics(jobs)
-		statistics.Name = job.OutputName
-		result = append(result, statistics)
-	}
-	return result, nil
+	return testgrid.ReqTestgridDashboardSummaries(testgridURLs)
 }
 
 // PrintTestgridReportData used to print testgrid report data out to the console
-func PrintTestgridReportData(stats []TestgridStatistics) {
-	for _, stat := range stats {
-		fmt.Printf("Failures in %s\n", stat.Name)
-		fmt.Printf("\t%d jobs total\n", stat.Total)
-		fmt.Printf("\t%d are passing\n", stat.Passing)
-		fmt.Printf("\t%d are flaking\n", stat.Flaking)
-		fmt.Printf("\t%d are failing\n", stat.Failing)
-		fmt.Printf("\t%d are stale\n", stat.Stale)
-		fmt.Print("\n\n")
-	}
-}
-
-func getStatistics(jobs map[string]overview) TestgridStatistics {
-	result := TestgridStatistics{}
-	for _, v := range jobs {
-		if v.OverallStatus == "PASSING" {
-			result.Passing++
-		} else if v.OverallStatus == "FAILING" {
-			result.Failing++
-		} else if v.OverallStatus == "FLAKY" {
-			result.Flaking++
-		} else {
-			result.Stale++
+func PrintTestgridReportData(cfg ReporterConfig, stats *testgrid.DashboardData) error {
+	printShortReport := func(name testgrid.DashboardName, jobData *testgrid.JobData) error {
+		overview, err := jobData.Overview()
+		if err != nil {
+			return errors.Wrap(err, "could not get testgrid data overview")
 		}
-		result.Total++
+		fmt.Printf("\nOverview for %s\n", name)
+		fmt.Printf("\t%d jobs total\n", len(overview.FailingJobs)+len(overview.FlakyJobs)+len(overview.PassingJobs)+len(overview.StaleJobs))
+		fmt.Printf("\t%d are passing\n", len(overview.PassingJobs))
+		fmt.Printf("\t%d are flaking\n", len(overview.FlakyJobs))
+		fmt.Printf("\t%d are failing\n", len(overview.FailingJobs))
+		if len(overview.StaleJobs) > 0 {
+			fmt.Printf("\t%d are stale\n", len(overview.StaleJobs))
+		}
+		return nil
 	}
-	return result
-}
 
-// TestgridStatistics specifies a testgrid job overview
-type TestgridStatistics struct {
-	Name    string
-	Total   int
-	Passing int
-	Flaking int
-	Failing int
-	Stale   int
-}
+	printLongReport := func(name testgrid.DashboardName, jobData *testgrid.JobData) {
+		fmt.Printf("\nDetails for %s\n", name)
+		for jobName := range *jobData {
+			j := *jobData
+			jobData := j[jobName]
+			if jobData.OverallStatus != testgrid.Passing {
+				fmt.Printf("%s: %s\n", jobData.OverallStatus, jobName)
+				fmt.Printf("- %s\n", jobData.GetJobURL(jobName))
+				fmt.Printf("- %s\n", jobData.Status)
+			} else if jobData.OverallStatus == testgrid.Failing {
+				// Filter sigs
+				sigRegex := regexp.MustCompile(`sig-[a-zA-Z]+`)
+				sigsInvolved := map[string]int{}
+				for i := range jobData.Tests {
+					sigs := sigRegex.FindAllString(jobData.Tests[i].TestName, -1)
+					for _, sig := range sigs {
+						sigsInvolved[sig]++
+					}
+				}
+				sigs := reflect.ValueOf(sigsInvolved).MapKeys()
+				fmt.Printf("- Currently %d test are failing\n", len(jobData.Tests))
+				fmt.Printf("- Sig's involved %v\n", sigs)
+			}
+		}
+	}
 
-type overview struct {
-	OverallStatus string `json:"overall_status"`
+	// if the short flag ist set, only print the short report otherwise print both the short & long report
+	for name := range *stats {
+		s := *stats
+		data := s[name]
+		err := printShortReport(name, &data)
+		if err != nil {
+			return err
+		}
+		if !cfg.ShortReport {
+			printLongReport(name, &data)
+		}
+	}
+	return nil
 }

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -77,7 +76,10 @@ func PrintTestgridReportData(cfg ReporterConfig, stats *testgrid.DashboardData) 
 						sigsInvolved[sig]++
 					}
 				}
-				sigs := reflect.ValueOf(sigsInvolved).MapKeys()
+				sigs := []string{}
+				for k := range sigsInvolved {
+					sigs = append(sigs, k)
+				}
 				fmt.Printf("- Currently %d test are failing\n", len(jobData.Tests))
 				fmt.Printf("- Sig's involved %v\n", sigs)
 			}

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -90,8 +90,7 @@ func PrintTestgridReportData(cfg ReporterConfig, stats *testgrid.DashboardData) 
 	for name := range *stats {
 		s := *stats
 		data := s[name]
-		err := printShortReport(name, &data)
-		if err != nil {
+		if err := printShortReport(name, &data); err != nil {
 			return err
 		}
 		if !cfg.ShortReport {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-github/v39 v39.2.0
 	github.com/google/licenseclassifier/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/mitchellh/mapstructure v1.4.2
@@ -74,7 +75,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/in-toto/in-toto-golang v0.3.3

--- a/pkg/testgrid/testgrid-scraper.go
+++ b/pkg/testgrid/testgrid-scraper.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testgrid
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// SummaryLookup this type is used if multiple testgrid summaries are getting requested concurrently
+type SummaryLookup struct {
+	Dashboard DashboardName
+	Error     error
+	Summary   JobData
+}
+
+// ReqTestgridDashboardSummaries this function requests multiple testgrid summaries concurrently
+// This function implements a concurrency pattern to send http requests concurrently
+func ReqTestgridDashboardSummaries(dashboardNames []DashboardName) (DashboardData, error) {
+	// Worker
+	requestData := func(done <-chan interface{}, dashboardNames ...DashboardName) <-chan SummaryLookup {
+		summaryLookups := make(chan SummaryLookup)
+		go func() {
+			defer close(summaryLookups)
+			for _, dashboardName := range dashboardNames {
+				summary, err := ReqTestgridDashboardSummary(dashboardName)
+				select {
+				case <-done:
+					return
+				case summaryLookups <- SummaryLookup{
+					Dashboard: dashboardName,
+					Error:     err,
+					Summary:   summary,
+				}:
+				}
+			}
+		}()
+		return summaryLookups
+	}
+
+	done := make(chan interface{})
+	defer close(done)
+	dashboardData := DashboardData{}
+	var err error
+
+	// Collect data from buffered channel
+	for lookups := range requestData(done, dashboardNames...) {
+		if lookups.Error != nil {
+			err = multierror.Append(err, errors.Wrapf(lookups.Error, "error requesting summary for dashboard %s", lookups.Dashboard))
+		} else {
+			dashboardData[lookups.Dashboard] = lookups.Summary
+		}
+	}
+	return dashboardData, err
+}
+
+// ReqTestgridDashboardSummary used to retrieve summary information about a testgrid dashboard
+func ReqTestgridDashboardSummary(dashboardName DashboardName) (JobData, error) {
+	resp, err := http.Get(fmt.Sprintf("https://testgrid.k8s.io/%s/summary", dashboardName))
+	if err != nil {
+		return nil, errors.Wrap(err, "request remote content")
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+	summary, err := UnmarshalTestgridSummary(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal response body")
+	}
+	return summary, nil
+}
+
+// Overview used to get an overview about a testgrid board without additional information
+type Overview struct {
+	PassingJobs []JobName
+	FlakyJobs   []JobName
+	FailingJobs []JobName
+	StaleJobs   []JobName
+}
+
+// Overview used to get an overview about a testgrid dashboard
+func (d *JobData) Overview() (Overview, error) {
+	overview := Overview{}
+	for job := range *d {
+		data := *d
+		switch data[job].OverallStatus {
+		case Passing:
+			overview.PassingJobs = append(overview.PassingJobs, job)
+		case Flaky:
+			overview.FlakyJobs = append(overview.FlakyJobs, job)
+		case Failing:
+			overview.FailingJobs = append(overview.FailingJobs, job)
+		case Stale:
+			overview.StaleJobs = append(overview.StaleJobs, job)
+		default:
+			return Overview{}, fmt.Errorf("unrecognized job status: %s with summary info %v", data[job].OverallStatus, data[job])
+		}
+	}
+	return overview, nil
+}
+
+//
+// Types that reflect from testgrid summary
+//
+
+// JobName type for testgrid jobs
+type JobName string
+
+// DashboardData used to store testgrid dashboards
+type DashboardData map[DashboardName]JobData
+
+// JobData used to store multiple TestgridJobs TestgridJobSummary
+type JobData map[JobName]JobSummary
+
+// UnmarshalTestgridSummary used to unmarshal bytes into TestgridSummary
+func UnmarshalTestgridSummary(data []byte) (JobData, error) {
+	var r JobData
+	err := json.Unmarshal(data, &r)
+	return r, err
+}
+
+// Marshal used to marshal TestgridSummary into bytes
+func (d *JobData) Marshal() ([]byte, error) {
+	return json.Marshal(d)
+}
+
+// JobSummary contains information about a testgrid job
+type JobSummary struct {
+	Alert               string        `json:"alert"`
+	LastRunTimestamp    int64         `json:"last_run_timestamp"`
+	LastUpdateTimestamp int64         `json:"last_update_timestamp"`
+	LatestGreen         string        `json:"latest_green"`
+	OverallStatus       OverallStatus `json:"overall_status"`
+	OverallStatusIcon   string        `json:"overall_status_icon"`
+	Status              string        `json:"status"`
+	Tests               []Test        `json:"tests"`
+	DashboardName       DashboardName `json:"dashboard_name"`
+	BugURL              string        `json:"bug_url"`
+}
+
+// GetJobURL used to get the testgrid job url
+func (j *JobSummary) GetJobURL(jobName JobName) string {
+	return fmt.Sprintf("https://testgrid.k8s.io/%s/summary#%s", j.DashboardName, jobName)
+}
+
+// Test contains information about tests if the status if the Job is failing
+type Test struct {
+	DisplayName    string        `json:"display_name"`
+	TestName       string        `json:"test_name"`
+	FailCount      int64         `json:"fail_count"`
+	FailTimestamp  int64         `json:"fail_timestamp"`
+	PassTimestamp  int64         `json:"pass_timestamp"`
+	BuildLink      string        `json:"build_link"`
+	BuildURLText   string        `json:"build_url_text"`
+	BuildLinkText  string        `json:"build_link_text"`
+	FailureMessage string        `json:"failure_message"`
+	LinkedBugs     []interface{} `json:"linked_bugs"`
+	FailTestLink   string        `json:"fail_test_link"`
+}
+
+// DashboardName type for the testgrid dashboard (like sig-release-master-blocking)
+type DashboardName string
+
+const (
+	// SigReleaseMasterInforming one of the dashboard names that can be used to scrapo a testgrid summary
+	SigReleaseMasterInforming DashboardName = "sig-release-master-informing"
+	// SigReleaseMasterBlocking one of the dashboard names that can be used to scrapo a testgrid summary
+	SigReleaseMasterBlocking DashboardName = "sig-release-master-blocking"
+)
+
+// OverallStatus of a job in testgrid
+type OverallStatus string
+
+const (
+	// Failing job status
+	Failing OverallStatus = "FAILING"
+	// Flaky job status
+	Flaky OverallStatus = "FLAKY"
+	// Passing job status
+	Passing OverallStatus = "PASSING"
+	// Stale job status
+	Stale OverallStatus = "STALE"
+)

--- a/pkg/testgrid/testgrid-scraper_test.go
+++ b/pkg/testgrid/testgrid-scraper_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testgrid
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	negDashboardNames = []DashboardName{DashboardName(""), DashboardName("sig-release-master"), DashboardName("no-dashboard-here")}
+	posDashboardNames = []DashboardName{SigReleaseMasterBlocking, SigReleaseMasterInforming}
+)
+
+func TestRequestTestgridSummaryPos(t *testing.T) {
+	// Given
+	// positive dashboard names
+
+	for _, dashboardName := range posDashboardNames {
+		// When
+		summary, err := ReqTestgridDashboardSummary(dashboardName)
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, summary)
+		for _, jobs := range summary {
+			assert.Equal(t, dashboardName, jobs.DashboardName)
+		}
+	}
+}
+
+func TestRequestTestgridSummaryNeg(t *testing.T) {
+	// Given
+	// negative dashboard names
+
+	for _, dashboardName := range negDashboardNames {
+		// When
+		summary, err := ReqTestgridDashboardSummary(dashboardName)
+
+		// Then
+		assert.Error(t, err)
+		assert.Nil(t, summary)
+	}
+}
+
+func TestRequestTestgridSummariesPos(t *testing.T) {
+	// Given
+	// positive dashboard names
+
+	// When
+	data, err := ReqTestgridDashboardSummaries(posDashboardNames)
+
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, len(posDashboardNames), len(data))
+}
+
+func TestRequestTestgridSummariesNeg(t *testing.T) {
+	// Given
+	// negative dashboard names
+
+	// When
+	data, err := ReqTestgridDashboardSummaries(negDashboardNames)
+
+	// Then
+	assert.Error(t, err)
+	assert.Empty(t, data)
+}
+
+func TestRequestTestgridSummariesPosNeg(t *testing.T) {
+	// Given
+	// Request positive and negative dashboard names, expect to get an error and receive positive dashboard name summaries
+
+	// When
+	data, err := ReqTestgridDashboardSummaries(append(negDashboardNames, posDashboardNames...))
+
+	// Then
+	assert.Error(t, err, "an error should be returned as not all dashboard name references are correct")
+	assert.NotEmpty(t, data, "response shouldn't be empty because valid data das been added alongside faulty data - the correct data should be getting processed nonetheless")
+	assert.Equal(t, len(posDashboardNames), len(data))
+}
+
+type jobGeneratorDef struct {
+	amountOfJobs  int
+	overallStatus OverallStatus
+}
+
+func TestOverviewPos(t *testing.T) {
+	// Given
+	passingJobs := 4
+	flakyJobs := 3
+	failingJobs := 2
+	staleJobs := 1
+	jobGeneratorDef := []jobGeneratorDef{
+		{amountOfJobs: passingJobs, overallStatus: Passing},
+		{amountOfJobs: flakyJobs, overallStatus: Flaky},
+		{amountOfJobs: failingJobs, overallStatus: Failing},
+		{amountOfJobs: staleJobs, overallStatus: Stale},
+	}
+	data := JobData{}
+	for _, jobDef := range jobGeneratorDef {
+		for i := 0; i < jobDef.amountOfJobs; i++ {
+			data[JobName(fmt.Sprintf("%s-%d", jobDef.overallStatus, i))] = JobSummary{
+				OverallStatus: jobDef.overallStatus,
+				DashboardName: "sample-dashboard",
+			}
+		}
+	}
+
+	// When
+	o, err := data.Overview()
+
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, failingJobs, len(o.FailingJobs))
+	assert.Equal(t, flakyJobs, len(o.FlakyJobs))
+	assert.Equal(t, passingJobs, len(o.PassingJobs))
+	assert.Equal(t, staleJobs, len(o.StaleJobs))
+}
+
+func TestOverviewNeg(t *testing.T) {
+	// Given
+	data := []JobData{{"sampleTest": {OverallStatus: OverallStatus("")}}}
+
+	for _, s := range data {
+		// When
+		o, err := s.Overview()
+
+		// Then
+		assert.Error(t, err)
+		assert.Empty(t, o)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR continuous to clean up the ci-signal reporter tool as discussed in #2316 (align testgrid pkg with testgrid reporter methods (align with k/release) + add tests).

* Move testgrid logic from cmd/ci-reporter/testgrid to pkg/testgrid/testgrid-scraper
* Add tests pkg/testgrid/testgrid-scraper_test
* Add concurrency if multiple dashboards are being requested
* Extended testgrid report if the short flag is not set (see user-facing changes)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Open clean-up task after this one
* align github pkg with github reporter methods (align with k/release) + add tests

The new logic in testgrid/testgrid-scraper does not leverage from the existing testgrid/testgrid logic. 
The testgrid.go logic works with a testgrid config which is stored here: https://storage.googleapis.com/k8s-testgrid/config. I dont have access to the config. I think it would be nice if everybody could use the ci-signal tool without any process needed to given them access rights. JSON parsing from endpoints like https://testgrid.k8s.io/sig-release-master-informing/summary does not require authorization (as the website is public). I am curios what everybody things about that. 

#### Does this PR introduce a user-facing change?

```release-note
Extended testgrid report from the ci-reporter if the short flag is not set that includeds details about failing and flaky tests
```

/label tide/merge-method-squash
/assign @puerco 