### PR TITLE
Replace git.io links

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         language: [ 'go' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        # Learn more about CodeQL language support at https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
 
     steps:
     - name: Harden Runner
@@ -64,7 +64,7 @@ jobs:
       uses: github/codeql-action/autobuild@1ed1437484560351c5be56cf73a48a279d116b78 # v2.1.6
 
     # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+    # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project


### PR DESCRIPTION

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Effective 04-29-2022, [git.io is being discontinued and will no longer redirect](https://github.blog/changelog/2022-04-25-git-io-deprecation/).

This change replaces two URLs in code comments which use git.io with the actual URLs to which they redirect.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
