### PR TITLE
fixed release-notes ssh git checkout website pr

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -788,7 +788,7 @@ func releaseNotesJSON(repoPath, tag string) (jsonString string, err error) {
 
 	// Preclone the repo to be able to read branches and tags
 	logrus.Infof("Cloning %s/%s", git.DefaultGithubOrg, git.DefaultGithubRepo)
-	repo, err := git.CloneOrOpenDefaultGitHubRepoSSH(repoPath)
+	repo, err := git.CloneOrOpenGitHubRepo(repoPath, git.DefaultGithubOrg, git.DefaultGithubRepo, false)
 	if err != nil {
 		return "", errors.Wrap(err, "cloning default github repo")
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### Which issue(s) this PR fixes:

Fixes #2420

```release-note
Fixed krel release-notes git ssh fatal error when using single flag `--create-website-pr`
```
