### PR TITLE
Replace pkg/errors dependency

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -234,7 +234,6 @@ func (c *Changelog) Run() error {
 	}
 
 	return nil
-
 }
 
 func (c *Changelog) generateReleaseNotes(

--- a/pkg/cve/client.go
+++ b/pkg/cve/client.go
@@ -17,10 +17,9 @@ limitations under the License.
 package cve
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"k8s.io/release/pkg/release"
 	"sigs.k8s.io/release-sdk/object"
@@ -64,12 +63,12 @@ func NewClient() *Client {
 // Write writes a map to the bucket
 func (c *Client) Write(cve, mapPath string) error {
 	if err := c.impl.CheckID(cve); err != nil {
-		return errors.Wrap(err, "checking CVE identifier")
+		return fmt.Errorf("checking CVE identifier: %w", err)
 	}
 
 	// Validate the information in the data maps
 	if err := c.impl.ValidateCVEMap(cve, mapPath, &c.options); err != nil {
-		return errors.Wrap(err, "validating CVE data in map file")
+		return fmt.Errorf("validating CVE data in map file: %w", err)
 	}
 
 	destPath := object.GcsPrefix + filepath.Join(
@@ -80,7 +79,7 @@ func (c *Client) Write(cve, mapPath string) error {
 	if err := c.impl.CopyFile(
 		mapPath, destPath, &c.options,
 	); err != nil {
-		return errors.Wrapf(err, "writing %s map file to CVE bucket", cve)
+		return fmt.Errorf("writing %s map file to CVE bucket: %w", cve, err)
 	}
 
 	return nil
@@ -94,7 +93,7 @@ func (c *Client) CheckID(cve string) error {
 // Delete removes a CVE entry from the security bucket location
 func (c *Client) Delete(cve string) error {
 	if err := c.impl.CheckID(cve); err != nil {
-		return errors.Wrap(err, "checking CVE identifier")
+		return fmt.Errorf("checking CVE identifier: %w", err)
 	}
 
 	return c.impl.DeleteFile(

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cve
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
-	"github.com/pkg/errors"
 	cvss "github.com/spiegel-im-spiegel/go-cvss/v3/metric"
 )
 
@@ -94,7 +94,7 @@ func (cve *CVE) Validate() error {
 	// Parse the vector string to make sure it is well formed
 	bm, err := cvss.NewBase().Decode(cve.CVSSVector)
 	if err != nil {
-		return errors.Wrap(err, "parsing CVSS vector string")
+		return fmt.Errorf("parsing CVSS vector string: %w", err)
 	}
 	cve.CalcLink = fmt.Sprintf(
 		"https://www.first.org/cvss/calculator/%s#%s", bm.Ver.String(), cve.CVSSVector,
@@ -108,7 +108,7 @@ func (cve *CVE) Validate() error {
 	}
 
 	if err := ValidateID(cve.ID); err != nil {
-		return errors.Wrap(err, "checking CVE ID")
+		return fmt.Errorf("checking CVE ID: %w", err)
 	}
 
 	// Title and description must not be empty

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -76,19 +76,19 @@ func (cve *CVE) ReadRawInterface(cvedata interface{}) error {
 func (cve *CVE) Validate() error {
 	// Verify that rating is defined and a known string
 	if cve.CVSSRating == "" {
-		return errors.New("CVSS rating missing from CVE data")
+		return errors.New("missing CVSS rating from CVE data")
 	}
 
 	// Check rating is a valid string
 	if _, ok := map[string]bool{
 		"None": true, "Low": true, "Medium": true, "High": true, "Critical": true,
 	}[cve.CVSSRating]; !ok {
-		return errors.New("Invalid CVSS rating")
+		return errors.New("invalid CVSS rating")
 	}
 
 	// Check vector string is not empty
 	if cve.CVSSVector == "" {
-		return errors.New("CVSS vector string missing from CVE data")
+		return errors.New("string CVSS vector missing from CVE data")
 	}
 
 	// Parse the vector string to make sure it is well formed
@@ -101,10 +101,10 @@ func (cve *CVE) Validate() error {
 	)
 
 	if cve.CVSSScore == 0 {
-		return errors.New("CVSS score missing from CVE data")
+		return errors.New("missing CVSS score from CVE data")
 	}
 	if cve.CVSSScore < 0 || cve.CVSSScore > 10 {
-		return errors.New("CVSS score out of range, should be 0.0 - 10.0")
+		return errors.New("out of range CVSS score, should be 0.0 - 10.0")
 	}
 
 	if err := ValidateID(cve.ID); err != nil {
@@ -113,11 +113,11 @@ func (cve *CVE) Validate() error {
 
 	// Title and description must not be empty
 	if cve.Title == "" {
-		return errors.New("Title missing from CVE data")
+		return errors.New("title missing from CVE data")
 	}
 
 	if cve.Description == "" {
-		return errors.New("CVE description missing from CVE data")
+		return errors.New("missing CVE description from CVE data")
 	}
 
 	return nil
@@ -126,12 +126,12 @@ func (cve *CVE) Validate() error {
 // ValidateID checks if a CVE IS string is valid
 func ValidateID(cveID string) error {
 	if cveID == "" {
-		return errors.New("CVE ID string is empty")
+		return errors.New("empty CVE ID string")
 	}
 
 	// Verify that the CVE ID is well formed
 	if !regexp.MustCompile(CVEIDRegExp).MatchString(cveID) {
-		return errors.New("CVS ID is not well formed")
+		return errors.New("not well formed CVS ID")
 	}
 
 	return nil

--- a/pkg/cve/impl.go
+++ b/pkg/cve/impl.go
@@ -18,6 +18,7 @@ package cve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
@@ -56,15 +56,16 @@ func (impl *defaultClientImplementation) CheckBucketWriteAccess(opts *ClientOpti
 
 	client, err := storage.NewClient(context.Background())
 	if err != nil {
-		return errors.Wrap(err,
+		return fmt.Errorf(
 			"fetching gcloud credentials, try running "+
-				`"gcloud auth application-default login"`,
+				`"gcloud auth application-default login: %w"`,
+			err,
 		)
 	}
 
 	bucket := client.Bucket(opts.Bucket)
 	if bucket == nil {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"unable to open CVE bucket: %s", opts.Bucket,
 		)
 	}
@@ -75,10 +76,10 @@ func (impl *defaultClientImplementation) CheckBucketWriteAccess(opts *ClientOpti
 		context.Background(), requiredGCSPerms,
 	)
 	if err != nil {
-		return errors.Wrap(err, "getting bucket permissions")
+		return fmt.Errorf("getting bucket permissions: %w", err)
 	}
 	if len(perms) != 1 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"GCP user must have at least %s permissions on bucket %s",
 			requiredGCSPerms, opts.Bucket,
 		)
@@ -92,22 +93,22 @@ func (impl *defaultClientImplementation) DeleteFile(
 	path string, opts *ClientOptions,
 ) error {
 	if err := impl.CheckBucketWriteAccess(opts); err != nil {
-		return errors.Wrap(err, "checking bucket permissions to delete data")
+		return fmt.Errorf("checking bucket permissions to delete data: %w", err)
 	}
 	gcs := object.NewGCS()
 	path, err := gcs.NormalizePath(path)
 	if err != nil {
-		return errors.Wrap(err, "normalizing bucket path")
+		return fmt.Errorf("normalizing bucket path: %w", err)
 	}
 	if err := impl.CheckBucketPath(path, opts); err != nil {
-		return errors.Wrap(err, "checking path to delete file")
+		return fmt.Errorf("checking path to delete file: %w", err)
 	}
 	if !strings.HasSuffix(path, ".yaml") {
 		return errors.New("only yaml files can be deleted")
 	}
 	exists, err := gcs.PathExists(path)
 	if err != nil {
-		return errors.Wrap(err, "checking if cve entry exists")
+		return fmt.Errorf("checking if cve entry exists: %w", err)
 	}
 	if !exists {
 		return errors.New("specified CVE entry not found")
@@ -121,7 +122,7 @@ func (impl *defaultClientImplementation) CopyToTemp(
 ) (*os.File, error) {
 	dir, err := os.MkdirTemp(os.TempDir(), "cve-maps-")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating temp dir")
+		return nil, fmt.Errorf("creating temp dir: %w", err)
 	}
 	gcs := object.NewGCS()
 	if err := gcs.CopyToLocal(
@@ -129,7 +130,7 @@ func (impl *defaultClientImplementation) CopyToTemp(
 			opts.Bucket, opts.Directory, cve+mapExt,
 		), dir,
 	); err != nil {
-		return nil, errors.Wrapf(err, "copying CVE %s to tempfile", cve)
+		return nil, fmt.Errorf("copying CVE %s to tempfile: %w", cve, err)
 	}
 	return os.Open(filepath.Join(dir, cve+mapExt))
 }
@@ -139,7 +140,7 @@ func (impl *defaultClientImplementation) CopyFile(
 	src, dest string, opts *ClientOptions,
 ) error {
 	if err := impl.CheckBucketWriteAccess(opts); err != nil {
-		return errors.Wrap(err, "checking bucket permissions to copy data")
+		return fmt.Errorf("checking bucket permissions to copy data: %w", err)
 	}
 	gcs := object.NewGCS()
 	gcs.SetOptions(
@@ -147,14 +148,14 @@ func (impl *defaultClientImplementation) CopyFile(
 	)
 	path, err := gcs.NormalizePath(dest)
 	if err != nil {
-		return errors.Wrap(err, "normalizing bucket path")
+		return fmt.Errorf("normalizing bucket path: %w", err)
 	}
 	if err := impl.CheckBucketPath(path, opts); err != nil {
-		return errors.Wrap(err, "checking path to copy file")
+		return fmt.Errorf("checking path to copy file: %w", err)
 	}
 
 	if err := gcs.CopyToRemote(src, path); err != nil {
-		return errors.Wrapf(err, "copying %s to bucket", path)
+		return fmt.Errorf("copying %s to bucket: %w", path, err)
 	}
 
 	// Copy the file to the bucket
@@ -168,7 +169,7 @@ func (impl *defaultClientImplementation) CheckBucketPath(
 	g := object.NewGCS()
 	path, err := g.NormalizePath(path)
 	if err != nil {
-		return errors.Wrap(err, "normalizing CVE bucket path")
+		return fmt.Errorf("normalizing CVE bucket path: %w", err)
 	}
 	path = strings.TrimPrefix(path, object.GcsPrefix)
 
@@ -193,7 +194,7 @@ func (impl *defaultClientImplementation) ValidateCVEMap(
 	// Parse the data map
 	maps, err := notes.ParseReleaseNotesMap(path)
 	if err != nil {
-		return errors.Wrap(err, "parsing CVE data map")
+		return fmt.Errorf("parsing CVE data map: %w", err)
 	}
 
 	// Cycle all data maps in file
@@ -205,10 +206,10 @@ func (impl *defaultClientImplementation) ValidateCVEMap(
 		// Cast the datafield as CVE data
 		cvedata := CVE{}
 		if err := cvedata.ReadRawInterface(dataMap.DataFields["cve"]); err != nil {
-			return errors.Wrap(err, "reading CVE data from YAML file")
+			return fmt.Errorf("reading CVE data from YAML file: %w", err)
 		}
 		if err := cvedata.Validate(); err != nil {
-			return errors.Wrapf(err, "validating map #%d in file %s", i, path)
+			return fmt.Errorf("validating map #%d in file %s: %w", i, path, err)
 		}
 
 		if cvedata.ID != cveID {
@@ -228,7 +229,7 @@ func (impl *defaultClientImplementation) CreateEmptyFile(cve string, opts *Clien
 	file *os.File, err error,
 ) {
 	if err := impl.CheckID(cve); err != nil {
-		return nil, errors.Wrap(err, "checking new CVE ID")
+		return nil, fmt.Errorf("checking new CVE ID: %w", err)
 	}
 
 	// Add a relnote-compatible struct with only the CVE data
@@ -247,18 +248,18 @@ func (impl *defaultClientImplementation) CreateEmptyFile(cve string, opts *Clien
 	// Marshall the data struct into yaml
 	yamlCode, err := yaml.Marshal(noteMap)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshalling CVE data map")
+		return nil, fmt.Errorf("marshalling CVE data map: %w", err)
 	}
 
 	file, err = os.CreateTemp(os.TempDir(), "cve-data-*.yaml")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new map file")
+		return nil, fmt.Errorf("creating new map file: %w", err)
 	}
 	if _, err := file.WriteString(newMapHeader); err != nil {
-		return nil, errors.Wrap(err, "writing empty CVE header")
+		return nil, fmt.Errorf("writing empty CVE header: %w", err)
 	}
 	if _, err := file.Write(yamlCode); err != nil {
-		return nil, errors.Wrap(err, "writing yaml code to file")
+		return nil, fmt.Errorf("writing yaml code to file: %w", err)
 	}
 
 	return file, nil
@@ -270,7 +271,7 @@ func (impl *defaultClientImplementation) EntryExists(
 ) (exists bool, err error) {
 	// Check the ID string to be valid
 	if err := ValidateID(cveID); err != nil {
-		return exists, errors.Wrap(err, "checking CVE ID string")
+		return exists, fmt.Errorf("checking CVE ID string: %w", err)
 	}
 
 	// Verify the expected file exists in the bucket
@@ -282,7 +283,7 @@ func (impl *defaultClientImplementation) EntryExists(
 		),
 	)
 	if err != nil {
-		return exists, errors.Wrap(err, "checking if CVE entry already exists")
+		return exists, fmt.Errorf("checking if CVE entry already exists: %w", err)
 	}
 	return gcs.PathExists(path)
 }

--- a/pkg/fastforward/fastforward_test.go
+++ b/pkg/fastforward/fastforward_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package fastforward
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/release/pkg/fastforward/fastforwardfakes"
 )

--- a/pkg/gcp/auth/auth.go
+++ b/pkg/gcp/auth/auth.go
@@ -17,9 +17,10 @@ limitations under the License.
 package auth
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/release-sdk/gcli"
 )
 
@@ -50,7 +51,7 @@ func ConfigureDocker() error {
 		"configure-docker",
 	)
 	if err != nil {
-		return errors.Wrapf(err, "running 'gcloud auth configure-docker'")
+		return fmt.Errorf("running 'gcloud auth configure-docker': %w", err)
 	}
 
 	return nil

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -228,9 +228,9 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 		}
 
 		if diskSizeInt > 1000 {
-			return errors.New("Selected disk size must be no greater than 1000 GB")
+			return errors.New("selected disk size must be no greater than 1000 GB")
 		} else if diskSizeInt <= 0 {
-			return errors.New("Selected disk size must be greater than 0 GB")
+			return errors.New("selected disk size must be greater than 0 GB")
 		}
 
 		diskSizeArg := fmt.Sprintf("--disk-size=%s", o.DiskSize)

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package build
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/api/cloudbuild/v1"
@@ -82,7 +82,7 @@ func PrepareBuilds(o *Options) error {
 
 	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
 		if err := os.Chdir(bazelWorkspace); err != nil {
-			return errors.Wrapf(err, "failed to chdir to bazel workspace (%s)", bazelWorkspace)
+			return fmt.Errorf("failed to chdir to bazel workspace (%s): %w", bazelWorkspace, err)
 		}
 	}
 
@@ -97,7 +97,7 @@ func PrepareBuilds(o *Options) error {
 	// when the config directory is not the same as the build directory.
 	absConfigDir, absErr := filepath.Abs(o.ConfigDir)
 	if absErr != nil {
-		return errors.Wrapf(absErr, "could not resolve absolute path for config directory")
+		return fmt.Errorf("could not resolve absolute path for config directory: %w", absErr)
 	}
 
 	o.ConfigDir = absConfigDir
@@ -105,14 +105,14 @@ func PrepareBuilds(o *Options) error {
 
 	configDirErr := o.ValidateConfigDir()
 	if configDirErr != nil {
-		return errors.Wrapf(configDirErr, "could not validate config directory")
+		return fmt.Errorf("could not validate config directory: %w", configDirErr)
 	}
 
 	logrus.Infof("Config directory: %s", o.ConfigDir)
 
 	logrus.Infof("Changing to build directory: %s", o.BuildDir)
 	if err := os.Chdir(o.BuildDir); err != nil {
-		return errors.Wrapf(err, "failed to chdir to build directory (%s)", o.BuildDir)
+		return fmt.Errorf("failed to chdir to build directory (%s): %w", o.BuildDir, err)
 	}
 
 	return nil
@@ -143,7 +143,7 @@ func (o *Options) ValidateConfigDir() error {
 func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
 	f, err := os.CreateTemp("", "")
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create temp file")
+		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	name := f.Name()
 	_ = f.Close()
@@ -151,7 +151,7 @@ func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
 
 	logrus.Infof("Creating source tarball at %s...", name)
 	if err := tar.Compress(name, ".", regexp.MustCompile(".git")); err != nil {
-		return "", errors.Wrap(err, "create tarball")
+		return "", fmt.Errorf("create tarball: %w", err)
 	}
 
 	u := uuid.New()
@@ -161,7 +161,7 @@ func (o *Options) uploadBuildDir(targetBucket string) (string, error) {
 		name,
 		uploaded,
 	); err != nil {
-		return "", errors.Wrap(err, "upload files to GCS")
+		return "", fmt.Errorf("upload files to GCS: %w", err)
 	}
 
 	return uploaded, nil
@@ -243,7 +243,7 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 		p := path.Join(o.LogDir, strings.ReplaceAll(jobName, "/", "-")+".log")
 		f, err := os.Create(p)
 		if err != nil {
-			return errors.Wrapf(err, "couldn't create %s", p)
+			return fmt.Errorf("couldn't create %s: %w", p, err)
 		}
 
 		defer f.Close()
@@ -252,7 +252,7 @@ func RunSingleJob(o *Options, jobName, uploaded, version string, subs map[string
 
 	logrus.Infof("cloudbuild command to send to gcp: %s", cmd.String())
 	if err := cmd.RunSuccess(); err != nil {
-		return errors.Wrapf(err, "error running %s", cmd.String())
+		return fmt.Errorf("error running %s: %w", cmd.String(), err)
 	}
 
 	return nil
@@ -264,10 +264,10 @@ func getVariants(o *Options) (variants, error) {
 	content, err := os.ReadFile(path.Join(o.ConfigDir, "variants.yaml"))
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return nil, errors.Wrapf(err, "failed to load variants.yaml")
+			return nil, fmt.Errorf("failed to load variants.yaml: %w", err)
 		}
 		if o.Variant != "" {
-			return nil, errors.Errorf("no variants.yaml found, but a build variant (%q) was specified", o.Variant)
+			return nil, fmt.Errorf("no variants.yaml found, but a build variant (%q) was specified: %w", o.Variant, err)
 		}
 		return nil, nil
 	}
@@ -275,12 +275,12 @@ func getVariants(o *Options) (variants, error) {
 		Variants variants `json:"variants"`
 	}{}
 	if err := yaml.UnmarshalStrict(content, &v); err != nil {
-		return nil, errors.Wrapf(err, "failed to read variants.yaml")
+		return nil, fmt.Errorf("failed to read variants.yaml: %w", err)
 	}
 	if o.Variant != "" {
 		va, ok := v.Variants[o.Variant]
 		if !ok {
-			return nil, errors.Errorf("requested variant %q, which is not present in variants.yaml", o.Variant)
+			return nil, fmt.Errorf("requested variant %q, which is not present in variants.yaml", o.Variant)
 		}
 		return variants{o.Variant: va}, nil
 	}
@@ -294,7 +294,7 @@ func RunBuildJobs(o *Options) []error {
 			var err error
 			uploaded, err = o.uploadBuildDir(o.ScratchBucket + gcsSourceDir)
 			if err != nil {
-				return []error{errors.Wrapf(err, "failed to upload source")}
+				return []error{fmt.Errorf("failed to upload source: %w", err)}
 			}
 		}
 	} else {
@@ -341,7 +341,7 @@ func RunBuildJobs(o *Options) []error {
 			logrus.Infof("Starting job %q...", job)
 			if err := RunSingleJob(o, job, uploaded, tag, mergeMaps(extraSubs, vc)); err != nil {
 				logrus.Infof("Job %q failed: %v", job, err)
-				jobErrors = append(jobErrors, errors.Wrapf(err, "job %q failed", job))
+				jobErrors = append(jobErrors, fmt.Errorf("job %q failed: %w", job, err))
 			} else {
 				logrus.Infof("Job %q completed", job)
 			}
@@ -367,12 +367,12 @@ func ListJobs(project string, lastJobs int64) error {
 
 	service, err := cloudbuild.NewService(ctx, opts)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetching gcloud credentials... try running \"gcloud auth application-default login\"")
+		return fmt.Errorf("failed to fetching gcloud credentials... try running \"gcloud auth application-default login\": %w", err)
 	}
 
 	req, err := service.Projects.Builds.List(project).PageSize(lastJobs).Do()
 	if err != nil {
-		return errors.Wrap(err, "failed to listing the builds")
+		return fmt.Errorf("failed to listing the builds: %w", err)
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
@@ -392,12 +392,12 @@ func GetJobsByTag(project, tagsFilter string) ([]*cloudbuild.Build, error) {
 
 	service, err := cloudbuild.NewService(ctx, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetching gcloud credentials... try running \"gcloud auth application-default login\"")
+		return nil, fmt.Errorf("failed to fetching gcloud credentials... try running \"gcloud auth application-default login\": %w", err)
 	}
 
 	req, err := service.Projects.Builds.List(project).Filter(tagsFilter).PageSize(50).Do()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to listing the builds")
+		return nil, fmt.Errorf("failed to listing the builds: %w", err)
 	}
 
 	return req.Builds, nil

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -302,7 +302,6 @@ func (g *GCB) Submit() error {
 	}
 
 	return nil
-
 }
 
 // SetGCBSubstitutions takes a set of `Options` and returns a map of GCB

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -371,7 +371,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 
 	buildVersion := g.options.BuildVersion
 	if g.options.Release && buildVersion == "" {
-		return gcbSubs, errors.New("Build version must be specified when sending a release GCB run")
+		return gcbSubs, errors.New("build version must be specified when sending a release GCB run")
 	}
 
 	if g.options.Stage && g.options.BuildAtHead {

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -19,6 +19,7 @@ package gcb
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/pkg/gcp/auth"
@@ -165,7 +165,7 @@ func (o *Options) Validate() error {
 
 	if o.Branch == git.DefaultBranch {
 		if o.ReleaseType == release.ReleaseTypeRC || o.ReleaseType == release.ReleaseTypeOfficial {
-			return errors.Errorf("cannot cut a release candidate or an official release from %s", git.DefaultBranch)
+			return fmt.Errorf("cannot cut a release candidate or an official release from %s", git.DefaultBranch)
 		}
 	} else {
 		if o.ReleaseType == release.ReleaseTypeAlpha || o.ReleaseType == release.ReleaseTypeBeta {
@@ -187,7 +187,7 @@ func (o *Options) Validate() error {
 // Submit is the main method responsible for submitting release jobs to GCB.
 func (g *GCB) Submit() error {
 	if err := g.options.Validate(); err != nil {
-		return errors.Wrap(err, "validating GCB options")
+		return fmt.Errorf("validating GCB options: %w", err)
 	}
 
 	toolOrg := release.GetToolOrg()
@@ -195,15 +195,15 @@ func (g *GCB) Submit() error {
 	toolRef := release.GetToolRef()
 
 	if err := gcli.PreCheck(); err != nil {
-		return errors.Wrap(err, "pre-checking for GCP package usage")
+		return fmt.Errorf("pre-checking for GCP package usage: %w", err)
 	}
 
 	if err := g.repoClient.Open(); err != nil {
-		return errors.Wrap(err, "open release repo")
+		return fmt.Errorf("open release repo: %w", err)
 	}
 
 	if err := g.repoClient.CheckState(toolOrg, toolRepo, toolRef, g.options.NoMock); err != nil {
-		return errors.Wrap(err, "verifying repository state")
+		return fmt.Errorf("verifying repository state: %w", err)
 	}
 
 	logrus.Infof("Running GCB with the following options: %+v", g.options)
@@ -294,13 +294,15 @@ func (g *GCB) Submit() error {
 
 	version, err := g.repoClient.GetTag()
 	if err != nil {
-		return errors.Wrap(err, "getting current tag")
+		return fmt.Errorf("getting current tag: %w", err)
 	}
 
-	return errors.Wrap(
-		build.RunSingleJob(&g.options.Options, "", "", version, gcbSubs),
-		"run GCB job",
-	)
+	if err := build.RunSingleJob(&g.options.Options, "", "", version, gcbSubs); err != nil {
+		return fmt.Errorf("run GCB job: %w", err)
+	}
+
+	return nil
+
 }
 
 // SetGCBSubstitutions takes a set of `Options` and returns a map of GCB
@@ -341,7 +343,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 		// If the kubecross version is not set, we will get a 404 from GitHub.
 		// In that case, we do not err but use the latest version (unless we're on main branch)
 		if g.options.Branch == git.DefaultBranch || !strings.Contains(err.Error(), "404") {
-			return gcbSubs, errors.Wrap(err, "retrieve kube-cross version")
+			return gcbSubs, fmt.Errorf("retrieve kube-cross version: %w", err)
 		}
 		logrus.Infof("KubeCross version not set for %s, falling back to latest", g.options.Branch)
 	}
@@ -350,7 +352,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 	if g.options.Branch != git.DefaultBranch {
 		kcVersionLatest, err = kc.Latest()
 		if err != nil {
-			return gcbSubs, errors.Wrap(err, "retrieve latest kube-cross version")
+			return gcbSubs, fmt.Errorf("retrieve latest kube-cross version: %w", err)
 		}
 
 		// if kcVersionBranch is empty, the branch does not exist yet, we use
@@ -375,14 +377,12 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 	if g.options.Stage && g.options.BuildAtHead {
 		hash, err := git.LSRemoteExec(git.GetDefaultKubernetesRepoURL(), "rev-parse", g.options.Branch)
 		if err != nil {
-			return gcbSubs, errors.Wrapf(
-				err, "execute rev-parse for branch %s", g.options.Branch,
-			)
+			return gcbSubs, fmt.Errorf("execute rev-parse for branch %s: %w", g.options.Branch, err)
 		}
 
 		fields := strings.Fields(hash)
 		if len(fields) < 1 {
-			return gcbSubs, errors.Errorf("unexpected output: %s", hash)
+			return gcbSubs, fmt.Errorf("unexpected output: %s", hash)
 		}
 
 		buildVersion = fields[0]
@@ -402,25 +402,25 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef string) (map[string
 
 	buildVersionSemver, err := util.TagStringToSemver(buildVersion)
 	if err != nil {
-		return gcbSubs, errors.Wrap(err, "parse build version")
+		return gcbSubs, fmt.Errorf("parse build version: %w", err)
 	}
 
 	createBranch, err := g.releaseClient.NeedsCreation(
 		g.options.Branch, g.options.ReleaseType, buildVersionSemver,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "check if branch needs to be created")
+		return nil, fmt.Errorf("check if branch needs to be created: %w", err)
 	}
 	versions, err := g.releaseClient.GenerateReleaseVersion(
 		g.options.ReleaseType, buildVersion,
 		g.options.Branch, createBranch,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "generate release version")
+		return nil, fmt.Errorf("generate release version: %w", err)
 	}
 	primeSemver, err := util.TagStringToSemver(versions.Prime())
 	if err != nil {
-		return gcbSubs, errors.Wrap(err, "parse prime version")
+		return gcbSubs, fmt.Errorf("parse prime version: %w", err)
 	}
 
 	gcbSubs["MAJOR_VERSION_TAG"] = strconv.FormatUint(primeSemver.Major, 10)

--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -17,12 +17,12 @@ limitations under the License.
 package gcb
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/cloudbuild/v1"
 
@@ -105,7 +105,7 @@ var status = map[string]string{
 func (h *History) Run() error {
 	from, to, err := h.parseDateRange()
 	if err != nil {
-		return errors.Wrap(err, "parse from and to dates")
+		return fmt.Errorf("parse from and to dates: %w", err)
 	}
 
 	logrus.Infof("Running history with the following options: %+v", h.opts)
@@ -115,7 +115,7 @@ func (h *History) Run() error {
 	)
 	jobs, err := h.impl.GetJobsByTag(h.opts.Project, tagFilter)
 	if err != nil {
-		return errors.Wrap(err, "get GCP build jobs by tag")
+		return fmt.Errorf("get GCP build jobs by tag: %w", err)
 	}
 
 	tableString := &strings.Builder{}
@@ -158,11 +158,11 @@ func (h *History) Run() error {
 		const layout = "2006-01-02T15:04:05.99Z"
 		tStart, err := h.impl.ParseTime(layout, start)
 		if err != nil {
-			return errors.Wrap(err, "parsing the start job time")
+			return fmt.Errorf("parsing the start job time: %w", err)
 		}
 		tEnd, err := h.impl.ParseTime(layout, end)
 		if err != nil {
-			return errors.Wrap(err, "parsing the end job time")
+			return fmt.Errorf("parsing the end job time: %w", err)
 		}
 		diff := tEnd.Sub(tStart)
 		out := time.Time{}.Add(diff)
@@ -195,7 +195,7 @@ func (h *History) parseDateRange() (from, to string, err error) {
 	)
 	timeStampFrom, err := h.impl.ParseTime(parseLayout, h.opts.DateFrom)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "convert date from")
+		return "", "", fmt.Errorf("convert date from: %w", err)
 	}
 	from = timeStampFrom.Format(resultLayout)
 
@@ -209,7 +209,7 @@ func (h *History) parseDateRange() (from, to string, err error) {
 	} else {
 		timeStampTo, err := h.impl.ParseTime(parseLayout, h.opts.DateTo)
 		if err != nil {
-			return "", "", errors.Wrapf(err, "convert date to")
+			return "", "", fmt.Errorf("convert date to: %w", err)
 		}
 		// Set the ending date to midnight of the next day
 		dateTo := time.Date(


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A new approach to replace the pkg/errors dependency on a package-by-package basis. Concerned packages for this PR:
[pkg/changelog](https://github.com/kubernetes/release/tree/master/pkg/changelog)
[pkg/cve](https://github.com/kubernetes/release/tree/master/pkg/cve)
[pkg/fastforward](https://github.com/kubernetes/release/tree/master/pkg/fastforward)
[pkg/gcp](https://github.com/kubernetes/release/tree/master/pkg/gcp)

#### Which issue(s) this PR fixes:
Refers to: https://github.com/kubernetes/release/issues/2549

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```
