### PR TITLE
Stop building rc.0 versions after official patches

### DIFF
--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -192,12 +191,6 @@ func GenerateReleaseVersion(
 
 		if releaseType == ReleaseTypeOfficial {
 			releaseVersions.official = releaseVersions.prime
-			// Only primary branches get rc releases
-			if regexp.MustCompile(`^release-(\d+)\.(\d+)$`).MatchString(branch) {
-				releaseVersions.rc = fmt.Sprintf(
-					"v%d.%d.%d-rc.0", v.Major, v.Minor, v.Patch+1,
-				)
-			}
 		} else if releaseType == ReleaseTypeRC {
 			releaseVersions.rc = fmt.Sprintf(
 				"%s-rc.%d", releaseVersions.prime, labelID,

--- a/pkg/release/release_version_test.go
+++ b/pkg/release/release_version_test.go
@@ -43,11 +43,11 @@ func TestGenerateReleaseVersion(t *testing.T) {
 				require.Nil(t, err)
 				require.Equal(t, "v1.18.4", res.Prime())
 				require.Equal(t, "v1.18.4", res.Official())
-				require.Equal(t, "v1.18.5-rc.0", res.RC())
+				require.Empty(t, res.RC())
 				require.Empty(t, res.Beta())
 				require.Empty(t, res.Alpha())
 				require.Equal(t,
-					[]string{"v1.18.4", "v1.18.5-rc.0"},
+					[]string{"v1.18.4"},
 					res.Ordered(),
 				)
 			},


### PR DESCRIPTION

#### What type of PR is this?


/kind deprecation

#### What this PR does / why we need it:
We now do not build release candidates after official patches any more.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

##### Testing

```shell
export TOOL_ORG=saschagrunert TOOL_REF=official-patches-no-rc && \
go run ./cmd/krel stage --type=official --branch=release-1.25
```
:heavy_check_mark: https://console.cloud.google.com/cloud-build/builds/a08abe6e-0508-4f72-aa98-41e0770124df?project=kubernetes-release-test

```shell
export TOOL_ORG=saschagrunert TOOL_REF=official-patches-no-rc && \
go run ./cmd/krel release --type=official --branch=release-1.25 --build-version=v1.25.5-rc.0.1+21e06572c3bcd7
```
:heavy_check_mark:  https://console.cloud.google.com/cloud-build/builds;region=global/24495dd9-26f5-4ff4-af28-05bef74c350c?project=kubernetes-release-test
 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed patch release process to stop building rc.0 versions together with the official.
```
