### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using Go 1.18

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -253,13 +253,6 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # Golang (previous release branches: 1.20)
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.20)"
-    version: 1.15.15
-    refPaths:
-    - path: images/releng/k8s-ci-builder/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
   # Golang images (for previous release branches)
   - name: "gcr.io/k8s-staging-releng/releng-ci: image revision (for previous release branches)"
     version: 0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.17.8
+    version: 1.18
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -231,10 +231,27 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.24.0-go1.18rc1-bullseye.0
+    version: v1.24.0-go1.18-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  # Golang (previous release branches: 1.23)
+  - name: "golang (previous release branches: 1.23)"
+    version: 1.17.8
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
+    version: 1.17.8
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branches: 1.22, 1.21)
   - name: "golang (previous release branches: 1.22, 1.21)"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.24-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18rc1-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.18-bullseye.0'
   v1.24-cross1.17-bullseye:
     CONFIG: 'cross1.17'
     KUBE_CROSS_VERSION: 'v1.24.0-go1.17.8-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.17.8-${OS_CODENAME} AS builder
+FROM golang:1.18-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.17.8
+GO_VERSION ?= 1.18
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.17.8'
+    GO_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -23,7 +23,3 @@ variants:
     CONFIG: '1.21'
     GO_VERSION: '1.16.15'
     OS_CODENAME: 'buster'
-  '1.20':
-    CONFIG: '1.20'
-    GO_VERSION: '1.15.15'
-    OS_CODENAME: 'buster'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- drop config for 1.20 branch
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.18 

k/k prs is merged https://github.com/kubernetes/kubernetes/pull/https://github.com/kubernetes/kubernetes/pull/108870
#### Which issue(s) this PR fixes:

xref #2307 

#### Does this PR introduce a user-facing change?

```release-note
k8s-cloud-builder/k8s-ci-builder: build using Go 1.18 
```

/assign @saschagrunert @xmudrii @Verolop @puerco @dims 
cc @kubernetes/release-engineering 
