### PR TITLE
Add SBOM generation support to publish-release

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/release/pkg/announce"
 )
@@ -124,6 +125,17 @@ func init() {
 		false,
 		"Mark the release as a draft in GitHub so you can finish editing and publish it manually.",
 	)
+
+	for _, f := range []string{"template", "asset"} {
+		if err := githuPageCmd.MarkPersistentFlagFilename(f); err != nil {
+			logrus.Error(err)
+		}
+	}
+
+	if err := githuPageCmd.MarkPersistentFlagRequired("repo"); err != nil {
+		logrus.Error(err)
+	}
+
 	rootCmd.AddCommand(githuPageCmd)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This commit adds SBOM generation support to the `publish-release` utility:

![image](https://user-images.githubusercontent.com/3935899/146608270-d2dc9711-c194-47dd-b572-48d1f4ba2f99.png)


The generated SPDX SBOM describes the source code repo and all the artifacts uploaded to the GitHub release page.

A new flag --sbom (defaulting to true) controls if the utility generates an SBOM and attaches
it to the github release page when uploading data for a release.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

To see an example of the generated SBOM check out this repository:
https://github.com/mattermost/builder/releases/tag/v0.0.1

#### Does this PR introduce a user-facing change?
```release-note
Our utility to manage release publishing  `publish-release`, now automatically generates an SBOM describing the source code repository and all artifacts uploaded as assets to the GitHub release page.
```
