### PR TITLE
debian-base: Build bullseye-v1.4.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -404,7 +404,7 @@ dependencies:
       match: "OS_CODENAME: 'bullseye'"
 
   - name: "k8s.gcr.io/build-image/debian-base"
-    version: bullseye-v1.4.1
+    version: bullseye-v1.4.2
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -453,7 +453,7 @@ dependencies:
 
   # Base images (next candidate)
   - name: "k8s.gcr.io/build-image/debian-base (next candidate)"
-    version: bullseye-v1.4.1
+    version: bullseye-v1.4.2
     refPaths:
     - path: images/build/debian-base/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.4.1
+IMAGE_VERSION ?= bullseye-v1.4.2
 CONFIG ?= bullseye
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -2,7 +2,7 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.4.1'
+    IMAGE_VERSION: 'bullseye-v1.4.2'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'


### PR DESCRIPTION

#### What type of PR is this?

/kind feature
/area dependency release-eng/security

#### What this PR does / why we need it:

Creating a new bullseye-v1.4.2 image. This should patch the following CVEs:

- [CVE-2022-2509](https://nvd.nist.gov/vuln/detail/CVE-2022-2509)
- [CVE-2021-46828](https://nvd.nist.gov/vuln/detail/CVE-2021-46828)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'm just bumping patch version based since this is largely the same, based on discussion the last PR in https://github.com/kubernetes/release/pull/2609.

#### Does this PR introduce a user-facing change?


```release-note
debian-base: Build bullseye-v1.4.2 images
```
