### PR TITLE
update ci-signal tool reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -34,7 +34,6 @@ aliases:
     - mehabhalodiya # 1.26 CI Signal Shadow
     - Namanl2001 # 1.26 CI Signal Shadow
     - bharitwal # 1.26 CI Signal Shadow
-  reviewers:
     - Debanitrkl
     - RinkiyaKeDad
     - RobertKielty

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -34,6 +34,11 @@ aliases:
     - mehabhalodiya # 1.26 CI Signal Shadow
     - Namanl2001 # 1.26 CI Signal Shadow
     - bharitwal # 1.26 CI Signal Shadow
+  reviewers:
+    - Debanitrkl
+    - RinkiyaKeDad
+    - RobertKielty
+    - leonardpahlke
   krel-approvers:
     - cpanato
     - puerco

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -34,10 +34,7 @@ aliases:
     - mehabhalodiya # 1.26 CI Signal Shadow
     - Namanl2001 # 1.26 CI Signal Shadow
     - bharitwal # 1.26 CI Signal Shadow
-    - Debanitrkl
-    - RinkiyaKeDad
-    - RobertKielty
-    - leonardpahlke
+    - leonardpahlke # 1.26 Release Lead
   krel-approvers:
     - cpanato
     - puerco

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,11 +29,11 @@ aliases:
     - MushuEE
     - spiffxp
   ci-signal-reporter-reviewers:
-    - leonardpahlke # 1.24 CI Signal Lead
-    - voigt # 1.24 CI Signal Shadow
-    - lauralorenz # 1.24 CI Signal Shadow
-    - shuheiktgw # 1.24 CI Signal Shadow
-    - nivedita-coder # 1.24 CI Signal Shadow
+    - Nivedita-coder # 1.26 CI Signal Lead
+    - shuheiktgw # 1.26 CI Signal Shadow
+    - mehabhalodiya # 1.26 CI Signal Shadow
+    - Namanl2001 # 1.26 CI Signal Shadow
+    - bharitwal # 1.26 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
update ci signal team (reviewers for the ci signal tool) [(1.26 ci signal team)](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
cc @leonardpahlke 
add @shuheiktgw @mehabhalodiya @Namanl2001 @bharitwal as ci signal tool reviewers.