### PR TITLE
add k8s-cloud-builder for go1.19

### DIFF
--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,7 @@
 variants:
+  v1.25-cross1.19-bullseye:
+    CONFIG: 'cross1.19'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.19-bullseye.0'
   v1.25-cross1.18-bullseye:
     CONFIG: 'cross1.18'
     KUBE_CROSS_VERSION: 'v1.25.0-go1.18.5-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- k8s-cloud-builder: build using Go 1.19


#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2575

#### Does this PR introduce a user-facing change?

```release-note
- k8s-cloud-builder: build using Go 1.19
```

/assign @saschagrunert @xmudrii @Verolop @puerco @dims 
cc @kubernetes/release-engineering 
