### PR TITLE
Rebase the main branch instead of merging it

### DIFF
--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -17,6 +17,7 @@ limitations under the License.
 package release
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/blang/semver"
@@ -226,8 +227,15 @@ func (gp *GitObjectPusher) PushMain() error {
 	}
 	logrus.Info(lastLog)
 
-	if err := gp.mergeRemoteIfRequired(git.DefaultBranch); err != nil {
-		return errors.Wrap(err, "merge remote if required")
+	logrus.Info("Rebase master branch")
+
+	_, err = gp.repo.FetchRemote(git.DefaultRemote)
+	if err != nil {
+		return errors.Wrap(err, "while fetching origin repository")
+	}
+
+	if err := gp.repo.Rebase(fmt.Sprintf("%s/%s", git.DefaultRemote, git.DefaultBranch)); err != nil {
+		return errors.Wrap(err, "rebasing repository")
 	}
 
 	logrus.Infof("Pushing%s %s branch", dryRunLabel[gp.opts.DryRun], git.DefaultBranch)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit is a partial revert of
kubernetes#2131

The reason why we are reverting this change is that merging on the main
(master) branch can cause the git mainline to end up in an undesired
state (i.e. it can become not straight). This can cause publishing-bot
to stop working or to miss commits around the release.

This issue can occur if there are merges between starting the stage
and running the release step. This often happens on the master
branch, especially when there's no code freeze in the effect
(e.g. for alpha/beta releases).

#### Which issue(s) this PR fixes:

Related to #2337

#### Does this PR introduce a user-facing change?

```release-note
Rebase the main (master) branch instead of merging when syncing with upstream on release
```

/assign @puerco @justaugustus 
cc: @kubernetes/release-engineering 
/priority critical-urgent