### PR TITLE
Remove "Kubernetes Source Code" from being published on GitHub Releases

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -596,18 +596,6 @@ func (d *DefaultRelease) CreateAnnouncement() error {
 // UpdateGitHubPage Update the GitHub release page, uploading the
 // source code
 func (d *DefaultRelease) UpdateGitHubPage() error {
-	// Array of assets to be published in the release page
-	assetList := []string{
-		// Build the path to the kubernetes tar file:
-		filepath.Join(
-			gitRoot, // /workspace/src/k8s.io/kubernetes
-			fmt.Sprintf("%s-%s", release.BuildDir, d.state.versions.Prime()), // _output-v1.20.0-beta.3/
-			release.GCSStagePath,     // gcs-stage/
-			d.state.versions.Prime(), // v1.20.0-beta.3
-			release.KubernetesTar,    // kubernetes.tar.gz
-		) + ":Kubernetes Source Code",
-	}
-
 	// URL to the changelog:
 	changelogURL := fmt.Sprintf(
 		"https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-%d.%d.md",
@@ -617,7 +605,6 @@ func (d *DefaultRelease) UpdateGitHubPage() error {
 
 	// Build the options set for the GitHub page
 	ghPageOpts := &announce.GitHubPageOptions{
-		AssetFiles:            assetList,
 		Tag:                   d.state.versions.Prime(),
 		NoMock:                d.options.NoMock,
 		UpdateIfReleaseExists: true,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As discussed in https://github.com/kubernetes/kubernetes/issues/100460 and announced in https://groups.google.com/a/kubernetes.io/g/dev/c/mLAxBdgawcM/m/vSew-lLdAgAJ, we're removing the "Kubernetes Source Code" artifact from GitHub Releases.

This change will go into effect starting with the January patch releases.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/100460

#### Special notes for your reviewer:

This change is supposed to go into effect for January patch releases, so I'll put this PR on hold until then.
/hold

#### Does this PR introduce a user-facing change?

```release-note
Remove "Kubernetes Source Code" artifact from being published on GitHub Releases
```

cc @kubernetes/release-engineering FYI