### PR TITLE
add kube-cross variant for k8s 1.24 next release

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -161,7 +161,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.23.0-go1.17.4-bullseye.0
+    version: v1.24.0-go1.17.4-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -225,7 +225,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.23.0-go1.17.4-bullseye.0
+    version: v1.24.0-go1.17.4-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -288,6 +288,12 @@ dependencies:
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: REVISION:\ '\d+'
+
+  - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.23)"
+    version: v1.23.0-go1.17.4-bullseye.0
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.22, 1.21)"
     version: v1.22.0-go1.16.11-buster.0

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.24-go1.17-bullseye:
+    CONFIG: 'go1.17-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.24.0-go1.17.4-bullseye.0'
+    KUBERNETES_VERSION: 'v1.24.0'
+    GO_VERSION: '1.17.4'
+    GO_MAJOR_VERSION: '1.17'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.7.0'
   v1.23-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Just realized that the master branch is now 1.24 so might be good to add the kubecross variant for v1.24

part of https://github.com/kubernetes/release/issues/2341

/assign @justaugustus @Verolop @saschagrunert @puerco @xmudrii 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add kube-cross variant for k8s 1.24 next release
```
