### PR TITLE
k8s-cloud-builder/k8s-ci-builder: build using go1.18.5 and go1.17.13

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.18.4
+    version: 1.18.5
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -181,7 +181,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.25.0-go1.18.4-bullseye.0
+    version: v1.25.0-go1.18.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -231,7 +231,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.25.0-go1.18.4-bullseye.0
+    version: v1.25.0-go1.18.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -248,7 +248,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.18.4
+    version: 1.18.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -265,13 +265,13 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
-    version: 1.17.12
+    version: 1.17.13
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # Golang (previous release branches: 1.22, 1.21)
-  - name: "golang (previous release branches: 1.22, 1.21)"
+  # Golang (previous release branches: 1.22)
+  - name: "golang (previous release branches: 1.22)"
     version: 1.16.15
     refPaths:
     - path: images/build/cross/variants.yaml
@@ -281,7 +281,7 @@ dependencies:
     - path: images/releng/ci/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22, 1.21)"
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22)"
     version: 1.16.15
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,13 +1,13 @@
 variants:
   v1.25-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.18.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.18.5-bullseye.0'
   v1.24-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.5-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.12-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.13-bullseye.0'
   v1.22-cross1.16-buster:
     CONFIG: 'cross1.16'
     KUBE_CROSS_VERSION: 'v1.22.0-go1.16.15-buster.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.18.4-${OS_CODENAME} AS builder
+FROM golang:1.18.5-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.18.4
+GO_VERSION ?= 1.18.5
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.18.4'
+    GO_VERSION: '1.18.5'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -13,11 +13,11 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.18.4'
+    GO_VERSION: '1.18.5'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.12'
+    GO_VERSION: '1.17.13'
     OS_CODENAME: 'bullseye'
   '1.22':
     CONFIG: '1.22'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- k8s-cloud-builder/k8s-ci-builder: build using Go 1.18.5
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.13


k/k prs are merged  https://github.com/kubernetes/kubernetes/pull/111639 / https://github.com/kubernetes/kubernetes/pull/111640

#### Which issue(s) this PR fixes:

xref #2625 

#### Does this PR introduce a user-facing change?

```release-note
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.18.5
- k8s-cloud-builder/k8s-ci-builder: build using Go 1.17.13
```

/assign @saschagrunert @xmudrii @Verolop @puerco @dims 
cc @kubernetes/release-engineering 
