### PR TITLE
krel: Support Tempral CVE metrics

### DIFF
--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -91,14 +91,25 @@ func (cve *CVE) Validate() error {
 		return errors.New("string CVSS vector missing from CVE data")
 	}
 
-	// Parse the vector string to make sure it is well formed
-	bm, err := cvss.NewBase().Decode(cve.CVSSVector)
-	if err != nil {
-		return fmt.Errorf("parsing CVSS vector string: %w", err)
+	if len(cve.CVSSVector) == 44 {
+		// Parse the vector string to make sure it is well formed
+		bm, err := cvss.NewBase().Decode(cve.CVSSVector)
+		if err != nil {
+			return fmt.Errorf("parsing CVSS vector string: %w", err)
+		}
+		cve.CalcLink = fmt.Sprintf(
+			"https://www.first.org/cvss/calculator/%s#%s", bm.Ver.String(), cve.CVSSVector,
+		)
+	} else {
+		// Parse the vector string to make sure it is well formed
+		bm, err := cvss.NewTemporal().Decode(cve.CVSSVector)
+		if err != nil {
+			return fmt.Errorf("parsing CVSS vector string: %w", err)
+		}
+		cve.CalcLink = fmt.Sprintf(
+			"https://www.first.org/cvss/calculator/%s#%s", bm.Ver.String(), cve.CVSSVector,
+		)
 	}
-	cve.CalcLink = fmt.Sprintf(
-		"https://www.first.org/cvss/calculator/%s#%s", bm.Ver.String(), cve.CVSSVector,
-	)
 
 	if cve.CVSSScore == 0 {
 		return errors.New("missing CVSS score from CVE data")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR modifies our cve package to support temporal CVE scores in our YAML release notes file.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

@kubernetes/release-engineering 
/cc @PushkarJ 

#### Does this PR introduce a user-facing change?
```release-note
`krel cve` now supports ingesting CVE information data with a temporal vector metric.
```
