### PR TITLE
debian-base: Build bullseye-v1.4.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -379,7 +379,7 @@ dependencies:
       match: "OS_CODENAME: 'bullseye'"
 
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: bullseye-v1.3.0
+    version: bullseye-v1.4.0
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -422,7 +422,7 @@ dependencies:
 
   # Base images (next candidate)
   - name: "k8s.gcr.io/build-image/debian-base (next candidate)"
-    version: bullseye-v1.3.0
+    version: bullseye-v1.4.0
     refPaths:
     - path: images/build/debian-base/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.3.0
+IMAGE_VERSION ?= bullseye-v1.4.0
 CONFIG ?= bullseye
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -2,7 +2,7 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.3.0'
+    IMAGE_VERSION: 'bullseye-v1.4.0'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'


### PR DESCRIPTION


#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Creating a new bullseye-v1.4.0 image. This should patch the following CVEs:

- CVE-2022-1664 
- CVE-2022-2068 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
debian-base: Build bullseye-v1.4.0 images
```
