### PR TITLE
OWNERS: Cleanup pt. 2

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,7 @@ aliases:
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - cici37 # Release Manager Associate
+    - jimangel # Release Manager Associate
     - jrsapi # Release Manager Associate
     - salaxander # Release Manager Associate
   build-admins:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,22 +20,10 @@ aliases:
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - cici37 # Release Manager Associate
-    - jimangel # Release Manager Associate
     - jrsapi # Release Manager Associate
-    - onlydole # Release Manager Associate
     - salaxander # Release Manager Associate
-    - sethmccombs # Release Manager Associate
-    - wilsonehusin # Release Manager Associate
-  build-admins:
-    - BenjaminKazemi
-    - MushuEE
-    - spiffxp
+  build-admins: []
   ci-signal-reporter-reviewers:
-    - Nivedita-coder # 1.26 CI Signal Lead
-    - shuheiktgw # 1.26 CI Signal Shadow
-    - mehabhalodiya # 1.26 CI Signal Shadow
-    - Namanl2001 # 1.26 CI Signal Shadow
-    - bharitwal # 1.26 CI Signal Shadow
     - leonardpahlke # 1.26 Release Lead
   krel-approvers:
     - cpanato
@@ -46,26 +34,6 @@ aliases:
     - puerco
     - saschagrunert
   sig-network-approvers:
-    - andrewsykim
-    - aojea
-    - bowei
-    - caseydavenport
-    - danwinship
-    - dcbw
-    - freehan
-    - khenidak
-    - mrhohn
     - robscott
-    - thockin
   sig-network-reviewers:
-    - andrewsykim
-    - aojea
-    - bowei
-    - caseydavenport
-    - danwinship
-    - dcbw
-    - freehan
-    - khenidak
-    - mrhohn
     - robscott
-    - thockin

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,13 +30,13 @@ aliases:
     - leonardpahlke
     - palnabarun
   ci-signal-reporter-reviewers:
-    - Nivedita-coder # 1.26 CI Signal Lead
-    - shuheiktgw # 1.26 CI Signal Shadow
-    - mehabhalodiya # 1.26 CI Signal Shadow
-    - Namanl2001 # 1.26 CI Signal Shadow
     - bharitwal # 1.26 CI Signal Shadow
     - leonardpahlke
+    - mehabhalodiya # 1.26 CI Signal Shadow
+    - Namanl2001 # 1.26 CI Signal Shadow
+    - Nivedita-coder # 1.26 CI Signal Lead
     - palnabarun
+    - shuheiktgw # 1.26 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,13 +26,17 @@ aliases:
     - BenjaminKazemi
     - MushuEE
     - spiffxp
+  ci-signal-reporter-approvers:
+    - leonardpahlke
+    - palnabarun
   ci-signal-reporter-reviewers:
     - Nivedita-coder # 1.26 CI Signal Lead
     - shuheiktgw # 1.26 CI Signal Shadow
     - mehabhalodiya # 1.26 CI Signal Shadow
     - Namanl2001 # 1.26 CI Signal Shadow
     - bharitwal # 1.26 CI Signal Shadow
-    - leonardpahlke # 1.26 Release Lead
+    - leonardpahlke
+    - palnabarun
   krel-approvers:
     - cpanato
     - puerco

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,8 +22,16 @@ aliases:
     - cici37 # Release Manager Associate
     - jrsapi # Release Manager Associate
     - salaxander # Release Manager Associate
-  build-admins: []
+  build-admins:
+    - BenjaminKazemi
+    - MushuEE
+    - spiffxp
   ci-signal-reporter-reviewers:
+    - Nivedita-coder # 1.26 CI Signal Lead
+    - shuheiktgw # 1.26 CI Signal Shadow
+    - mehabhalodiya # 1.26 CI Signal Shadow
+    - Namanl2001 # 1.26 CI Signal Shadow
+    - bharitwal # 1.26 CI Signal Shadow
     - leonardpahlke # 1.26 Release Lead
   krel-approvers:
     - cpanato
@@ -34,6 +42,26 @@ aliases:
     - puerco
     - saschagrunert
   sig-network-approvers:
+    - andrewsykim
+    - aojea
+    - bowei
+    - caseydavenport
+    - danwinship
+    - dcbw
+    - freehan
+    - khenidak
+    - mrhohn
     - robscott
+    - thockin
   sig-network-reviewers:
+    - andrewsykim
+    - aojea
+    - bowei
+    - caseydavenport
+    - danwinship
+    - dcbw
+    - freehan
+    - khenidak
+    - mrhohn
     - robscott
+    - thockin

--- a/cmd/ci-reporter/OWNERS
+++ b/cmd/ci-reporter/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - ci-signal-reporter-approvers
 reviewers:
   - ci-signal-reporter-reviewers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

