### PR TITLE
Update link for 'Published by your Release Managers'

### DIFF
--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -52,7 +52,7 @@ const releaseAnnouncementMsg = `Kubernetes Community,
 <p><hr>{{ .ChangelogHTML }}<hr></p>
 
 <p><br>Contributors, the <a href=https://git.k8s.io/kubernetes/{{ .ChangelogFilePath }}/#{{ .StrippedTag }} target="_blank">{{ .ChangelogFileName }}</a> has been bootstrapped with {{ .Tag }} release notes and you may edit now as needed.</p>
-<p><br><br>Published by your <a href=https://git.k8s.io/sig-release/release-managers.md href target="_blank">Kubernetes Release Managers</a>.</p>
+<p><br><br>Published by your <a href=https://kubernetes.io/releases/release-managers/ href target="_blank">Kubernetes Release Managers</a>.</p>
 `
 
 // buildAnnounceCmd represents the subcommand for `krel announce build`

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -65,7 +65,7 @@ Contributors, the
 %s release notes and you may edit now as needed.
 <p><br><br>
 Published by your
-<a href=https://git.k8s.io/sig-release/release-managers.md>Kubernetes Release
+<a href=https://kubernetes.io/releases/release-managers/>Kubernetes Release
 Managers</a>.
 `
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We have the following message at the end of each release announcement:

> Published by your Kubernetes Release Managers.

with a link to the Release Managers page. However, that link is pointing to the old page that doesn't exist any longer. This PR updates the link to the new one (on the Kubernetes website).

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @cpanato @saschagrunert @Verolop @puerco 
cc @kubernetes/release-engineering 