### PR TITLE
distroless-iptables: bump gorunner image version to v2.3.1-go1.19.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -438,7 +438,7 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/distroless-iptables"
-    version: v0.1.1
+    version: v0.1.2
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.1.1
+IMAGE_VERSION ?= v0.1.2
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bullseye-slim
-GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.19.1-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.1.1'
-    GORUNNER_VERSION: 'v2.3.1-go1.17.3-bullseye.0'
+    IMAGE_VERSION: 'v0.1.2'
+    GORUNNER_VERSION: 'v2.3.1-go1.19.1-bullseye.0'


### PR DESCRIPTION
build-image/go-runner:v2.3.1-go1.19.1-bullseye.0

This picks up CVE fixes in Go stdlib. The rebuild would also bring in the fix for CVE-2021-3999.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It picks up CVE fixes in Go stdlib and fixes vulnerabilities in /go-runner. It also picks up CVE fixes in glibc because of an updated debian:bullseye-slim.

#### Which issue(s) this PR fixes:

CVE-2022-23806 | Critical | 6.4 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-28131 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30631 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-32189 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-24675 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-24921 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2021-44716 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-23773 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-23772 | High | 7.8 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30633 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-28327 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30635 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30630 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30632 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-27664 | High | 0 | – | go | Go stdlib | VIEW |  
CVE-2022-30580 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-1962 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-32148 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-1705 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2021-3999 | Unspecified | 0 | Yes | glibc | OS | VIEW FIX |  

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
