### PR TITLE
debian-base: Update dependents to use bullseye-v1.4.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -412,7 +412,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents"
-    version: bullseye-v1.4.0
+    version: bullseye-v1.4.2
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: DEBIAN_BASE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -424,7 +424,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: bullseye-v1.5.0
+    version: bullseye-v1.5.1
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -444,7 +444,7 @@ dependencies:
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+
 
   - name: "k8s.gcr.io/build-image/setcap"
-    version: bullseye-v1.4.0
+    version: bullseye-v1.4.1
     refPaths:
     - path: images/build/setcap/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -459,7 +459,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-base: dependents (next candidate)"
-    version: bullseye-v1.4.0
+    version: bullseye-v1.4.2
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -467,13 +467,13 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
-    version: bullseye-v1.5.0
+    version: bullseye-v1.5.1
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/setcap (next candidate)"
-    version: bullseye-v1.4.0
+    version: bullseye-v1.4.1
     refPaths:
     - path: images/build/setcap/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.5.0
+IMAGE_VERSION ?= bullseye-v1.5.1
 CONFIG ?= bullseye
-DEBIAN_BASE_VERSION ?= bullseye-v1.4.0
+DEBIAN_BASE_VERSION ?= bullseye-v1.4.2
 GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0
 
 ARCH?=amd64

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,8 +2,8 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.5.0'
-    DEBIAN_BASE_VERSION: 'bullseye-v1.4.0'
+    IMAGE_VERSION: 'bullseye-v1.5.1'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.4.2'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/setcap
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.4.0
+IMAGE_VERSION ?= bullseye-v1.4.1
 CONFIG ?= bullseye
-DEBIAN_BASE_VERSION ?= bullseye-v1.4.0
+DEBIAN_BASE_VERSION ?= bullseye-v1.4.2
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -2,8 +2,8 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.4.0'
-    DEBIAN_BASE_VERSION: 'bullseye-v1.4.0'
+    IMAGE_VERSION: 'bullseye-v1.4.1'
+    DEBIAN_BASE_VERSION: 'bullseye-v1.4.2'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update images that depend on debian-base (debian-iptables, setcap) to pick up CVE fixes. Followup to these:

- Build debian-base: https://github.com/kubernetes/release/pull/2641
- Promote: https://github.com/kubernetes/k8s.io/pull/4124

I just incremented the patch version, since we started doing that with debian-base and this is just a system package upgrade. Also - I realize debian-iptables is no longer used for kube-proxy in favor of distroless-iptables, but I'd like to create a new version to ease the transition for any components that haven't yet migrated. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- debian-base: Update dependents to use bullseye-v1.4.2
  - debian-iptables: Build bullseye-v1.5.1 image
  - setcap: Build bullseye-v1.4.1 image
```
