### PR TITLE
Fix release-sdk `LsRemote()` usage

### DIFF
--- a/pkg/release/repository.go
+++ b/pkg/release/repository.go
@@ -161,20 +161,11 @@ func (r *Repo) CheckState(expOrg, expRepo, expRev string, nomock bool) error {
 	)
 
 	logrus.Info("Verifying remote HEAD commit")
-	args := []string{
-		"--heads",
-		foundRemote.Name(),
-		fmt.Sprintf("refs/heads/%s", branch),
-	}
+	ref := fmt.Sprintf("refs/heads/%s", branch)
 	if branch == "" {
-		args = []string{
-			"--tags",
-			"--heads",
-			foundRemote.Name(),
-			fmt.Sprintf("refs/tags/%s^{}", expRev),
-		}
+		ref = fmt.Sprintf("refs/tags/%s^{}", expRev)
 	}
-	lsRemoteOut, err := r.repo.LsRemote(args...)
+	lsRemoteOut, err := r.repo.LsRemote(foundRemote.Name(), ref)
 	if err != nil {
 		return fmt.Errorf("getting remote HEAD: %w", err)
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We introduced a new `LsRemote` fix for malicious code injection in https://github.com/kubernetes-sigs/release-sdk/pull/136. This makes the current usage of the API to break with the error message:

```
verifying repository state: getting remote HEAD: running git ls-remote:
command /usr/bin/git ls-remote -- --heads origin refs/heads/master did
not succeed: fatal: strange pathname '--heads' blocked
```

We now omit the additional `--heads` and `--tags` since they should not be needed at all.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
