### PR TITLE
Remove `krel changelog` docs

### DIFF
--- a/docs/krel/README.md
+++ b/docs/krel/README.md
@@ -32,7 +32,6 @@ krel has several subcommands that perform various tasks during the release lifec
 | Subcommand                          | Description                                                                                 |
 | ----------------------------------- | --------------------------------------------------------------------------------------------|
 | announce                            | Build and announce Kubernetes releases                                                      |
-| [changelog](changelog.md)           | Automate the lifecycle of CHANGELOG-x.y.{md,html} files in a k/k repository                 |
 | ci-build                            | Build Kubernetes in CI and push release artifacts to Google Cloud Storage (GCS)             |
 | cve                                 | Add and edit CVE information                                                                |
 | [ff](ff.md)                         | Fast forward a Kubernetes release branch                                                    |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR removes the `krel changelog` documentation since this subcommand no longer exists. It was removed on https://github.com/kubernetes/release/pull/2401

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
