### PR TITLE
Temporarily make image signature verification soft-fail

### DIFF
--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -90,8 +90,10 @@ func (*defaultImageImpl) SignImage(signer *sign.Signer, reference string) error 
 }
 
 func (*defaultImageImpl) VerifyImage(signer *sign.Signer, reference string) error {
-	_, err := signer.VerifyImage(reference)
-	return err
+	if _, err := signer.VerifyImage(reference); err != nil {
+		logrus.Warnf("signature verification failed on %s: %s", reference, err.Error())
+	}
+	return nil
 }
 
 var tagRegex = regexp.MustCompile(`^.+/(.+):.+$`)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR modifies the image verification code in krel to
make signature verification soft-fail. This change is temporary
and meant to allow v1.25.0-rc.1 to be released.

To be reverted after the release is done.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/sig-release/issues/1992
/cc @Verolop 

#### Special notes for your reviewer:

As mentioned in the PR body, this PR will be reverted once v1.25.0-rc.1 is released

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
