### PR TITLE
Add s390x support to kube-cross image

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -36,7 +36,7 @@ TYPE ?= default
 
 # Build args
 BASEIMAGE ?= golang:$(GO_VERSION)-$(OS_CODENAME)
-PROTOBUF_VERSION ?= 3.7.0
+PROTOBUF_VERSION ?= 3.19.4
 
 IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
@@ -50,10 +50,10 @@ IMAGE_VERSION = $(KUBERNETES_VERSION)-$(BUILD_METADATA)
 # Ensure support for 'docker buildx' and 'docker manifest' commands
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-# TODO: Support multi-arch kube-cross images for linux/arm linux/s390x
+# TODO: Support multi-arch kube-cross images for linux/arm
 #       Currently some of the components references in the Dockerfile are
-#       not supported in specific architectures (example etcd does not support s390x)
-PLATFORMS ?= linux/amd64 linux/arm64 linux/ppc64le #linux/arm linux/s390x
+#       not supported in specific architectures
+PLATFORMS ?= linux/amd64 linux/arm64 linux/ppc64le linux/s390x #linux/arm
 
 # for legacy images only build linux/amd64
 ifeq ($(TYPE), legacy)

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -71,7 +71,7 @@ RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
 fi
 
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
-  && if [ ${targetArch} = "arm64" ] || [ ${targetArch} = "ppc64le" ]; then \
+  && if [ ${targetArch} = "arm64" ] || [ ${targetArch} = "ppc64le" ] || [ ${targetArch} = "s390x" ]; then \
     echo "deb http://ports.ubuntu.com/ubuntu-ports/ xenial main" > /etc/apt/sources.list.d/ports.list \
     && apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
     && apt-get update \
@@ -86,6 +86,8 @@ elif [ ${targetArch} = "arm64" ]; then \
   ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-aarch_64.zip"; \
 elif [ ${targetArch} = "ppc64le" ]; then \
   ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-ppcle_64.zip"; \
+elif [ ${targetArch} = "s390x" ]; then \
+  ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-s390_64.zip"; \
 fi \
   && mkdir /tmp/protoc && cd /tmp/protoc \
   && wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/${ZIPNAME}" \

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -8,7 +8,7 @@ variants:
     GO_MAJOR_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.24-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'
@@ -18,7 +18,7 @@ variants:
     GO_MAJOR_VERSION: '1.17'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.23-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'
@@ -28,7 +28,7 @@ variants:
     GO_MAJOR_VERSION: '1.17'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.22-go1.16-buster:
     CONFIG: 'go1.16-buster'
     TYPE: 'default'
@@ -38,7 +38,7 @@ variants:
     GO_MAJOR_VERSION: '1.16'
     OS_CODENAME: 'buster'
     REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.21-go1.16-buster:
     CONFIG: 'go1.16-buster'
     TYPE: 'default'
@@ -48,4 +48,4 @@ variants:
     GO_MAJOR_VERSION: '1.16'
     OS_CODENAME: 'buster'
     REVISION: '0'
-    PROTOBUF_VERSION: '3.7.0'
+    PROTOBUF_VERSION: '3.19.4'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area dependency

#### What this PR does / why we need it:
To add s390x support to kube-cross docker image

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
This PR changes protobuf version to latest stable as it has s390x support. 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Build/update kube-cross images using latest stable protobuf (v3.19.4)
```
