### PR TITLE
k8s-cloud-builder: Build go1.18rc1 variant

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -231,7 +231,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.24.0-go1.18beta1-bullseye.0
+    version: v1.24.0-go1.18rc1-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.24-cross1.18-bullseye:
-    CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18beta1-bullseye.0'
+    CONFIG: 'cross1.18'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.18rc1-bullseye.0'
   v1.24-cross1.17-bullseye:
     CONFIG: 'cross1.17'
     KUBE_CROSS_VERSION: 'v1.24.0-go1.17.7-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/release/issues/2307.
k8s-cloud-builder: Build go1.18rc1 variant

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
k8s-cloud-builder: Build go1.18rc1 variant
```
