### PR TITLE
Record GitHub API without concurrency

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -681,7 +681,7 @@ func (g *Gatherer) gatherNotes(commits []*gogithub.RepositoryCommit) (filtered [
 			commit.GetSHA(),
 		)
 
-		if g.options.ReplayDir == "" {
+		if g.options.ReplayDir == "" && g.options.RecordDir == "" {
 			go notesForCommit(commit)
 		} else {
 			// Ensure the same order like recorded


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This will lead into wrong results when using replay. Right now most of our tests are compromised by that bug, so I'll follow-up an regenerate the data afterwards.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to not record the GitHub API in parallel.
```
