### PR TITLE
Add support for running krel fast-forward in GCB

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -31,13 +31,18 @@ var ffOpts = &fastforward.Options{}
 
 // ffCmd represents the base command when called without any subcommands
 var ffCmd = &cobra.Command{
-	Use:   "ff --branch <release-branch> [--ref <main-ref>] [--nomock] [--cleanup]",
-	Short: "Fast forward a Kubernetes release branch",
-	Long: fmt.Sprintf(`ff fast forwards a branch to a specified git object (defaults to %s).
+	Use:     "fast-forward --branch <release-branch> [--ref <main-ref>] [--nomock] [--cleanup]",
+	Short:   "Fast forward a Kubernetes release branch",
+	Aliases: []string{"ff"},
+	Long: fmt.Sprintf(`fast-forward fast forwards a branch to a specified git object (defaults to %s).
 
-krel ff pre-checks that the local branch to be forwarded is an actual
-'release-x.y' branch and that the branch exists remotely. If that is not the
-case, krel ff will fail.
+krel fast-forward pre-checks that the provided branch to be forwarded is an
+actual 'release-x.y' branch and that the branch exists remotely. If that is not
+the case, krel fast-forward will fail.
+
+If no branch is provided, then krel will try to find the latest upstream k/k
+release branch. If this release branch already contains a final minor release,
+then krel ff will do nothing at all.
 
 After that preflight-check, the release branch will be checked out and krel
 verifies that the latest merge base tag is the same for the main and the
@@ -47,8 +52,14 @@ forwarded.
 krel merges the provided ref into the release branch and asks for a final
 confirmation if the push should really happen. The push will only be executed
 as real push if the '--nomock' flag is specified.
+
+If --non-interactive is set to true, then krel will not require any user
+interaction.  This mode is mainly made for CI purposes.
+
+If --submit is set to true, then krel fast-forward will run by submitting a new
+Google Cloud Build job.
 `, kgit.Remotify(kgit.DefaultBranch)),
-	Example:       "krel ff --branch release-1.17 --ref origin/master --cleanup",
+	Example:       "krel fast-forward --branch release-1.17 --ref origin/master --cleanup",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,6 +74,7 @@ func init() {
 	ffCmd.PersistentFlags().StringVar(&ffOpts.MainRef, "ref", kgit.Remotify(kgit.DefaultBranch), "ref on the main branch")
 	ffCmd.PersistentFlags().BoolVar(&ffOpts.Cleanup, "cleanup", false, "cleanup the repository after the run")
 	ffCmd.PersistentFlags().BoolVar(&ffOpts.NonInteractive, "non-interactive", false, "do not require any user interaction")
+	ffCmd.PersistentFlags().BoolVar(&ffOpts.Submit, "submit", false, "run inside of Google Cloud Build by submitting a new job")
 
 	rootCmd.AddCommand(ffCmd)
 }

--- a/gcb/fast-forward/cloudbuild.yaml
+++ b/gcb/fast-forward/cloudbuild.yaml
@@ -1,0 +1,78 @@
+timeout: 14400s
+
+#### SECURITY NOTICE ####
+# Google Cloud Build (GCB) supports the usage of secrets for build requests.
+# Secrets appear within GCB configs as base64-encoded strings.
+# These secrets are GCP Cloud KMS-encrypted and cannot be decrypted by any human or system
+# outside of GCP Cloud KMS for the GCP project this encrypted resource was created for.
+# Seeing the base64-encoded encrypted blob here is not a security event for the project.
+#
+# More details on using encrypted resources on Google Cloud Build can be found here:
+# https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials
+#
+# (Please do not remove this security notice.)
+secrets:
+- kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
+  secretEnv:
+    GITHUB_TOKEN: CiQAIkWjMODH+TR8+6KmsAValHBKkX2PjVWSzyNdScGCIl0rBlYSUQBLz1D++mrhyd+wXohoQEGDuyQHvFzQyT7NEvI2BR/WBmnu1S9+E5GgER8OOnaQg+dGEMrYzEQIiTOB8WPxU7ecsIyo0AuegcBH24dj9L2tDw==
+
+steps:
+- name: gcr.io/cloud-builders/git
+  dir: "go/src/k8s.io"
+  args:
+  - "clone"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: gcr.io/cloud-builders/git
+  entrypoint: "bash"
+  dir: "go/src/k8s.io/release"
+  args:
+  - '-c'
+  - |
+    git fetch
+    echo "Checking out ${_TOOL_REF}"
+    git checkout ${_TOOL_REF}
+
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
+  dir: "go/src/k8s.io/release"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  args:
+  - "./compile-release-tools"
+  - "krel"
+
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: "/workspace"
+  env:
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
+  - "K8S_ORG=${_K8S_ORG}"
+  - "K8S_REPO=${_K8S_REPO}"
+  - "K8S_REF=${_K8S_REF}"
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+  - "bin/krel"
+  - "fast-forward"
+  - "--log-level=${_LOG_LEVEL}"
+  - "--non-interactive"
+  - "${_NOMOCK}"
+
+tags:
+- ${_GCP_USER_TAG}
+- ${_NOMOCK_TAG}
+- FAST_FORWARD
+- ${_GIT_TAG}
+- ${_RELEASE_BRANCH}
+- ${_TYPE_TAG}
+- ${_TYPE}
+
+options:
+  machineType: N1_HIGHCPU_32
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'

--- a/pkg/fastforward/fastforward_test.go
+++ b/pkg/fastforward/fastforward_test.go
@@ -95,6 +95,59 @@ func TestRun(t *testing.T) {
 				require.Nil(t, err)
 			},
 		},
+		{ // success submit
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				return &Options{Submit: true}
+			},
+			assert: func(err error) {
+				require.Nil(t, err)
+			},
+		},
+		{ // success token
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				mock.IsReleaseBranchReturns(true)
+				mock.RepoHasRemoteBranchReturns(true, nil)
+				mock.EnvDefaultReturns("token")
+				return &Options{Branch: branch, NonInteractive: true}
+			},
+			assert: func(err error) {
+				require.Nil(t, err)
+			},
+		},
+		{ // failure with token on RepoSetURL
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				mock.IsReleaseBranchReturns(true)
+				mock.RepoHasRemoteBranchReturns(true, nil)
+				mock.EnvDefaultReturns("token")
+				mock.IsDefaultK8sUpstreamReturns(true)
+				mock.RepoSetURLReturns(errTest)
+				return &Options{Branch: branch, NonInteractive: true}
+			},
+			assert: func(err error) {
+				require.NotNil(t, err)
+			},
+		},
+		{ // failure with token on CloneOrOpenGitHubRepo
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				mock.IsReleaseBranchReturns(true)
+				mock.RepoHasRemoteBranchReturns(true, nil)
+				mock.EnvDefaultReturns("token")
+				mock.CloneOrOpenGitHubRepoReturns(nil, errTest)
+				return &Options{Branch: branch, NonInteractive: true}
+			},
+			assert: func(err error) {
+				require.NotNil(t, err)
+			},
+		},
+		{ // failure on Submit
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				mock.SubmitReturns(errTest)
+				return &Options{Submit: true}
+			},
+			assert: func(err error) {
+				require.NotNil(t, err)
+			},
+		},
 		{ // failure on RepoLatestReleaseBranch
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.RepoLatestReleaseBranchReturns("", errTest)

--- a/pkg/fastforward/fastforwardfakes/fake_impl.go
+++ b/pkg/fastforward/fastforwardfakes/fake_impl.go
@@ -20,6 +20,7 @@ package fastforwardfakes
 import (
 	"sync"
 
+	"k8s.io/release/pkg/gcp/gcb"
 	"sigs.k8s.io/release-sdk/git"
 )
 
@@ -53,6 +54,44 @@ type FakeImpl struct {
 	cloneOrOpenDefaultGitHubRepoSSHReturnsOnCall map[int]struct {
 		result1 *git.Repo
 		result2 error
+	}
+	CloneOrOpenGitHubRepoStub        func(string, string, string, bool) (*git.Repo, error)
+	cloneOrOpenGitHubRepoMutex       sync.RWMutex
+	cloneOrOpenGitHubRepoArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}
+	cloneOrOpenGitHubRepoReturns struct {
+		result1 *git.Repo
+		result2 error
+	}
+	cloneOrOpenGitHubRepoReturnsOnCall map[int]struct {
+		result1 *git.Repo
+		result2 error
+	}
+	EnvDefaultStub        func(string, string) string
+	envDefaultMutex       sync.RWMutex
+	envDefaultArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	envDefaultReturns struct {
+		result1 string
+	}
+	envDefaultReturnsOnCall map[int]struct {
+		result1 string
+	}
+	IsDefaultK8sUpstreamStub        func() bool
+	isDefaultK8sUpstreamMutex       sync.RWMutex
+	isDefaultK8sUpstreamArgsForCall []struct {
+	}
+	isDefaultK8sUpstreamReturns struct {
+		result1 bool
+	}
+	isDefaultK8sUpstreamReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	IsReleaseBranchStub        func(string) bool
 	isReleaseBranchMutex       sync.RWMutex
@@ -225,6 +264,30 @@ type FakeImpl struct {
 	repoSetDryArgsForCall []struct {
 		arg1 *git.Repo
 	}
+	RepoSetURLStub        func(*git.Repo, string, string) error
+	repoSetURLMutex       sync.RWMutex
+	repoSetURLArgsForCall []struct {
+		arg1 *git.Repo
+		arg2 string
+		arg3 string
+	}
+	repoSetURLReturns struct {
+		result1 error
+	}
+	repoSetURLReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SubmitStub        func(*gcb.Options) error
+	submitMutex       sync.RWMutex
+	submitArgsForCall []struct {
+		arg1 *gcb.Options
+	}
+	submitReturns struct {
+		result1 error
+	}
+	submitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -360,6 +423,188 @@ func (fake *FakeImpl) CloneOrOpenDefaultGitHubRepoSSHReturnsOnCall(i int, result
 		result1 *git.Repo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepo(arg1 string, arg2 string, arg3 string, arg4 bool) (*git.Repo, error) {
+	fake.cloneOrOpenGitHubRepoMutex.Lock()
+	ret, specificReturn := fake.cloneOrOpenGitHubRepoReturnsOnCall[len(fake.cloneOrOpenGitHubRepoArgsForCall)]
+	fake.cloneOrOpenGitHubRepoArgsForCall = append(fake.cloneOrOpenGitHubRepoArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 bool
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.CloneOrOpenGitHubRepoStub
+	fakeReturns := fake.cloneOrOpenGitHubRepoReturns
+	fake.recordInvocation("CloneOrOpenGitHubRepo", []interface{}{arg1, arg2, arg3, arg4})
+	fake.cloneOrOpenGitHubRepoMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepoCallCount() int {
+	fake.cloneOrOpenGitHubRepoMutex.RLock()
+	defer fake.cloneOrOpenGitHubRepoMutex.RUnlock()
+	return len(fake.cloneOrOpenGitHubRepoArgsForCall)
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepoCalls(stub func(string, string, string, bool) (*git.Repo, error)) {
+	fake.cloneOrOpenGitHubRepoMutex.Lock()
+	defer fake.cloneOrOpenGitHubRepoMutex.Unlock()
+	fake.CloneOrOpenGitHubRepoStub = stub
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepoArgsForCall(i int) (string, string, string, bool) {
+	fake.cloneOrOpenGitHubRepoMutex.RLock()
+	defer fake.cloneOrOpenGitHubRepoMutex.RUnlock()
+	argsForCall := fake.cloneOrOpenGitHubRepoArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepoReturns(result1 *git.Repo, result2 error) {
+	fake.cloneOrOpenGitHubRepoMutex.Lock()
+	defer fake.cloneOrOpenGitHubRepoMutex.Unlock()
+	fake.CloneOrOpenGitHubRepoStub = nil
+	fake.cloneOrOpenGitHubRepoReturns = struct {
+		result1 *git.Repo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) CloneOrOpenGitHubRepoReturnsOnCall(i int, result1 *git.Repo, result2 error) {
+	fake.cloneOrOpenGitHubRepoMutex.Lock()
+	defer fake.cloneOrOpenGitHubRepoMutex.Unlock()
+	fake.CloneOrOpenGitHubRepoStub = nil
+	if fake.cloneOrOpenGitHubRepoReturnsOnCall == nil {
+		fake.cloneOrOpenGitHubRepoReturnsOnCall = make(map[int]struct {
+			result1 *git.Repo
+			result2 error
+		})
+	}
+	fake.cloneOrOpenGitHubRepoReturnsOnCall[i] = struct {
+		result1 *git.Repo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) EnvDefault(arg1 string, arg2 string) string {
+	fake.envDefaultMutex.Lock()
+	ret, specificReturn := fake.envDefaultReturnsOnCall[len(fake.envDefaultArgsForCall)]
+	fake.envDefaultArgsForCall = append(fake.envDefaultArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.EnvDefaultStub
+	fakeReturns := fake.envDefaultReturns
+	fake.recordInvocation("EnvDefault", []interface{}{arg1, arg2})
+	fake.envDefaultMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) EnvDefaultCallCount() int {
+	fake.envDefaultMutex.RLock()
+	defer fake.envDefaultMutex.RUnlock()
+	return len(fake.envDefaultArgsForCall)
+}
+
+func (fake *FakeImpl) EnvDefaultCalls(stub func(string, string) string) {
+	fake.envDefaultMutex.Lock()
+	defer fake.envDefaultMutex.Unlock()
+	fake.EnvDefaultStub = stub
+}
+
+func (fake *FakeImpl) EnvDefaultArgsForCall(i int) (string, string) {
+	fake.envDefaultMutex.RLock()
+	defer fake.envDefaultMutex.RUnlock()
+	argsForCall := fake.envDefaultArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) EnvDefaultReturns(result1 string) {
+	fake.envDefaultMutex.Lock()
+	defer fake.envDefaultMutex.Unlock()
+	fake.EnvDefaultStub = nil
+	fake.envDefaultReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeImpl) EnvDefaultReturnsOnCall(i int, result1 string) {
+	fake.envDefaultMutex.Lock()
+	defer fake.envDefaultMutex.Unlock()
+	fake.EnvDefaultStub = nil
+	if fake.envDefaultReturnsOnCall == nil {
+		fake.envDefaultReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.envDefaultReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeImpl) IsDefaultK8sUpstream() bool {
+	fake.isDefaultK8sUpstreamMutex.Lock()
+	ret, specificReturn := fake.isDefaultK8sUpstreamReturnsOnCall[len(fake.isDefaultK8sUpstreamArgsForCall)]
+	fake.isDefaultK8sUpstreamArgsForCall = append(fake.isDefaultK8sUpstreamArgsForCall, struct {
+	}{})
+	stub := fake.IsDefaultK8sUpstreamStub
+	fakeReturns := fake.isDefaultK8sUpstreamReturns
+	fake.recordInvocation("IsDefaultK8sUpstream", []interface{}{})
+	fake.isDefaultK8sUpstreamMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) IsDefaultK8sUpstreamCallCount() int {
+	fake.isDefaultK8sUpstreamMutex.RLock()
+	defer fake.isDefaultK8sUpstreamMutex.RUnlock()
+	return len(fake.isDefaultK8sUpstreamArgsForCall)
+}
+
+func (fake *FakeImpl) IsDefaultK8sUpstreamCalls(stub func() bool) {
+	fake.isDefaultK8sUpstreamMutex.Lock()
+	defer fake.isDefaultK8sUpstreamMutex.Unlock()
+	fake.IsDefaultK8sUpstreamStub = stub
+}
+
+func (fake *FakeImpl) IsDefaultK8sUpstreamReturns(result1 bool) {
+	fake.isDefaultK8sUpstreamMutex.Lock()
+	defer fake.isDefaultK8sUpstreamMutex.Unlock()
+	fake.IsDefaultK8sUpstreamStub = nil
+	fake.isDefaultK8sUpstreamReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeImpl) IsDefaultK8sUpstreamReturnsOnCall(i int, result1 bool) {
+	fake.isDefaultK8sUpstreamMutex.Lock()
+	defer fake.isDefaultK8sUpstreamMutex.Unlock()
+	fake.IsDefaultK8sUpstreamStub = nil
+	if fake.isDefaultK8sUpstreamReturnsOnCall == nil {
+		fake.isDefaultK8sUpstreamReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isDefaultK8sUpstreamReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeImpl) IsReleaseBranch(arg1 string) bool {
@@ -1217,6 +1462,130 @@ func (fake *FakeImpl) RepoSetDryArgsForCall(i int) *git.Repo {
 	return argsForCall.arg1
 }
 
+func (fake *FakeImpl) RepoSetURL(arg1 *git.Repo, arg2 string, arg3 string) error {
+	fake.repoSetURLMutex.Lock()
+	ret, specificReturn := fake.repoSetURLReturnsOnCall[len(fake.repoSetURLArgsForCall)]
+	fake.repoSetURLArgsForCall = append(fake.repoSetURLArgsForCall, struct {
+		arg1 *git.Repo
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.RepoSetURLStub
+	fakeReturns := fake.repoSetURLReturns
+	fake.recordInvocation("RepoSetURL", []interface{}{arg1, arg2, arg3})
+	fake.repoSetURLMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) RepoSetURLCallCount() int {
+	fake.repoSetURLMutex.RLock()
+	defer fake.repoSetURLMutex.RUnlock()
+	return len(fake.repoSetURLArgsForCall)
+}
+
+func (fake *FakeImpl) RepoSetURLCalls(stub func(*git.Repo, string, string) error) {
+	fake.repoSetURLMutex.Lock()
+	defer fake.repoSetURLMutex.Unlock()
+	fake.RepoSetURLStub = stub
+}
+
+func (fake *FakeImpl) RepoSetURLArgsForCall(i int) (*git.Repo, string, string) {
+	fake.repoSetURLMutex.RLock()
+	defer fake.repoSetURLMutex.RUnlock()
+	argsForCall := fake.repoSetURLArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) RepoSetURLReturns(result1 error) {
+	fake.repoSetURLMutex.Lock()
+	defer fake.repoSetURLMutex.Unlock()
+	fake.RepoSetURLStub = nil
+	fake.repoSetURLReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) RepoSetURLReturnsOnCall(i int, result1 error) {
+	fake.repoSetURLMutex.Lock()
+	defer fake.repoSetURLMutex.Unlock()
+	fake.RepoSetURLStub = nil
+	if fake.repoSetURLReturnsOnCall == nil {
+		fake.repoSetURLReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.repoSetURLReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) Submit(arg1 *gcb.Options) error {
+	fake.submitMutex.Lock()
+	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
+	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
+		arg1 *gcb.Options
+	}{arg1})
+	stub := fake.SubmitStub
+	fakeReturns := fake.submitReturns
+	fake.recordInvocation("Submit", []interface{}{arg1})
+	fake.submitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) SubmitCallCount() int {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	return len(fake.submitArgsForCall)
+}
+
+func (fake *FakeImpl) SubmitCalls(stub func(*gcb.Options) error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = stub
+}
+
+func (fake *FakeImpl) SubmitArgsForCall(i int) *gcb.Options {
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
+	argsForCall := fake.submitArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) SubmitReturns(result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	fake.submitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) SubmitReturnsOnCall(i int, result1 error) {
+	fake.submitMutex.Lock()
+	defer fake.submitMutex.Unlock()
+	fake.SubmitStub = nil
+	if fake.submitReturnsOnCall == nil {
+		fake.submitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.submitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1224,6 +1593,12 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.askMutex.RUnlock()
 	fake.cloneOrOpenDefaultGitHubRepoSSHMutex.RLock()
 	defer fake.cloneOrOpenDefaultGitHubRepoSSHMutex.RUnlock()
+	fake.cloneOrOpenGitHubRepoMutex.RLock()
+	defer fake.cloneOrOpenGitHubRepoMutex.RUnlock()
+	fake.envDefaultMutex.RLock()
+	defer fake.envDefaultMutex.RUnlock()
+	fake.isDefaultK8sUpstreamMutex.RLock()
+	defer fake.isDefaultK8sUpstreamMutex.RUnlock()
 	fake.isReleaseBranchMutex.RLock()
 	defer fake.isReleaseBranchMutex.RUnlock()
 	fake.repoCheckoutMutex.RLock()
@@ -1252,6 +1627,10 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.repoPushMutex.RUnlock()
 	fake.repoSetDryMutex.RLock()
 	defer fake.repoSetDryMutex.RUnlock()
+	fake.repoSetURLMutex.RLock()
+	defer fake.repoSetURLMutex.RUnlock()
+	fake.submitMutex.RLock()
+	defer fake.submitMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/fastforward/impl.go
+++ b/pkg/fastforward/impl.go
@@ -17,7 +17,11 @@ limitations under the License.
 package fastforward
 
 import (
+	"k8s.io/release/pkg/gcp/gcb"
+	"k8s.io/release/pkg/release"
+
 	"sigs.k8s.io/release-sdk/git"
+	"sigs.k8s.io/release-utils/env"
 	"sigs.k8s.io/release-utils/util"
 )
 
@@ -42,6 +46,11 @@ type impl interface {
 	RepoPush(*git.Repo, string) error
 	RepoLatestReleaseBranch(*git.Repo) (string, error)
 	RepoHasRemoteTag(*git.Repo, string) (bool, error)
+	Submit(*gcb.Options) error
+	EnvDefault(string, string) string
+	CloneOrOpenGitHubRepo(string, string, string, bool) (*git.Repo, error)
+	IsDefaultK8sUpstream() bool
+	RepoSetURL(*git.Repo, string, string) error
 }
 
 func (*defaultImpl) CloneOrOpenDefaultGitHubRepoSSH(repo string) (*git.Repo, error) {
@@ -106,4 +115,24 @@ func (*defaultImpl) RepoLatestReleaseBranch(r *git.Repo) (string, error) {
 
 func (*defaultImpl) RepoHasRemoteTag(r *git.Repo, tag string) (bool, error) {
 	return r.HasRemoteTag(tag)
+}
+
+func (*defaultImpl) Submit(options *gcb.Options) error {
+	return gcb.New(options).Submit()
+}
+
+func (*defaultImpl) EnvDefault(key, def string) string {
+	return env.Default(key, def)
+}
+
+func (*defaultImpl) CloneOrOpenGitHubRepo(repoPath, owner, repo string, useSSH bool) (*git.Repo, error) {
+	return git.CloneOrOpenGitHubRepo(repoPath, owner, repo, useSSH)
+}
+
+func (*defaultImpl) IsDefaultK8sUpstream() bool {
+	return release.IsDefaultK8sUpstream()
+}
+
+func (*defaultImpl) RepoSetURL(r *git.Repo, remote, newURL string) error {
+	return r.SetURL(remote, newURL)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- We now support a new `krel fast-forward --submit` flag to run in GCB.
- Renamed `krel ff` to `krel fast-forward` while keeping the alias.
- Documentation for the `krel fast-forward` command has been added as well.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/release/issues/2386

#### Special notes for your reviewer:

##### Demo

```
> export TOOL_ORG=saschagrunert TOOL_REF=ff-job && go run ./cmd/krel fast-forward --submit
```

Logs: https://console.cloud.google.com/cloud-build/builds/bb5ffc59-14f4-4031-b287-9d3d705094fc?project=648026197307

```
Step #3: level=info msg="Preparing to fast-forward from origin/master"
Step #3: level=info msg="Found GitHub token, using it for repository interactions"
Step #3: level=info msg="Cloning repository using HTTPs"
Step #3: level=info msg="Using dry mode, which does not modify any remote content"
Step #3: level=info msg="No release branch specified, finding the latest"
Step #3: level=info msg="Found latest release branch: release-1.23"
Step #3: level=info msg="Tag v1.23.0 found in default remote"
Step #3: level=info msg="Fast forward not required because final tag already exists for latest release branch release-1.23"
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support to run `krel fast-forward` (former `krel ff`) in GCB via its new `--submit` flag.
```
