### PR TITLE
Add 1.26 variant for kubecross

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.26-go1.19-bullseye:
+    CONFIG: 'go1.19-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.26.0-go1.19.3-bullseye.0'
+    KUBERNETES_VERSION: 'v1.26.0'
+    GO_VERSION: '1.19.3'
+    GO_MAJOR_VERSION: '1.19'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.25-go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
     TYPE: 'default'


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a 1.26 variant for kube cross

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 
Fixes #

or

None
-->

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

Can merge this after https://github.com/kubernetes/release/pull/2794 and rebase it so it gets the new go versions

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
