### PR TITLE
debian-iptables: bump gorunner image version to v2.3.1-go1.19.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -430,7 +430,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables"
-    version: bullseye-v1.5.1
+    version: bullseye-v1.5.2
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -473,7 +473,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/debian-iptables (next candidate)"
-    version: bullseye-v1.5.1
+    version: bullseye-v1.5.2
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.5.1
+IMAGE_VERSION ?= bullseye-v1.5.2
 CONFIG ?= bullseye
 DEBIAN_BASE_VERSION ?= bullseye-v1.4.2
-GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.19.1-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,10 +2,10 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.5.1'
+    IMAGE_VERSION: 'bullseye-v1.5.2'
     DEBIAN_BASE_VERSION: 'bullseye-v1.4.2'
   # Debian 10 - Kubernetes 1.22 and older
   buster:
     CONFIG: 'buster'
-    IMAGE_VERSION: 'buster-v1.8.0'
+    IMAGE_VERSION: 'buster-v1.8.1'
     DEBIAN_BASE_VERSION: 'buster-v1.10.0'


### PR DESCRIPTION
build-image/go-runner:v2.3.1-go1.19.1-bullseye.0

This picks up CVE fixes in Go stdlib.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It picks up CVE fixes in Go stdlib and fixes vulnerabilities in /go-runner.

#### Which issue(s) this PR fixes:

CVE-2022-23806 | Critical | 6.4 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-28131 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30631 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-32189 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-24675 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-24921 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2021-44716 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-23773 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-23772 | High | 7.8 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30633 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-28327 | High | 5 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30635 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30630 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-30632 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-27664 | High | 0 | – | go | Go stdlib | VIEW |  
CVE-2022-30580 | High | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-1962 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-32148 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  
CVE-2022-1705 | Medium | 0 | Yes | go | Go stdlib | VIEW FIX |  

Maybe plus more from OS packages?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```