### PR TITLE
update ci signal tool reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,12 +29,11 @@ aliases:
     - MushuEE
     - spiffxp
   ci-signal-reporter-reviewers:
-    - calvh # 1.23 CI Signal Shadow
-    - encodeflush # 1.23 CI Signal Lead
-    - leonardpahlke # 1.23 CI Signal Shadow
-    - rajula96reddy # 1.23 CI Signal Shadow
-    - RinkiyaKeDad # 1.23 CI Signal Shadow
-    - simrangupta234 # 1.23 CI Signal Shadow
+    - leonardpahlke # 1.24 CI Signal Lead
+    - voigt # 1.24 CI Signal Shadow
+    - lauralorenz # 1.24 CI Signal Lead
+    - shuheiktgw # 1.24 CI Signal Shadow
+    - nivedita-coder # 1.24 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,7 +31,7 @@ aliases:
   ci-signal-reporter-reviewers:
     - leonardpahlke # 1.24 CI Signal Lead
     - voigt # 1.24 CI Signal Shadow
-    - lauralorenz # 1.24 CI Signal Lead
+    - lauralorenz # 1.24 CI Signal Shadow
     - shuheiktgw # 1.24 CI Signal Shadow
     - nivedita-coder # 1.24 CI Signal Shadow
   krel-approvers:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

update ci signal team (reviewers for the ci signal tool) ([1.24 ci signal team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)) 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

cc @JamesLaverack 
add @voigt @lauralorenz @shuheiktgw and @nivedita-coder as ci signal tool reviewers