### PR TITLE
Fix missing `v` for version string in GCS bucket

### DIFF
--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -435,7 +435,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 	gcbSubs["KUBERNETES_VERSION_TAG"] = primeSemver.String()
 
 	if g.options.Release {
-		gcbSubs["KUBERNETES_GCS_BUCKET"] = fmt.Sprintf("%s/stage/%s/%s/gcs-stage/%s", gcsBucket, buildVersion, primeSemver.String(), primeSemver.String())
+		gcbSubs["KUBERNETES_GCS_BUCKET"] = fmt.Sprintf("%s/stage/%s/%s/gcs-stage/%s", gcsBucket, buildVersion, versions.Prime(), versions.Prime())
 	}
 
 	return gcbSubs, nil

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -216,7 +216,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"MINOR_VERSION_TAG":      "33",
 				"PATCH_VERSION_TAG":      "7",
 				"KUBERNETES_VERSION_TAG": "1.33.7",
-				"KUBERNETES_GCS_BUCKET":  "gs://test-bucket/stage/v1.33.7/1.33.7/gcs-stage/1.33.7",
+				"KUBERNETES_GCS_BUCKET":  "gs://test-bucket/stage/v1.33.7/v1.33.7/gcs-stage/v1.33.7",
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
To fix the error:
```
Step #3: level=fatal msg="listing bucket contents: executing gsutil: command /opt/google/google-cloud-sdk/bin/gsutil ls -R gs://kubernetes-release-gcb/stage/v1.26.0-rc.0.63+f5b5dcadb2b5d4/1.26.0-rc.1/gcs-stage/1.26.0-rc.1 did not succeed: CommandException: One or more URLs matched no objects.\n"
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
