### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.17.5
+    version: 1.17.6
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -181,7 +181,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.24.0-go1.17.5-bullseye.0
+    version: v1.24.0-go1.17.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,10 +4,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.24.0-go1.18beta1-bullseye.0'
   v1.24-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.17.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.17.6-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.6-bullseye.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.12-buster.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.17.5-${OS_CODENAME} AS builder
+FROM golang:1.17.6-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.17.5
+GO_VERSION ?= 1.17.6
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.17.5'
+    GO_VERSION: '1.17.6'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -13,7 +13,7 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.5'
+    GO_VERSION: '1.17.6'
     OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.6

PRs in k/k updating Go versions: https://github.com/kubernetes/kubernetes/pull/107612 (master), https://github.com/kubernetes/kubernetes/pull/107613 (release-1.23) 

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2379

/assign @puerco @cpanato @Verolop @xmudrii @justaugustus @saschagrunert 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.6
```
