### PR TITLE
update GORUNNER_VERSION base image for debian-iptables

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -442,7 +442,7 @@ dependencies:
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.17.3-bullseye.0
+    version: v2.3.1-go1.19.1-bullseye.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -21,7 +21,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= bullseye-v1.5.1
 CONFIG ?= bullseye
 DEBIAN_BASE_VERSION ?= bullseye-v1.4.2
-GORUNNER_VERSION ?= v2.3.1-go1.17.3-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.19.1-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

update GORUNNER_VERSION base image for debian-iptables


/assign @saschagrunert @puerco @xmudrii @Verolop @palnabarun 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/2507



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update GORUNNER_VERSION base image for debian-iptables
```
