### PR TITLE
Fix bug where incorrect count was used when assets had no tag

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -171,7 +171,7 @@ func getAssetsFromStrings(assetStrings []string) []announce.Asset {
 	for _, s := range assetStrings {
 		parts := strings.Split(s, ":")
 		l := ""
-		if len(parts) > 0 {
+		if len(parts) > 1 {
 			l = parts[1]
 		}
 		r = append(r, announce.Asset{


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
A bug was found when splitting arguments strings caused publish-release to crash.
When uploaded tagged assets to a release page, trying to upload untagged assets (ie those
that have no name defined) would crash the app with an out of bounds
slice.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
none
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug when splitting asset arguments strings that caused publish-release to crash.
```
