### PR TITLE
Do not sign `SHA512SUMS`

### DIFF
--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -119,8 +119,8 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 		for _, file := range strings.Fields(output) {
 			if strings.HasSuffix(file, ".sha256") || strings.HasSuffix(file, ".sha512") ||
 				strings.HasSuffix(file, ":") || strings.HasSuffix(file, ".docker_tag") ||
-				strings.Contains(file, "SHA256SUMS") || strings.Contains(file, "README") ||
-				strings.Contains(file, "Makefile") {
+				strings.Contains(file, "SHA256SUMS") || strings.Contains(file, "SHA512SUMS") ||
+				strings.Contains(file, "README") || strings.Contains(file, "Makefile") {
 				continue
 			}
 			temp := strings.TrimPrefix(file, object.GcsPrefix)


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Skipping the 512 SHA's in the same way like the 256 ones.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
