### PR TITLE
Use latest CNI version for deb packages

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,8 +27,6 @@ dependencies:
   - name: "CNI plugins: minimum version"
     version: 0.8.6
     refPaths:
-    - path: packages/deb/build.go
-      match: minimumCNIVersion\s+= "\d+\.\d+.\d+"
     - path: packages/rpm/kubelet.spec
       match: kubernetes-cni >= \d+\.\d+.\d+
     - path: pkg/kubepkg/kubepkg.go

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -42,7 +42,6 @@ const (
 	ChannelNightly  ChannelType = "nightly"
 
 	currentCNIVersion  = "1.1.1"
-	minimumCNIVersion  = "0.8.6"
 	criToolsVersion    = "1.25.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"
@@ -306,7 +305,7 @@ func getReleaseDownloadLinkBase(v version) (string, error) {
 }
 
 func getKubeadmDependencies(v version) (string, error) {
-	cniVersion, err := getCNIVersion(v)
+	cniVersion, err := getCNIVersion()
 	if err != nil {
 		return "", err
 	}
@@ -365,16 +364,7 @@ func getKubeadmKubeletConfigFile(v version) (string, error) {
 	return latestkubeadmconf, nil
 }
 
-func getCNIVersion(v version) (string, error) {
-	sv, err := semver.Make(v.Version)
-	if err != nil {
-		return "", err
-	}
-
-	if int(sv.Minor) <= 16 {
-		return minimumCNIVersion, nil
-	}
-
+func getCNIVersion() (string, error) {
 	return currentCNIVersion, nil
 }
 
@@ -457,19 +447,19 @@ func main() {
 			Distros: distros,
 			Versions: []version{
 				{
-					Version:  currentCNIVersion,
-					Revision: revision,
-					Channel:  ChannelStable,
+					GetVersion: getCNIVersion,
+					Revision:   revision,
+					Channel:    ChannelStable,
 				},
 				{
-					Version:  currentCNIVersion,
-					Revision: revision,
-					Channel:  ChannelUnstable,
+					GetVersion: getCNIVersion,
+					Revision:   revision,
+					Channel:    ChannelUnstable,
 				},
 				{
-					Version:  currentCNIVersion,
-					Revision: revision,
-					Channel:  ChannelNightly,
+					GetVersion: getCNIVersion,
+					Revision:   revision,
+					Channel:    ChannelNightly,
 				},
 			},
 		},
@@ -612,7 +602,7 @@ func main() {
 			log.Fatalf("error getting kubeadm dependencies: %v", err)
 		}
 
-		c.CNIVersion, err = getCNIVersion(v)
+		c.CNIVersion, err = getCNIVersion()
 		if err != nil {
 			log.Fatalf("error getting kubelet CNI Version: %v", err)
 		}


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We do not require the minimum CNI version any more and just use the latest for debian based packages.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/821#issuecomment-1250371849

#### Special notes for your reviewer:
None 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use the latest CNI plugins version for for deb packages.
```
