### PR TITLE
remove check for outdated dependencies

### DIFF
--- a/compile-release-tools
+++ b/compile-release-tools
@@ -47,19 +47,6 @@ compile() {
   echo "${tool} compiled & installed"
 }
 
-check_deps() {
-  echo "Checking dependencies..."
-
-  compile github.com/psampaz/go-mod-outdated
-
-  local gmo_args=( '-update' '-direct' )
-  if [ -n "${FAIL_ON_OUTDATED:-}" ]; then
-    gmo_args+=( '-ci' )
-  fi
-
-  go list -u -m -json all | go-mod-outdated "${gmo_args[@]}"
-}
-
 compile_with_flags() {
   local git_tree_state
   local pkg
@@ -87,7 +74,6 @@ main() {
   cd "$(dirname "${BASH_SOURCE[0]}")"
 
   setup_env
-  check_deps
 
   if [ $# -gt 0 ]; then
     for tool in "$@"; do


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We used to have this check to alert us when we have outdated dependencies, but now with dependabot we dont need this check anymore, also this is failing to fetch some dependencies, like ` github.com/Azure/azure-sdk-for-go ` due to large codebase size (https://github.com/Azure/azure-sdk-for-go/issues/18209)

also can check the slack thread https://kubernetes.slack.com/archives/CJH2GBF7Y/p1653380102679589

/assign @saschagrunert 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
remove check for outdated dependencies
```
