### PR TITLE
WIP: Fix krel stage for using custom k8s refs

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -502,7 +502,10 @@ func (d *DefaultStage) TagRepository() error {
 		// If we are on master/main we do not create an empty commit,
 		// but we detach the head at the specified commit to avoid having
 		// commits merged between the BuildVersion commit and the tag:
-		if branch != "" && !strings.HasPrefix(branch, "release-") {
+		detachHead := release.IsDefaultK8sUpstream() &&
+			branch != "" &&
+			!strings.HasPrefix(branch, "release-")
+		if detachHead {
 			logrus.Infof("Detaching HEAD at commit %s to create tag %s", commit, version)
 			if err := d.impl.Checkout(repo, commit); err != nil {
 				return errors.Wrap(err, "checkout release commit")
@@ -535,7 +538,7 @@ func (d *DefaultStage) TagRepository() error {
 		// detached HEAD state. So we checkout the branch again.
 		// The next stage (build) will checkout the branch it needs, but
 		// let's not end this step with a detached HEAD
-		if branch != "" && !strings.HasPrefix(branch, "release-") {
+		if detachHead {
 			logrus.Infof("Checking out %s to reattach HEAD", d.options.ReleaseBranch)
 			if err := d.impl.Checkout(repo, d.options.ReleaseBranch); err != nil {
 				return errors.Wrapf(err, "checking out branch %s", d.options.ReleaseBranch)


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Fixing krel stage for custom Kubernetes refs.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Found in https://github.com/kubernetes/kubernetes/pull/109938
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `krel stage` for using custom Kubernetes refs via `K8S_ORG`, `K8S_REF` or `K8S_REPO`.
```
