### PR TITLE
cmd/schedule-builder: replace github.com/pkg/errors dependency with native error wrapping

### DIFF
--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -111,13 +111,13 @@ func initLogging(*cobra.Command, []string) error {
 
 func run(opts *options) error {
 	if err := opts.SetAndValidate(); err != nil {
-		return errors.Wrap(err, "validating schedule-path options")
+		return fmt.Errorf("validating schedule-path options: %w", err)
 	}
 
 	logrus.Infof("Reading the schedule file %s...", opts.configPath)
 	data, err := os.ReadFile(opts.configPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to read the file")
+		return fmt.Errorf("failed to read the file: %w", err)
 	}
 
 	var (
@@ -131,7 +131,7 @@ func run(opts *options) error {
 	switch opts.typeFile {
 	case "patch":
 		if err := yaml.UnmarshalStrict(data, &patchSchedule); err != nil {
-			return errors.Wrap(err, "failed to decode the file")
+			return fmt.Errorf("failed to decode the file: %w", err)
 		}
 
 		logrus.Info("Generating the markdown output...")
@@ -139,7 +139,7 @@ func run(opts *options) error {
 
 	case "release":
 		if err := yaml.UnmarshalStrict(data, &releaseSchedule); err != nil {
-			return errors.Wrap(err, "failed to decode the file")
+			return fmt.Errorf("failed to decode the file: %w", err)
 		}
 
 		logrus.Info("Generating the markdown output...")
@@ -155,7 +155,7 @@ func run(opts *options) error {
 		// 0600 or less
 		err := os.WriteFile(opts.outputFile, []byte(scheduleOut), 0o644)
 		if err != nil {
-			return errors.Wrap(err, "failed to save schedule to the file")
+			return fmt.Errorf("failed to save schedule to the file: %w", err)
 		}
 		logrus.Info("File saved")
 	}
@@ -168,7 +168,7 @@ func (o *options) SetAndValidate() error {
 	logrus.Info("Validating schedule-path options...")
 
 	if o.configPath == "" {
-		return errors.Errorf("need to set the config-path")
+		return fmt.Errorf("need to set the config-path")
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR updates the [cmd/schedule-builder](https://github.com/kubernetes/release/tree/master/cmd/schedule-builder) go packege to replace `github.com/pkg/errors dependency` with native error wrapping

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2549

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
