### PR TITLE
replace github.com/pkg/errors dependency in release notes package

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -324,12 +324,12 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(releaseNotes.ByPR()); err != nil {
-			return fmt.Errorf(err, "encoding JSON output: %w", err)
+			return fmt.Errorf("encoding JSON output: %w", err)
 		}
 	} else {
 		doc, err := document.New(releaseNotes, opts.StartRev, opts.EndRev)
 		if err != nil {
-			return fmt.Errorf(err, "creating release note document: %w", err)
+			return fmt.Errorf("creating release note document: %w", err)
 		}
 
 		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, "", opts.GoTemplate)
@@ -347,7 +347,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 					url, opts.StartSHA, opts.EndSHA,
 				)
 				if err != nil {
-					return fmt.Errorf(err, "generating dependency report")
+					return fmt.Errorf("generating dependency report: %w", err)
 				}
 				markdown += strings.Repeat(nl, 2) + deps
 			}
@@ -360,13 +360,13 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 				MaxDepth:   mdtoc.MaxHeaderDepth,
 			})
 			if err != nil {
-				return errors.Wrap(err, "generating table of contents")
+				return fmt.Errorf("generating table of contents: %w", err)
 			}
 			markdown = toc + nl + markdown
 		}
 
 		if _, err := output.WriteString(markdown); err != nil {
-			return errors.Wrap(err, "writing output file")
+			return fmt.Errorf("writing output file: %w", err)
 		}
 	}
 
@@ -377,7 +377,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 func run(*cobra.Command, []string) error {
 	releaseNotes, err := notes.GatherReleaseNotes(opts)
 	if err != nil {
-		return errors.Wrapf(err, "gathering release notes")
+		return fmt.Errorf("gathering release notes: %w", err)
 	}
 
 	return WriteReleaseNotes(releaseNotes)

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -284,12 +283,12 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 	if releaseNotesOpts.outputFile != "" {
 		output, err = os.OpenFile(releaseNotesOpts.outputFile, os.O_RDWR|os.O_CREATE, os.FileMode(0o644))
 		if err != nil {
-			return errors.Wrapf(err, "opening the supplied output file")
+			return fmt.Errorf("opening the supplied output file: %w", err)
 		}
 	} else {
 		output, err = os.CreateTemp("", "release-notes-")
 		if err != nil {
-			return errors.Wrapf(err, "creating a temporary file to write the release notes to")
+			return fmt.Errorf("creating a temporary file to write the release notes to: %w", err)
 		}
 	}
 
@@ -302,7 +301,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 
 		if len(byteValue) > 0 {
 			if err := json.Unmarshal(byteValue, &existingNotes); err != nil {
-				return errors.Wrapf(err, "unmarshalling existing notes")
+				return fmt.Errorf("unmarshalling existing notes: %w", err)
 			}
 		}
 
@@ -325,17 +324,17 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(releaseNotes.ByPR()); err != nil {
-			return errors.Wrapf(err, "encoding JSON output")
+			return fmt.Errorf(err, "encoding JSON output: %w", err)
 		}
 	} else {
 		doc, err := document.New(releaseNotes, opts.StartRev, opts.EndRev)
 		if err != nil {
-			return errors.Wrapf(err, "creating release note document")
+			return fmt.Errorf(err, "creating release note document: %w", err)
 		}
 
 		markdown, err := doc.RenderMarkdownTemplate(opts.ReleaseBucket, opts.ReleaseTars, "", opts.GoTemplate)
 		if err != nil {
-			return errors.Wrapf(err, "rendering release note document with template")
+			return fmt.Errorf("rendering release note document with template: %w", err)
 		}
 
 		const nl = "\n"
@@ -348,7 +347,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 					url, opts.StartSHA, opts.EndSHA,
 				)
 				if err != nil {
-					return errors.Wrap(err, "generating dependency report")
+					return fmt.Errorf(err, "generating dependency report")
 				}
 				markdown += strings.Repeat(nl, 2) + deps
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind cleanup


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
Replaces the github.com/pkg/errors dependency with native error wrapping in the `pkg/release-notes` package
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #2549 

or

None
-->
Fixes #2549 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
