### PR TITLE
Update cri-tools to v1.26.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -34,7 +34,7 @@ dependencies:
 
   # CRI Tools
   - name: "crictl"
-    version: 1.25.0
+    version: 1.26.0
     refPaths:
     - path: packages/deb/build.go
       match: criToolsVersion\s+= "\d+\.\d+.\d+"

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -42,7 +42,7 @@ const (
 	ChannelNightly  ChannelType = "nightly"
 
 	currentCNIVersion  = "1.1.1"
-	criToolsVersion    = "1.25.0"
+	criToolsVersion    = "1.26.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"
 	latestkubeadmconf  = "post-1.10/10-kubeadm.conf"

--- a/packages/deb/build_test.go
+++ b/packages/deb/build_test.go
@@ -74,7 +74,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.25.0)",
+				"cri-tools (>= 1.26.0)",
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.25.0)",
+				"cri-tools (>= 1.26.0)",
 			},
 		},
 	}

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -12,7 +12,7 @@
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
 %global CNI_VERSION 1.1.1
-%global CRI_TOOLS_VERSION 1.25.0
+%global CRI_TOOLS_VERSION 1.26.0
 
 Name: kubelet
 Version: %{KUBE_VERSION}
@@ -157,6 +157,9 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Thu Dec 14 2022 Sascha Grunert <sgrunert@redhat.com> - 1.26.0
+- Update cri-tools to v1.26.0
+
 * Thu Aug 30 2022 Sascha Grunert <sgrunert@redhat.com> - 1.25.0
 - Update CNI plugins to v1.1.1
 


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Update cri-tools to the latest release.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/cri-tools/issues/1039
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated cri-tools to v1.26.0
```
