### PR TITLE
debian-base: Update dependents to use bullseye-v1.1.0 / buster-v1.10.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -371,7 +371,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: DEBIAN_BASE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -412,7 +412,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents (next candidate)"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -397,7 +397,7 @@ dependencies:
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+
 
   - name: "k8s.gcr.io/build-image/setcap"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: images/build/setcap/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -426,7 +426,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/setcap (next candidate)"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: images/build/setcap/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -383,7 +383,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: bullseye-v1.1.0
+    version: bullseye-v1.2.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -420,7 +420,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
-    version: bullseye-v1.1.0
+    version: bullseye-v1.2.0
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.1.0
+IMAGE_VERSION ?= bullseye-v1.2.0
 CONFIG ?= bullseye
 DEBIAN_BASE_VERSION ?= bullseye-v1.1.0
 GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -20,7 +20,7 @@ IMAGE=$(REGISTRY)/debian-iptables
 TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= bullseye-v1.1.0
 CONFIG ?= bullseye
-DEBIAN_BASE_VERSION ?= bullseye-v1.0.0
+DEBIAN_BASE_VERSION ?= bullseye-v1.1.0
 GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0
 
 ARCH?=amd64

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,10 +2,10 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.1.0'
+    IMAGE_VERSION: 'bullseye-v1.2.0'
     DEBIAN_BASE_VERSION: 'bullseye-v1.1.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.7.0'
+    IMAGE_VERSION: 'buster-v1.8.0'
     DEBIAN_BASE_VERSION: 'buster-v1.10.0'

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -3,9 +3,9 @@ variants:
   bullseye:
     CONFIG: 'bullseye'
     IMAGE_VERSION: 'bullseye-v1.1.0'
-    DEBIAN_BASE_VERSION: 'bullseye-v1.0.0'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.1.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v1.7.0'
-    DEBIAN_BASE_VERSION: 'buster-v1.9.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.10.0'

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/setcap
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.0.0
+IMAGE_VERSION ?= bullseye-v1.1.0
 CONFIG ?= bullseye
 DEBIAN_BASE_VERSION ?= bullseye-v1.1.0
 

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -20,7 +20,7 @@ IMAGE=$(REGISTRY)/setcap
 TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= bullseye-v1.0.0
 CONFIG ?= bullseye
-DEBIAN_BASE_VERSION ?= bullseye-v1.0.0
+DEBIAN_BASE_VERSION ?= bullseye-v1.1.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -3,9 +3,9 @@ variants:
   bullseye:
     CONFIG: 'bullseye'
     IMAGE_VERSION: 'bullseye-v1.0.0'
-    DEBIAN_BASE_VERSION: 'bullseye-v1.0.0'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.1.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
     IMAGE_VERSION: 'buster-v2.0.4'
-    DEBIAN_BASE_VERSION: 'buster-v1.9.0'
+    DEBIAN_BASE_VERSION: 'buster-v1.10.0'

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -2,10 +2,10 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.0.0'
+    IMAGE_VERSION: 'bullseye-v1.1.0'
     DEBIAN_BASE_VERSION: 'bullseye-v1.1.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v2.0.4'
+    IMAGE_VERSION: 'buster-v2.1.0'
     DEBIAN_BASE_VERSION: 'buster-v1.10.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Continuation of CVE fixes from https://github.com/kubernetes/release/pull/2371.

- debian-base: Update dependents to use bullseye-v1.1.0 / buster-v1.10.0 
  - debian-iptables: Build bullseye-v1.2.0 / buster-v1.8.0 images
  - setcap: Build bullseye-v1.1.0 / buster-v2.1.0 images

/assign @puerco @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- debian-base: Update dependents to use bullseye-v1.1.0 / buster-v1.10.0 
  - debian-iptables: Build bullseye-v1.2.0 / buster-v1.8.0 images
  - setcap: Build bullseye-v1.1.0 / buster-v2.1.0 images
```
