### PR TITLE
Split options.Validate into two functions and handle empty stage build version 

### DIFF
--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -231,7 +231,6 @@ func TestValidateOptions(t *testing.T) {
 			provided: &anago.Options{
 				ReleaseType:   release.ReleaseTypeAlpha,
 				ReleaseBranch: git.DefaultBranch,
-				BuildVersion:  "v1.20.0-beta.1.203+8f6ffb24df9896",
 			},
 			shouldError: false,
 		},
@@ -248,11 +247,79 @@ func TestValidateOptions(t *testing.T) {
 			},
 			shouldError: true,
 		},
+	} {
+		err := tc.provided.Validate()
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+func TestValidateBuildVersion(t *testing.T) {
+	for _, tc := range []struct {
+		provided    *anago.Options
+		shouldError bool
+	}{
+		{ // success
+			provided: &anago.Options{
+				ReleaseType:   release.ReleaseTypeAlpha,
+				ReleaseBranch: git.DefaultBranch,
+				BuildVersion:  "v1.20.0-beta.1.203+8f6ffb24df9896",
+			},
+			shouldError: false,
+		},
 		{ // invalid build version
 			provided: &anago.Options{
 				ReleaseType:   release.ReleaseTypeAlpha,
 				ReleaseBranch: git.DefaultBranch,
 				BuildVersion:  "invalid",
+			},
+			shouldError: true,
+		},
+	} {
+		state := anago.DefaultState()
+		err := tc.provided.ValidateBuildVersion(state)
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}
+
+func TestStagingOptionsValidate(t *testing.T) {
+	for _, tc := range []struct {
+		provided    *anago.StageOptions
+		shouldError bool
+	}{
+		{ // valid build version should validate
+			provided: &anago.StageOptions{
+				&anago.Options{
+					ReleaseType:   release.ReleaseTypeAlpha,
+					ReleaseBranch: git.DefaultBranch,
+					BuildVersion:  "v1.20.0-beta.1.203+8f6ffb24df9896",
+				},
+			},
+			shouldError: false,
+		},
+		{ // empty build version should validate
+			provided: &anago.StageOptions{
+				&anago.Options{
+					ReleaseType:   release.ReleaseTypeAlpha,
+					ReleaseBranch: git.DefaultBranch,
+				},
+			},
+			shouldError: false,
+		},
+		{ // invalid build version should not validate
+			provided: &anago.StageOptions{
+				&anago.Options{
+					ReleaseType:   release.ReleaseTypeAlpha,
+					ReleaseBranch: git.DefaultBranch,
+					BuildVersion:  "decaf-bad",
+				},
 			},
 			shouldError: true,
 		},


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR splits the `options.Validate` method in `pkg/anago` into two: one that handles generic options and one that validates the Build Version (and sets the analog state accodingly). The StagingOptions Validate method is also updated to only validate the BuildVersion if it is provided. 

#### Which issue(s) this PR fixes:

None 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
