### PR TITLE
golang: Build 1.20rc1 images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -131,7 +131,7 @@ dependencies:
   # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
   # - v1.100-go1.17-bullseye.0 does not
   - name: "Kubernetes version (stable.0)"
-    version: v1.25.0
+    version: v1.26.0
     refPaths:
     - path: images/build/cross/Makefile
       match: KUBERNETES_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -139,7 +139,7 @@ dependencies:
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.25.0
+    version: v1.26.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -171,7 +171,7 @@ dependencies:
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: config variant"
-    version: go1.17-bullseye
+    version: go1.19-bullseye
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
@@ -192,7 +192,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.19
+    version: 1.20rc1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -211,7 +211,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/go-runner (next candidate)"
-    version: v2.3.1-go1.19.4-bullseye.0
+    version: v2.3.1-go1.20rc1-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -223,13 +223,13 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross (next candidate)"
-    version: v1.26.0-go1.19.4-bullseye.1
+    version: v1.27.0-go1.20rc1-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: config variant (next candidate)"
-    version: go1.18-bullseye
+    version: go1.19-bullseye
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -45,7 +45,7 @@ dependencies:
 
   # cosign
   - name: "gcr.io/projectsigstore/cosign"
-    version: v1.11.1@sha256:f9fd5a287a67f4b955d08062a966df10f9a600b6b8583fd367bce3f1f000a429
+    version: v1.13.1@sha256:fd5b09be23ef1027e1bdd490ce78dcc65d2b15902e1f4ba8e04f3b4019cc1057
     refPaths:
     - path: images/build/go-runner/cloudbuild.yaml
       match: gcr.io/projectsigstore/cosign:v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?@sha256:[a-f0-9]{64}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -274,23 +274,6 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # Golang (previous release branches: 1.22)
-  - name: "golang (previous release branches: 1.22)"
-    version: 1.16.15
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/build/go-runner/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/releng/ci/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.22)"
-    version: 1.16.15
-    refPaths:
-    - path: images/releng/k8s-ci-builder/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
   # Golang images (for previous release branches)
   - name: "gcr.io/k8s-staging-releng/releng-ci: image revision (for previous release branches)"
     version: 0
@@ -306,12 +289,6 @@ dependencies:
 
   - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.23)"
     version: v2.3.1-go1.17.13-bullseye.0
-    refPaths:
-    - path: images/build/go-runner/variants.yaml
-      match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-
-  - name: "k8s.gcr.io/build-image/go-runner (previous release branches: 1.22)"
-    version: v2.3.1-go1.16.15-buster.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -339,18 +316,6 @@ dependencies:
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.22)"
-    version: v1.22.0-go1.16.15-buster.0
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "k8s.gcr.io/build-image/kube-cross: config variant (previous release branches: 1.22)"
-    version: go1.16-buster
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-buster'"
 
   # golangci-lint-version
   - name: "golangci-lint"

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -27,7 +27,7 @@ IMGNAME = kube-cross
 # Example:
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
-KUBERNETES_VERSION ?= v1.25.0
+KUBERNETES_VERSION ?= v1.26.0
 GO_VERSION ?= 1.19.4
 GO_MAJOR_VERSION ?= 1.19
 OS_CODENAME ?= bullseye

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,14 @@
 variants:
+  v1.27-go1.20-bullseye:
+    CONFIG: 'go1.20-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.27.0-go1.20rc1-bullseye.0'
+    KUBERNETES_VERSION: 'v1.27.0'
+    GO_VERSION: '1.20rc1'
+    GO_MAJOR_VERSION: '1.20'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    PROTOBUF_VERSION: '3.19.4'
   v1.26-go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
     TYPE: 'default'

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -39,13 +39,3 @@ variants:
     OS_CODENAME: 'bullseye'
     REVISION: '0'
     PROTOBUF_VERSION: '3.19.4'
-  v1.22-go1.16-buster:
-    CONFIG: 'go1.16-buster'
-    TYPE: 'default'
-    IMAGE_VERSION: 'v1.22.0-go1.16.15-buster.0'
-    KUBERNETES_VERSION: 'v1.22.0'
-    GO_VERSION: '1.16.15'
-    GO_MAJOR_VERSION: '1.16'
-    OS_CODENAME: 'buster'
-    REVISION: '0'
-    PROTOBUF_VERSION: '3.19.4'

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -10,7 +10,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/projectsigstore/cosign:v1.11.1@sha256:f9fd5a287a67f4b955d08062a966df10f9a600b6b8583fd367bce3f1f000a429'
+  - name: 'gcr.io/projectsigstore/cosign:v1.13.1@sha256:fd5b09be23ef1027e1bdd490ce78dcc65d2b15902e1f4ba8e04f3b4019cc1057'
     dir: ./images/build/go-runner
     args:
     - 'verify'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -23,11 +23,3 @@ variants:
     REVISION: '0'
     GO_VERSION: '1.17.13'
     DISTROLESS_IMAGE: 'static-debian11'
-  go1.16-buster:
-    CONFIG: 'go1.16-buster'
-    IMAGE_VERSION: 'v2.3.1-go1.16.15-buster.0'
-    GO_MAJOR_VERSION: '1.16'
-    OS_CODENAME: 'buster'
-    REVISION: '0'
-    GO_VERSION: '1.16.15'
-    DISTROLESS_IMAGE: 'static-debian10'

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,4 +1,12 @@
 variants:
+  go1.20-bullseye:
+    CONFIG: 'go1.20-bullseye'
+    IMAGE_VERSION: 'v2.3.1-go1.20rc1-bullseye.0'
+    GO_MAJOR_VERSION: '1.20'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+    GO_VERSION: '1.20rc1'
+    DISTROLESS_IMAGE: 'static-debian11'
   go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
     IMAGE_VERSION: 'v2.3.1-go1.19.4-bullseye.0'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -14,8 +14,3 @@ variants:
     GO_VERSION: '1.17.13'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-  go1.16-buster:
-    CONFIG: 'go1.16-buster'
-    GO_VERSION: '1.16.15'
-    OS_CODENAME: 'buster'
-    REVISION: '0'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  go1.20-bullseye:
+    CONFIG: 'go1.20-bullseye'
+    GO_VERSION: '1.20rc1'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   go1.19-bullseye:
     CONFIG: 'go1.19-bullseye'
     GO_VERSION: '1.19.4'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,10 +1,18 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.18.9'
+    GO_VERSION: '1.19.4'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
+    GO_VERSION: '1.20rc1'
+    OS_CODENAME: 'bullseye'
+  '1.27':
+    CONFIG: '1.27'
+    GO_VERSION: '1.20rc1'
+    OS_CODENAME: 'bullseye'
+  '1.26':
+    CONFIG: '1.26'
     GO_VERSION: '1.19.4'
     OS_CODENAME: 'bullseye'
   '1.25':

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -19,7 +19,3 @@ variants:
     CONFIG: '1.23'
     GO_VERSION: '1.17.13'
     OS_CODENAME: 'bullseye'
-  '1.22':
-    CONFIG: '1.22'
-    GO_VERSION: '1.16.15'
-    OS_CODENAME: 'buster'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- golang: Build 1.20rc1 images

also updates/cleanup:

- drop 1.22 and go 1.16 build variants
- update cosign image


/hold
/assign @saschagrunert @xmudrii @Verolop @palnabarun 
cc @kubernetes/release-managers 


#### Which issue(s) this PR fixes:

Related to https://github.com/kubernetes/release/issues/2815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- drop 1.22 and go 1.16 build variants
- update cosign image
- golang: Build 1.20rc1 images
```
