### PR TITLE
golang: Build 1.18beta2 images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -188,7 +188,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.18beta1
+    version: 1.18beta2
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -207,7 +207,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (next candidate)"
-    version: v2.3.1-go1.18beta1-bullseye.0
+    version: v2.3.1-go1.18beta2-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -219,7 +219,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.24.0-go1.18beta1-bullseye.0
+    version: v1.24.0-go1.18beta2-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,9 +2,9 @@ variants:
   v1.24-go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.24.0-go1.18beta1-bullseye.0'
+    IMAGE_VERSION: 'v1.24.0-go1.18beta2-bullseye.0'
     KUBERNETES_VERSION: 'v1.24.0'
-    GO_VERSION: '1.18beta1'
+    GO_VERSION: '1.18beta2'
     GO_MAJOR_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
     REVISION: '0'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
-    IMAGE_VERSION: 'v2.3.1-go1.18beta1-bullseye.0'
+    IMAGE_VERSION: 'v2.3.1-go1.18beta2-bullseye.0'
     GO_MAJOR_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    GO_VERSION: '1.18beta1'
+    GO_VERSION: '1.18beta2'
     DISTROLESS_IMAGE: 'static-debian11'
   go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
-    GO_VERSION: '1.18beta1'
+    GO_VERSION: '1.18beta2'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   go1.17-bullseye:

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,11 +5,11 @@ variants:
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.18beta1'
+    GO_VERSION: '1.18beta2'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.18beta1'
+    GO_VERSION: '1.18beta2'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/release/issues/2307.

- golang: Set next candidate to go1.18beta2
- golang: Build 1.18beta2 images 

/assign @justaugustus  @saschagrunert @puerco 
/cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- golang: Set next candidate to go1.18beta2
- golang: Build 1.18beta2 images
```
