### PR TITLE
when downloading copy o local using the same directory structure

### DIFF
--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -123,16 +123,17 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 				strings.Contains(file, "README") || strings.Contains(file, "Makefile") {
 				continue
 			}
-			temp := strings.TrimPrefix(file, object.GcsPrefix)
-			err = gcsClient.CopyToLocal(file, tempDir)
+			destinationPath := strings.TrimPrefix(file, object.GcsPrefix)
+			localPath := filepath.Join(tempDir, filepath.Dir(destinationPath), filepath.Base(destinationPath))
+			err = gcsClient.CopyToLocal(file, localPath)
 			if err != nil {
 				return fmt.Errorf("copying file to sign: %w", err)
 			}
 
 			bundle = append(bundle, signingBundle{
-				destinationPathToCopy: filepath.Dir(temp),
-				fileToSign:            filepath.Base(temp),
-				fileLocalLocation:     fmt.Sprintf("%s/%s", tempDir, filepath.Base(temp)),
+				destinationPathToCopy: filepath.Dir(destinationPath),
+				fileToSign:            filepath.Base(destinationPath),
+				fileLocalLocation:     localPath,
 			})
 		}
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
- when downloading copy o local using the same directory structure
/assign @saschagrunert @xmudrii @puerco 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
when downloading copy o local using the same directory structure
```
