### PR TITLE
Bumping distroless-iptables to 0.1.1 to patch vulnerability

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -438,7 +438,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/distroless-iptables"
-    version: v0.1.0
+    version: v0.1.1
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.1.0
+IMAGE_VERSION ?= v0.1.1
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bullseye-slim
 GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.1.0'
+    IMAGE_VERSION: 'v0.1.1'
     GORUNNER_VERSION: 'v2.3.1-go1.17.3-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This bumps distroless-iptables to patch a vulnerability identified by @wespanther in https://github.com/kubernetes/kubernetes/pull/111060#issuecomment-1190800117.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
