### PR TITLE
Update ci-reporter project board filtering

### DIFF
--- a/cmd/ci-reporter/cmd/github.go
+++ b/cmd/ci-reporter/cmd/github.go
@@ -76,18 +76,18 @@ func (r GithubReporter) GetCIReporterHead() CIReporterInfo {
 // CollectReportData implementation from CIReporter
 func (r GithubReporter) CollectReportData(cfg *Config) ([]*CIReportRecord, error) {
 	// set filter configuration
-	fieldFilter := map[FilteredFieldName][]FilteredBlacklistVal{}
+	blackListFilter := map[FilteredFieldName][]FilteredListVal{}
+	whiteListFilter := map[FilteredFieldName][]FilteredListVal{
+		FilteredFieldName("view"): {"issue-tracking"},
+	}
 	if cfg.ShortReport {
-		fieldFilter[FilteredFieldName("Status")] = []FilteredBlacklistVal{
-			FilteredBlacklistVal("RESOLVED"),
-			FilteredBlacklistVal("PASSING"),
-		}
+		blackListFilter[FilteredFieldName("Status")] = []FilteredListVal{FilteredListVal("RESOLVED"), FilteredListVal("PASSING")}
 	}
 	if cfg.ReleaseVersion != "" {
-		fieldFilter[FilteredFieldName("K8s Release")] = []FilteredBlacklistVal{FilteredBlacklistVal(cfg.ReleaseVersion)}
+		whiteListFilter[FilteredFieldName("K8s Release")] = []FilteredListVal{FilteredListVal(cfg.ReleaseVersion)}
 	}
 	// request github projectboard data
-	githubReportData, err := GetGithubReportData(*cfg, fieldFilter)
+	githubReportData, err := GetGithubReportData(*cfg, blackListFilter, whiteListFilter)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting GitHub report data")
 	}
@@ -203,12 +203,12 @@ type (
 	}
 
 	// Types for project board filtering
-	FilteredFieldName    string
-	FilteredBlacklistVal string
+	FilteredFieldName string
+	FilteredListVal   string
 )
 
 // GetGithubReportData used to request the raw report data from github
