### PR TITLE
Revert "Temporarily make image signature verification soft-fail"

### DIFF
--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -90,10 +90,8 @@ func (*defaultImageImpl) SignImage(signer *sign.Signer, reference string) error 
 }
 
 func (*defaultImageImpl) VerifyImage(signer *sign.Signer, reference string) error {
-	if _, err := signer.VerifyImage(reference); err != nil {
-		logrus.Warnf("signature verification failed on %s: %s", reference, err.Error())
-	}
-	return nil
+	_, err := signer.VerifyImage(reference)
+	return err
 }
 
 var tagRegex = regexp.MustCompile(`^.+/(.+):.+$`)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This reverts commit 035e4c4df528642d9eda0e13389c0a08c223b147.

This PR reverts the signature soft-fail modification done to allow the 1.25.0-rc.1 release to finish.

Merging this will make krel fail on signature verification again.

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/sig-release/issues/1992
Reverts https://github.com/kubernetes/release/pull/2635

#### Special notes for your reviewer:

:point_right:  **Do not merge until 1.25.0-rc.1 is released**
/hold 

/cc @Verolop 


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
