### PR TITLE
Add container images to changelog

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -926,7 +926,7 @@ func buildNotesResult(startTag string, releaseNotes *notes.ReleaseNotes) (*relea
 
 	// Create the markdown
 	markdown, err := doc.RenderMarkdownTemplate(
-		"", "", options.GoTemplateDefault,
+		"", "", "", options.GoTemplateDefault,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -336,7 +336,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 			return errors.Wrapf(err, "creating release note document")
 		}
 
-		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, opts.GoTemplate)
+		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, "", opts.GoTemplate)
 		if err != nil {
 			return errors.Wrapf(err, "rendering release note document with template")
 		}

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -570,6 +570,10 @@ func (d *DefaultStage) GenerateChangelog() error {
 	if d.state.createReleaseBranch {
 		branch = git.DefaultBranch
 	}
+	buildDir := filepath.Join(
+		gitRoot,
+		fmt.Sprintf("%s-%s", release.BuildDir, d.state.versions.Prime()),
+	)
 	return d.impl.GenerateChangelog(&changelog.Options{
 		RepoPath:     gitRoot,
 		Tag:          d.state.versions.Prime(),
@@ -579,11 +583,8 @@ func (d *DefaultStage) GenerateChangelog() error {
 		JSONFile:     releaseNotesJSONFile,
 		Dependencies: true,
 		CloneCVEMaps: true,
-		Tars: filepath.Join(
-			gitRoot,
-			fmt.Sprintf("%s-%s", release.BuildDir, d.state.versions.Prime()),
-			release.ReleaseTarsPath,
-		),
+		Tars:         filepath.Join(buildDir, release.ReleaseTarsPath),
+		Images:       buildDir,
 	})
 }
 

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -41,6 +41,7 @@ type Options struct {
 	Branch       string
 	Bucket       string
 	Tars         string
+	Images       string
 	HTMLFile     string
 	JSONFile     string
 	RecordDir    string
@@ -115,7 +116,7 @@ func (c *Changelog) Run() error {
 
 			if err := c.impl.CreateDownloadsTable(
 				downloadsTable, c.options.Bucket, c.options.Tars,
-				startRev, c.options.Tag,
+				c.options.Images, startRev, c.options.Tag,
 			); err != nil {
 				return errors.Wrapf(err, "create downloads table")
 			}
@@ -281,7 +282,7 @@ func (c *Changelog) generateReleaseNotes(
 	}
 
 	markdown, err = c.impl.RenderMarkdownTemplate(
-		doc, c.options.Bucket, c.options.Tars,
+		doc, c.options.Bucket, c.options.Tars, c.options.Images,
 		options.GoTemplateInline+releaseNotesTemplate,
 	)
 	if err != nil {

--- a/pkg/changelog/changelogfakes/fake_impl.go
+++ b/pkg/changelog/changelogfakes/fake_impl.go
@@ -95,7 +95,7 @@ type FakeImpl struct {
 	commitReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateDownloadsTableStub        func(io.Writer, string, string, string, string) error
+	CreateDownloadsTableStub        func(io.Writer, string, string, string, string, string) error
 	createDownloadsTableMutex       sync.RWMutex
 	createDownloadsTableArgsForCall []struct {
 		arg1 io.Writer
@@ -103,6 +103,7 @@ type FakeImpl struct {
 		arg3 string
 		arg4 string
 		arg5 string
+		arg6 string
 	}
 	createDownloadsTableReturns struct {
 		result1 error
@@ -255,13 +256,14 @@ type FakeImpl struct {
 		result1 []byte
 		result2 error
 	}
-	RenderMarkdownTemplateStub        func(*document.Document, string, string, string) (string, error)
+	RenderMarkdownTemplateStub        func(*document.Document, string, string, string, string) (string, error)
 	renderMarkdownTemplateMutex       sync.RWMutex
 	renderMarkdownTemplateArgsForCall []struct {
 		arg1 *document.Document
 		arg2 string
 		arg3 string
 		arg4 string
+		arg5 string
 	}
 	renderMarkdownTemplateReturns struct {
 		result1 string
@@ -697,7 +699,7 @@ func (fake *FakeImpl) CommitReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) CreateDownloadsTable(arg1 io.Writer, arg2 string, arg3 string, arg4 string, arg5 string) error {
+func (fake *FakeImpl) CreateDownloadsTable(arg1 io.Writer, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string) error {
 	fake.createDownloadsTableMutex.Lock()
 	ret, specificReturn := fake.createDownloadsTableReturnsOnCall[len(fake.createDownloadsTableArgsForCall)]
 	fake.createDownloadsTableArgsForCall = append(fake.createDownloadsTableArgsForCall, struct {
@@ -706,13 +708,14 @@ func (fake *FakeImpl) CreateDownloadsTable(arg1 io.Writer, arg2 string, arg3 str
 		arg3 string
 		arg4 string
 		arg5 string
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 string
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.CreateDownloadsTableStub
 	fakeReturns := fake.createDownloadsTableReturns
-	fake.recordInvocation("CreateDownloadsTable", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("CreateDownloadsTable", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.createDownloadsTableMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
@@ -726,17 +729,17 @@ func (fake *FakeImpl) CreateDownloadsTableCallCount() int {
 	return len(fake.createDownloadsTableArgsForCall)
 }
 
-func (fake *FakeImpl) CreateDownloadsTableCalls(stub func(io.Writer, string, string, string, string) error) {
+func (fake *FakeImpl) CreateDownloadsTableCalls(stub func(io.Writer, string, string, string, string, string) error) {
 	fake.createDownloadsTableMutex.Lock()
 	defer fake.createDownloadsTableMutex.Unlock()
 	fake.CreateDownloadsTableStub = stub
 }
 
-func (fake *FakeImpl) CreateDownloadsTableArgsForCall(i int) (io.Writer, string, string, string, string) {
+func (fake *FakeImpl) CreateDownloadsTableArgsForCall(i int) (io.Writer, string, string, string, string, string) {
 	fake.createDownloadsTableMutex.RLock()
 	defer fake.createDownloadsTableMutex.RUnlock()
 	argsForCall := fake.createDownloadsTableArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeImpl) CreateDownloadsTableReturns(result1 error) {
@@ -1460,7 +1463,7 @@ func (fake *FakeImpl) ReadFileReturnsOnCall(i int, result1 []byte, result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) RenderMarkdownTemplate(arg1 *document.Document, arg2 string, arg3 string, arg4 string) (string, error) {
+func (fake *FakeImpl) RenderMarkdownTemplate(arg1 *document.Document, arg2 string, arg3 string, arg4 string, arg5 string) (string, error) {
 	fake.renderMarkdownTemplateMutex.Lock()
 	ret, specificReturn := fake.renderMarkdownTemplateReturnsOnCall[len(fake.renderMarkdownTemplateArgsForCall)]
 	fake.renderMarkdownTemplateArgsForCall = append(fake.renderMarkdownTemplateArgsForCall, struct {
@@ -1468,13 +1471,14 @@ func (fake *FakeImpl) RenderMarkdownTemplate(arg1 *document.Document, arg2 strin
 		arg2 string
 		arg3 string
 		arg4 string
-	}{arg1, arg2, arg3, arg4})
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.RenderMarkdownTemplateStub
 	fakeReturns := fake.renderMarkdownTemplateReturns
-	fake.recordInvocation("RenderMarkdownTemplate", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("RenderMarkdownTemplate", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.renderMarkdownTemplateMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1488,17 +1492,17 @@ func (fake *FakeImpl) RenderMarkdownTemplateCallCount() int {
 	return len(fake.renderMarkdownTemplateArgsForCall)
 }
 
-func (fake *FakeImpl) RenderMarkdownTemplateCalls(stub func(*document.Document, string, string, string) (string, error)) {
+func (fake *FakeImpl) RenderMarkdownTemplateCalls(stub func(*document.Document, string, string, string, string) (string, error)) {
 	fake.renderMarkdownTemplateMutex.Lock()
 	defer fake.renderMarkdownTemplateMutex.Unlock()
 	fake.RenderMarkdownTemplateStub = stub
 }
 
-func (fake *FakeImpl) RenderMarkdownTemplateArgsForCall(i int) (*document.Document, string, string, string) {
+func (fake *FakeImpl) RenderMarkdownTemplateArgsForCall(i int) (*document.Document, string, string, string, string) {
 	fake.renderMarkdownTemplateMutex.RLock()
 	defer fake.renderMarkdownTemplateMutex.RUnlock()
 	argsForCall := fake.renderMarkdownTemplateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeImpl) RenderMarkdownTemplateReturns(result1 string, result2 error) {

--- a/pkg/changelog/const.go
+++ b/pkg/changelog/const.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package changelog
 
+import "k8s.io/release/pkg/notes/document"
+
 const (
 	// The default CHANGELOG directory inside the k/k repository.
 	RepoChangelogDir = "CHANGELOG"
@@ -28,10 +30,11 @@ const (
 {{- $PreviousRevision := .PreviousRevision -}}
 # {{$CurrentRevision}}
 
-{{if .Downloads}}
+{{if or .FileDownloads .ImageDownloads}}
 ## Downloads for {{$CurrentRevision}}
 
-{{- with .Downloads.Source }}
+{{if .FileDownloads}}
+{{- with .FileDownloads.Source }}
 
 ### Source Code
 
@@ -40,7 +43,7 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Client -}}
+{{- with .FileDownloads.Client -}}
 ### Client Binaries
 
 filename | sha512 hash
@@ -48,7 +51,7 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Server -}}
+{{- with .FileDownloads.Server -}}
 ### Server Binaries
 
 filename | sha512 hash
@@ -56,12 +59,23 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Node -}}
+{{- with .FileDownloads.Node -}}
 ### Node Binaries
 
 filename | sha512 hash
 -------- | -----------
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
+{{end -}}
+
+{{if .ImageDownloads}}
+{{- with .ImageDownloads -}}
+` + document.ContainerImagesDescription + `
+name | architectures
+---- | -------------
+{{range .}}{{.Name}} | {{ range $i, $a := .Architectures}}{{if $i}}, {{end}}{{$a}}{{end}}{{println}}{{end}}
+{{end -}}
+
+{{end -}}
 {{end -}}
 {{- end -}}
 ## Changelog since {{$PreviousRevision}}

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -52,7 +52,7 @@ type impl interface {
 	RevParse(repo *git.Repo, rev string) (string, error)
 	RevParseTag(repo *git.Repo, rev string) (string, error)
 	CreateDownloadsTable(
-		w io.Writer, bucket, tars, prevTag, newTag string,
+		w io.Writer, bucket, tars, images, prevTag, newTag string,
 	) error
 	LatestGitHubTagsPerBranch() (github.TagsPerBranch, error)
 	GenerateTOC(markdown string) (string, error)
@@ -66,7 +66,7 @@ type impl interface {
 		releaseNotes *notes.ReleaseNotes, previousRev, currentRev string,
 	) (*document.Document, error)
 	RenderMarkdownTemplate(
-		document *document.Document, bucket, fileDir, templateSpec string,
+		document *document.Document, bucket, tars, images, templateSpec string,
 	) (string, error)
 
 	// Used in `writeMarkdown()`
@@ -118,9 +118,9 @@ func (*defaultImpl) RevParseTag(repo *git.Repo, rev string) (string, error) {
 }
 
 func (*defaultImpl) CreateDownloadsTable(
-	w io.Writer, bucket, tars, prevTag, newTag string,
+	w io.Writer, bucket, tars, images, prevTag, newTag string,
 ) error {
-	return document.CreateDownloadsTable(w, bucket, tars, prevTag, newTag)
+	return document.CreateDownloadsTable(w, bucket, tars, images, prevTag, newTag)
 }
 
 func (*defaultImpl) LatestGitHubTagsPerBranch() (github.TagsPerBranch, error) {
@@ -160,9 +160,9 @@ func (*defaultImpl) NewDocument(
 }
 
 func (*defaultImpl) RenderMarkdownTemplate(
-	doc *document.Document, bucket, fileDir, templateSpec string,
+	doc *document.Document, bucket, tars, images, templateSpec string,
 ) (string, error) {
-	return doc.RenderMarkdownTemplate(bucket, fileDir, templateSpec)
+	return doc.RenderMarkdownTemplate(bucket, tars, images, templateSpec)
 }
 
 func (*defaultImpl) RepoDir(repo *git.Repo) string {

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -65,7 +65,7 @@ func TestFileMetadata(t *testing.T) {
 		))
 	}
 
-	metadata, err := fetchMetadata(dir, "http://test.com", "test-release")
+	metadata, err := fetchFileMetadata(dir, "http://test.com", "test-release")
 	require.Nil(t, err)
 
 	expected := &FileMetadata{
@@ -151,7 +151,7 @@ func TestDocument_RenderMarkdownTemplateFailure(t *testing.T) {
 			}
 
 			doc := Document{}
-			_, err = doc.RenderMarkdownTemplate("", "", tt.templateSpec)
+			_, err = doc.RenderMarkdownTemplate("", "", "", tt.templateSpec)
 			require.Error(t, err, "Unexpected success")
 		})
 	}
@@ -167,7 +167,7 @@ func TestCreateDownloadsTable(t *testing.T) {
 	// When
 	output := &strings.Builder{}
 	require.Nil(t, CreateDownloadsTable(
-		output, release.ProductionBucket, dir, "v1.16.0", "v1.16.1",
+		output, release.ProductionBucket, dir, "", "v1.16.0", "v1.16.1",
 	))
 
 	// Then
@@ -514,7 +514,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 			}
 
 			// When
-			got, err := doc.RenderMarkdownTemplate(release.ProductionBucket, dir, templateSpec)
+			got, err := doc.RenderMarkdownTemplate(release.ProductionBucket, dir, "", templateSpec)
 
 			// Then
 			require.NoError(t, err, "Unexpected error.")

--- a/pkg/notes/document/template.go
+++ b/pkg/notes/document/template.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package document
 
+const ContainerImagesDescription = `### Container Images
+
+All container images are available as manifest lists and support the described
+architectures. It is also possible to pull a specific architecture directly by
+adding the "-$ARCH" suffix  to the container image name.
+`
+
 // defaultReleaseNotesTemplate is the text template for the default release notes.
 // k8s/release/cmd/release-notes uses text/template to render markdown
 // templates.
@@ -23,10 +30,10 @@ const defaultReleaseNotesTemplate = `
 {{- $CurrentRevision := .CurrentRevision -}}
 {{- $PreviousRevision := .PreviousRevision -}}
 
-{{if .Downloads}}
+{{if .FileDownloads}}
 ## Downloads for {{$CurrentRevision}}
 
-{{- with .Downloads.Source }}
+{{- with .FileDownloads.Source }}
 
 ### Source Code
 
@@ -35,7 +42,7 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Client -}}
+{{- with .FileDownloads.Client -}}
 ### Client Binaries
 
 filename | sha512 hash
@@ -43,7 +50,7 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Server -}}
+{{- with .FileDownloads.Server -}}
 ### Server Binaries
 
 filename | sha512 hash
@@ -51,7 +58,7 @@ filename | sha512 hash
 {{range .}}[{{.Name}}]({{.URL}}) | {{.Checksum}}{{println}}{{end}}
 {{end}}
 
-{{- with .Downloads.Node -}}
+{{- with .FileDownloads.Node -}}
 ### Node Binaries
 
 filename | sha512 hash

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -90,7 +90,7 @@ func (i *Images) Publish(registry, version, buildPath string) error {
 		releaseImagesPath, registry,
 	)
 
-	manifestImages, err := i.getManifestImages(
+	manifestImages, err := i.GetManifestImages(
 		registry, version, buildPath,
 		func(path, origTag, newTagWithArch string) error {
 			if err := i.Execute(
@@ -177,7 +177,7 @@ func (i *Images) Validate(registry, version, buildPath string) error {
 	logrus.Infof("Validating image manifests in %s", registry)
 	version = i.normalizeVersion(version)
 
-	manifestImages, err := i.getManifestImages(
+	manifestImages, err := i.GetManifestImages(
 		registry, version, buildPath, nil,
 	)
 	if err != nil {
@@ -306,7 +306,9 @@ func (i *Images) Exists(registry, version string, fast bool) (bool, error) {
 	return true, nil
 }
 
-func (i *Images) getManifestImages(
+// GetManifestImages can be used to retrieve the map of built images and
+// architectures.
+func (i *Images) GetManifestImages(
 	registry, version, buildPath string,
 	forTarballFn func(path, origTag, newTagWithArch string) error,
 ) (map[string][]string, error) {


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Adding a container images section to the changelog when running `krel stage`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Example run:  https://console.cloud.google.com/cloud-build/builds;region=global/dc2ca2c0-adf6-454a-97fe-a60686098843?project=kubernetes-release-test

How does it look: [CHANGELOG-1.23.md](https://github.com/kubernetes/release/files/7913572/CHANGELOG-1.23.md)


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added container images to changelog
```
