### PR TITLE
Replace git.io URLs with the full URL to which they redirect

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         language: [ 'go' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        # Learn more about CodeQL language support at
+        # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks
 
     steps:
     - name: Harden Runner
@@ -64,7 +65,7 @@ jobs:
       uses: github/codeql-action/autobuild@2f58583a1b24a7d3c7034f6bf9fa506d23b1183b # v2.1.6
 
     # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+    # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
GitHub recently [planned to discontinue the git.io URL shortener](https://github.blog/changelog/2022-04-25-git-io-deprecation/), but then changed their mind, due to developer feedback.

It is clear that the use of git.io shortened URLs is being discouraged by GitHub, so this PR is replacing a couple git.io shortened URLs with the full URLs to which they redirect.

The replaced URLs are just in some comments in a yaml file.

#### Which issue(s) this PR fixes:
Fixes #2509

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
