### PR TITLE
Adding new features to ci-signal-report

### DIFF
--- a/cmd/ci-reporter/README.md
+++ b/cmd/ci-reporter/README.md
@@ -65,64 +65,56 @@ curl \
 ```
 GITHUB_TOKEN=xxx go run cmd/ci-reporter/main.go -s
 GITHUB REPORT
-     ID    |                  TITLE                  |       CATEGORY        | STATUS |              SIGS              |                          URL                           | TS
------------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
-    106278 | New Windows kubelet stats               | In flight             |        | [sig windows]                  | https://github.com/kubernetes/kubernetes/issues/106278 |
-           | collection test flaking                 |                       |        |                                |                                                        |
-     98180 | [Flaky Test] [sig-apps]                 |                       |        | [sig apps]                     | https://github.com/kubernetes/kubernetes/issues/98180  |
-           | Deployment should run the               |                       |        |                                |                                                        |
-           | lifecycle of a Deployment               |                       |        |                                |                                                        |
-     97783 | Device manager for Windows              |                       |        | [sig windows]                  | https://github.com/kubernetes/kubernetes/issues/97783  |
-           | passes when run on cluster              |                       |        |                                |                                                        |
-           | that does not have a GPU but            |                       |        |                                |                                                        |
-           | cuases cascading errors                 |                       |        |                                |                                                        |
-     97071 | [Flaky test] [sig-storage]              |                       |        | [sig scalability sig storage]  | https://github.com/kubernetes/kubernetes/issues/97071  |
-           | In-tree Volumes [Driver:                |                       |        |                                |                                                        |
-           | gcepd] [Testpattern:                    |                       |        |                                |                                                        |
-           | Pre-provisioned PV                      |                       |        |                                |                                                        |
-           | (xfs)][Slow] volumes should             |                       |        |                                |                                                        |
-           | store data                              |                       |        |                                |                                                        |
-    103742 | [Flaking Test] [sig-scalability]        |                       |        | [sig scalability sig           | https://github.com/kubernetes/kubernetes/issues/103742 |
-           | restarting konnectivity-agent           |                       |        | cloud-provider]                |                                                        |
-           | (ci-kubernetes-e2e-gci-gce-scalability) |                       |        |                                |                                                        |
-     93740 | [Flaky Test][sig-network]               |                       |        | [sig network]                  | https://github.com/kubernetes/kubernetes/issues/93740  |
-           | Loadbalancing: L7 GCE [Slow]            |                       |        |                                |                                                        |
-           | [Feature:Ingress] should                |                       |        |                                |                                                        |
-           | conform to Ingress spec                 |                       |        |                                |                                                        |
-    100230 | [Flaky Test]                            | New/Not Yet Started   |        | [sig cloud-provider]           | https://github.com/kubernetes/kubernetes/issues/100230 |
-           | [sig-cloud-provider-gcp] Nodes          |                       |        |                                |                                                        |
-           | [Disruptive] Resize [Slow]              |                       |        |                                |                                                        |
-           | should be able to delete nodes          |                       |        |                                |                                                        |
-    105677 | HPA Custom metrics tests are            |                       |        | [sig autoscaling sig testing]  | https://github.com/kubernetes/kubernetes/issues/105677 |
-           | failing                                 |                       |        |                                |                                                        |
------------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
-  TOTAL: 8 |                                            IN FLIGHT:6 NEW/NOT  |
-           |                                               YET STARTED:2     |
------------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
-TESTGRID REPORT
-                    ID                    |            TITLE             | CATEGORY  |      STATUS       | SIGS |                                             URL                                              |           TS
-------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
-  gce-ubuntu-master-default               | sig-release-master-informing | FAILING   | 0 of 10 (0.0%)    | []   | https://testgrid.k8s.io/sig-release-master-informing#gce-ubuntu-master-default               | 2021-12-16 19:32:53 CET
-  post-release-push-image-setcap          |                              | FLAKY     | 0 of 1 (0.0%)     |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-setcap          | 2021-11-16 20:53:34 CET
-  capg-conformance-main-ci-artifacts      |                              |           | 10 of 10 (100.0%) |      | https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-main-ci-artifacts      | 2021-12-16 12:59:28 CET
-  ci-crio-cgroupv1-node-e2e-conformance   |                              |           | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#ci-crio-cgroupv1-node-e2e-conformance   | 2021-12-16 19:06:16 CET
-  gce-master-scale-performance            |                              |           | 8 of 9 (88.9%)    |      | https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-performance            | 2021-12-16 18:01:16 CET
-  post-release-push-image-go-runner       |                              |           | 4 of 9 (44.4%)    |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-go-runner       | 2021-12-12 14:52:01 CET
-  periodic-conformance-main-k8s-main      |                              | FAILING   | 8 of 10 (80.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#periodic-conformance-main-k8s-main      | 2021-12-16 15:31:06 CET
-  post-release-push-image-debian-base     |                              | FLAKY     | 0 of 1 (0.0%)     |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-debian-base     | 2021-11-16 20:53:34 CET
-  post-release-push-image-debian-iptables |                              |           |                   |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-debian-iptables |
-  capg-conformance-v1beta1-ci-artifacts   |                              |           | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-v1beta1-ci-artifacts   | 2021-12-16 12:59:15 CET
-  gce-cos-master-slow                     |                              |           | 7 of 9 (77.8%)    |      | https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-slow                     | 2021-12-16 19:48:46 CET
-  kubeadm-kinder-upgrade-1-23-latest      |                              |           | 8 of 9 (88.9%)    |      | https://testgrid.k8s.io/sig-release-master-informing#kubeadm-kinder-upgrade-1-23-latest      | 2021-12-16 19:41:46 CET
-  kubeadm-kinder-latest                   |                              |           |                   |      | https://testgrid.k8s.io/sig-release-master-informing#kubeadm-kinder-latest                   | 2021-12-16 19:42:46 CET
-  aks-engine-windows-containerd-master    |                              |           | 4 of 9 (44.4%)    |      | https://testgrid.k8s.io/sig-release-master-informing#aks-engine-windows-containerd-master    | 2021-12-16 18:55:16 CET
-  verify-master                           | sig-release-master-blocking  |           | 7 of 9 (77.8%)    |      | https://testgrid.k8s.io/sig-release-master-blocking#verify-master                            | 2021-12-16 18:45:16 CET
-  gce-device-plugin-gpu-master            |                              | FAILING   | 0 of 10 (0.0%)    |      | https://testgrid.k8s.io/sig-release-master-blocking#gce-device-plugin-gpu-master             | 2021-12-16 18:30:16 CET
-  kind-ipv6-master-parallel               |                              | FLAKY     | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-blocking#kind-ipv6-master-parallel                | 2021-12-16 19:08:16 CET
-  ci-kubernetes-unit                      |                              |           | 8 of 10 (80.0%)   |      | https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit                       | 2021-12-16 19:14:16 CET
-------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
-                 TOTAL: 18                |                                FAILING:3 |
-                                          |                                FLAKY:15  |
-------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
+     ID    |                  TITLE                  |       CATEGORY        | STATUS
+-----------+-----------------------------------------+-----------------------+---------
+    100230 | [Flaky Test]                            | New/Not Yet Started   |
+           | [sig-cloud-provider-gcp] Nodes          |                       |
+           | [Disruptive] Resize [Slow]              |                       |
+           | should be able to delete nodes          |                       |
+    105677 | HPA Custom metrics tests are            |                       |
+           | failing                                 |                       |
+    106278 | New Windows kubelet stats               | In flight             |
+           | collection test flaking                 |                       |
+     98180 | [Flaky Test] [sig-apps]                 |                       |
+           | Deployment should run the               |                       |
+           | lifecycle of a Deployment               |                       |
+     97783 | Device manager for Windows              |                       |
+           | passes when run on cluster              |                       |
+           | that does not have a GPU but            |                       |
+           | cuases cascading errors                 |                       |
+    103742 | [Flaking Test] [sig-scalability]        |                       |
+           | restarting konnectivity-agent           |                       |
+           | (ci-kubernetes-e2e-gci-gce-scalability) |                       |
+-----------+-----------------------------------------+-----------------------+---------
+  TOTAL: 6 |                                           NEW/NOT YET STARTED:2 |
+           |                                                IN FLIGHT:4      |
+-----------+-----------------------------------------+-----------------------+---------
 
+TESTGRID REPORT
+               ID              |                  TITLE                  | CATEGORY  |      STATUS
+-------------------------------+-----------------------------------------+-----------+--------------------
+  sig-release-master-blocking  | ci-kubernetes-unit                      | FLAKY     | 8 of 9 (88.9%)
+                               | gce-device-plugin-gpu-master            | FAILING   | 0 of 10 (0.0%)
+                               | gci-gce-ingress                         | FLAKY     | 8 of 10 (80.0%)
+                               | kind-master-parallel                    |           | 8 of 9 (88.9%)
+                               | integration-master                      |           |
+                               | verify-master                           |           | 9 of 9 (100.0%)
+  sig-release-master-informing | post-release-push-image-debian-base     |           | 0 of 1 (0.0%)
+                               | post-release-push-image-setcap          |           |
+                               | capg-conformance-main-ci-artifacts      |           | 10 of 10 (100.0%)
+                               | capg-conformance-v1beta1-ci-artifacts   |           | 8 of 10 (80.0%)
+                               | ci-crio-cgroupv1-node-e2e-conformance   |           | 9 of 10 (90.0%)
+                               | gce-ubuntu-master-default               | FAILING   | 0 of 9 (0.0%)
+                               | kubeadm-kinder-upgrade-1-23-latest      | FLAKY     | 8 of 9 (88.9%)
+                               | post-release-push-image-debian-iptables |           | 0 of 1 (0.0%)
+                               | aks-engine-windows-containerd-master    |           | 7 of 10 (70.0%)
+                               | post-release-push-image-go-runner       |           | 4 of 9 (44.4%)
+                               | gce-cos-master-slow                     |           | 8 of 10 (80.0%)
+                               | gce-master-scale-performance            |           | 9 of 10 (90.0%)
+                               | periodic-conformance-main-k8s-main      | FAILING   | 8 of 10 (80.0%)
+-------------------------------+-----------------------------------------+-----------+--------------------
+           TOTAL: 19           |                                           FLAKY:16  |
+                               |                                           FAILING:3 |
+                               |                                                     |
+-------------------------------+-----------------------------------------+-----------+--------------------
 ```

