### PR TITLE
golang: Build 1.18beta1 images and drop temp `buster` variants

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -135,7 +135,7 @@ dependencies:
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.23.0
+    version: v1.24.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -194,7 +194,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.17
+    version: 1.18beta1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -213,7 +213,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (next candidate)"
-    version: v2.3.1-go1.17.5-bullseye.0
+    version: v2.3.1-go1.18beta1-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -225,7 +225,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.24.0-go1.17.5-bullseye.0
+    version: v1.24.0-go1.18beta1-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.24-go1.18-bullseye:
+    CONFIG: 'go1.18-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.24.0-go1.18beta1-bullseye.0'
+    KUBERNETES_VERSION: 'v1.24.0'
+    GO_VERSION: '1.18beta1'
+    GO_MAJOR_VERSION: '1.18'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.7.0'
   v1.24-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'
@@ -17,16 +27,6 @@ variants:
     GO_VERSION: '1.17.5'
     GO_MAJOR_VERSION: '1.17'
     OS_CODENAME: 'bullseye'
-    REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
-  v1.23-go1.17-buster:
-    CONFIG: 'go1.17-buster'
-    TYPE: 'default'
-    IMAGE_VERSION: 'v1.23.0-go1.17.5-buster.0'
-    KUBERNETES_VERSION: 'v1.23.0'
-    GO_VERSION: '1.17.5'
-    GO_MAJOR_VERSION: '1.17'
-    OS_CODENAME: 'buster'
     REVISION: '0'
     PROTOBUF_VERSION: '3.7.0'
   v1.22-go1.16-buster:

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,4 +1,12 @@
 variants:
+  go1.18-bullseye:
+    CONFIG: 'go1.18-bullseye'
+    IMAGE_VERSION: 'v2.3.1-go1.18beta1-bullseye.0'
+    GO_MAJOR_VERSION: '1.18'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    GO_VERSION: '1.18beta1'
+    DISTROLESS_IMAGE: 'static-debian11'
   go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     IMAGE_VERSION: 'v2.3.1-go1.17.5-bullseye.0'
@@ -7,14 +15,6 @@ variants:
     REVISION: '0'
     GO_VERSION: '1.17.5'
     DISTROLESS_IMAGE: 'static-debian11'
-  go1.17-buster:
-    CONFIG: 'go1.17-buster'
-    IMAGE_VERSION: 'v2.3.1-go1.17.5-buster.0'
-    GO_MAJOR_VERSION: '1.17'
-    OS_CODENAME: 'buster'
-    REVISION: '0'
-    GO_VERSION: '1.17.5'
-    DISTROLESS_IMAGE: 'static-debian10'
   go1.16-buster:
     CONFIG: 'go1.16-buster'
     IMAGE_VERSION: 'v2.3.1-go1.16.12-buster.0'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,13 +1,13 @@
 variants:
+  go1.18-bullseye:
+    CONFIG: 'go1.18-bullseye'
+    GO_VERSION: '1.18beta1'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     GO_VERSION: '1.17.5'
     OS_CODENAME: 'bullseye'
-    REVISION: '0'
-  go1.17-buster:
-    CONFIG: 'go1.17-buster'
-    GO_VERSION: '1.17.5'
-    OS_CODENAME: 'buster'
     REVISION: '0'
   go1.16-buster:
     CONFIG: 'go1.16-buster'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,20 +1,20 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.16.12'
-    OS_CODENAME: 'buster'
+    GO_VERSION: '1.17.5'
+    OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.17.5'
+    GO_VERSION: '1.18beta1'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.17.5'
+    GO_VERSION: '1.18beta1'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
     GO_VERSION: '1.17.5'
-    OS_CODENAME: 'buster'
+    OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'
     GO_VERSION: '1.16.12'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/release/issues/2307.

- Set next release version to v1.24.0
- golang: Set next candidate to go1.18beta1
- golang: Build 1.18beta1 images and drop temp buster variants

/assign @cpanato @saschagrunert @puerco 
/cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Set next release version to v1.24.0
- golang: Set next candidate to go1.18beta1
- golang: Build 1.18beta1 images and drop temp `buster` variants
```
