### PR TITLE
k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.12

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -254,7 +254,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22, 1.21)"
-    version: 1.16.11
+    version: 1.16.12
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -10,7 +10,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.23.0-go1.17.5-buster.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.11-buster.0'
+    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.12-buster.0'
   v1.21-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.11-buster.0'
+    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.12-buster.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.11'
+    GO_VERSION: '1.16.12'
     OS_CODENAME: 'buster'
   next:
     CONFIG: next
@@ -17,11 +17,11 @@ variants:
     OS_CODENAME: 'buster'
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: '1.16.11'
+    GO_VERSION: '1.16.12'
     OS_CODENAME: 'buster'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.11'
+    GO_VERSION: '1.16.12'
     OS_CODENAME: 'buster'
   '1.20':
     CONFIG: '1.20'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.12

PRs in k/k that uses go 1.16.12 are merged: https://github.com/kubernetes/kubernetes/pull/106982 / https://github.com/kubernetes/kubernetes/pull/106983

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/release/issues/2349

/assign @puerco @Verolop  @xmudrii @justaugustus @saschagrunert 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: Build image using go1.16.12
```
