### PR TITLE
Build Go 1.19.2 and 1.18.7 based images

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.1-bullseye AS builder
+FROM golang:1.19.2-bullseye AS builder
 
 ENV GO111MODULE=on
 

--- a/Dockerfile-kubepkg-rpm
+++ b/Dockerfile-kubepkg-rpm
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.1-bullseye AS builder
+FROM golang:1.19.2-bullseye AS builder
 
 ENV GO111MODULE=on
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.19.1
+    version: 1.19.2
     refPaths:
     - path: Dockerfile-kubepkg
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
@@ -165,7 +165,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross"
-    version: v1.25.0-go1.19.1-bullseye.0
+    version: v1.25.0-go1.19.2-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -211,7 +211,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (next candidate)"
-    version: v2.3.1-go1.19.1-bullseye.0
+    version: v2.3.1-go1.19.2-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -223,7 +223,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.25.0-go1.19.1-bullseye.0
+    version: v1.25.0-go1.19.2-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -242,7 +242,7 @@ dependencies:
 
   # Golang (previous release branches: 1.24)
   - name: "golang (previous release branches: 1.24)"
-    version: 1.18.6
+    version: 1.18.7
     refPaths:
     - path: images/build/cross/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -299,7 +299,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.24)"
-    version: v2.3.1-go1.18.6-bullseye.0
+    version: v2.3.1-go1.18.7-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -323,7 +323,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.24)"
-    version: v1.24.0-go1.18.6-bullseye.0
+    version: v1.24.0-go1.18.7-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -28,7 +28,7 @@ IMGNAME = kube-cross
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
 KUBERNETES_VERSION ?= v1.25.0
-GO_VERSION ?= 1.19.1
+GO_VERSION ?= 1.19.2
 GO_MAJOR_VERSION ?= 1.19
 OS_CODENAME ?= bullseye
 REVISION ?= 0

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,9 +2,9 @@ variants:
   v1.25-go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.25.0-go1.19.1-bullseye.0'
+    IMAGE_VERSION: 'v1.25.0-go1.19.2-bullseye.0'
     KUBERNETES_VERSION: 'v1.25.0'
-    GO_VERSION: '1.19.1'
+    GO_VERSION: '1.19.2'
     GO_MAJOR_VERSION: '1.19'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
@@ -12,9 +12,9 @@ variants:
   v1.24-go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.24.0-go1.18.6-bullseye.0'
+    IMAGE_VERSION: 'v1.24.0-go1.18.7-bullseye.0'
     KUBERNETES_VERSION: 'v1.24.0'
-    GO_VERSION: '1.18.6'
+    GO_VERSION: '1.18.7'
     GO_MAJOR_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
     REVISION: '0'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -21,7 +21,7 @@ GO_MAJOR_VERSION ?= 1.19
 REVISION ?= 0
 
 # Build args
-GO_VERSION ?= 1.19.1
+GO_VERSION ?= 1.19.2
 OS_CODENAME ?= bullseye
 DISTROLESS_IMAGE ?= static-debian11
 

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,19 +1,19 @@
 variants:
   go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
-    IMAGE_VERSION: 'v2.3.1-go1.19.1-bullseye.0'
+    IMAGE_VERSION: 'v2.3.1-go1.19.2-bullseye.0'
     GO_MAJOR_VERSION: '1.19'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    GO_VERSION: '1.19.1'
+    GO_VERSION: '1.19.2'
     DISTROLESS_IMAGE: 'static-debian11'
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
-    IMAGE_VERSION: 'v2.3.1-go1.18.6-bullseye.0'
+    IMAGE_VERSION: 'v2.3.1-go1.18.7-bullseye.0'
     GO_MAJOR_VERSION: '1.18'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    GO_VERSION: '1.18.6'
+    GO_VERSION: '1.18.7'
     DISTROLESS_IMAGE: 'static-debian11'
   go1.17-bullseye:
     CONFIG: 'go1.17-bullseye'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
-    GO_VERSION: '1.19.1'
+    GO_VERSION: '1.19.2'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   go1.18-bullseye:
     CONFIG: 'go1.18-bullseye'
-    GO_VERSION: '1.18.6'
+    GO_VERSION: '1.18.7'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   go1.17-bullseye:

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.1-bullseye
+FROM golang:1.19.2-bullseye
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

Build Go 1.19.2 and 1.18.7 based images

#### Which issue(s) this PR fixes:

Part of #2694 

#### Does this PR introduce a user-facing change?

```release-note
Build Go 1.19.2 and 1.18.7 based images
```

cc @kubernetes/release-engineering 