### PR TITLE
Fix file signing verification error and bucket upload

### DIFF
--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -201,7 +201,7 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 			}
 
 			logrus.Infof("Copying %s and %s...", certFiles, signFiles)
-			_, err = gcli.GSUtilOutput("cp", "-n", certFiles, signFiles, fmt.Sprintf("%s%s", object.GcsPrefix, fileBundle.destinationPathToCopy))
+			_, err = gcli.GSUtilOutput("cp", certFiles, signFiles, fmt.Sprintf("%s%s", object.GcsPrefix, fileBundle.destinationPathToCopy))
 			if err != nil {
 				return fmt.Errorf("copying certificates and signatures to the bucket: %w", err)
 			}

--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -126,7 +126,8 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 			if strings.HasSuffix(file, ".sha256") || strings.HasSuffix(file, ".sha512") ||
 				strings.HasSuffix(file, ":") || strings.HasSuffix(file, ".docker_tag") ||
 				strings.Contains(file, "SHA256SUMS") || strings.Contains(file, "SHA512SUMS") ||
-				strings.Contains(file, "README") || strings.Contains(file, "Makefile") {
+				strings.Contains(file, "README") || strings.Contains(file, "Makefile") ||
+				strings.HasSuffix(file, ".cert") || strings.HasSuffix(file, ".sig") || strings.HasSuffix(file, "pem") {
 				continue
 			}
 			destinationPath := strings.TrimPrefix(file, object.GcsPrefix)

--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -135,8 +135,7 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 
 			destinationPath := strings.TrimPrefix(file, object.GcsPrefix)
 			localPath := filepath.Join(tempDir, filepath.Dir(destinationPath), filepath.Base(destinationPath))
-			err = gcsClient.CopyToLocal(file, localPath)
-			if err != nil {
+			if err := gcsClient.CopyToLocal(file, localPath); err != nil {
 				return fmt.Errorf("copying file to sign: %w", err)
 			}
 
@@ -174,8 +173,7 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 			}
 
 			signer := sign.New(signerOpts)
-			_, err := signer.SignFile(fileBundle.fileLocalLocation)
-			if err != nil {
+			if _, err := signer.SignFile(fileBundle.fileLocalLocation); err != nil {
 				t.Done(fmt.Errorf("signing the file %s: %w", fileBundle.fileLocalLocation, err))
 				return
 			}
@@ -201,8 +199,9 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 			}
 
 			logrus.Infof("Copying %s and %s...", certFiles, signFiles)
-			_, err = gcli.GSUtilOutput("cp", certFiles, signFiles, fmt.Sprintf("%s%s", object.GcsPrefix, fileBundle.destinationPathToCopy))
-			if err != nil {
+			if _, err := gcli.GSUtilOutput(
+				"cp", certFiles, signFiles, fmt.Sprintf("%s%s", object.GcsPrefix, fileBundle.destinationPathToCopy),
+			); err != nil {
 				return fmt.Errorf("copying certificates and signatures to the bucket: %w", err)
 			}
 		}

--- a/cmd/krel/cmd/sign_blobs.go
+++ b/cmd/krel/cmd/sign_blobs.go
@@ -92,11 +92,17 @@ func init() {
 	signCmd.AddCommand(signBlobCmd)
 }
 
-func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []string) error {
-	err := validateSignBlobsArgs(args)
-	if err != nil {
+func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []string) (err error) {
+	if err := validateSignBlobsArgs(args); err != nil {
 		return fmt.Errorf("blobs to be signed does not exist: %w", err)
 	}
+
+	var tempDir string
+	defer func() {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+	}()
 
 	var bundle []signingBundle
 	isGCSBucket := false
@@ -104,7 +110,7 @@ func runSignBlobs(signOpts *signOptions, signBlobOpts *signBlobOptions, args []s
 		// GCS Bucket remote location
 		isGCSBucket = true
 
-		tempDir, err := os.MkdirTemp("", "release-sign-blobs-")
+		tempDir, err = os.MkdirTemp("", "release-sign-blobs-")
 		if err != nil {
 			return fmt.Errorf("creating a temporary directory to save the files to be signed: %w", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Following @xmudrii 's intuition, this PR modifies `krel sign blob` to stop synching down from the bucket any existing certificates and signatures. For some reason, this seems to avoid the verification error encountered during the v1.26.0-rc.1 release. 

My theory is that when resigning a file, the signatures are not written to disk if a .sig file already exists (or there is a race condition somewhere). And then the verification fails because it checks against a previous signature. I tried looking for the bug but could not find it yet. This PR avoids copying the signatures down so krel sign blob will not find them. 

It also fixes another bug where copying back to the bucket would not send new signatures and certs as the `noclobber` option of `gsutil` was enabled.

#### Which issue(s) this PR fixes:
Fixes the verification error encountered during the v1.26.0-rc.1 release.

#### Special notes for your reviewer:

/cc @cpanato @xmudrii @jeremyrickard @saschagrunert 

#### Does this PR introduce a user-facing change?


```release-note
- `krel sign blob` will not sync down existing signatures and certs when signing files in a gcs bucket to work around a bug causing file verification to fail
- Fixed a bug where `krel sign blob` would not sync new signatures to a bucket that already signed files.
```
