### PR TITLE
Remove duplicate call to `logrus.StandardLogger`

### DIFF
--- a/pkg/binary/elf.go
+++ b/pkg/binary/elf.go
@@ -130,7 +130,7 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 		return nil, fmt.Errorf("reading the binary header: %w", err)
 	}
 
-	logrus.StandardLogger().Debugf("Header bytes: %+v", hBytes)
+	logrus.Debugf("Header bytes: %+v", hBytes)
 
 	// Check we're dealing with an elf binary:
 	if string(hBytes[1:4]) != "ELF" {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We do not have to call the standard logger explicitly there and can just refer to the usual debug log invocation.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Found during code search :) 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
