### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using Go 1.16.13

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -248,7 +248,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22, 1.21)"
-    version: 1.16.12
+    version: 1.16.13
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -10,7 +10,7 @@ variants:
     KUBE_CROSS_VERSION: 'v1.23.0-go1.17.5-bullseye.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.12-buster.0'
+    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.13-buster.0'
   v1.21-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.12-buster.0'
+    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.13-buster.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -17,11 +17,11 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: '1.16.12'
+    GO_VERSION: '1.16.13'
     OS_CODENAME: 'buster'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.12'
+    GO_VERSION: '1.16.13'
     OS_CODENAME: 'buster'
   '1.20':
     CONFIG: '1.20'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: build using Go 1.16.13

PRs in k/k updating Go versions: https://github.com/kubernetes/kubernetes/pull/107614 (release-1.22), https://github.com/kubernetes/kubernetes/pull/107615 (release-1.21) 

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2379

/assign @puerco @cpanato @Verolop  @xmudrii @justaugustus @saschagrunert 
cc @kubernetes/release-engineering 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
k8s-cloud-builder/k8s-ci-builder: build using Go 1.16.13
```
