### PR TITLE
Fix fastforward git user configuration

### DIFF
--- a/pkg/fastforward/fastforward.go
+++ b/pkg/fastforward/fastforward.go
@@ -203,6 +203,11 @@ func (f *FastForward) Run() (err error) {
 	}
 	logrus.Infof("Latest release branch revision is %s", releaseRev)
 
+	logrus.Info("Configuring git user and email")
+	if err := f.ConfigureGlobalDefaultUserAndEmail(); err != nil {
+		return errors.Wrap(err, "configure git user and email")
+	}
+
 	logrus.Info("Merging main branch changes into release branch")
 	if err := f.RepoMerge(repo, f.options.MainRef); err != nil {
 		return errors.Wrap(err, "merge main ref")

--- a/pkg/fastforward/fastforward_test.go
+++ b/pkg/fastforward/fastforward_test.go
@@ -275,6 +275,17 @@ func TestRun(t *testing.T) {
 				require.NotNil(t, err)
 			},
 		},
+		{ // failure on ConfigureGlobalDefaultUserAndEmail
+			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
+				mock.IsReleaseBranchReturns(true)
+				mock.RepoHasRemoteBranchReturns(true, nil)
+				mock.ConfigureGlobalDefaultUserAndEmailReturns(errTest)
+				return &Options{Branch: branch}
+			},
+			assert: func(err error) {
+				require.NotNil(t, err)
+			},
+		},
 		{ // failure on RepoMergeBase
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.IsReleaseBranchReturns(true)

--- a/pkg/fastforward/fastforwardfakes/fake_impl.go
+++ b/pkg/fastforward/fastforwardfakes/fake_impl.go
@@ -82,6 +82,16 @@ type FakeImpl struct {
 		result1 *git.Repo
 		result2 error
 	}
+	ConfigureGlobalDefaultUserAndEmailStub        func() error
+	configureGlobalDefaultUserAndEmailMutex       sync.RWMutex
+	configureGlobalDefaultUserAndEmailArgsForCall []struct {
+	}
+	configureGlobalDefaultUserAndEmailReturns struct {
+		result1 error
+	}
+	configureGlobalDefaultUserAndEmailReturnsOnCall map[int]struct {
+		result1 error
+	}
 	EnvDefaultStub        func(string, string) string
 	envDefaultMutex       sync.RWMutex
 	envDefaultArgsForCall []struct {
@@ -598,6 +608,59 @@ func (fake *FakeImpl) CloneOrOpenGitHubRepoReturnsOnCall(i int, result1 *git.Rep
 		result1 *git.Repo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeImpl) ConfigureGlobalDefaultUserAndEmail() error {
+	fake.configureGlobalDefaultUserAndEmailMutex.Lock()
+	ret, specificReturn := fake.configureGlobalDefaultUserAndEmailReturnsOnCall[len(fake.configureGlobalDefaultUserAndEmailArgsForCall)]
+	fake.configureGlobalDefaultUserAndEmailArgsForCall = append(fake.configureGlobalDefaultUserAndEmailArgsForCall, struct {
+	}{})
+	stub := fake.ConfigureGlobalDefaultUserAndEmailStub
+	fakeReturns := fake.configureGlobalDefaultUserAndEmailReturns
+	fake.recordInvocation("ConfigureGlobalDefaultUserAndEmail", []interface{}{})
+	fake.configureGlobalDefaultUserAndEmailMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) ConfigureGlobalDefaultUserAndEmailCallCount() int {
+	fake.configureGlobalDefaultUserAndEmailMutex.RLock()
+	defer fake.configureGlobalDefaultUserAndEmailMutex.RUnlock()
+	return len(fake.configureGlobalDefaultUserAndEmailArgsForCall)
+}
+
+func (fake *FakeImpl) ConfigureGlobalDefaultUserAndEmailCalls(stub func() error) {
+	fake.configureGlobalDefaultUserAndEmailMutex.Lock()
+	defer fake.configureGlobalDefaultUserAndEmailMutex.Unlock()
+	fake.ConfigureGlobalDefaultUserAndEmailStub = stub
+}
+
+func (fake *FakeImpl) ConfigureGlobalDefaultUserAndEmailReturns(result1 error) {
+	fake.configureGlobalDefaultUserAndEmailMutex.Lock()
+	defer fake.configureGlobalDefaultUserAndEmailMutex.Unlock()
+	fake.ConfigureGlobalDefaultUserAndEmailStub = nil
+	fake.configureGlobalDefaultUserAndEmailReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) ConfigureGlobalDefaultUserAndEmailReturnsOnCall(i int, result1 error) {
+	fake.configureGlobalDefaultUserAndEmailMutex.Lock()
+	defer fake.configureGlobalDefaultUserAndEmailMutex.Unlock()
+	fake.ConfigureGlobalDefaultUserAndEmailStub = nil
+	if fake.configureGlobalDefaultUserAndEmailReturnsOnCall == nil {
+		fake.configureGlobalDefaultUserAndEmailReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.configureGlobalDefaultUserAndEmailReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeImpl) EnvDefault(arg1 string, arg2 string) string {
@@ -1892,6 +1955,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.cloneOrOpenDefaultGitHubRepoSSHMutex.RUnlock()
 	fake.cloneOrOpenGitHubRepoMutex.RLock()
 	defer fake.cloneOrOpenGitHubRepoMutex.RUnlock()
+	fake.configureGlobalDefaultUserAndEmailMutex.RLock()
+	defer fake.configureGlobalDefaultUserAndEmailMutex.RUnlock()
 	fake.envDefaultMutex.RLock()
 	defer fake.envDefaultMutex.RUnlock()
 	fake.existsMutex.RLock()

--- a/pkg/fastforward/impl.go
+++ b/pkg/fastforward/impl.go
@@ -57,6 +57,7 @@ type impl interface {
 	RemoveAll(string) error
 	MkdirTemp(string, string) (string, error)
 	Exists(string) bool
+	ConfigureGlobalDefaultUserAndEmail() error
 }
 
 func (*defaultImpl) CloneOrOpenDefaultGitHubRepoSSH(repo string) (*git.Repo, error) {
@@ -157,4 +158,8 @@ func (*defaultImpl) MkdirTemp(dir, pattern string) (string, error) {
 
 func (*defaultImpl) Exists(path string) bool {
 	return util.Exists(path)
+}
+
+func (*defaultImpl) ConfigureGlobalDefaultUserAndEmail() error {
+	return git.ConfigureGlobalDefaultUserAndEmail()
 }


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The recent git auto fast forward jobs fails because of the misconfigured
git user:

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-fast-forward/1516649755411746816/build-log.txt

```
Step #3: level=info msg="Merging main branch changes into release branch"
Step #3: level=fatal msg="merge main ref: run git merge: command /usr/bin/git merge -X ours origin/master did not succeed: Committer identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: unable to auto-detect email address (got 'root@c96ac26cb82d.(none)')\n"
Finished Step #3
ERROR
```

We now fix this by doing the same configuration like we do in krel
stage and release.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/2386 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed git configuration in `krel fast-forward`.
```
