### PR TITLE
Update docs to use "go install"

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -4,10 +4,10 @@ This directory contains a tool called `release-notes` and a set of library utili
 
 ## Install
 
-The simplest way to install the `release-notes` CLI is via `go get`:
+The simplest way to install the `release-notes` CLI is via `go install`:
 
 ```
-GO111MODULE=on go get k8s.io/release/cmd/release-notes
+$ go install k8s.io/release/cmd/release-notes@latest
 ```
 
 This will install `release-notes` to `$(go env GOPATH)/bin/release-notes`.

--- a/cmd/schedule-builder/README.md
+++ b/cmd/schedule-builder/README.md
@@ -7,10 +7,10 @@ Release cycle as well as Kubernetes Release Cycles schedules ([like 1.23](https:
 
 ## Install
 
-The simplest way to install the `schedule-builder` CLI is via `go get`:
+The simplest way to install the `schedule-builder` CLI is via `go install`:
 
 ```
-$ go get k8s.io/release/cmd/schedule-builder
+$ go install k8s.io/release/cmd/schedule-builder@latest
 ```
 
 This will install `schedule-builder` to `$(go env GOPATH)/bin/schedule-builder`.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

On go v1.17+, we need to use "go install" instead of "go get".
In addition, go v1.16 is EOL today.
This updates docs to use the command.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