--- a/cmd/ci-reporter/README.md
+++ b/cmd/ci-reporter/README.md
@@ -10,7 +10,7 @@ It needs a GitHub token to be able to query the project board for CI signal. For
 
 ## Prerequisites
 
-- GoLang >=1.16
+-   GoLang >=1.16
 
 ## Run the report
 
@@ -31,11 +31,22 @@ CI-Signal reporter that generates github and testgrid reports.
 
 Usage:
   reporter [flags]
+  reporter [command]
+
+Available Commands:
+  completion  generate the autocompletion script for the specified shell
+  github      Github report generator
+  help        Help about any command
+  testgrid    Testgrid report generator
 
 Flags:
   -h, --help                     help for reporter
+      --json                     Report output in json format
   -v, --release-version string   Specify a Kubernetes release versions like '1.22' which will populate the report additionally
   -s, --short                    A short report for mails and slack
+
+Use "reporter [command] --help" for more information about a command.
+
 ```
 
 ## Rate limits
@@ -50,7 +61,7 @@ curl \
   https://api.github.com/rate_limit
 ```
 
-## Example output
+## Example table output
 
 ```
 GITHUB_TOKEN=xxx go run cmd/ci-reporter/main.go -s

--- a/cmd/ci-reporter/README.md
+++ b/cmd/ci-reporter/README.md
@@ -46,7 +46,6 @@ Flags:
   -s, --short                    A short report for mails and slack
 
 Use "reporter [command] --help" for more information about a command.
-
 ```
 
 ## Rate limits
