### PR TITLE
gcb: Update authentication for releases

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -14,7 +14,7 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAIkWjMImwKwjbMsGh/N6QPg/AgdFo8f/6kNTBESxQLfTtWuMSUQBLz1D+ff3d7WKkopX86uyuO2xZH1k6KZRo2dXv6X5SbEkMoV5l6Bzm2owbIqJUMqWIyrMPJvNGi30iOERBOfbJ6IISMK81RDV+JmWzLCcANA==
+    GITHUB_TOKEN: CiQAIkWjMODH+TR8+6KmsAValHBKkX2PjVWSzyNdScGCIl0rBlYSUQBLz1D++mrhyd+wXohoQEGDuyQHvFzQyT7NEvI2BR/WBmnu1S9+E5GgER8OOnaQg+dGEMrYzEQIiTOB8WPxU7ecsIyo0AuegcBH24dj9L2tDw==
 
 steps:
 - name: gcr.io/cloud-builders/git

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -14,7 +14,7 @@ timeout: 14400s
 secrets:
 - kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/encrypt-0
   secretEnv:
-    GITHUB_TOKEN: CiQAIkWjMFgubym04n054BpfS8ED1VAiDVzF2WtEAE9kpXL1HEASUQBLz1D++TFNeowLVAI8MAQ86xJvshtqevcU5lcHEo3K+39HHIZr3uojPto5vm235XkfWWeMM3/VBOwZoelmAyvY2RPHpo7u/Y9kKfCrJu5coA==
+    GITHUB_TOKEN: CiQAIkWjMHZABAFJqEFQir1WipsO3rAGkhw1pwhp1er/m3px/kESUQBLz1D+hzzlrovRVuetP+sCqzjfKZl/iB0aiQIT36imOk8j7laYDZjprxGGQQQiUVaqYvstroJH3D53f4JKQHzXUvWziSSnhH3HFZz++RT/yQ==
     DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
 
 steps:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area release-eng/security

#### What this PR does / why we need it:

gcb: Update GH authentication for releases

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Stage token: no scope, read-only
Release token: `public_repo` scope

ref: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
previous examples: https://github.com/kubernetes/release/pull/2140, https://github.com/kubernetes/release/pull/2126

/cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
