### PR TITLE
get the correct path to upload to github release page

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -206,6 +206,7 @@ func getAssetsFromStrings(assetStrings []string) ([]announce.Asset, error) {
 			Label:    l,
 		})
 	}
+
 	return r, nil
 }
 
@@ -288,9 +289,17 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 		}
 	}
 
+	newAssets := make([]string, len(assets)+1)
+	for i, a := range assets {
+		newAssets[i] = a.ReadFrom
+	}
+
+	// add sbom to the path to upload
+	newAssets[len(assets)] = sbom
+
 	// Build the release page options
 	announceOpts := announce.GitHubPageOptions{
-		AssetFiles:            opts.assets,
+		AssetFiles:            newAssets,
 		Tag:                   commandLineOpts.tag,
 		NoMock:                commandLineOpts.nomock,
 		UpdateIfReleaseExists: !opts.noupdate,


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

- get the correct path to upload to github release page

#### Which issue(s) this PR fixes:


None

/assign @puerco @saschagrunert @jeremyrickard 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
get the correct path to upload to github release page
```
