### PR TITLE
Use native error wrapping for `anago` package

### DIFF
--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -17,11 +17,11 @@ limitations under the License.
 package anago
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/release"
@@ -96,17 +96,17 @@ func (o *Options) Validate(state *State) error {
 		o.ReleaseType != release.ReleaseTypeBeta &&
 		o.ReleaseType != release.ReleaseTypeRC &&
 		o.ReleaseType != release.ReleaseTypeOfficial {
-		return errors.Errorf("invalid release type: %s", o.ReleaseType)
+		return fmt.Errorf("invalid release type: %s", o.ReleaseType)
 	}
 
 	if !git.IsReleaseBranch(o.ReleaseBranch) {
-		return errors.Errorf("invalid release branch: %s", o.ReleaseBranch)
+		return fmt.Errorf("invalid release branch: %s", o.ReleaseBranch)
 	}
 
 	// Verify the build version is correct:
 	correct, err := release.IsValidReleaseBuild(o.BuildVersion)
 	if err != nil {
-		return errors.Wrap(err, "checking for a valid build version")
+		return fmt.Errorf("checking for a valid build version: %w", err)
 	}
 	if !correct {
 		return errors.New("invalid BuildVersion specified")
@@ -114,7 +114,7 @@ func (o *Options) Validate(state *State) error {
 
 	semverBuildVersion, err := util.TagStringToSemver(o.BuildVersion)
 	if err != nil {
-		return errors.Wrapf(err, "invalid build version: %s", o.BuildVersion)
+		return fmt.Errorf("invalid build version: %s: %w", o.BuildVersion, err)
 	}
 	state.semverBuildVersion = semverBuildVersion
 
@@ -206,7 +206,7 @@ func (s *StageOptions) String() string {
 // Validate if the options are correctly set.
 func (s *StageOptions) Validate(state *State) error {
 	if err := s.Options.Validate(state); err != nil {
-		return errors.Wrap(err, "validating generic options")
+		return fmt.Errorf("validating generic options: %w", err)
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ func (s *Stage) SetClient(client stageClient) {
 func (s *Stage) Submit(stream bool) error {
 	logrus.Info("Submitting stage GCB job")
 	if err := s.client.Submit(stream); err != nil {
-		return errors.Wrap(err, "submit stage job")
+		return fmt.Errorf("submit stage job: %w", err)
 	}
 	return nil
 }
@@ -241,7 +241,7 @@ func (s *Stage) Run() error {
 	s.client.InitState()
 
 	if err := s.client.InitLogFile(); err != nil {
-		return errors.Wrap(err, "init log file")
+		return fmt.Errorf("init log file: %w", err)
 	}
 
 	logger := log.NewStepLogger(11)
@@ -249,57 +249,57 @@ func (s *Stage) Run() error {
 
 	logger.WithStep().Info("Validating options")
 	if err := s.client.ValidateOptions(); err != nil {
-		return errors.Wrap(err, "validate options")
+		return fmt.Errorf("validate options: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
 	if err := s.client.CheckPrerequisites(); err != nil {
-		return errors.Wrap(err, "check prerequisites")
+		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
 	if err := s.client.CheckReleaseBranchState(); err != nil {
-		return errors.Wrap(err, "check release branch state")
+		return fmt.Errorf("check release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
 	if err := s.client.GenerateReleaseVersion(); err != nil {
-		return errors.Wrap(err, "generate release version")
+		return fmt.Errorf("generate release version: %w", err)
 	}
 
 	logger.WithStep().Info("Preparing workspace")
 	if err := s.client.PrepareWorkspace(); err != nil {
-		return errors.Wrap(err, "prepare workspace")
+		return fmt.Errorf("prepare workspace: %w", err)
 	}
 
 	logger.WithStep().Info("Tagging repository")
 	if err := s.client.TagRepository(); err != nil {
-		return errors.Wrap(err, "tag repository")
+		return fmt.Errorf("tag repository: %w", err)
 	}
 
 	logger.WithStep().Info("Building release")
 	if err := s.client.Build(); err != nil {
-		return errors.Wrap(err, "build release")
+		return fmt.Errorf("build release: %w", err)
 	}
 
 	logger.WithStep().Info("Generating changelog")
 	if err := s.client.GenerateChangelog(); err != nil {
-		return errors.Wrap(err, "generate changelog")
+		return fmt.Errorf("generate changelog: %w", err)
 	}
 
 	logger.WithStep().Info("Verifying artifacts")
 	if err := s.client.VerifyArtifacts(); err != nil {
-		return errors.Wrap(err, "verifying artifacts")
+		return fmt.Errorf("verifying artifacts: %w", err)
 	}
 
 	logger.WithStep().Info("Generating bill of materials")
 	if err := s.client.GenerateBillOfMaterials(); err != nil {
-		return errors.Wrap(err, "generating sbom")
+		return fmt.Errorf("generating sbom: %w", err)
 	}
 
 	logger.WithStep().Info("Staging artifacts")
 	if err := s.client.StageArtifacts(); err != nil {
-		return errors.Wrap(err, "stage release artifacts")
+		return fmt.Errorf("stage release artifacts: %w", err)
 	}
 
 	logger.Info("Stage done")
@@ -338,7 +338,7 @@ func (r *ReleaseOptions) String() string {
 // Validate if the options are correctly set.
 func (r *ReleaseOptions) Validate(state *State) error {
 	if err := r.Options.Validate(state); err != nil {
-		return errors.Wrap(err, "validating generic options")
+		return fmt.Errorf("validating generic options: %w", err)
 	}
 	return nil
 }
@@ -362,7 +362,7 @@ func (r *Release) SetClient(client releaseClient) {
 func (r *Release) Submit(stream bool) error {
 	logrus.Info("Submitting release GCB job")
 	if err := r.client.Submit(stream); err != nil {
-		return errors.Wrap(err, "submit release job")
+		return fmt.Errorf("submit release job: %w", err)
 	}
 	return nil
 }
@@ -372,7 +372,7 @@ func (r *Release) Run() error {
 	r.client.InitState()
 
 	if err := r.client.InitLogFile(); err != nil {
-		return errors.Wrap(err, "init log file")
+		return fmt.Errorf("init log file: %w", err)
 	}
 
 	logger := log.NewStepLogger(11)
@@ -380,59 +380,59 @@ func (r *Release) Run() error {
 
 	logger.WithStep().Info("Validating options")
 	if err := r.client.ValidateOptions(); err != nil {
-		return errors.Wrap(err, "validate options")
+		return fmt.Errorf("validate options: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
 	if err := r.client.CheckPrerequisites(); err != nil {
-		return errors.Wrap(err, "check prerequisites")
+		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
 	if err := r.client.CheckReleaseBranchState(); err != nil {
-		return errors.Wrap(err, "check release branch state")
+		return fmt.Errorf("check release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
 	if err := r.client.GenerateReleaseVersion(); err != nil {
-		return errors.Wrap(err, "generate release version")
+		return fmt.Errorf("generate release version: %w", err)
 	}
 
 	logger.WithStep().Info("Preparing workspace")
 	if err := r.client.PrepareWorkspace(); err != nil {
-		return errors.Wrap(err, "prepare workspace")
+		return fmt.Errorf("prepare workspace: %w", err)
 	}
 
 	logger.WithStep().Info("Checking artifacts provenance")
 	if err := r.client.CheckProvenance(); err != nil {
 		// For now, we ony notify provenance errors as not to treat
 		// them as fatal while we finish testing SLSA compliance.
-		logrus.Warn(errors.Wrap(err, "checking provenance attestation"))
+		logrus.Warnf("Unable to check provenance attestation: %v", err)
 	}
 
 	logger.WithStep().Info("Pushing artifacts")
 	if err := r.client.PushArtifacts(); err != nil {
-		return errors.Wrap(err, "push artifacts")
+		return fmt.Errorf("push artifacts: %w", err)
 	}
 
 	logger.WithStep().Info("Pushing git objects")
 	if err := r.client.PushGitObjects(); err != nil {
-		return errors.Wrap(err, "push git objects")
+		return fmt.Errorf("push git objects: %w", err)
 	}
 
 	logger.WithStep().Info("Creating announcement")
 	if err := r.client.CreateAnnouncement(); err != nil {
-		return errors.Wrap(err, "create announcement")
+		return fmt.Errorf("create announcement: %w", err)
 	}
 
 	logger.WithStep().Info("Updating GitHub release page")
 	if err := r.client.UpdateGitHubPage(); err != nil {
-		return errors.Wrap(err, "updating github page")
+		return fmt.Errorf("updating github page: %w", err)
 	}
 
 	logger.WithStep().Info("Archiving release")
 	if err := r.client.Archive(); err != nil {
-		return errors.Wrap(err, "archive release")
+		return fmt.Errorf("archive release: %w", err)
 	}
 
 	logger.Info("Release done")

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -26,7 +26,6 @@ import (
 	"github.com/blang/semver"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/build"
@@ -331,7 +330,7 @@ func (d *defaultStageImpl) VerifyArtifacts(versions []string) error {
 
 	// Ensure binaries are of the correct architecture
 	if err := checker.CheckBinaryArchitectures(); err != nil {
-		return errors.Wrap(err, "checking binary architectures")
+		return fmt.Errorf("checking binary architectures: %w", err)
 	}
 
 	return nil
@@ -343,7 +342,7 @@ func (d *DefaultStage) InitLogFile() error {
 	)
 	logFile := filepath.Join(os.TempDir(), "stage.log")
 	if err := d.impl.ToFile(logFile); err != nil {
-		return errors.Wrap(err, "setup log file")
+		return fmt.Errorf("setup log file: %w", err)
 	}
 	d.state.logFile = logFile
 	logrus.Infof("Additionally logging to file %s", d.state.logFile)
@@ -356,7 +355,7 @@ func (d *DefaultStage) InitState() {
 
 func (d *DefaultStage) ValidateOptions() error {
 	if err := d.options.Validate(d.state.State); err != nil {
-		return errors.Wrap(err, "validating options")
+		return fmt.Errorf("validating options: %w", err)
 	}
 	return nil
 }
@@ -372,7 +371,7 @@ func (d *DefaultStage) CheckReleaseBranchState() error {
 		d.state.semverBuildVersion,
 	)
 	if err != nil {
-		return errors.Wrap(err, "check if release branch needs creation")
+		return fmt.Errorf("check if release branch needs creation: %w", err)
 	}
 	d.state.createReleaseBranch = createReleaseBranch
 	return nil
@@ -386,7 +385,7 @@ func (d *DefaultStage) GenerateReleaseVersion() error {
 		d.state.createReleaseBranch,
 	)
 	if err != nil {
-		return errors.Wrap(err, "generating release versions for stage")
+		return fmt.Errorf("generating release versions for stage: %w", err)
 	}
 	// Set the versions on the state
 	d.state.versions = versions
@@ -395,7 +394,7 @@ func (d *DefaultStage) GenerateReleaseVersion() error {
 
 func (d *DefaultStage) PrepareWorkspace() error {
 	if err := d.impl.PrepareWorkspaceStage(d.options.NoMock); err != nil {
-		return errors.Wrap(err, "prepare workspace")
+		return fmt.Errorf("prepare workspace: %w", err)
 	}
 	return nil
 }
@@ -403,7 +402,7 @@ func (d *DefaultStage) PrepareWorkspace() error {
 func (d *DefaultStage) TagRepository() error {
 	repo, err := d.impl.OpenRepo(gitRoot)
 	if err != nil {
-		return errors.Wrap(err, "open Kubernetes repository")
+		return fmt.Errorf("open Kubernetes repository: %w", err)
 	}
 
 	for _, version := range d.state.versions.Ordered() {
@@ -411,7 +410,7 @@ func (d *DefaultStage) TagRepository() error {
 
 		// Ensure that the tag not already exists
 		if _, err := d.impl.RevParseTag(repo, version); err == nil {
-			return errors.Errorf("tag %s already exists", version)
+			return fmt.Errorf("tag %s already exists: %w", version, err)
 		}
 
 		// Usually the build version contains a commit we can reference. If
@@ -434,7 +433,7 @@ func (d *DefaultStage) TagRepository() error {
 				if err := d.impl.Checkout(
 					repo, "-b", d.options.ReleaseBranch, commit,
 				); err != nil {
-					return errors.Wrap(err, "create new release branch")
+					return fmt.Errorf("create new release branch: %w", err)
 				}
 			} else {
 				logrus.Infof(
@@ -442,13 +441,13 @@ func (d *DefaultStage) TagRepository() error {
 					version, git.DefaultBranch,
 				)
 				if err := d.impl.Checkout(repo, git.DefaultBranch); err != nil {
-					return errors.Wrapf(err, "checkout %s branch", git.DefaultBranch)
+					return fmt.Errorf("checkout %s branch: %w", git.DefaultBranch, err)
 				}
 			}
 		} else {
 			logrus.Infof("Checking out branch %s", d.options.ReleaseBranch)
 			if err := d.impl.Checkout(repo, d.options.ReleaseBranch); err != nil {
-				return errors.Wrapf(err, "checking out branch %s", d.options.ReleaseBranch)
+				return fmt.Errorf("checking out branch %s: %w", d.options.ReleaseBranch, err)
 			}
 		}
 
@@ -456,7 +455,7 @@ func (d *DefaultStage) TagRepository() error {
 		// then in detached head state.
 		branch, err := d.impl.CurrentBranch(repo)
 		if err != nil {
-			return errors.Wrap(err, "get current branch")
+			return fmt.Errorf("get current branch: %w", err)
 		}
 		if branch != "" {
 			logrus.Infof("Current branch is %s", branch)
@@ -495,7 +494,7 @@ func (d *DefaultStage) TagRepository() error {
 				repo,
 				fmt.Sprintf("Release commit for Kubernetes %s", version),
 			); err != nil {
-				return errors.Wrap(err, "create empty release commit")
+				return fmt.Errorf("create empty release commit: %w", err)
 			}
 		}
 
@@ -508,7 +507,7 @@ func (d *DefaultStage) TagRepository() error {
 		if detachHead {
 			logrus.Infof("Detaching HEAD at commit %s to create tag %s", commit, version)
 			if err := d.impl.Checkout(repo, commit); err != nil {
-				return errors.Wrap(err, "checkout release commit")
+				return fmt.Errorf("checkout release commit: %w", err)
 			}
 		}
 
@@ -518,7 +517,7 @@ func (d *DefaultStage) TagRepository() error {
 		if ref != release.DefaultK8sRef {
 			logrus.Infof("Merging custom ref: %s", ref)
 			if err := d.impl.Merge(repo, git.Remotify(ref)); err != nil {
-				return errors.Wrap(err, "merge k8s ref")
+				return fmt.Errorf("merge k8s ref: %w", err)
 			}
 		}
 
@@ -531,7 +530,7 @@ func (d *DefaultStage) TagRepository() error {
 				"Kubernetes %s release %s", d.options.ReleaseType, version,
 			),
 		); err != nil {
-			return errors.Wrap(err, "tag version")
+			return fmt.Errorf("tag version: %w", err)
 		}
 
 		// if we are working on master/main at this point, we are in
@@ -541,7 +540,7 @@ func (d *DefaultStage) TagRepository() error {
 		if detachHead {
 			logrus.Infof("Checking out %s to reattach HEAD", d.options.ReleaseBranch)
 			if err := d.impl.Checkout(repo, d.options.ReleaseBranch); err != nil {
-				return errors.Wrapf(err, "checking out branch %s", d.options.ReleaseBranch)
+				return fmt.Errorf("checking out branch %s: %w", d.options.ReleaseBranch, err)
 			}
 		}
 	}
@@ -551,13 +550,13 @@ func (d *DefaultStage) TagRepository() error {
 func (d *DefaultStage) Build() error {
 	// Log in to Docker Hub to avoid getting rate limited
 	if err := d.impl.DockerHubLogin(); err != nil {
-		return errors.Wrap(err, "loging into Docker Hub")
+		return fmt.Errorf("loging into Docker Hub: %w", err)
 	}
 
 	// Call MakeCross for each of the versions we are building
 	for _, version := range d.state.versions.Ordered() {
 		if err := d.impl.MakeCross(version); err != nil {
-			return errors.Wrap(err, "build artifacts")
+			return fmt.Errorf("build artifacts: %w", err)
 		}
 	}
 	return nil
@@ -620,20 +619,20 @@ func (d *DefaultStage) GenerateChangelog() error {
 func (d *defaultStageImpl) AddBinariesToSBOM(sbom *spdx.Document, version string) error {
 	binaries, err := d.ListBinaries(version)
 	if err != nil {
-		return errors.Wrapf(err, "Getting binaries list for %s", version)
+		return fmt.Errorf("getting binaries list for %s: %w", version, err)
 	}
 
 	// Add the binaries, taking care of their docs
 	for _, bin := range binaries {
 		file := spdx.NewFile()
 		if err := file.ReadSourceFile(bin.Path); err != nil {
-			return errors.Wrapf(err, "reading binary sourcefile from %s", bin.Path)
+			return fmt.Errorf("reading binary sourcefile from %s: %w", bin.Path, err)
 		}
 		file.Name = filepath.Join("bin", bin.Platform, bin.Arch, filepath.Base(bin.Path))
 		file.FileName = file.Name
 		file.LicenseConcluded = LicenseIdentifier
 		if err := sbom.AddFile(file); err != nil {
-			return errors.Wrap(err, "adding file to artifacts sbom")
+			return fmt.Errorf("adding file to artifacts sbom: %w", err)
 		}
 		file.AddRelationship(&spdx.Relationship{
 			FullRender:       false,
@@ -650,20 +649,20 @@ func (d *defaultStageImpl) AddBinariesToSBOM(sbom *spdx.Document, version string
 func (d *defaultStageImpl) AddTarfilesToSBOM(sbom *spdx.Document, version string) error {
 	tarballs, err := d.ListTarballs(version)
 	if err != nil {
-		return errors.Wrapf(err, "listing release tarballs for %s", version)
+		return fmt.Errorf("listing release tarballs for %s: %w", version, err)
 	}
 
 	// Once the initial doc is generated, add the tarfiles
 	for _, tar := range tarballs {
 		file := spdx.NewFile()
 		if err := file.ReadSourceFile(tar); err != nil {
-			return errors.Wrapf(err, "reading tarball sourcefile from %s", tar)
+			return fmt.Errorf("reading tarball sourcefile from %s: %w", tar, err)
 		}
 		file.Name = filepath.Base(tar)
 		file.LicenseConcluded = LicenseIdentifier
 		file.FileName = filepath.Base(tar)
 		if err := sbom.AddFile(file); err != nil {
-			return errors.Wrap(err, "adding file to artifacts sbom")
+			return fmt.Errorf("adding file to artifacts sbom: %w", err)
 		}
 		file.AddRelationship(&spdx.Relationship{
 			FullRender:       false,
@@ -684,7 +683,7 @@ func (d *defaultStageImpl) BuildBaseArtifactsSBOM(options *spdx.DocGenerateOptio
 func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
 	images, err := d.ListImageArchives(version)
 	if err != nil {
-		return errors.Wrap(err, "getting artifacts list")
+		return fmt.Errorf("getting artifacts list: %w", err)
 	}
 
 	// Build the base artifacts sbom. We only pass it the images for
@@ -700,15 +699,15 @@ func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
 		OutputFile:     filepath.Join(),
 	})
 	if err != nil {
-		return errors.Wrapf(err, "generating base artifacts sbom for %s", version)
+		return fmt.Errorf("generating base artifacts sbom for %s: %w", version, err)
 	}
 
 	// Add the binaries and tarballs
 	if err := d.AddBinariesToSBOM(doc, version); err != nil {
-		return errors.Wrapf(err, "adding binaries to %s SBOM", version)
+		return fmt.Errorf("adding binaries to %s SBOM: %w", version, err)
 	}
 	if err := d.AddTarfilesToSBOM(doc, version); err != nil {
-		return errors.Wrapf(err, "adding tarballs to %s SBOM", version)
+		return fmt.Errorf("adding tarballs to %s SBOM: %w", version, err)
 	}
 
 	// Reference the source code SBOM as external document
@@ -719,7 +718,7 @@ func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
 	if err := extRef.ReadSourceFile(
 		filepath.Join(os.TempDir(), fmt.Sprintf("source-bom-%s.spdx", version)),
 	); err != nil {
-		return errors.Wrap(err, "reading the source file as external reference")
+		return fmt.Errorf("reading the source file as external reference: %w", err)
 	}
 	doc.ExternalDocRefs = append(doc.ExternalDocRefs, extRef)
 
@@ -736,7 +735,7 @@ func (d *defaultStageImpl) GenerateVersionArtifactsBOM(version string) error {
 
 	// Write the Releas Artifacts SBOM to disk
 	if err := doc.Write(filepath.Join(os.TempDir(), fmt.Sprintf("release-bom-%s.spdx", version))); err != nil {
-		return errors.Wrapf(err, "writing artifacts SBOM for %s", version)
+		return fmt.Errorf("writing artifacts SBOM for %s: %w", version, err)
 	}
 	return nil
 }
@@ -746,7 +745,10 @@ func (d *defaultStageImpl) GenerateSourceTreeBOM(
 ) (*spdx.Document, error) {
 	logrus.Info("Generating Kubernetes source SBOM file")
 	doc, err := spdx.NewDocBuilder().Generate(options)
-	return doc, errors.Wrap(err, "Generating kubernetes source code SBOM")
+	if err != nil {
+		return nil, fmt.Errorf("generating Kubernetes source code SBOM: %w", err)
+	}
+	return doc, nil
 }
 
 // WriteSourceBOM takes a source code SBOM and writes it into a file, updating
@@ -756,10 +758,10 @@ func (d *defaultStageImpl) WriteSourceBOM(
 ) error {
 	spdxDoc.Namespace = fmt.Sprintf("https://sbom.k8s.io/%s/source", version)
 	spdxDoc.Name = fmt.Sprintf("kubernetes-%s", version)
-	return errors.Wrap(
-		spdxDoc.Write(filepath.Join(os.TempDir(), fmt.Sprintf("source-bom-%s.spdx", version))),
-		"writing the source code SBOM",
-	)
+	if err := spdxDoc.Write(filepath.Join(os.TempDir(), fmt.Sprintf("source-bom-%s.spdx", version))); err != nil {
+		return fmt.Errorf("writing the source code SBOM: %w", err)
+	}
+	return nil
 }
 
 func (d *DefaultStage) GenerateBillOfMaterials() error {
@@ -776,7 +778,7 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 		Directories:      []string{gitRoot},
 	})
 	if err != nil {
-		return errors.Wrap(err, "generating the kubernetes source SBOM")
+		return fmt.Errorf("generating the kubernetes source SBOM: %w", err)
 	}
 
 	// We generate an artifacts sbom for each of the versions
@@ -784,12 +786,12 @@ func (d *DefaultStage) GenerateBillOfMaterials() error {
 	for _, version := range d.state.versions.Ordered() {
 		// Render the common source SBOM for this version
 		if err := d.impl.WriteSourceBOM(spdxDOC, version); err != nil {
-			return errors.Wrapf(err, "writing SBOM for version %s", version)
+			return fmt.Errorf("writing SBOM for version %s: %w", version, err)
 		}
 
 		// Render the artifacts SBOM for version
 		if err := d.impl.GenerateVersionArtifactsBOM(version); err != nil {
-			return errors.Wrapf(err, "generating SBOM for version %s", version)
+			return fmt.Errorf("generating SBOM for version %s: %w", version, err)
 		}
 	}
 
@@ -800,7 +802,7 @@ func (d *DefaultStage) StageArtifacts() error {
 	// Generate the intoto attestation, reloaded with the current run data
 	statement, err := d.impl.GenerateAttestation(d.state, d.options)
 	if err != nil {
-		return errors.Wrap(err, "generating the provenance attestation")
+		return fmt.Errorf("generating the provenance attestation: %w", err)
 	}
 	// Init push options for provenance document
 	pushBuildOptions := &build.Options{
@@ -810,7 +812,7 @@ func (d *DefaultStage) StageArtifacts() error {
 		ValidateRemoteImageDigests: true,
 	}
 	if err := d.impl.CheckReleaseBucket(pushBuildOptions); err != nil {
-		return errors.Wrap(err, "check release bucket access")
+		return fmt.Errorf("check release bucket access: %w", err)
 	}
 
 	// Stage the local source tree
@@ -819,7 +821,7 @@ func (d *DefaultStage) StageArtifacts() error {
 		workspaceDir,
 		d.options.BuildVersion,
 	); err != nil {
-		return errors.Wrap(err, "staging local source tree")
+		return fmt.Errorf("staging local source tree: %w", err)
 	}
 
 	// Add the sources tarball to the attestation
@@ -827,7 +829,7 @@ func (d *DefaultStage) StageArtifacts() error {
 		d.options, filepath.Join(workspaceDir, release.SourcesTar),
 	)
 	if err != nil {
-		return errors.Wrap(err, "adding sources tarball to provenance attestation")
+		return fmt.Errorf("adding sources tarball to provenance attestation: %w", err)
 	}
 	statement.Subject = append(statement.Subject, subjects...)
 
@@ -842,7 +844,7 @@ func (d *DefaultStage) StageArtifacts() error {
 
 		// Stage local artifacts and write checksums
 		if err := d.impl.StageLocalArtifacts(pushBuildOptions); err != nil {
-			return errors.Wrap(err, "staging local artifacts")
+			return fmt.Errorf("staging local artifacts: %w", err)
 		}
 		gcsPath := filepath.Join(
 			d.options.Bucket(), release.StagePath, d.options.BuildVersion, version,
@@ -854,7 +856,7 @@ func (d *DefaultStage) StageArtifacts() error {
 			filepath.Join(buildDir, release.GCSStagePath, version),
 			filepath.Join(gcsPath, release.GCSStagePath, version),
 		); err != nil {
-			return errors.Wrap(err, "pushing release artifacts")
+			return fmt.Errorf("pushing release artifacts: %w", err)
 		}
 
 		// Push container release-images to GCS
@@ -863,12 +865,12 @@ func (d *DefaultStage) StageArtifacts() error {
 			filepath.Join(buildDir, release.ImagesPath),
 			filepath.Join(gcsPath, release.ImagesPath),
 		); err != nil {
-			return errors.Wrap(err, "pushing release artifacts")
+			return fmt.Errorf("pushing release artifacts: %w", err)
 		}
 
 		// Push container images into registry
 		if err := d.impl.PushContainerImages(pushBuildOptions); err != nil {
-			return errors.Wrap(err, "pushing container images")
+			return fmt.Errorf("pushing container images: %w", err)
 		}
 
 		// Add artifacts to the attestation, this should get both release-images
@@ -877,19 +879,19 @@ func (d *DefaultStage) StageArtifacts() error {
 			d.options, buildDir, version,
 		)
 		if err != nil {
-			return errors.Wrapf(err, "adding provenance of release-images for version %s", version)
+			return fmt.Errorf("adding provenance of release-images for version %s: %w", version, err)
 		}
 		statement.Subject = append(statement.Subject, subjects...)
 	}
 
 	// Push the attestation metadata file to the bucket
 	if err := d.impl.PushAttestation(statement, d.options); err != nil {
-		return errors.Wrap(err, "writing provenance metadata to disk")
+		return fmt.Errorf("writing provenance metadata to disk: %w", err)
 	}
 
 	// Delete the local source tarball
 	if err := d.impl.DeleteLocalSourceTarball(pushBuildOptions, workspaceDir); err != nil {
-		return errors.Wrap(err, "delete source tarball")
+		return fmt.Errorf("delete source tarball: %w", err)
 	}
 
 	args := ""
@@ -926,13 +928,13 @@ func (d *defaultStageImpl) GenerateAttestation(state *StageState, options *Stage
 	// Fetch the last commit:
 	repo, err := git.OpenRepo(gitRoot)
 	if err != nil {
-		return nil, errors.Wrap(err, "opening repository to check commit hash")
+		return nil, fmt.Errorf("opening repository to check commit hash: %w", err)
 	}
 
 	// Get the k/k commit we are building
 	commitSHA, err := repo.LastCommitSha()
 	if err != nil {
-		return nil, errors.Wrap(err, "getting k/k build point")
+		return nil, fmt.Errorf("getting k/k build point: %w", err)
 	}
 
 	// Create the predicate to populate it with the current
@@ -973,11 +975,11 @@ func (d *defaultStageImpl) PushAttestation(attestation *provenance.Statement, op
 	// Create a temporary file:
 	f, err := os.CreateTemp("", "provenance-")
 	if err != nil {
-		return errors.Wrap(err, "creating temp file for provenance metadata")
+		return fmt.Errorf("creating temp file for provenance metadata: %w", err)
 	}
 	// Write the provenance statement to disk:
 	if err := attestation.Write(f.Name()); err != nil {
-		return errors.Wrap(err, "writing provenance attestation to disk")
+		return fmt.Errorf("writing provenance attestation to disk: %w", err)
 	}
 
 	// TODO for SLSA2: Sign the attestation
@@ -989,14 +991,15 @@ func (d *defaultStageImpl) PushAttestation(attestation *provenance.Statement, op
 	}
 
 	if err := d.CheckReleaseBucket(pushBuildOptions); err != nil {
-		return errors.Wrap(err, "check release bucket access")
+		return fmt.Errorf("check release bucket access: %w", err)
 	}
 
 	// Push the provenance file to GCS
-	return errors.Wrap(
-		d.PushReleaseArtifacts(pushBuildOptions, f.Name(), filepath.Join(gcsPath, release.ProvenanceFilename)),
-		"pushing provenance manifest",
-	)
+	if err := d.PushReleaseArtifacts(pushBuildOptions, f.Name(), filepath.Join(gcsPath, release.ProvenanceFilename)); err != nil {
+		return fmt.Errorf("pushing provenance manifest: %w", err)
+	}
+
+	return nil
 }
 
 // GetOutputDirSubjects reads the built artifacts and returns them


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
A new approach to replace the `pkg/errors` dependency on a package-by-package basis.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/2549
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
