### PR TITLE
Enable `whyNoLint` and `ifElseChain` `gocritic` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,6 +185,7 @@ linters-settings:
       - exposedSyncMutex
       - hexLiteral
       - httpNoBody
+      - ifElseChain
       - ioutilDeprecated
       - methodExprCall
       - newDeref
@@ -208,10 +209,9 @@ linters-settings:
       - unlambda
       - unslice
       - valSwap
+      - whyNoLint
       - wrapperFunc
       - yodaStyleExpr
-      # - ifElseChain
-      # - whyNoLint
 
       # Opinionated
       - builtinShadow

--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	sendgridAPIKeyEnvKey = "SENDGRID_API_KEY" // nolint: gosec
+	sendgridAPIKeyEnvKey = "SENDGRID_API_KEY" // nolint:gosec // it's just the key
 	nameFlag             = "name"
 	emailFlag            = "email"
 )

--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -870,7 +870,7 @@ const minorReleaseExpectedContent = `# Changelog since v1.20.0
 
 PSP as an admission controller resource is being deprecated. Deployed PodSecurityPolicy's will keep working until version 1.25, their target removal from the codebase. A new feature, with a working title of "PSP replacement policy", is being developed in [KEP-2579](https://features.k8s.io/2579). To learn more, read [PodSecurityPolicy Deprecation: Past, Present, and Future](https://blog.k8s.io/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).`
 
