### PR TITLE
.github: Add dependency review action

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -8,7 +8,13 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab # v1.4.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: 'Checkout Repository'
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d
+        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d # v1


### PR DESCRIPTION
- https://github.blog/2022-04-06-prevent-introduction-known-vulnerabilities-into-your-code/

This helps prevent including dependencies that have vulnerabilities.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
