### PR TITLE
OWNERS: Cleanup of leaf OWNERS and reconcile RMAs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,10 +20,8 @@ aliases:
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - jimangel # Release Manager Associate
-    - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
     - sethmccombs # Release Manager Associate
-    - thejoycekung # Release Manager Associate
     - wilsonehusin # Release Manager Associate
   build-admins:
     - BenjaminKazemi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,8 +19,11 @@ aliases:
     - Verolop # subproject owner / Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
+    - cici37 # Release Manager Associate
     - jimangel # Release Manager Associate
+    - jrsapi # Release Manager Associate
     - onlydole # Release Manager Associate
+    - salaxander # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - wilsonehusin # Release Manager Associate
   build-admins:

--- a/hack/rapture/OWNERS
+++ b/hack/rapture/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- build-admins
+  - build-admins
 reviewers:
-- build-admins
+  - build-admins

--- a/images/build/debian-base/OWNERS
+++ b/images/build/debian-base/OWNERS
@@ -5,7 +5,6 @@ approvers:
   - BenTheElder
 reviewers:
   - release-engineering-reviewers
-
 emeritus_approvers:
   - mkumatag
   - tallclair

--- a/images/build/debian-iptables/OWNERS
+++ b/images/build/debian-iptables/OWNERS
@@ -5,7 +5,6 @@ approvers:
   - BenTheElder
 reviewers:
   - release-engineering-reviewers
-
 emeritus_approvers:
   - bowei
   - freehan

--- a/images/build/distroless-iptables/OWNERS
+++ b/images/build/distroless-iptables/OWNERS
@@ -7,7 +7,6 @@ approvers:
 reviewers:
   - release-engineering-reviewers
   - sig-network-reviewers
-
 emeritus_approvers:
   - bowei
   - freehan

--- a/pkg/notes/OWNERS
+++ b/pkg/notes/OWNERS
@@ -4,4 +4,3 @@ approvers:
   - release-notes-approvers
 reviewers:
   - release-engineering-reviewers
-  - wilsonehusin


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- OWNERS(generated): Cleanup of leaf OWNERS
- OWNERS: @mkorbi (https://github.com/kubernetes/sig-release/issues/2072) and @thejoycekung (via DM) stepping down as Release Manager Associates
- OWNERS: Add @cici37, @jrsapi, and @salaxander as Release Manager Associates

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @jeremyrickard @Verolop @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

The first commit was generated via https://github.com/kubernetes-sigs/maintainers.
The `--exclude` list is @kubernetes/sig-release-leads, who should not be removed from OWNERS.
I then committed only the changes to leaf OWNERS (will do a follow-up for root-level).

```log
❯ time GOPATH=$(go env GOPATH) maintainers prune \
  --repository-devstats "kubernetes/release" \
  --repository-github "kubernetes/release" \
  --dryrun=false \
  --exclude cpanato,jeremyrickard,justaugustus,puerco,saschagrunert,Verolop
Running script : 11-25-2022 16:52:03
Processed /Users/augustus/prj/k8s/release/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/ci-reporter/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/krel/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/kubepkg/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/release-notes/OWNERS
Processed /Users/augustus/prj/k8s/release/hack/rapture/OWNERS
Processed /Users/augustus/prj/k8s/release/images/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/debian-base/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/debian-iptables/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/distroless-iptables/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/go-runner/OWNERS
Processed /Users/augustus/prj/k8s/release/packages/deb/OWNERS
Processed /Users/augustus/prj/k8s/release/packages/rpm/OWNERS
Processed /Users/augustus/prj/k8s/release/pkg/OWNERS
Processed /Users/augustus/prj/k8s/release/pkg/notes/OWNERS
Processed /Users/augustus/prj/k8s/release/OWNERS_ALIASES
Found 9 unique aliases
Found 36 unique users
........................................


>>>>> Contributions from kubernetes/release devstats repo and kubernetes/release github repo : 24
>>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
cpanato : 452 : 336
saschagrunert : 365 : 167
puerco : 132 : 51
xmudrii : 97 : 32
justaugustus : 84 : 36
palnabarun : 83 : 21
ameukam : 49 : 33
robscott : 13 : 12
aojea : 14 : 5
wilsonehusin : 18 : 5
Verolop : 16 : 11
leonardpahlke : 107 : 10
onlydole : 3 : 5
jimangel : 2 : 4
BenTheElder : 36 : 4
jeremyrickard : 18 : 2
bowei : 2 : 1
danwinship : 16 : 1
Nivedita-coder : 7 : 1
MushuEE : 2 : 1
sethmccombs : 1 : 1
spiffxp : 2 : 0
bharitwal : 2 : 1
BenjaminKazemi : 2 : 1


>>>>> Missing Contributions in kubernetes/release (devstats == 0): 12
Namanl2001
andrewsykim
caseydavenport
dcbw
freehan
khenidak
mehabhalodiya
mkorbi
mrhohn
shuheiktgw
thejoycekung
thockin


>>>>> Low reviews/approvals in kubernetes/release (GH pr comments <= 10 && devstats <=20): 13
BenjaminKazemi
MushuEE
Nivedita-coder
aojea
bharitwal
bowei
danwinship
jeremyrickard
jimangel
onlydole
sethmccombs
spiffxp
wilsonehusin
Fixing up /Users/augustus/prj/k8s/release/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/ci-reporter/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/krel/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/kubepkg/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/release-notes/OWNERS
Fixing up /Users/augustus/prj/k8s/release/hack/rapture/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/debian-base/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/debian-iptables/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/distroless-iptables/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/go-runner/OWNERS
Fixing up /Users/augustus/prj/k8s/release/packages/deb/OWNERS
Fixing up /Users/augustus/prj/k8s/release/packages/rpm/OWNERS
Fixing up /Users/augustus/prj/k8s/release/pkg/OWNERS
Fixing up /Users/augustus/prj/k8s/release/pkg/notes/OWNERS
Fixing up /Users/augustus/prj/k8s/release/OWNERS_ALIASES
GOPATH=$(go env GOPATH) maintainers prune --repository-devstats     --exclude  0.18s user 0.11s system 0% cpu 2:18.23 total
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
