### PR TITLE
Allow fastforward to run non-interactive

### DIFF
--- a/pkg/fastforward/fastforward.go
+++ b/pkg/fastforward/fastforward.go
@@ -84,6 +84,7 @@ func (f *FastForward) Run() (err error) {
 		options := gcb.NewDefaultOptions()
 		options.FastForward = true
 		options.NoMock = f.options.NoMock
+		options.NonInteractive = f.options.NonInteractive
 		options.Stream = true
 		options.Project = f.options.GCPProjectID
 		options.ScratchBucket = "gs://" + f.options.GCPProjectID + "-gcb"


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
Recent runs of the fast-forward jobs are failing because we have no `non-interactive` flag for the GCB job run. We now fix that by making the question optional.

Example: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-fast-forward/1522088732356775936/build-log.txt

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #2386 
#### Special notes for your reviewer:
Gave it a test run in https://console.cloud.google.com/cloud-build/builds/c601bfb8-bf5e-4934-86f7-6f2165379823
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `NonInteractive` flag to gcb options to allow asking no questions when running in nomock mode.
```
