### PR TITLE
Remove `_KUBERNETES_GCS_BUCKET` from build tags

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -93,7 +93,6 @@ tags:
 - ${_MINOR_VERSION_TAG}
 - ${_PATCH_VERSION_TAG}
 - ${_KUBERNETES_VERSION_TAG}
-- ${_KUBERNETES_GCS_BUCKET}
 
 options:
   machineType: N1_HIGHCPU_32


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The build tags have to match a pattern, which is not guaranteed for the GCS bucket. Without this patch we will encounter the error:

```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: invalid
build tag
"gs://kubernetes-release-gcb/stage/v1.26.0-rc.0.63+f5b5dcadb2b5d4/1.26.0-rc.1/gcs-stage/1.26.0-rc.1":
must match format "^[\\w][\\w.-]{0,127}$"
```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