-// nolint: misspell
+// nolint:misspell // there is a spelling mistake in the notes
 const minorReleaseExpectedHTML = `<!DOCTYPE html>
 <html>
   <head>

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -809,7 +809,7 @@ func releaseNotesJSON(repoPath, tag string) (jsonString string, err error) {
 		tagChoice = "previous patch release"
 	} else {
 		// From 1.20 the notes for the first alpha start from the previous minor
-		if len(tagVersion.Pre) == 2 &&
+		if len(tagVersion.Pre) == 2 && // nolint:gocritic // a switch case would not make it better
 			tagVersion.Pre[0].String() == "alpha" &&
 			tagVersion.Pre[1].VersionNum == 1 {
 			startTag = util.SemverToTagString(semver.Version{

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -128,21 +128,24 @@ func run(opts *options) error {
 
 	logrus.Info("Parsing the schedule...")
 
-	if opts.typeFile == "patch" {
+	switch opts.typeFile {
+	case "patch":
 		if err := yaml.UnmarshalStrict(data, &patchSchedule); err != nil {
 			return errors.Wrap(err, "failed to decode the file")
 		}
 
 		logrus.Info("Generating the markdown output...")
 		scheduleOut = parseSchedule(patchSchedule)
-	} else if opts.typeFile == "release" {
+
+	case "release":
 		if err := yaml.UnmarshalStrict(data, &releaseSchedule); err != nil {
 			return errors.Wrap(err, "failed to decode the file")
 		}
 
 		logrus.Info("Generating the markdown output...")
 		scheduleOut = parseReleaseSchedule(releaseSchedule)
-	} else {
+
+	default:
 		return errors.New("type must be either `release` or `patch`")
 	}
 

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -141,7 +141,7 @@ func (o *Options) ContainerRegistry() string {
 // it's state mutates as each step es executed
 type State struct {
 	// logFile is the internal logging file target.
-	logFile string // nolint: structcheck
+	logFile string // nolint:structcheck // it is used
 
 	// semverBuildVersion is the parsed build version which is set after the
 	// validation.

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: dupl
+// nolint:dupl // test duplications are fine
 package anago_test
 
 import (

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: dupl
+// nolint:dupl // test duplications are fine
 package anago_test
 
 import (

--- a/pkg/binary/elf.go
+++ b/pkg/binary/elf.go
@@ -141,11 +141,14 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 
 	// Check if binary byte order is big or little endian
 	var endianness binary.ByteOrder
-	if hBytes[5] == 2 {
-		endianness = binary.BigEndian
-	} else if hBytes[5] == 1 {
+	switch hBytes[5] {
+	case 1:
 		endianness = binary.LittleEndian
-	} else {
+
+	case 2:
+		endianness = binary.BigEndian
+
+	default:
 		return nil, errors.Wrap(err, "invalid endianness specified in elf binary")
 	}
 

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -104,7 +104,7 @@ func (c *Changelog) Run() error {
 
 	var markdown, jsonStr, startRev, endRev string
 	if tag.Patch == 0 {
-		if len(tag.Pre) == 0 {
+		if len(tag.Pre) == 0 { // nolint:gocritic // a switch case would not make it better
 			// Still create the downloads table
 			downloadsTable := &bytes.Buffer{}
 			startTag := util.SemverToTagString(semver.Version{

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -311,7 +311,7 @@ func New(
 		}
 
 		// TODO: Refactor the logic here and add testing.
-		if note.DuplicateKind {
+		if note.DuplicateKind { // nolint:gocritic // a switch case would not make it better
 			kind := mapKind(highestPriorityKind(note.Kinds))
 			if existing, ok := kindCategory[kind]; ok {
 				*existing.NoteEntries = append(*existing.NoteEntries, processNote(note.Markdown))
@@ -531,14 +531,20 @@ func mapKind(kind notes.Kind) notes.Kind {
 }
 
 func prettyKind(kind notes.Kind) string {
-	if kind == notes.KindAPIChange {
+	switch kind {
+	case notes.KindAPIChange:
 		return "API Change"
-	} else if kind == notes.KindFailingTest {
+
+	case notes.KindFailingTest:
 		return "Failing Test"
-	} else if kind == notes.KindBug {
+
+	case notes.KindBug:
 		return "Bug or Regression"
-	} else if kind == notes.KindOther {
+
+	case notes.KindOther:
 		return string(notes.KindOther)
+
+	default:
+		return cases.Title(language.English).String(string(kind))
 	}
-	return cases.Title(language.English).String(string(kind))
 }

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1048,11 +1048,14 @@ func prettifySIGList(sigs []string) string {
 	sort.Strings(sigs)
 
 	for i, sig := range sigs {
-		if i == 0 {
+		switch i {
+		case 0:
 			sigList = fmt.Sprintf("SIG %s", prettySIG(sig))
-		} else if i == len(sigs)-1 {
+
+		case len(sigs) - 1:
 			sigList = fmt.Sprintf("%s and %s", sigList, prettySIG(sig))
-		} else {
+
+		default:
 			sigList = fmt.Sprintf("%s, %s", sigList, prettySIG(sig))
 		}
 	}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -390,8 +390,8 @@ func TestApplyMap(t *testing.T) {
 		require.True(t, ok, "found map test without testcase")
 
 		// Read the property this test case checks
-		//nolint:errcheck
-		property := testcase.(map[interface{}]interface{})["property"].(string)
+		property, ok := testcase.(map[interface{}]interface{})["property"].(string)
+		require.True(t, ok)
 		require.NotEmpty(t, property)
 		require.NotEmpty(t, property, "testcase found without property")
 		require.NotEqual(t, lastProp, property)
@@ -401,8 +401,8 @@ func TestApplyMap(t *testing.T) {
 		originalVal := reflect.Indirect(reflectedOriginalNote).FieldByName(property)
 
 		// Factor the test name
-		//nolint:errcheck
-		testName := testcase.(map[interface{}]interface{})["name"].(string)
+		testName, ok := testcase.(map[interface{}]interface{})["name"].(string)
+		require.True(t, ok)
 
 		switch expectedValue := testcase.(map[interface{}]interface{})["expected"].(type) {
 		case bool:

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -290,15 +290,20 @@ func (o *Options) resolveDiscoverMode() error {
 	}
 
 	var result git.DiscoverResult
-	if o.DiscoverMode == RevisionDiscoveryModeMergeBaseToLatest {
+	switch o.DiscoverMode {
+	case RevisionDiscoveryModeMergeBaseToLatest:
 		result, err = repo.LatestReleaseBranchMergeBaseToLatest()
-	} else if o.DiscoverMode == RevisionDiscoveryModePatchToPatch {
+
+	case RevisionDiscoveryModePatchToPatch:
 		result, err = repo.LatestPatchToPatch(o.Branch)
-	} else if o.DiscoverMode == RevisionDiscoveryModePatchToLatest {
+
+	case RevisionDiscoveryModePatchToLatest:
 		result, err = repo.LatestPatchToLatest(o.Branch)
-	} else if o.DiscoverMode == RevisionDiscoveryModeMinorToMinor {
+
+	case RevisionDiscoveryModeMinorToMinor:
 		result, err = repo.LatestNonPatchFinalToMinor()
 	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -151,7 +151,7 @@ func GenerateReleaseVersion(
 	// session/type Other labels such as alpha, beta, and rc are set as needed
 	// Index ordering is important here as it's how they are processed
 	releaseVersions := &Versions{}
-	if branchFromMaster {
+	if branchFromMaster { // nolint:gocritic // a switch case would not make it better
 		branchMatch := regex.BranchRegex.FindStringSubmatch(branch)
 		if len(branchMatch) < 3 {
 			return nil, errors.Errorf("invalid formatted branch %s", branch)

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/golang/protobuf/proto" // nolint: staticcheck
+	"github.com/golang/protobuf/proto" // nolint:staticcheck // this import was done on purpose
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/release/pkg/testgrid"


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This enables the rest of the missing gocritic linters and fixes their reports.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
