### PR TITLE
Fix unbound variable if no version is specified in `hack/rapture/build-packages.sh`

### DIFF
--- a/hack/rapture/build-packages.sh
+++ b/hack/rapture/build-packages.sh
@@ -36,10 +36,11 @@ fatal() {
   exit 1
 }
 
+version=${1:-""}
 
-[[ -n "$1" ]] || fatal "no version specified"
-version="$1"
-
+if [[ "$version" == "" ]]; then
+  fatal "no version specified"
+fi
 
 build_debs() {
   local distro=xenial
@@ -53,7 +54,7 @@ build_debs() {
   sed -i -r -e 's/\b(Revision:\s*)"[0-9]{2}"/\1"00"/' build.go
 
   log "Building debs for Kubernetes v${version}"
-  ./jenkins.sh --kube-version $version --distros $distro
+  ./jenkins.sh --kube-version "$version" --distros $distro
 
   log "Changing file owner from root to ${USER}"
   sudo chown -R "${USER}" bin


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:


This fixes the unbound variable `$1` error if no version is specified and displays the correct message.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed unbound variable if no version is specified in `hack/rapture/build-packages.sh`
```
