### PR TITLE
chore(krel): update CLI message for GITHUB_TOKEN #2574

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -948,7 +948,7 @@ func (o *releaseNotesOptions) Validate() error {
 	// Check that we have a GitHub token set
 	token, isset := os.LookupEnv(github.TokenEnvKey)
 	if !isset || token == "" {
-		return errors.New("cannot generate release notes if GitHub token is not set")
+		return fmt.Errorf("cannot generate release notes if %s env variable is not set", github.TokenEnvKey)
 	}
 
 	// If a tag is defined, see if it is a valid semver tag

--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -294,7 +294,7 @@ func (o *TestGridOptions) Validate() error {
 	if o.gitHubIssue != -1 {
 		token, isSet := os.LookupEnv(github.TokenEnvKey)
 		if !isSet || token == "" {
-			return errors.New("cannot send the screenshots if GitHub token is not set")
+			return fmt.Errorf("cannot send the screenshots if %s environment variable is not set", github.TokenEnvKey)
 		}
 
 		gh := github.New()

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -32,7 +32,7 @@ import (
 func githubClient(t *testing.T) (kgithub.Client, context.Context) {
 	_, tokenSet := os.LookupEnv(kgithub.TokenEnvKey)
 	if !tokenSet {
-		t.Skipf("%s is not set", kgithub.TokenEnvKey)
+		t.Skipf("%s environment variable is not set", kgithub.TokenEnvKey)
 	}
 
 	c := kgithub.New()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Clearer error message when env variable isn't set

#### Which issue(s) this PR fixes:
Fixes #2574

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes - small change in error message. I'm not sure if this requires release note though.

```release-note
Tools that fail when no GitHub token is set now fail with a message asking the user to set GITHUB_TOKEN as an environment variable.
```

