### PR TITLE
Update 1.23 ci and builders to go1.19.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -259,7 +259,7 @@ dependencies:
 
   # Golang (previous release branches: 1.23)
   - name: "golang (previous release branches: 1.23)"
-    version: 1.17.13
+    version: 1.19.4
     refPaths:
     - path: images/build/cross/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -269,7 +269,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
-    version: 1.17.13
+    version: 1.19.4
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -312,7 +312,7 @@ dependencies:
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "k8s.gcr.io/build-image/kube-cross (previous release branches: 1.23)"
-    version: v1.23.0-go1.17.13-bullseye.0
+    version: v1.23.0-go1.19.4-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -11,6 +11,9 @@ variants:
   v1.24-cross1.18-bullseye:
     CONFIG: 'cross1.18'
     KUBE_CROSS_VERSION: 'v1.24.0-go1.18.9-bullseye.0'
+  v1.23-cross1.19-bullseye:
+    CONFIG: 'cross1.19'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.19.4-bullseye.0'
   v1.23-cross1.17-bullseye:
     CONFIG: 'cross1.17'
     KUBE_CROSS_VERSION: 'v1.23.0-go1.17.13-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -25,5 +25,5 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.17.13'
+    GO_VERSION: '1.19.4'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
Replay of https://github.com/kubernetes/release/pull/2830 for 1.23

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates 1.23 branch builders and CI to use go1.19.4

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2822

#### Does this PR introduce a user-facing change?

```release-note
release-1.23 builders and CI updated to go1.19.4
```

/assign @cpanato @puerco @dims
/hold for 1.24 post-submit signal on https://github.com/kubernetes/kubernetes/pull/113956