### PR TITLE
Verify provided args on `krel stage`

### DIFF
--- a/cmd/krel/cmd/stage.go
+++ b/cmd/krel/cmd/stage.go
@@ -137,6 +137,11 @@ func runStage(options *anago.StageOptions) error {
 	options.NoMock = rootOpts.nomock
 	stage := anago.NewStage(options)
 	if submitJob {
+		// Perform a local check of the specified options before launching a
+		// Cloud Build job:
+		if err := options.Validate(&anago.State{}); err != nil {
+			return fmt.Errorf("prechecking stage options: %w", err)
+		}
 		return stage.Submit(stream)
 	}
 	return stage.Run()


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We already do this in `krel release` but somehow missed it for `krel stage`. Means we now verify the arguments before passing them to GCB.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added command line parameter verification for `krel stage`.
```