@@ -65,43 +64,65 @@ curl \
 
 ```
 GITHUB_TOKEN=xxx go run cmd/ci-reporter/main.go -s
-
-In flight
-#106278 [sig windows]
- - New Windows kubelet stats collection test flaking
- - https://github.com/kubernetes/kubernetes/issues/106278
-#98180 [sig apps]
- - [Flaky Test] [sig-apps] Deployment should run the lifecycle of a Deployment
- - https://github.com/kubernetes/kubernetes/issues/98180
-#97783 [sig windows]
- - Device manager for Windows passes when run on cluster that does not have a GPU but cuases cascading errors
- - https://github.com/kubernetes/kubernetes/issues/97783
-#97071 [sig scalability sig storage]
- - [Flaky test] [sig-storage] In-tree Volumes [Driver: gcepd] [Testpattern: Pre-provisioned PV (xfs)][Slow] volumes should store data
- - https://github.com/kubernetes/kubernetes/issues/97071
-
-New/Not Yet Started
-#100230 [sig cloud-provider]
- - [Flaky Test] [sig-cloud-provider-gcp] Nodes [Disruptive] Resize [Slow] should be able to delete nodes
- - https://github.com/kubernetes/kubernetes/issues/100230
-#105677 [sig autoscaling sig testing]
- - HPA Custom metrics tests are failing
- - https://github.com/kubernetes/kubernetes/issues/105677
-
-
-Failures in Master-Blocking
-	18 jobs total
-	13 are passing
-	5 are flaking
-	0 are failing
-	0 are stale
-
-
-Failures in Master-Informing
-	23 jobs total
-	11 are passing
-	8 are flaking
-	4 are failing
-	0 are stale
+GITHUB REPORT
+     ID    |                  TITLE                  |       CATEGORY        | STATUS |              SIGS              |                          URL                           | TS
+-----------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
+    106278 | New Windows kubelet stats               | In flight             |        | [sig windows]                  | https://github.com/kubernetes/kubernetes/issues/106278 |
+           | collection test flaking                 |                       |        |                                |                                                        |
+     98180 | [Flaky Test] [sig-apps]                 |                       |        | [sig apps]                     | https://github.com/kubernetes/kubernetes/issues/98180  |
+           | Deployment should run the               |                       |        |                                |                                                        |
+           | lifecycle of a Deployment               |                       |        |                                |                                                        |
+     97783 | Device manager for Windows              |                       |        | [sig windows]                  | https://github.com/kubernetes/kubernetes/issues/97783  |
+           | passes when run on cluster              |                       |        |                                |                                                        |
+           | that does not have a GPU but            |                       |        |                                |                                                        |
+           | cuases cascading errors                 |                       |        |                                |                                                        |
+     97071 | [Flaky test] [sig-storage]              |                       |        | [sig scalability sig storage]  | https://github.com/kubernetes/kubernetes/issues/97071  |
+           | In-tree Volumes [Driver:                |                       |        |                                |                                                        |
+           | gcepd] [Testpattern:                    |                       |        |                                |                                                        |
+           | Pre-provisioned PV                      |                       |        |                                |                                                        |
+           | (xfs)][Slow] volumes should             |                       |        |                                |                                                        |
+           | store data                              |                       |        |                                |                                                        |
+    103742 | [Flaking Test] [sig-scalability]        |                       |        | [sig scalability sig           | https://github.com/kubernetes/kubernetes/issues/103742 |
+           | restarting konnectivity-agent           |                       |        | cloud-provider]                |                                                        |
+           | (ci-kubernetes-e2e-gci-gce-scalability) |                       |        |                                |                                                        |
+     93740 | [Flaky Test][sig-network]               |                       |        | [sig network]                  | https://github.com/kubernetes/kubernetes/issues/93740  |
+           | Loadbalancing: L7 GCE [Slow]            |                       |        |                                |                                                        |
+           | [Feature:Ingress] should                |                       |        |                                |                                                        |
+           | conform to Ingress spec                 |                       |        |                                |                                                        |
+    100230 | [Flaky Test]                            | New/Not Yet Started   |        | [sig cloud-provider]           | https://github.com/kubernetes/kubernetes/issues/100230 |
+           | [sig-cloud-provider-gcp] Nodes          |                       |        |                                |                                                        |
+           | [Disruptive] Resize [Slow]              |                       |        |                                |                                                        |
+           | should be able to delete nodes          |                       |        |                                |                                                        |
+    105677 | HPA Custom metrics tests are            |                       |        | [sig autoscaling sig testing]  | https://github.com/kubernetes/kubernetes/issues/105677 |
+           | failing                                 |                       |        |                                |                                                        |
+-----------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
+  TOTAL: 8 |                                            IN FLIGHT:6 NEW/NOT  |
+           |                                               YET STARTED:2     |
+-----------+-----------------------------------------+-----------------------+--------+--------------------------------+--------------------------------------------------------+-----
+TESTGRID REPORT
+                    ID                    |            TITLE             | CATEGORY  |      STATUS       | SIGS |                                             URL                                              |           TS
+------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
+  gce-ubuntu-master-default               | sig-release-master-informing | FAILING   | 0 of 10 (0.0%)    | []   | https://testgrid.k8s.io/sig-release-master-informing#gce-ubuntu-master-default               | 2021-12-16 19:32:53 CET
+  post-release-push-image-setcap          |                              | FLAKY     | 0 of 1 (0.0%)     |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-setcap          | 2021-11-16 20:53:34 CET
+  capg-conformance-main-ci-artifacts      |                              |           | 10 of 10 (100.0%) |      | https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-main-ci-artifacts      | 2021-12-16 12:59:28 CET
+  ci-crio-cgroupv1-node-e2e-conformance   |                              |           | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#ci-crio-cgroupv1-node-e2e-conformance   | 2021-12-16 19:06:16 CET
+  gce-master-scale-performance            |                              |           | 8 of 9 (88.9%)    |      | https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-performance            | 2021-12-16 18:01:16 CET
+  post-release-push-image-go-runner       |                              |           | 4 of 9 (44.4%)    |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-go-runner       | 2021-12-12 14:52:01 CET
+  periodic-conformance-main-k8s-main      |                              | FAILING   | 8 of 10 (80.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#periodic-conformance-main-k8s-main      | 2021-12-16 15:31:06 CET
+  post-release-push-image-debian-base     |                              | FLAKY     | 0 of 1 (0.0%)     |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-debian-base     | 2021-11-16 20:53:34 CET
+  post-release-push-image-debian-iptables |                              |           |                   |      | https://testgrid.k8s.io/sig-release-master-informing#post-release-push-image-debian-iptables |
+  capg-conformance-v1beta1-ci-artifacts   |                              |           | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-v1beta1-ci-artifacts   | 2021-12-16 12:59:15 CET
+  gce-cos-master-slow                     |                              |           | 7 of 9 (77.8%)    |      | https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-slow                     | 2021-12-16 19:48:46 CET
+  kubeadm-kinder-upgrade-1-23-latest      |                              |           | 8 of 9 (88.9%)    |      | https://testgrid.k8s.io/sig-release-master-informing#kubeadm-kinder-upgrade-1-23-latest      | 2021-12-16 19:41:46 CET
+  kubeadm-kinder-latest                   |                              |           |                   |      | https://testgrid.k8s.io/sig-release-master-informing#kubeadm-kinder-latest                   | 2021-12-16 19:42:46 CET
+  aks-engine-windows-containerd-master    |                              |           | 4 of 9 (44.4%)    |      | https://testgrid.k8s.io/sig-release-master-informing#aks-engine-windows-containerd-master    | 2021-12-16 18:55:16 CET
+  verify-master                           | sig-release-master-blocking  |           | 7 of 9 (77.8%)    |      | https://testgrid.k8s.io/sig-release-master-blocking#verify-master                            | 2021-12-16 18:45:16 CET
+  gce-device-plugin-gpu-master            |                              | FAILING   | 0 of 10 (0.0%)    |      | https://testgrid.k8s.io/sig-release-master-blocking#gce-device-plugin-gpu-master             | 2021-12-16 18:30:16 CET
+  kind-ipv6-master-parallel               |                              | FLAKY     | 9 of 10 (90.0%)   |      | https://testgrid.k8s.io/sig-release-master-blocking#kind-ipv6-master-parallel                | 2021-12-16 19:08:16 CET
+  ci-kubernetes-unit                      |                              |           | 8 of 10 (80.0%)   |      | https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit                       | 2021-12-16 19:14:16 CET
+------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
+                 TOTAL: 18                |                                FAILING:3 |
+                                          |                                FLAKY:15  |
+------------------------------------------+------------------------------+-----------+-------------------+------+----------------------------------------------------------------------------------------------+--------------------------
 
 ```