-func GetGithubReportData(cfg Config, fieldFilter map[FilteredFieldName][]FilteredBlacklistVal) ([]*TransformedProjectBoardItem, error) {
+func GetGithubReportData(cfg Config, blackListFieldFilter, whiteListFieldFilter map[FilteredFieldName][]FilteredListVal) ([]*TransformedProjectBoardItem, error) {
 	// lookup project board information
 	var queryCiSignalProjectBoard ciSignalProjectBoardGraphQLQuery
 	variablesProjectBoardFields := map[string]interface{}{
@@ -233,7 +233,6 @@ func GetGithubReportData(cfg Config, fieldFilter map[FilteredFieldName][]Filtere
 	)
 	projectBoardFieldIDs := map[projectBoardFieldID]projectBoardFieldName{}
 
-	// populate listOfSettingsIDs with IDs
 	for _, field := range queryCiSignalProjectBoard.Node.ProjectNext.Fields.Nodes {
 		var fieldSettings GitHubProjectBoardFieldSettings
 		if err := json.Unmarshal([]byte(field.Settings), &fieldSettings); err != nil {
@@ -257,15 +256,27 @@ func GetGithubReportData(cfg Config, fieldFilter map[FilteredFieldName][]Filtere
 				// ID detected replace ID with Name
 				fieldVal = string(val)
 			}
-			// check if field name is a filtered field
-			// with the filter map it is possible to filter the results
-			// example: "Status" field gets filtered with blacklist values, "RESOLVED"
-			// 	no "Status": "RESOLVED" items will be added to the output
-			if blacklistValues, filteredFieldFound := fieldFilter[FilteredFieldName(field.ProjectField.Name)]; filteredFieldFound {
+
+			// filter out black listed values
+			if blacklistValues, filteredFieldFound := blackListFieldFilter[FilteredFieldName(field.ProjectField.Name)]; filteredFieldFound {
 				// The field is a filtered field since it could be found in the fieldFilter map
 				// 	check if the value of the field is blacklisted
 				for _, bv := range blacklistValues {
 					if fieldVal == string(bv) {
+						itemBlacklisted = true
+						break
+					}
+				}
+				if itemBlacklisted {
+					break
+				}
+			}
+			// filter for white listed values
+			if whitelistValues, filteredFieldFound := whiteListFieldFilter[FilteredFieldName(field.ProjectField.Name)]; filteredFieldFound {
+				// The field is a filtered field since it could be found in the fieldFilter map
+				// 	check if the value of the field is blacklisted
+				for _, bv := range whitelistValues {
+					if fieldVal != string(bv) {
 						itemBlacklisted = true
 						break
 					}

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -61,7 +61,7 @@ type Config struct {
 var cfg = &Config{}
 
 func init() {
-	rootCmd.Flags().StringVarP(&cfg.ReleaseVersion, "release-version", "v", "", "Specify a Kubernetes release versions like '1.22' which will populate the report additionally")
+	rootCmd.PersistentFlags().StringVarP(&cfg.ReleaseVersion, "release-version", "v", "", "Specify a Kubernetes release versions like '1.22' which will populate the report additionally")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.ShortReport, "short", "s", false, "A short report for mails and slack")
 	rootCmd.PersistentFlags().BoolVar(&cfg.JSONOutput, "json", false, "Report output in json format")
 	rootCmd.PersistentFlags().StringVarP(&cfg.Filepath, "file", "f", "", "Specify a filepath to write the report to a file")


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The ci signal project board needs to be updated to track only testgrid job failures/flakes. The project board now also includes information about who reports for the release team / helps with cutting the release, but this should not be written to the report.

#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/release/issues/2514

#### Special notes for your reviewer:

Right now, the filtering happens after querying the API. 
I find it a bit difficult to put the filtering into the query since GitHub has a generic structure with lists and so on that is structured in quite some depths, see line 158 `cmd/ci-reporter/github.go`.

The query…
```go
type ciSignalProjectBoardGraphQLQuery struct {
	Node struct {
		ProjectNext struct {
			// Fields information about the column headers of the project
			// --> | Title | Testgrid Board | Testgrid URL | UpdatedAt | ... |
			Fields struct {
				Nodes []struct {
					Name     string
					Settings string
				}
			} `graphql:"fields(first: 100)"`
			// Items board rows with content
			Items struct {
				Nodes []struct {
					ID          string
					Title       string
					FieldValues struct {
						Nodes []struct {
							Value        string
							ProjectField struct {
								Name string
							}
						}
					} `graphql:"fieldValues(first: 20)"`
					Content struct {
						Issue struct {
							URL string
						} `graphql:"... on Issue"`
						PullRequest struct {
							URL string
						} `graphql:"... on PullRequest"`
					}
				}
			} `graphql:"items(first: 100)"`
		} `graphql:"... on ProjectNext"`
	} `graphql:"node(id: $projectBoardID)"`
}
```

(in the same file right after the query)

Filtering afterwards with blacklists and whitelists. Which should not be necessary if we apply filters in the query.
```go
for _, item := range queryCiSignalProjectBoard.Node.ProjectNext.Items.Nodes {
		transFields := map[fieldName]fieldValue{}
		itemBlacklisted := false
		for _, field := range item.FieldValues.Nodes {
			fieldVal := field.Value
			if val, ok := projectBoardFieldIDs[projectBoardFieldID(field.Value)]; ok {
				fieldVal = string(val)
			}

			if blacklistValues, filteredFieldFound := blackListFieldFilter[FilteredFieldName(field.ProjectField.Name)]; filteredFieldFound {
				for _, bv := range blacklistValues {
					if fieldVal == string(bv) {
						itemBlacklisted = true
						break
					}
				}
				if itemBlacklisted {
					break
				}
			}
			// filter for white listed values
			if whitelistValues, filteredFieldFound := whiteListFieldFilter[FilteredFieldName(field.ProjectField.Name)]; filteredFieldFound {
				for _, bv := range whitelistValues {
					if fieldVal != string(bv) {
						itemBlacklisted = true
						break
					}
				}
				if itemBlacklisted {
					break
				}
			}
			transFields[fieldName(field.ProjectField.Name)] = fieldValue(fieldVal)
		}
		if itemBlacklisted {
			continue
		}
		if item.Content.Issue.URL != "" {
			transFields[fieldName("Issue URL")] = fieldValue(item.Content.Issue.URL)
		}
		if item.Content.PullRequest.URL != "" {
			transFields[fieldName("PullRequest URL")] = fieldValue(item.Content.PullRequest.URL)
		}
		transformedProjectBoardItems = append(transformedProjectBoardItems, &TransformedProjectBoardItem{
			ID:     item.ID,
			Title:  item.Title,
			Fields: transFields,
		})
	}
```

@saschagrunert @puerco @RobertKielty any thoughts how to update the query to enable filtering?

To generate a short report, we for example do not display the Statuses `RESOLVED` and `PASSING`
```go
blackListFilter[FilteredFieldName("Status")] = []FilteredListVal{FilteredListVal("RESOLVED"), FilteredListVal("PASSING")}
```

* CI SIgnal Project board: https://github.com/orgs/kubernetes/projects/68
* GraphQL library used: https://github.com/shurcooL/githubv4
* GitHub GraphQL API, see: https://docs.github.com/en/issues/trying-out-the-new-projects-
* GraphQL filtering: https://dgraph.io/docs/graphql/queries/search-filtering/

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


