### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using go1.18.4 and go1.17.12

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.18.3
+    version: 1.18.4
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -181,7 +181,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.25.0-go1.18.3-bullseye.0
+    version: v1.25.0-go1.18.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -231,7 +231,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.25.0-go1.18.3-bullseye.0
+    version: v1.25.0-go1.18.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -248,7 +248,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.18.3
+    version: 1.18.4
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -265,7 +265,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
-    version: 1.17.11
+    version: 1.17.12
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -14,6 +14,3 @@ variants:
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.15-buster.0'
-  v1.21-cross1.16-buster:
-    CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.21.0-go1.16.15-buster.0'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,16 +1,13 @@
 variants:
   v1.25-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.18.3-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.18.4-bullseye.0'
   v1.24-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.3-bullseye.0'
-  v1.24-cross1.17-bullseye:
-    CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.17.11-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.4-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.11-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.12-bullseye.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.15-buster.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.18.3-${OS_CODENAME} AS builder
+FROM golang:1.18.4-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.18.3
+GO_VERSION ?= 1.18.4
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -23,7 +23,3 @@ variants:
     CONFIG: '1.22'
     GO_VERSION: '1.16.15'
     OS_CODENAME: 'buster'
-  '1.21':
-    CONFIG: '1.21'
-    GO_VERSION: '1.16.15'
-    OS_CODENAME: 'buster'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.18.3'
+    GO_VERSION: '1.18.4'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -13,11 +13,11 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.18.3'
+    GO_VERSION: '1.18.4'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.11'
+    GO_VERSION: '1.17.12'
     OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- k8s-cloud-builder/k8s-ci-builder: build using Go 1.18.4
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.12
- drop configs for v1.21 due to EOL

k/k prs are merged  https://github.com/kubernetes/kubernetes/pull/111464 / https://github.com/kubernetes/kubernetes/pull/111465

#### Which issue(s) this PR fixes:

xref #2620 

#### Does this PR introduce a user-facing change?

```release-note
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.18.4
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.12
- drop configs for v1.21 due to EOL
```

/assign @saschagrunert @xmudrii @Verolop @puerco @dims 
cc @kubernetes/release-engineering 
