### PR TITLE
Update REAMDE.md to remove gh2gcs and cip-mm reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Individual tools can be installed via `go install k8s.io/release/cmd/$TOOL@lates
 - [Artifact Management](#artifact-management)
   - [`kpromo`](#kpromo)
   - [`kubepkg`](#kubepkg)
-  - [`cip-mm`](#cip-mm)
-  - [`gh2gcs`](#gh2gcs)
 - [End User](#end-user)
   - [`bom`](#bom)
   - [`release-notes`](#release-notes)
@@ -77,25 +75,6 @@ Status: In Progress
 Audience: [Release Managers][release-managers]
 
 Details: [Documentation](/cmd/kubepkg/README.md)
-
-### [`cip-mm`](https://sigs.k8s.io/promo-tools/cmd/cip-mm)
-
-Modify container image manifests for promotion.
-
-Status: In Progress
-
-Details: [Documentation](https://sigs.k8s.io/promo-tools/cmd/cip-mm/README.md)
-
-### [`gh2gcs`](https://sigs.k8s.io/promo-tools/cmd/gh2gcs)
-
-Upload GitHub release assets to Google Cloud Storage.
-
-Status: In Progress
-
-Audience: [Release Managers][release-managers] and subproject maintainers
-responsible for promoting container artifacts
-
-Details: [Documentation](https://sigs.k8s.io/promo-tools/cmd/gh2gcs/README.md)
 
 ## End User
 


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Both tools are now part of kpromo and therefore do not need to be
mentioned here anymore.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `cip-mm` and `gh2gcs` reference from [README.md](/README.md), they're now part of [kpromo](https://github.com/kubernetes-sigs/promo-tools#kpromo)
```
