### PR TITLE
publish-release: Support adding release notes from a file

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -71,15 +71,16 @@ to the asset file:
 }
 
 type githubPageCmdLineOptions struct {
-	noupdate      bool
-	draft         bool
-	sbom          bool
-	name          string
-	repo          string
-	template      string
-	repoPath      string
-	substitutions []string
-	assets        []string
+	noupdate         bool
+	draft            bool
+	sbom             bool
+	name             string
+	repo             string
+	template         string
+	repoPath         string
+	ReleaseNotesFile string
+	substitutions    []string
+	assets           []string
 }
 
 var ghPageOpts = &githubPageCmdLineOptions{}
@@ -145,6 +146,13 @@ func init() {
 		"Path to the source code repository",
 	)
 
+	githubPageCmd.PersistentFlags().StringVar(
+		&ghPageOpts.ReleaseNotesFile,
+		"release-notes-file",
+		"",
+		"Path to a release notes markdown file to include in the release",
+	)
+
 	for _, f := range []string{"template", "asset"} {
 		if err := githubPageCmd.MarkPersistentFlagFilename(f); err != nil {
 			logrus.Error(err)
@@ -206,6 +214,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 		UpdateIfReleaseExists: !opts.noupdate,
 		Name:                  opts.name,
 		Draft:                 opts.draft,
+		ReleaseNotesFile:      opts.ReleaseNotesFile,
 	}
 
 	// Assign the repository data

--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -48,16 +48,12 @@ const ghPageBody = `{{ if .Substitutions.logo }}
 {{ if .Substitutions.changelog }}
 See [the CHANGELOG]({{ .Substitutions.changelog }}) for more details.
 {{ end }}
-### Release Assets
+{{ if .Substitutions.ReleaseNotes }}
+### Release Notes
 
-{{ range .Assets }}
-<table>
-<tr><td colspan="2">{{ if .name }}<b>{{ .name }}: </b> {{ .filename }}{{else}}<b>{{ .filename }}</b>{{end}}</td><tr>
-<tr><td>SHA256</td><td>{{ .sha256 }}</td></tr>
-<tr><td>SHA512</td><td>{{ .sha512 }}</td></tr>
-</table>
+{{ .Substitutions.ReleaseNotes }}
+{{ end }}
 
-{{end}}
 `
 
 // GitHubPageOptions data for building the release page
@@ -98,6 +94,9 @@ type GitHubPageOptions struct {
 	// We can use a custom page template by spcifiying the path. The
 	// file is a go template file that renders markdown.
 	PageTemplate string
+
+	// File to read the release notes from
+	ReleaseNotesFile string
 
 	// We automatizally calculate most values, but more substitutions for
 	// the template can be supplied
@@ -206,6 +205,16 @@ func UpdateGitHubPage(opts *GitHubPageOptions) (err error) {
 	}{
 		Substitutions: opts.Substitutions,
 		Assets:        releaseAssets,
+	}
+
+	// If we have a release notes file defined and set a substitution
+	// entry for its contents
+	if opts.ReleaseNotesFile != "" {
+		rnData, err := os.ReadFile(opts.ReleaseNotesFile)
+		if err != nil {
+			return errors.Wrap(err, "reading release notes file")
+		}
+		subs.Substitutions["ReleaseNotes"] = string(rnData)
 	}
 
 	// Open the template file (if a custom)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This commit adds a tiny new feature to `publish-release`. It introduces a new flag to the `github` subcommand:

`--release-notes-file`

When pointed to a Markdown file, this flag will read its contents and include it in the default release page template.

It also removes the assets list from the default template as the information is mostly intended for machines and the hashes are already published in the SBOM produced with the release.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

For a sample of the new release page, check out the v0.2.0 release of `bom`:
https://github.com/kubernetes-sigs/bom/releases/tag/v0.2.0

#### Does this PR introduce a user-facing change?

```release-note
- `publish-release` now supports a new `--release-notes-file` flag. When defined it will read a file and include its contents in a new section on the release page.
- The default template for the GitHub page no longer lists the release assets. The information was redundant as it already listed in the SBOM.
```
