### PR TITLE
Write the CI Signal report to a file & markdown formatting

### DIFF
--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -55,7 +55,6 @@ type Config struct {
 	ReleaseVersion string
 	ShortReport    bool
 	JSONOutput     bool
-	MarkdownOutput bool
 	Filepath       string
 }
 

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v34/github"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/tj/go-spin"
 )
 
 var rootCmd = &cobra.Command{
@@ -53,6 +55,8 @@ type Config struct {
 	ReleaseVersion string
 	ShortReport    bool
 	JSONOutput     bool
+	MarkdownOutput bool
+	Filepath       string
 }
 
 var cfg = &Config{
@@ -61,16 +65,26 @@ var cfg = &Config{
 	ReleaseVersion: "",
 	ShortReport:    false,
 	JSONOutput:     false,
+	Filepath:       "",
 }
 
 func init() {
 	rootCmd.Flags().StringVarP(&cfg.ReleaseVersion, "release-version", "v", "", "Specify a Kubernetes release versions like '1.22' which will populate the report additionally")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.ShortReport, "short", "s", false, "A short report for mails and slack")
 	rootCmd.PersistentFlags().BoolVar(&cfg.JSONOutput, "json", false, "Report output in json format")
+	rootCmd.PersistentFlags().StringVarP(&cfg.Filepath, "file", "f", "", "Specify a filepath to write the report to a file")
 }
 
 // RunReport used to execute
 func RunReport(cfg *Config, reporters *CIReporters) error {
+	go func() {
+		s := spin.New()
+		for {
+			fmt.Printf("\rloading data %s ", s.Next())
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
 	// collect data from filtered reporters
 	reports, err := reporters.CollectReportDataFromReporters(cfg)
 	if err != nil {
@@ -178,19 +192,50 @@ func (r *CIReporters) CollectReportDataFromReporters(cfg *Config) (*CIReportData
 }
 
 // PrintReporterData used to print report data
+// 1. Get a output stream to write the data to
+// 2. Write data to stream
+// 	2.1. Write data in JSON format if set so
+// 	2.2. Write data in table format
 func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
+	// Get a stream to write the data to (file stream / standard out stream)
+	var out *os.File
+	if cfg.Filepath != "" {
+		// open output file
+		fileOut, err := os.OpenFile(cfg.Filepath, os.O_WRONLY|os.O_CREATE, 0o666)
+		if err != nil {
+			return errors.Wrapf(err, "could not open or create a file at %s to write the ci signal report to", cfg.Filepath)
+		}
+		out = fileOut
+	} else {
+		out = os.Stdout
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	// Write data to stream
 	if cfg.JSONOutput {
 		// print report in json format
 		d, err := reports.Marshal()
 		if err != nil {
 			return nil
 		}
-		fmt.Print(string(d))
+		_, err = out.WriteString(string(d))
+		if err != nil {
+			return errors.Wrap(err, "could not write to output stream")
+		}
 	} else {
 		// print report in table format, (short table differs)
 		for _, r := range *reports {
-			fmt.Printf("\n%s REPORT\n", strings.ToUpper(string(r.Info.Name)))
-			table := tablewriter.NewWriter(os.Stdout)
+			// write header
+			_, err := out.WriteString(fmt.Sprintf("\n%s REPORT\n\n", strings.ToUpper(string(r.Info.Name))))
+			if err != nil {
+				return errors.Wrap(err, "could not write to output stream")
+			}
+
+			table := tablewriter.NewWriter(out)
 			data := [][]string{}
 
 			// table in short version differs from regular table
@@ -205,7 +250,13 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 					data = append(data, []string{record.ID, record.Title, record.Category, record.Status, fmt.Sprintf("%v", record.Sigs), record.URL, record.CreatedTimestamp})
 				}
 			}
+			table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+			table.AppendBulk(data)
+			table.SetCenterSeparator("|")
+			table.SetAutoMergeCells(true)
+			table.Render()
 
+			// write a summary
 			countCategories := map[string]int{}
 			categoryIndex := 2
 			for i := range data {
@@ -213,17 +264,12 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 			}
 			categoryCounts := ""
 			for category, categoryCount := range countCategories {
-				categoryCounts += fmt.Sprintf("%s:%d\n", category, categoryCount)
+				categoryCounts += fmt.Sprintf("%s:%d ", category, categoryCount)
 			}
-			if cfg.ShortReport {
-				table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, ""})
-			} else {
-				table.SetFooter([]string{fmt.Sprintf("Total: %d", len(data)), "", categoryCounts, "", "", "", ""})
+			_, err = out.WriteString(fmt.Sprintf("\nSUMMARY - Total:%d %s\n", len(data), categoryCounts))
+			if err != nil {
+				return errors.Wrap(err, "could not write to output stream")
 			}
-			table.SetBorder(false)
-			table.AppendBulk(data)
-			table.SetAutoMergeCells(true)
-			table.Render()
 		}
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spiegel-im-spiegel/go-cvss v0.4.0
 	github.com/stretchr/testify v1.7.0
+	github.com/tj/go-spin v1.1.0
 	github.com/yuin/goldmark v1.4.5
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
 	google.golang.org/api v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -1031,6 +1031,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tetafro/godot v0.2.5/go.mod h1:pT6/T8+h6//L/LwQcFc4C0xpfy1euZwzS1sHdrFCms0=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
+github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
+github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add new & requested features to the CI Signal report CLI.
* Write report to a file
* report table output get's written in markdown format 

#### Which issue(s) this PR fixes:

Fixes #2359
Fixes #2358

#### Special notes for your reviewer:

I added a small new dependency to visualize the load time for the data request.
This gives feedback to the user that everything is ok, as the data query can take a few seconds (depending on the request). (see [go-spin](https://github.com/tj/go-spin))

#### Does this PR introduce a user-facing change?

```release-note
Add the flag 'flag' / 'f' command to the CLI, which writes the report output to a local file.
Report table output now has Markdown formatting
```

cc @kubernetes/ci-signal 

/label tide/merge-method-squash
/assign @puerco