### PR TITLE
Retry `docker manifest push` on network failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/text v0.5.0
 	google.golang.org/api v0.103.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/apimachinery v0.26.0
 	sigs.k8s.io/bom v0.4.1
 	sigs.k8s.io/mdtoc v1.1.0
 	sigs.k8s.io/promo-tools/v3 v3.4.10
@@ -337,7 +338,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.10.0 // indirect
 	k8s.io/api v0.25.0 // indirect
-	k8s.io/apimachinery v0.26.0 // indirect
 	k8s.io/cli-runtime v0.25.0 // indirect
 	k8s.io/client-go v0.25.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect


### PR DESCRIPTION


#### What type of PR is this?


/kind flake


#### What this PR does / why we need it:
We can encounter network issues on pushing the manifest as described in: https://github.com/kubernetes/release/issues/2810

We now retry in case of that network error up to 5 times by using an exponential back off timer.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/2810
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Retry `docker manifest push` on network failure.
```