--- a/cmd/ci-reporter/cmd/github.go
+++ b/cmd/ci-reporter/cmd/github.go
@@ -81,7 +81,7 @@ func (r GithubReporter) GetCIReporterHead() CIReporterInfo {
 func (r GithubReporter) CollectReportData(cfg *Config) ([]*CIReportRecord, error) {
 	githubReportData, err := GetGithubReportData(*cfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getting GitHub report data")
 	}
 	records := []*CIReportRecord{}
 

--- a/cmd/ci-reporter/cmd/github.go
+++ b/cmd/ci-reporter/cmd/github.go
@@ -22,12 +22,89 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/google/go-github/v34/github"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+	"sigs.k8s.io/release-utils/env"
 )
+
+var githubCmd = &cobra.Command{
+	Use:    "github",
+	Short:  "Github report generator",
+	Long:   "CI-Signal reporter that generates only a github report.",
+	PreRun: setGithubConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RunReport(cfg, &CIReporters{GithubReporter{}})
+	},
+}
+
+// look for token in environment variables & create a github client
+func setGithubConfig(cmd *cobra.Command, args []string) {
+	cfg.GithubToken = env.Default("GITHUB_TOKEN", "")
+	if cfg.GithubToken == "" {
+		logrus.Fatal("Please specify your Github access token via the environment variable 'GITHUB_TOKEN' to generate a ci-report")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cfg.GithubToken})
+	tc := oauth2.NewClient(ctx, ts)
+	cfg.GithubClient = github.NewClient(tc)
+}
+
+// GithubReporterName used to identify github reporter
+var GithubReporterName CIReporterName = "github"
+
+func init() {
+	rootCmd.AddCommand(githubCmd)
+}
+
+//
+// GithubReporter implementation
+//
+
+// GithubReporter github CIReporter implementation
+type GithubReporter struct{}
+
+// GetCIReporterHead implementation from CIReporter
+func (r GithubReporter) GetCIReporterHead() CIReporterInfo {
+	return CIReporterInfo{Name: GithubReporterName}
+}
+
+// CollectReportData implementation from CIReporter
+func (r GithubReporter) CollectReportData(cfg *Config) ([]*CIReportRecord, error) {
+	githubReportData, err := GetGithubReportData(*cfg)
+	if err != nil {
+		return nil, err
+	}
+	records := []*CIReportRecord{}
+
+	for columnTitle, issues := range githubReportData {
+		for _, issue := range issues {
+			records = append(records, &CIReportRecord{
+				ID:       fmt.Sprintf("%d", issue.ID),
+				Title:    issue.Title,
+				URL:      issue.URL,
+				Category: string(columnTitle),
+				Sigs:     issue.Sigs,
+				// information not collected
+				Status:           "",
+				CreatedTimestamp: "",
+			})
+		}
+	}
+	return records, nil
+}
+
+//
+// Helper functions to collect github data
+//
 
 // This regex is getting used to identify sig lables on github issues
 var sigRegex = regexp.MustCompile(`sig/[a-zA-Z-]+`)
