### PR TITLE
Remove darwin/386 from cross Dockerfile

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -36,7 +36,7 @@ ENV KUBE_CROSSPLATFORMS \
   linux/arm linux/arm64 \
   linux/ppc64le \
   linux/s390x \
-  darwin/amd64 darwin/386 \
+  darwin/amd64 \
   windows/amd64 windows/386
 
 ##------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jrickard@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`darwin/386` was removed in Go 1.15. This removes it from the cross Dockerfile, since it's not a valid platform/arch combo anymore.

#### Which issue(s) this PR fixes:

Fixes #2759 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removes darwin/386 from KUBE_CROSSPLATFORMS which is used to prebuild the standard library with target arch is amd64
```
