### PR TITLE
krel/announce: update kubernetes-dev email distribution

### DIFF
--- a/pkg/mail/mail.go
+++ b/pkg/mail/mail.go
@@ -33,7 +33,7 @@ type GoogleGroup string
 
 const (
 	KubernetesAnnounceGoogleGroup     GoogleGroup = "kubernetes-announce"
-	KubernetesDevGoogleGroup          GoogleGroup = "kubernetes-dev"
+	KubernetesDevGoogleGroup          GoogleGroup = "dev"
 	KubernetesAnnounceTestGoogleGroup GoogleGroup = "kubernetes-announce-test"
 )
 
@@ -200,7 +200,16 @@ func (s *Sender) SetRecipients(recipientArgs ...string) error {
 func (s *Sender) SetGoogleGroupRecipients(groups ...GoogleGroup) error {
 	args := []string{}
 	for _, group := range groups {
-		args = append(args, string(group), fmt.Sprintf("%s@googlegroups.com", group))
+		if group == "dev" {
+			args = append(args, string(group), fmt.Sprintf("%s@kubernetes.io", group))
+		} else {
+			args = append(args, string(group), fmt.Sprintf("%s@googlegroups.com", group))
+		}
 	}
 	return s.SetRecipients(args...)
+}
+
+// GetRecipients can be used to get the recipients
+func (s *Sender) GetRecipients() []*mail.Email {
+	return s.recipients
 }

--- a/pkg/mail/mail_test.go
+++ b/pkg/mail/mail_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	"github.com/sendgrid/rest"
+	sendgridMail "github.com/sendgrid/sendgrid-go/helpers/mail"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/release/pkg/mail"
 	"k8s.io/release/pkg/mail/mailfakes"
 	it "k8s.io/release/pkg/testing"
@@ -266,4 +268,30 @@ func testRecipient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetGoogleGroupRecipients(t *testing.T) {
+	groups := []mail.GoogleGroup{
+		mail.KubernetesAnnounceGoogleGroup,
+		mail.KubernetesDevGoogleGroup,
+	}
+
+	expectedRecipients := []*sendgridMail.Email{
+		{
+			Address: "dev@kubernetes.io",
+			Name:    "dev",
+		},
+		{
+			Address: "kubernetes-announce@googlegroups.com",
+			Name:    "kubernetes-announce",
+		},
+	}
+
+	m := &mail.Sender{}
+	err := m.SetGoogleGroupRecipients(groups...)
+	require.NoError(t, err)
+
+	recipients := m.GetRecipients()
+	require.NotEmpty(t, recipients)
+	require.ElementsMatch(t, expectedRecipients, recipients)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
update the mailing list name from `kubernetes-dev` to the new one `dev`(dev at kubernetes dot io) that will be fully migrated starting `January 2, 2022`

- https://groups.google.com/g/kubernetes-dev/c/jiFUzxqFXro/m/-IhMzV--DQAJ
- https://github.com/kubernetes/community/issues/5877

/assign @justaugustus @puerco @saschagrunert @xmudrii @Verolop @palnabarun 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel/announce: update kubernetes-dev email distribution
```