@@ -60,27 +137,39 @@ type (
 
 // GithubProjectBoardColumn specifies a github project board column
 type GithubProjectBoardColumn struct {
-	ColumnTitle ColumnTitle
-	ColumnID    ColumnID
+	ColumnTitle ColumnTitle `json:"column_title"`
+	ColumnID    ColumnID    `json:"column_id"`
 }
 
 // GithubReportData defines the github report data structure
 type GithubReportData map[ColumnTitle][]IssueOverview
 
+// Marshal used to marshal GithubReportData into bytes
+func (d *GithubReportData) Marshal() ([]byte, error) {
+	return json.Marshal(d)
+}
+
 // IssueOverview defines the data types of a github issue in github report data
 type IssueOverview struct {
 	// URL github issue url
-	URL string
+	URL string `json:"url"`
 	// ID github issue id
-	ID int64
+	ID int64 `json:"id"`
 	// Title github issue title
-	Title string
+	Title string `json:"title"`
 	// Sigs kubernetes sigs that are referenced via label
-	Sigs []string
+	Sigs []string `json:"sigs"`
+}
+
+type issueDetail struct {
+	Number  int64          `json:"number"`
+	HTMLURL string         `json:"html_url"`
+	Title   string         `json:"title"`
+	Labels  []github.Label `json:"labels,omitempty"`
 }
 
 // GetGithubReportData used to request the raw report data from github
-func GetGithubReportData(cfg ReporterConfig) (GithubReportData, error) {
+func GetGithubReportData(cfg Config) (GithubReportData, error) {
 	ciSignalProjectBoard := []GithubProjectBoardColumn{newColumn, underInvestigationColumn}
 
 	// if the short flag is not set observingColumn & resolvedColumn will be added to the report
@@ -99,20 +188,7 @@ func GetGithubReportData(cfg ReporterConfig) (GithubReportData, error) {
 	return githubReportData, nil
 }
 
-// PrintGithubReportData used to print github report data out to the console
-func PrintGithubReportData(reportData map[ColumnTitle][]IssueOverview) {
-	for columnTitle, issuesInColumn := range reportData {
-		if len(issuesInColumn) > 0 {
-			fmt.Println("\n" + columnTitle)
-			for _, issue := range issuesInColumn {
-				fmt.Printf("#%d %v\n - %s\n - %s\n", issue.ID, issue.Sigs, issue.Title, issue.URL)
-			}
-		}
-	}
-	fmt.Print("\n\n")
-}
-
-func getCardsFromColumn(cfg ReporterConfig, cardsID ColumnID) ([]IssueOverview, error) {
+func getCardsFromColumn(cfg Config, cardsID ColumnID) ([]IssueOverview, error) {
 	opt := &github.ProjectCardListOptions{}
 	cards, _, err := cfg.GithubClient.Projects.ListProjectCards(context.Background(), int64(cardsID), opt)
 	if err != nil {
@@ -143,14 +219,7 @@ func getCardsFromColumn(cfg ReporterConfig, cardsID ColumnID) ([]IssueOverview, 
 	return issues, nil
 }
 
-type issueDetail struct {
-	Number  int64          `json:"number"`
-	HTMLURL string         `json:"html_url"`
-	Title   string         `json:"title"`
-	Labels  []github.Label `json:"labels,omitempty"`
-}
-
-func getIssueDetail(cfg ReporterConfig, url string) (*issueDetail, error) {
+func getIssueDetail(cfg Config, url string) (*issueDetail, error) {
 	// Create a new request using http
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -188,15 +188,25 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 		}
 		fmt.Print(string(d))
 	} else {
-		// print report in table format
+		// print report in table format, (short table differs)
 		for _, r := range *reports {
+			fmt.Printf("\n%s REPORT\n", strings.ToUpper(string(r.Info.Name)))
 			table := tablewriter.NewWriter(os.Stdout)
 			data := [][]string{}
-			for _, record := range r.Records {
-				data = append(data, []string{record.ID, record.Title, record.Category, record.Status, fmt.Sprintf("%v", record.Sigs), record.URL, record.CreatedTimestamp})
+
+			// table in short version differs from regular table
+			if cfg.ShortReport {
+				table.SetHeader([]string{"ID", "TITLE", "CATEGORY", "STATUS"})
+				for _, record := range r.Records {
+					data = append(data, []string{record.ID, record.Title, record.Category, record.Status})
+				}
+			} else {
+				table.SetHeader([]string{"ID", "TITLE", "CATEGORY", "STATUS", "SIGS", "URL", "TS"})
+				for _, record := range r.Records {
+					data = append(data, []string{record.ID, record.Title, record.Category, record.Status, fmt.Sprintf("%v", record.Sigs), record.URL, record.CreatedTimestamp})
+				}
 			}
-			fmt.Printf("%s REPORT\n", strings.ToUpper(string(r.Info.Name)))
-			table.SetHeader([]string{"ID", "TITLE", "CATEGORY", "STATUS", "SIGS", "URL", "TS"})
+
 			countCategories := map[string]int{}
 			categoryIndex := 2
 			for i := range data {
@@ -206,7 +216,11 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 			for category, categoryCount := range countCategories {
 				categoryCounts += fmt.Sprintf("%s:%d\n", category, categoryCount)
 			}
-			table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, "", "", "", ""})
+			if cfg.ShortReport {
+				table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, ""})
+			} else {
+				table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, "", "", "", ""})
+			}
 			table.SetBorder(false)
 			table.AppendBulk(data)
 			table.SetAutoMergeCells(true)

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -64,7 +64,7 @@ var cfg = &Config{
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&cfg.ReleaseVersion, "release-version", "v", "", "Specify a Kubernetes release versions like '1.22' which will populate the report additionally")
+	rootCmd.Flags().StringVarP(&cfg.ReleaseVersion, "release-version", "v", "", "Specify a Kubernetes release versions like '1.22' which will populate the report additionally")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.ShortReport, "short", "s", false, "A short report for mails and slack")
 	rootCmd.PersistentFlags().BoolVar(&cfg.JSONOutput, "json", false, "Report output in json format")
 }
@@ -197,7 +197,16 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 			}
 			fmt.Printf("%s REPORT\n", strings.ToUpper(string(r.Info.Name)))
 			table.SetHeader([]string{"ID", "TITLE", "CATEGORY", "STATUS", "SIGS", "URL", "TS"})
-			table.SetFooter([]string{"", "", "", "", "", "RECORDS", fmt.Sprintf("%d", len(r.Records))})
+			countCategories := map[string]int{}
+			categoryIndex := 2
+			for i := range data {
+				countCategories[data[i][categoryIndex]]++
+			}
+			categoryCounts := ""
+			for category, categoryCount := range countCategories {
+				categoryCounts += fmt.Sprintf("%s:%d\n", category, categoryCount)
+			}
+			table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, "", "", "", ""})
 			table.SetBorder(false)
 			table.AppendBulk(data)
 			table.SetAutoMergeCells(true)

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -18,13 +18,13 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/google/go-github/v34/github"
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -78,9 +78,8 @@ func RunReport(cfg *Config, reporters *CIReporters) error {
 	}
 
 	// visualize data