(Continues https://github.com/kubernetes/release/pull/2772.)

- OWNERS(generated): Prune via maintainers tool
- OWNERS: Restore non-critical path approvers removed via generator
- cmd/ci-reporter: Add `ci-signal-reporter-approvers` alias
- OWNERS: Alpha-sort members

The most notable change is that this PR prunes several members of the @kubernetes/release-engineering team, namely, the following Release Manager Associates:

- ~@jimangel~ (expressed interest in staying on in https://github.com/kubernetes/release/pull/2773#issuecomment-1338226879)
- @onlydole
- @sethmccombs
- @wilsonehusin

Note that I've opened this PR "for science" and as a means to frame the discussion.

If you are on the above list and still have the time/interest in continuing as a Release Manager Associate, feel free to comment here to that effect.

I'll also send a note to the release-managers@ list and we can discuss there or via DM, if you'd prefer.

Explicit hold for discussion ~(and to rebase out the commits from https://github.com/kubernetes/release/pull/2772)~:
/hold

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @jeremyrickard @Verolop @cpanato @puerco 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

The first commit was generated via https://github.com/kubernetes-sigs/maintainers.
The `--exclude` list is @kubernetes/sig-release-leads, who should not be removed from OWNERS, as well as the Release Manager Associates that were recently added in https://github.com/kubernetes/release/pull/2772.

```log
❯ time GOPATH=$(go env GOPATH) maintainers prune \
  --repository-devstats "kubernetes/release" \
  --repository-github "kubernetes/release" \
  --dryrun=false \
  --exclude cpanato,jeremyrickard,justaugustus,puerco,saschagrunert,Verolop,cici37,jrsapi,salaxander
Running script : 11-25-2022 17:27:42
Processed /Users/augustus/prj/k8s/release/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/ci-reporter/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/krel/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/kubepkg/OWNERS
Processed /Users/augustus/prj/k8s/release/cmd/release-notes/OWNERS
Processed /Users/augustus/prj/k8s/release/hack/rapture/OWNERS
Processed /Users/augustus/prj/k8s/release/images/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/debian-base/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/debian-iptables/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/distroless-iptables/OWNERS
Processed /Users/augustus/prj/k8s/release/images/build/go-runner/OWNERS
Processed /Users/augustus/prj/k8s/release/packages/deb/OWNERS
Processed /Users/augustus/prj/k8s/release/packages/rpm/OWNERS
Processed /Users/augustus/prj/k8s/release/pkg/OWNERS
Processed /Users/augustus/prj/k8s/release/pkg/notes/OWNERS
Processed /Users/augustus/prj/k8s/release/OWNERS_ALIASES
Found 9 unique aliases
Found 37 unique users
.........................................


>>>>> Contributions from kubernetes/release devstats repo and kubernetes/release github repo : 25
>>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
cpanato : 452 : 336
saschagrunert : 365 : 167
puerco : 132 : 51
xmudrii : 97 : 32
ameukam : 49 : 33
palnabarun : 83 : 21
Verolop : 16 : 11
leonardpahlke : 107 : 10
justaugustus : 84 : 36
aojea : 14 : 5
onlydole : 3 : 5
danwinship : 16 : 1
jeremyrickard : 18 : 2
wilsonehusin : 18 : 5
robscott : 13 : 12
Nivedita-coder : 7 : 1
cici37 : 3 : 2
BenTheElder : 36 : 4
bharitwal : 2 : 1
bowei : 2 : 1
MushuEE : 2 : 1
sethmccombs : 1 : 1
spiffxp : 2 : 0
jimangel : 2 : 4
BenjaminKazemi : 2 : 1


>>>>> Missing Contributions in kubernetes/release (devstats == 0): 12
Namanl2001
andrewsykim
caseydavenport
dcbw
freehan
jrsapi
khenidak
mehabhalodiya
mrhohn
salaxander
shuheiktgw
thockin


>>>>> Low reviews/approvals in kubernetes/release (GH pr comments <= 10 && devstats <=20): 14
BenjaminKazemi
MushuEE
Nivedita-coder
aojea
bharitwal
bowei
cici37
danwinship
jeremyrickard
jimangel
onlydole
sethmccombs
spiffxp
wilsonehusin
Fixing up /Users/augustus/prj/k8s/release/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/ci-reporter/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/krel/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/kubepkg/OWNERS
Fixing up /Users/augustus/prj/k8s/release/cmd/release-notes/OWNERS
Fixing up /Users/augustus/prj/k8s/release/hack/rapture/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/debian-base/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/debian-iptables/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/distroless-iptables/OWNERS
Fixing up /Users/augustus/prj/k8s/release/images/build/go-runner/OWNERS
Fixing up /Users/augustus/prj/k8s/release/packages/deb/OWNERS
Fixing up /Users/augustus/prj/k8s/release/packages/rpm/OWNERS
Fixing up /Users/augustus/prj/k8s/release/pkg/OWNERS
Fixing up /Users/augustus/prj/k8s/release/pkg/notes/OWNERS
Fixing up /Users/augustus/prj/k8s/release/OWNERS_ALIASES
GOPATH=$(go env GOPATH) maintainers prune --repository-devstats     --exclude  0.19s user 0.11s system 0% cpu 2:20.83 total
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
