### PR TITLE
krel: fix layout used to parse GCB time

### DIFF
--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -155,7 +155,7 @@ func (h *History) Run() error {
 		logs := job.LogUrl
 
 		// Calculate the duration of the job
-		const layout = "2006-01-02T15:04:05.000000000Z"
+		const layout = "2006-01-02T15:04:05.99Z"
 		tStart, err := h.impl.ParseTime(layout, start)
 		if err != nil {
 			return errors.Wrap(err, "parsing the start job time")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The layout we currently use doesn't work well if GCB returns a time that has less than 6 digits in seconds fraction. In such cases, it returns an error such as:

```
parsing the end job time: parsing time "2021-12-15T13:25:53.713850050Z" as "2006-01-02T15:04:05.000000Z": cannot parse "050Z" as "Z"
```

This error can be reproduced by running the following `krel history` command:

```
krel history --branch release-1.21 --date-from 2021-12-15
```

In this concrete case -- where we pass time returned by GCB, we want to allow any number of digits in seconds fraction.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
krel: fix layout used to parse GCB time
```
