### PR TITLE
add option to generate a release note with a set of specific kinds

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -266,6 +266,13 @@ func init() {
 		false,
 		"enable experimental implementation to list commits (ListReleaseNotesV2)",
 	)
+
+	cmd.PersistentFlags().StringSliceVar(
+		&opts.FilterKinds,
+		"filter-kinds",
+		[]string{},
+		"generate the release notes only if a set of specific kinds",
+	)
 }
 
 func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -328,6 +328,19 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 			}
 		}
 
+		toRemove := false
+		for _, filterKind := range g.options.FilterKinds {
+			if hasString(labelsWithPrefix(result.pullRequest, "kind"), filterKind) {
+				toRemove = false
+				break
+			}
+			toRemove = true
+		}
+
+		if toRemove {
+			continue
+		}
+
 		note, err := g.ReleaseNoteFromCommit(result)
 		if err != nil {
 			logrus.Errorf(

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -320,7 +320,7 @@ func TestMatchesExcludeFilter(t *testing.T) {
 			shouldExclude: false,
 		},
 		{
-			input: `@kubernetes/sig-auth-pr-reviews 
+			input: `@kubernetes/sig-auth-pr-reviews
 /milestone v1.19
 /priority important-longterm
 /kind cleanup

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -151,6 +151,19 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 		return nil, nil
 	}
 
+	toRemove := false
+	for _, filterKind := range g.options.FilterKinds {
+		if hasString(labelsWithPrefix(pr, "kind"), filterKind) {
+			toRemove = false
+			break
+		}
+		toRemove = true
+	}
+
+	if toRemove {
+		return nil, nil
+	}
+
 	text, err := noteTextFromString(prBody)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -127,6 +127,9 @@ type Options struct {
 	// This is useful when the release notes are outputted to a file. When using the GitHub release page to publish release notes,
 	// this option should be set to false to take advantage of Github's autolinked references.
 	AddMarkdownLinks bool
+
+	// Filter kinds to show in the release notes
+	FilterKinds []string
 }
 
 type RevisionDiscoveryMode string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- add option to generate a release note with a set of specific kinds

sometimes a user want to generate a release note with only with a specific set of kinds, for example to filter some that is not interest for a particular audience.

This PR adds this option to only add a set of kinds in the release notes

/assign @saschagrunert @xmudrii @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add option to generate a release note with a set of specific kinds
```
