### PR TITLE
Fix: Add id-token to scorecards analysis workflow

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -19,6 +19,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Scorecard analysis released v2 in September 2022. This introduces a breaking change where the OS projects that use `publish_results: true` need to include `id-token: write` in the workflow. 

https://github.com/ossf/scorecard-action#breaking-changes-in-v2

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #2820

or

None
-->
Fixes #2820

#### Special notes for your reviewer:
After this commit https://github.com/kubernetes/release/commit/5a98fd758132feb2a99500ca9064bc2fb1b03ce3 the workflows started to fail. This commit updates the scorecard analysis to v2 and introduces the breaking change. The error logs in all the failed scorecard analysis workflow say "expired token" but since the errors started just after the upgrade, it is more likely the breaking change is causing issues rather than some expired PAT.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
