### PR TITLE
Add `.go-version` file to the Golang updates template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dep-golang.md
+++ b/.github/ISSUE_TEMPLATE/dep-golang.md
@@ -52,6 +52,7 @@ SIG Release Slack thread:
   - [ ] go-runner image
   - [ ] publishing bot rules
   - [ ] test image
+  - [ ] `.go-version` file
 
 #### After kubernetes/kubernetes (master) has been updated
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

@liggitt added `.go-version` to k/k root so that we have the Go version in a file that's easily parsable: https://github.com/kubernetes/kubernetes/pull/114660

This PR updates the Golang updates template to include this file so that we know that we need to keep this file updated.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

cc @kubernetes/release-engineering @liggitt 