### PR TITLE
Ensure release-notes tool doesn't skip automated cherry picks

### DIFF
--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -335,26 +335,23 @@ func TestGatherNotes(t *testing.T) {
 			listPullRequestsWithCommitStubber: func(t *testing.T) listPullRequestsWithCommitStub {
 				prsPerCall := [][]*github.PullRequest{
 					// explicitly excluded
-					{pullRequest(1, "something ```release-note N/a``` something")},
-					{pullRequest(2, "something ```release-note Na``` something")},
-					{pullRequest(3, "something ```release-note None ``` something")},
-					{pullRequest(4, "something ```release-note 'None' ``` something")},
+					{pullRequest(1, "something ```release-note\nN/a\n``` something")},
+					{pullRequest(2, "something ```release-note\nNa\n``` something")},
+					{pullRequest(3, "something ```release-note\nNone \n``` something")},
+					{pullRequest(4, "something ```release-note\n'None' \n``` something")},
 					{pullRequest(5, "something /release-note-none something")},
-					// explicitly included
-					{pullRequest(6, "something release-note something")},
-					{pullRequest(7, "something Does this PR introduce a user-facing change something")},
 					// multiple PRs
 					{ // first does no match, second one matches, rest is ignored
-						pullRequest(8, ""),
-						pullRequest(9, " Does this PR introduce a user-facing change"),
-						pullRequest(10, "does-not-matter--is-not-considered"),
+						pullRequest(6, ""),
+						pullRequest(7, " something ```release-note\nTest\n``` something"),
+						pullRequest(8, "does-not-matter--is-not-considered"),
 					},
 					// some other strange things
-					{pullRequest(11, "Does this PR introduce a user-facing chang")}, // matches despite the missing 'e'
-					{pullRequest(12, "release-note /release-note-none")},            // excluded, the exclusion filters take precedence
-					{pullRequest(13, "```release-note NAAAAAAAAAA```")},             // included, does not match the N/A filter, but the 'release-note' check
-					{pullRequest(14, "```release-note none something ```")},         // included, does not match the N/A filter, but the 'release-note' check
-					{pullRequest(15, "release-noteNOOOO")},                          // included
+					{pullRequest(9, "release-note /release-note-none")},       // excluded, the exclusion filters take precedence
+					{pullRequest(10, "```release-note\nNAAAAAAAAAA\n```")},    // included, does not match the N/A filter, but the 'release-note' check
+					{pullRequest(11, "```release-note\nnone something\n```")}, // included, does not match the N/A filter, but the 'release-note' check
+					// empty release note block shouldn't be matched
+					{pullRequest(12, "```release-note\n\n```")},
 				}
 				var callCount int64 = -1
 
@@ -370,7 +367,7 @@ func TestGatherNotes(t *testing.T) {
 			resultsChecker: func(t *testing.T, results []*Result) {
 				// there is not much we can check on the Result, as all the fields are
 				// unexported
-				expectedResultSize := 13
+				expectedResultSize := 9
 				if e, a := expectedResultSize, len(results); e != a {
 					t.Errorf("Expected the result to be of size %d, got %d", e, a)
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

##### Motivation

We've recently discovered a bug in the release-notes tool causing automated cherry picks to be skipped. This is because those PRs have an empty release note block, which is handled like the release note is present. This is not correct behavior, instead, those PRs should be skipped. Instead of those PRs, the release-notes tool should take the parent PR and its release note.

##### Problem explained

Before I start with the problem explanation, the following diagram shows our workflow:

```mermaid
flowchart TD
    A[release-notes] --> B[GatherReleaseNotes]
    B --> C[ListReleaseNotes]
    C --> D[gatherNotes]
    D --> E[notesForCommit]
    E --> F[prsFromCommit]
    F --> G[prsForCommitFromMessage]
    G --> H[prsNumForCommitFromMessage]

    H --> |slice of PR numbers| G
    G --> |slice of PRs| F
    F --> |slice of PRs| E
    E --> |SINGLE PR selected based  on heuristics| D
    D --> |slice of release notes for all PRs| C
    C --> |complete release notes for all PRs| B
```

The release-notes tool calls a bunch of functions to determine a release note for PRs. We first take a list of commits for which we need to determine PRs. Those list of commits is passed to `gatherNotes` which takes each commit and passes it to `notesForCommit`. After calling a few more functions (as shown in the diagram), we end up with a list of candidate PRs for that commit (`prsNumForCommitFromMessage` function). Those candidate PRs are the original PR, parent PR if it's a cherry-pick, and we have special handling for squashed commits.

**Those candidate PRs are passed back to `notesForCommit` where we select a single PR out of those candidate PRs.**

This is where the problem appears. This function takes the PR body and checks if it contains the release-note block OR the `Does this PR introduce a user-facing change?` text. However, we do **NOT** check if it's a valid release note. We pass that single PR to `gatherNotes` where we check if it's actually a valid release note. However, we pass only that one single PR, we don't pass other candidate PRs. If it turns out to be an invalid release note, we can't check other PRs because we discarded them.

That's not a problem for PRs targeting the master/main branch. However, that is a problem for cherry picks where we have an empty release note block and where we excpect to inherit release note from the parent PR. **In this case, `notesForCommit` will think that the cherry pick has a valid release note (even if it's empty) and will discard the parent PR. This causes release notes to lose release note for that change/PR.**

##### Fix explained

This PR introduces two major changes:

- `notesForCommit` checks if the release note is valid instead of just checking for the presence of the release-note block or `Does this PR introduce a user-facing change?` text
  - If the PR is supposed to be excluded (NONE/release-note-none), we return that PR because it might have a map with a release note. If it doesn't, it will be skipped and that's okay because it has NONE/release-note-none.
- `noteExclusionFilters` is updated so that the release note MUST contain NONE/NO/NA. Currently, it excludes PRs with empty release notes, but this seems wrong because a PR without a release note should be considered as invalid

#### Which issue(s) this PR fixes:

xref #2679
ListReleaseNotesV2 is affected as well, but not fixed by this PR. It'll be done in a follow up PR.

#### Special notes for your reviewer:

Release note for this PR might include more details, I can update it if needed.

#### Does this PR introduce a user-facing change?

```release-note
Ensure release-notes tool doesn't skip automated cherry picks
```

/assign @puerco @jeremyrickard @cpanato @Verolop @palnabarun 
cc @kubernetes/release-engineering 