### PR TITLE
Fix kubelet restarts from kubeadm

### DIFF
--- a/cmd/kubepkg/templates/latest/deb/kubeadm/debian/control
+++ b/cmd/kubepkg/templates/latest/deb/kubeadm/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/kubernetes/kubernetes
 
 Package: kubeadm
 Architecture: {{ .BuildArch }}
-Depends: kubelet (>= {{ index .Dependencies "kubelet" }}), kubectl (>= {{ index .Dependencies "kubectl" }}), kubernetes-cni (>= {{ index .Dependencies "kubernetes-cni" }}), cri-tools (>= {{ index .Dependencies "cri-tools" }}), ${misc:Depends}
+Depends: cri-tools (>= {{ index .Dependencies "cri-tools" }}), ${misc:Depends}
 Description: Kubernetes Cluster Bootstrapping Tool
  The Kubernetes command line tool for bootstrapping a Kubernetes cluster.

--- a/cmd/kubepkg/templates/latest/deb/kubeadm/debian/postinst
+++ b/cmd/kubepkg/templates/latest/deb/kubeadm/debian/postinst
@@ -19,11 +19,6 @@ set -o nounset
 
 case "$1" in
     configure)
-        # because kubeadm package adds kubelet drop-ins, we must daemon-reload
-        # and restart kubelet now. restarting kubelet is ok because kubelet
-        # postinst configure step auto-starts it.
-        systemctl daemon-reload 2>/dev/null || true
-        systemctl restart kubelet 2>/dev/null || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/cmd/kubepkg/templates/latest/rpm/kubeadm/kubeadm.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubeadm/kubeadm.spec
@@ -11,9 +11,6 @@ Source1: 10-kubeadm.conf
 # TODO: Need to templatize dependencies
 BuildRequires: systemd
 BuildRequires: curl
-Requires: kubelet >= {{ index .Dependencies "kubelet" }}
-Requires: kubectl >= {{ index .Dependencies "kubectl" }}
-Requires: kubernetes-cni >= {{ index .Dependencies "kubernetes-cni" }}
 Requires: cri-tools >= {{ index .Dependencies "cri-tools" }}
 
 %description


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The dependencies for packaging are too strict and causing unexpected upgrades of components as well as unexpected restarts when upgrading other components.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #2412

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The kubeadm package no longer restarts the kubelet service, nor does it maintain any dependency on kubectl and kubelet.
```
