### PR TITLE
Adding parameterization to go-runner Dockerfile

### DIFF
--- a/images/build/go-runner/Dockerfile
+++ b/images/build/go-runner/Dockerfile
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GO_VERSION
-ARG OS_CODENAME
-# TODO(codename): Consider parameterizing in Makefile based on codename
 ARG DISTROLESS_IMAGE
-FROM golang:${GO_VERSION}-${OS_CODENAME} as builder
+ARG BUILDER_IMAGE
+FROM ${BUILDER_IMAGE} as builder
 WORKDIR /workspace
 
 # Copy the sources
@@ -52,7 +50,7 @@ RUN go build -ldflags '-s -w -buildid= -extldflags "-static"' \
     -o go-runner ${package}
 
 # Production image
-FROM gcr.io/distroless/${DISTROLESS_IMAGE}
+FROM ${DISTROLESS_IMAGE}
 LABEL maintainers="Kubernetes Authors"
 LABEL description="go based runner for distroless scenarios"
 WORKDIR /

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -19,11 +19,13 @@ IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)
 GO_MAJOR_VERSION ?= 1.19
 REVISION ?= 0
-
-# Build args
 GO_VERSION ?= 1.19.3
 OS_CODENAME ?= bullseye
+
+# Build args
+DISTROLESS_REGISTRY ?= gcr.io/distroless
 DISTROLESS_IMAGE ?= static-debian11
+BUILDER_IMAGE ?= golang:$(GO_VERSION)-$(OS_CODENAME)
 
 # Configuration
 CONFIG = go$(GO_MAJOR_VERSION)-$(OS_CODENAME)
@@ -50,6 +52,5 @@ build:
 clean:
 	rm go-runner
 
-BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
-             --build-arg=OS_CODENAME=$(OS_CODENAME) \
-             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_IMAGE)
+BUILD_ARGS = --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) \
+             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_REGISTRY)/$(DISTROLESS_IMAGE)


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jrickard@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR updates the go-runner Dockerfile to support better overriding of the builder and base images used.  BUILDER_IMAGE becomes an ARG and a new Makefile variable DISTROLESS_REGISRTRY is added to allow the  DISTROLESS_IMAGE build arg to receive the registry/repo as well. This is defaulted to `gcr.io/distroless` to not impact the existing configurations. The DISTROLESS_IMAGE build arg is populated with a combination of the DISTROLESS_REGISTRY and DISTROLESS_IMAGE Makefile variables:

```
BUILD_ARGS = --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) \
             --build-arg=DISTROLESS_IMAGE=$(DISTROLESS_REGISTRY)/$(DISTROLESS_IMAGE)
```

This allows you to completely override the build-arg but is backward compatible w/ the existing variants.yml and the cloudbuild.yaml

GO_VERSION and OS_CODENAME are no longer needed within the Dockerfile and are expressed entirely within the Makefile. 
 
#### Which issue(s) this PR fixes:

Fixes #2702 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 BUILDER_IMAGE can now be overridden when building the go-runner image. Additionally a new variable DISTROLESS_REGISTRY can be used to specify a different registry and repository, to more completely override the DISTROLESS_IMAGE build arg to support custom images. 
```
