### PR TITLE
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.4 and Go 1.18.9

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.18.8
+    version: 1.18.9
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -185,7 +185,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.25.0-go1.19.3-bullseye.0
+    version: v1.25.0-go1.19.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -235,7 +235,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.25.0-go1.19.3-bullseye.0
+    version: v1.25.0-go1.19.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -252,7 +252,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.18.8
+    version: 1.18.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -185,7 +185,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.25.0-go1.19.4-bullseye.0
+    version: v1.26.0-go1.19.4-bullseye.1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -235,7 +235,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.25.0-go1.19.4-bullseye.0
+    version: v1.26.0-go1.19.4-bullseye.1
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,10 +1,10 @@
 variants:
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.3-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.4-bullseye.0'
   v1.24-cross1.18-bullseye:
     CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.9-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
     KUBE_CROSS_VERSION: 'v1.23.0-go1.17.13-bullseye.0'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,7 @@
 variants:
+  v1.26-cross1.19-bullseye:
+    CONFIG: 'cross1.19'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.4-bullseye.1'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.19'
     KUBE_CROSS_VERSION: 'v1.25.0-go1.19.4-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.18.8-${OS_CODENAME} AS builder
+FROM golang:1.18.9-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.18.8
+GO_VERSION ?= 1.18.9
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,19 +1,19 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.18.8'
+    GO_VERSION: '1.18.9'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.19.3'
+    GO_VERSION: '1.19.4'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.19.3'
+    GO_VERSION: '1.19.4'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.18.8'
+    GO_VERSION: '1.18.9'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.4 and Go 1.18.9
- Build k8s-cloud-builder image based on kube-cross v1.26.0 (follow-up on #2798)

#### Which issue(s) this PR fixes:

Part of #2788 

#### Does this PR introduce a user-facing change?
```release-note
- Build k8s-cloud-builder and k8s-ci-builder using Go 1.19.4
- Build k8s-cloud-builder and k8s-ci-builder using Go 1.18.9
- Build k8s-cloud-builder image based on kube-cross v1.26.0 (`v1.26-cross1.19-bullseye`)
```

cc @kubernetes/release-engineering 