-	err = PrintReporterData(cfg, reports)
-	if err != nil {
-		return err
+	if err := PrintReporterData(cfg, reports); err != nil {
+		return errors.Wrap(err, "printing report data")
 	}
 
 	return nil

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -62,8 +62,8 @@ func (r TestgridReporter) CollectReportData(cfg *Config) ([]*CIReportRecord, err
 			jobSummary := jobData[jobName]
 			if !cfg.ShortReport || jobSummary.OverallStatus != testgrid.Passing {
 				records = append(records, &CIReportRecord{
-					ID:               string(jobName),
-					Title:            string(dashboardName),
+					ID:               string(dashboardName),
+					Title:            string(jobName),
 					URL:              jobSummary.GetJobURL(jobName),
 					Category:         string(jobSummary.OverallStatus),
 					Sigs:             jobSummary.FilterSigs(),

--- a/pkg/testgrid/testgrid-scraper.go
+++ b/pkg/testgrid/testgrid-scraper.go
@@ -189,12 +189,13 @@ const (
 	SigReleaseMasterInforming DashboardName = "sig-release-master-informing"
 	// SigReleaseMasterBlocking one of the dashboard names that can be used to scrapo a testgrid summary
 	SigReleaseMasterBlocking DashboardName = "sig-release-master-blocking"
+	sigRegexStr              string        = "sig-[a-zA-Z]+"
 )
+
+var sigRegex = regexp.MustCompile(sigRegexStr)
 
 // FilterSigs used to filter sigs from failing tests
 func (j *JobSummary) FilterSigs() []string {
-	// Filter sigs
-	sigRegex := regexp.MustCompile(`sig-[a-zA-Z]+`)
 	sigsInvolved := map[string]int{}
 	for i := range j.Tests {
 		sigs := sigRegex.FindAllString(j.Tests[i].TestName, -1)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR implements a couple of planned features to the ci signal report CLI (see referenced issues).

#### Which issue(s) this PR fixes:

* closes #2364
* closes #2363
* closes #2361
* closes #2360
* closes #2362

#### Special notes for your reviewer:

Some things I am thinking about:
* CIReporter interface (root.go): remove method GetCIReporterHead // not sure tho
* Adding colors to testgrid
* Reduce testgrid table width somehow (maybe force line breaks)

#### Does this PR introduce a user-facing change?

```release-note
Add the 'testgrid' command to the CLI, which creates only a testgrid report.
Add the 'github' command to the CLI, which creates only a github report
Add flag '--json' to print the report in json format.
Report will be printed in table format
```

/label tide/merge-method-squash
/assign @puerco