### PR TITLE
k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.17.3
+    version: 1.17.4
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -181,13 +181,13 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.23.0-go1.17.3-bullseye.0
+    version: v1.24.0-go1.17.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents buster"
-    version: v1.23.0-go1.17.3-buster.0
+    version: v1.23.0-go1.17.4-buster.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -237,7 +237,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.23.0-go1.17.3-bullseye.0
+    version: v1.24.0-go1.17.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,10 +1,13 @@
 variants:
+  v1.24-cross1.17-bullseye:
+    CONFIG: 'cross1.17'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.17.4-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.3-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.4-bullseye.0'
   v1.23-cross1.17-buster:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.3-buster.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.4-buster.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.10-buster.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.17.3-${OS_CODENAME} AS builder
+FROM golang:1.17.4-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.17.3
+GO_VERSION ?= 1.17.4
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,11 +5,11 @@ variants:
     OS_CODENAME: 'buster'
   next:
     CONFIG: next
-    GO_VERSION: '1.17.3'
+    GO_VERSION: '1.17.4'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.3'
+    GO_VERSION: '1.17.4'
     OS_CODENAME: 'buster'
   '1.22':
     CONFIG: '1.22'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -7,6 +7,10 @@ variants:
     CONFIG: next
     GO_VERSION: '1.17.4'
     OS_CODENAME: 'bullseye'
+  '1.24':
+    CONFIG: '1.24'
+    GO_VERSION: '1.17.4'
+    OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
     GO_VERSION: '1.17.4'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

- k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.4
- add k8s-ci-builder config for 1.24 

PRs in k/k that uses go 1.17.4 are merged: https://github.com/kubernetes/kubernetes/pull/106833

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2341

/assign @puerco @Verolop  @xmudrii @justaugustus @saschagrunert 
cc @kubernetes/release-engineering @mengjiao-liu 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- k8s-cloud-builder/k8s-ci-builder: Build image using go1.17.4
- add k8s-ci-builder config for 1.24 
```
