### PR TITLE
releng-ci: add mage

### DIFF
--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -30,6 +30,18 @@ RUN apt-get update && \
         jq && \
     rm -rf /var/lib/apt/lists/*
 
+# install mage
+ARG MAGE_VERSION=1.12.1
+ARG MAGE_SHA=bed46f9f509fd515382a9113c683841f029e86a8f2357380bfe80b75768ff099
+RUN  \
+    MAGE_DOWNLOAD_FILE=mage_${MAGE_VERSION}_Linux-64bit.tar.gz && \
+    MAGE_DOWNLOAD_URL=https://github.com/magefile/mage/releases/download/v${MAGE_VERSION}/${MAGE_DOWNLOAD_FILE} && \
+    wget ${MAGE_DOWNLOAD_URL} && \
+    echo "$MAGE_SHA $MAGE_DOWNLOAD_FILE" | sha256sum -c - || exit 1 && \
+    tar -xzf $MAGE_DOWNLOAD_FILE -C /usr/bin/ mage && \
+    rm $MAGE_DOWNLOAD_FILE && \
+    mage --help
+
 # Some tests require a working git executable, so we configure a pseudo-user
 RUN git config --global user.name releng-ci-user && \
     git config --global user.email nobody@k8s.io

--- a/images/releng/ci/test.yaml
+++ b/images/releng/ci/test.yaml
@@ -7,6 +7,7 @@ commandTests:
     command: /test.sh
     args:
       - gcc
+      - mage
     setup:
       -
         - bash


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Now in some projects, we are working on we are using `mage` (https://github.com/magefile/mage) to run the build/tests... 

for example in https://github.com/kubernetes-sigs/bom we have mage and in the proposed PR https://github.com/kubernetes-sigs/bom/pull/45 we want to use the releng-ci image to build the images and binaries, and will be handy if `mage` is preinstalled for us :)

/assign @saschagrunert @puerco @xmudrii @Verolop @justaugustus 
cc @kubernetes/release-engineering 

/hold for discussion 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
releng-ci: add mage
```
