### PR TITLE
Use golang reported tmp dir to write SBOM

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -741,7 +741,7 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 	spdxDOC, err := d.impl.GenerateSourceTreeBOM(&spdx.DocGenerateOptions{
 		ProcessGoModules: true,
 		License:          LicenseIdentifier,
-		OutputFile:       "/tmp/kubernetes-source.spdx",
+		OutputFile:       filepath.Join(os.TempDir(), "kubernetes-source.spdx"),
 		Namespace:        "https://sbom.k8s.io/REPLACE/source", // This one gets replaced when writing to disk
 		ScanLicenses:     true,
 		Directories:      []string{gitRoot},


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes a possible bug where the release process may be running out of tmp disk space.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
/assign @jimangel 
#### Does this PR introduce a user-facing change?


```release-note
Fix a hardcoded path when writing the SBOM, now we scratch it in the go reported directory
```
