### PR TITLE
restrict permissions on /etc/passwd-

### DIFF
--- a/images/build/debian-base/bullseye/Dockerfile.build
+++ b/images/build/debian-base/bullseye/Dockerfile.build
@@ -95,3 +95,5 @@ RUN apt-get autoremove -y && \
         /usr/share/man/man3 /usr/share/man/man4 \
         /usr/share/man/man5 /usr/share/man/man6 \
         /usr/share/man/man7 /usr/share/man/man8
+
+RUN chmod u-x,go-rwx /etc/passwd-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Restrict permissions on /etc/passwd- in base images since there was a violation coming in from the CIS Debian 10 Benchmark 1.0.0.

#### Which issue(s) this PR fixes:
Fixes #2719

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
