### PR TITLE
golang: Build 1.19beta1 images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -236,6 +236,23 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  # Golang (previous release branches: 1.24)
+  - name: "golang (previous release branches: 1.24)"
+    version: 1.18.3
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
+    version: 1.18.3
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
   # Golang (previous release branches: 1.23)
   - name: "golang (previous release branches: 1.23)"
     version: 1.17.11
@@ -277,6 +294,18 @@ dependencies:
     - path: images/releng/ci/variants.yaml
       match: REVISION:\ '\d+'
 
+  - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.24)"
+    version: v2.3.1-go1.18.3-bullseye.0
+    refPaths:
+    - path: images/build/go-runner/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
+  - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.23)"
+    version: v2.3.1-go1.17.11-bullseye.0
+    refPaths:
+    - path: images/build/go-runner/variants.yaml
+      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+
   - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.22, 1.21)"
     version: v2.3.1-go1.16.15-buster.0
     refPaths:
@@ -288,6 +317,12 @@ dependencies:
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: REVISION:\ '\d+'
+
+  - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.24)"
+    version: v1.24.0-go1.18.3-bullseye.0
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.23)"
     version: v1.23.0-go1.17.11-bullseye.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -283,10 +283,6 @@ dependencies:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
-  - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.20)"
-    version: v2.3.1-go1.15.15-buster.0
-    refPaths:
-
   - name: "k8s.gcr.io/build-image/go-runner: image revision (for previous release branches)"
     version: 0
     refPaths:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -135,7 +135,7 @@ dependencies:
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.24.0
+    version: v1.25.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -188,7 +188,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.18
+    version: 1.19beta1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -207,7 +207,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (next candidate)"
-    version: v2.3.1-go1.18.3-bullseye.0
+    version: v2.3.1-go1.19beta1-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -219,7 +219,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.25.0-go1.18.3-bullseye.0
+    version: v1.25.0-go1.19beta1-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.25-go1.19-bullseye:
+    CONFIG: 'go1.19-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.25.0-go1.19beta1-bullseye.0'
+    KUBERNETES_VERSION: 'v1.25.0'
+    GO_VERSION: '1.19beta1'
+    GO_MAJOR_VERSION: '1.19'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.25-go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
     TYPE: 'default'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -19,16 +19,6 @@ variants:
     OS_CODENAME: 'bullseye'
     REVISION: '0'
     PROTOBUF_VERSION: '3.19.4'
-  v1.24-go1.17-bullseye:
-    CONFIG: 'go1.17-bullseye'
-    TYPE: 'default'
-    IMAGE_VERSION: 'v1.24.0-go1.17.11-bullseye.0'
-    KUBERNETES_VERSION: 'v1.24.0'
-    GO_VERSION: '1.17.11'
-    GO_MAJOR_VERSION: '1.17'
-    OS_CODENAME: 'bullseye'
-    REVISION: '0'
-    PROTOBUF_VERSION: '3.19.4'
   v1.23-go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'
     TYPE: 'default'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,4 +1,12 @@
 variants:
+  go1.19-bullseye:
+    CONFIG: 'go1.19-bullseye'
+    IMAGE_VERSION: 'v2.3.1-go1.19beta1-bullseye.0'
+    GO_MAJOR_VERSION: '1.19'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    GO_VERSION: '1.19beta1'
+    DISTROLESS_IMAGE: 'static-debian11'
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
     IMAGE_VERSION: 'v2.3.1-go1.18.3-bullseye.0'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  go1.19-bullseye:
+    CONFIG: 'go1.19-bullseye'
+    GO_VERSION: '1.19beta1'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
     GO_VERSION: '1.18.3'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,11 +5,11 @@ variants:
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.18.3'
+    GO_VERSION: '1.19beta1'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.18.3'
+    GO_VERSION: '1.19beta1'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- remove old and not used dependency  for 1.20
- add dependencies for v1.24 release
- drop v1.24-go1.17-bullseye config for kube-cross
- golang: Build 1.19beta1 images

/hold to check if all looks good
/assign @justaugustus @saschagrunert @puerco @Verolop @palnabarun 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

None
xref: https://github.com/kubernetes/release/issues/2575

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- remove old and not used dependency for 1.20
- add dependencies for v1.24 release
- drop v1.24-go1.17-bullseye config for kube-cross
- golang: Build 1.19beta1 images
```
