### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.7 / 1.16.14

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -248,7 +248,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22, 1.21)"
-    version: 1.16.13
+    version: 1.16.14
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -7,10 +7,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.24.0-go1.17.7-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.7-bullseye.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.13-buster.0'
+    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.14-buster.0'
   v1.21-cross1.16-buster:
     CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.13-buster.0'
+    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.14-buster.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -13,15 +13,15 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.6'
+    GO_VERSION: '1.17.7'
     OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: '1.16.13'
+    GO_VERSION: '1.16.14'
     OS_CODENAME: 'buster'
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: '1.16.13'
+    GO_VERSION: '1.16.14'
     OS_CODENAME: 'buster'
   '1.20':
     CONFIG: '1.20'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.7 / 1.16.14.

This PR is a follow up of #2428 for patch releases (1.23, 1.22, and 1.21).

#### Which issue(s) this PR fixes:

xref #2425

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.7 / 1.16.14
```

/assign @saschagrunert @cpanato @puerco @palnabarun
cc @kubernetes/release-engineering 
/hold
waiting for https://github.com/kubernetes/kubernetes/pull/108102, https://github.com/kubernetes/kubernetes/pull/108101, https://github.com/kubernetes/kubernetes/pull/108100