### PR TITLE
Ensure it's possible to build rpms generated by kubepkg

### DIFF
--- a/cmd/kubepkg/templates/latest/rpm/cri-tools/cri-tools.spec
+++ b/cmd/kubepkg/templates/latest/rpm/cri-tools/cri-tools.spec
@@ -14,23 +14,12 @@ BuildRequires: curl
 Command-line utility for interacting with a container runtime.
 
 %prep
-%setup -c -a 7 -T -n cri-tools
-
-# TODO: Do we need these?
-#%autosetup
-#%build
-#%configure
-#%make_build
+%setup -c -a 0 -T -n cri-tools
 
 %install
-# TODO: Do we need this?
-#rm -rf $RPM_BUILD_ROOT
-
 cd %{_builddir}
+mkdir -p %{buildroot}%{_bindir}
 install -p -m 755 -t %{buildroot}%{_bindir}/ cri-tools/crictl
-
-# TODO: Do we need this?
-#%make_install
 
 %files
 %{_bindir}/crictl

--- a/cmd/kubepkg/templates/latest/rpm/kubeadm/kubeadm.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubeadm/kubeadm.spec
@@ -23,23 +23,15 @@ Command-line utility for administering a Kubernetes cluster.
 cp -p %SOURCE0 %{_builddir}/
 cp -p %SOURCE1 %{_builddir}/
 
-# TODO: Do we need these?
-#%autosetup
-#%build
-#%configure
-#%make_build
-
 %install
-# TODO: Do we need this?
-#rm -rf $RPM_BUILD_ROOT
-
 cd %{_builddir}
+mkdir -p %{buildroot}%{_sysconfdir}/kubernetes/manifests/
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_unitdir}/kubelet.service.d
+
 install -m 755 -d %{buildroot}%{_sysconfdir}/kubernetes/manifests/
 install -p -m 755 -t %{buildroot}%{_bindir}/ kubeadm
 install -p -m 644 -t %{buildroot}%{_unitdir}/kubelet.service.d/ 10-kubeadm.conf
-
-# TODO: Do we need this?
-#%make_install
 
 %files
 %{_bindir}/kubeadm

--- a/cmd/kubepkg/templates/latest/rpm/kubectl/kubectl.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubectl/kubectl.spec
@@ -16,21 +16,11 @@ Command-line utility for interacting with a Kubernetes cluster.
 %prep
 cp -p %SOURCE0 %{_builddir}/
 
-# TODO: Do we need these?
-#%autosetup
-#%build
-#%configure
-#%make_build
-
 %install
-# TODO: Do we need this?
-#rm -rf $RPM_BUILD_ROOT
 
 cd %{_builddir}
+mkdir -p %{buildroot}/%{_bindir}
 install -p -m 755 -t %{buildroot}%{_bindir}/ kubectl
-
-# TODO: Do we need this?
-#%make_install
 
 %files
 %{_bindir}/kubectl

--- a/cmd/kubepkg/templates/latest/rpm/kubelet/kubelet.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubelet/kubelet.spec
@@ -6,6 +6,8 @@ Summary: Container cluster management
 License: ASL 2.0
 URL: https://kubernetes.io
 Source0: {{ .DownloadLinkBase }}/bin/linux/{{ .GoArch }}/kubelet
+Source1: kubelet.env
+Source2: kubelet.service
 
 BuildRequires: systemd
 BuildRequires: curl
@@ -23,18 +25,16 @@ The node agent of Kubernetes, the container cluster manager.
 
 %prep
 cp -p %SOURCE0 %{_builddir}/
-
-# TODO: Do we need these?
-#%autosetup
-#%build
-#%configure
-#%make_build
+cp -p %SOURCE1 %{_builddir}/
+cp -p %SOURCE2 %{_builddir}/
 
 %install
-# TODO: Do we need this?
-#rm -rf $RPM_BUILD_ROOT
-
 cd %{_builddir}
+mkdir -p %{buildroot}%{_unitdir}/kubelet.service.d/
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}/var/lib/kubelet/
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig/
+
 install -m 755 -d %{buildroot}%{_unitdir}
 install -m 755 -d %{buildroot}%{_unitdir}/kubelet.service.d/
 install -m 755 -d %{buildroot}%{_bindir}
@@ -43,9 +43,6 @@ install -p -m 755 -t %{buildroot}%{_bindir}/ kubelet
 install -p -m 644 -t %{buildroot}%{_unitdir}/ kubelet.service
 install -m 755 -d %{buildroot}%{_sysconfdir}/sysconfig/
 install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
-
-# TODO: Do we need this?
-#%make_install
 
 %files
 %{_bindir}/kubelet

--- a/cmd/kubepkg/templates/latest/rpm/kubernetes-cni/kubernetes-cni.spec
+++ b/cmd/kubepkg/templates/latest/rpm/kubernetes-cni/kubernetes-cni.spec
@@ -15,25 +15,15 @@ Requires: kubelet
 Binaries required to provision container networking.
 
 %prep
-%setup -c -D -T -a 5 -n cni-plugins
-
-# TODO: Do we need these?
-#%autosetup
-#%build
-#%configure
-#%make_build
+%setup -c -D -T -a 0 -n cni-plugins
 
 %install
-# TODO: Do we need this?
-#rm -rf $RPM_BUILD_ROOT
-
 cd %{_builddir}
+mkdir -p %{buildroot}%{_sysconfdir}/cni/net.d/
+mkdir -p %{buildroot}/opt/cni/bin
 install -m 755 -d %{buildroot}%{_sysconfdir}/cni/net.d/
 install -m 755 -d %{buildroot}/opt/cni/bin
 mv cni-plugins/* %{buildroot}/opt/cni/bin/
-
-# TODO: Do we need this?
-#%make_install
 
 %files
 /opt/cni


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR modifies templates for generating rpms to ensure it's possible to build those rpms using `rpmbuild`. Currently, it's not possible to build rpms generated by kubepkg because of various errors. One of those errors is described in #2703 

#### Which issue(s) this PR fixes:

Fixes #2703

#### Does this PR introduce a user-facing change?

```release-note
Ensure it's possible to build rpms generated by kubepkg
```

cc @kubernetes/release-engineering 