### PR TITLE
Fix error and `fmt.Println` lints

### DIFF
--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -50,7 +50,7 @@ var ciBuildCmd = &cobra.Command{
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := runCIBuild(ciBuildOpts); err != nil {
-			return errors.Wrap(err, "Failed to run:")
+			return errors.Wrap(err, "failed to run")
 		}
 
 		return nil

--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -51,7 +51,7 @@ var pushBuildCmd = &cobra.Command{
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := runPushBuild(pushBuildOpts); err != nil {
-			return errors.Wrap(err, "Failed to run:")
+			return errors.Wrap(err, "failed to run")
 		}
 
 		return nil

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -443,7 +443,7 @@ func createDraftPR(repoPath, tag string) (err error) {
 		fmt.Println("  3. Submit a pull request to k/sig-release")
 		fmt.Println("\nYou can find your local copy here:")
 		fmt.Println(sigReleaseRepo.Dir())
-		fmt.Println(nl)
+		fmt.Print(nl + nl)
 		logrus.Warn("Changes were made locally, user needs to perform manual push and create pull request.")
 		return nil
 	}

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -46,7 +46,7 @@ func (bi *Instance) Build() error {
 
 	if workingDirRelative != expectedDirRelative {
 		return errors.Errorf(
-			"Build was executed from the %s directory but must be run from the %s directory. Exiting...",
+			"build was executed from the %s directory but must be run from the %s directory, exiting",
 			workingDirRelative,
 			expectedDirRelative,
 		)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Fixing a few error messages to not end with punctuation or start
uppercase. This patch also fixes a lint where `fmt.Println` ends with a
newline.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
