### PR TITLE
Bump cri-tools to v1.24.0

### DIFF
--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -43,7 +43,7 @@ const (
 
 	currentCNIVersion  = "0.8.7"
 	minimumCNIVersion  = "0.8.6"
-	criToolsVersion    = "1.23.0"
+	criToolsVersion    = "1.24.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"
 	latestkubeadmconf  = "post-1.10/10-kubeadm.conf"

--- a/packages/deb/build_test.go
+++ b/packages/deb/build_test.go
@@ -74,7 +74,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.23.0)",
+				"cri-tools (>= 1.24.0)",
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.23.0)",
+				"cri-tools (>= 1.24.0)",
 			},
 		},
 	}

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -12,7 +12,7 @@
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
 %global CNI_VERSION 0.8.7
-%global CRI_TOOLS_VERSION 1.23.0
+%global CRI_TOOLS_VERSION 1.24.0
 
 Name: kubelet
 Version: %{KUBE_VERSION}
@@ -157,6 +157,9 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Thu May 5 2022 Sascha Grunert <sgrunert@redhat.com> - 1.24.0
+- Update cri-tools to v1.24.0
+
 * Mon Mar 7 2022 Sascha Grunert <sgrunert@redhat.com> - 1.23.4
 - Update cri-tools to v1.23.0
 


### PR DESCRIPTION

#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Bump to the latest version.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/cri-tools/issues/922 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated cri-tools to v1.24.0
```
