### PR TITLE
ci-reporter: fixes broken report

### DIFF
--- a/cmd/ci-reporter/cmd/github.go
+++ b/cmd/ci-reporter/cmd/github.go
@@ -142,7 +142,7 @@ const (
 // --> | Testgrid Board | -> { ID: XXX, Name: Testgrid Board, ... }
 // This information is required to match the settings ID to the name since table entries ref. id
 type GitHubProjectBoardFieldSettings struct {
-	Width   string `json:"width"`
+	Width   int `json:"width"`
 	Options []struct {
 		ID       string `json:"id"`
 		Name     string `json:"name"`


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the ci-reporter so it that runs again. 

#### Which issue(s) this PR fixes:
Fixes #2473

#### Special notes for your reviewer:
To verify the fix you will need a GH personal access token setup locally and then then you can run

`go run cmd/ci-reporter/main.go `

from the repo root 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```