### PR TITLE
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.5

### DIFF
--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -67,6 +67,7 @@ const patchReleaseExpectedContent = `# v1.25.3
 _Nothing has changed._
 
 ### Changed
+- github.com/google/cel-go: [v0.12.5 → v0.12.6](https://github.com/google/cel-go/compare/v0.12.5...v0.12.6)
 - github.com/stretchr/objx: [v0.2.0 → v0.4.0](https://github.com/stretchr/objx/compare/v0.2.0...v0.4.0)
 - github.com/stretchr/testify: [v1.7.0 → v1.8.0](https://github.com/stretchr/testify/compare/v1.7.0...v1.8.0)
 - go.uber.org/goleak: v1.1.10 → v1.2.0
@@ -134,6 +135,7 @@ const patchReleaseExpectedHTML = `<!DOCTYPE html>
 <p><em>Nothing has changed.</em></p>
 <h3>Changed</h3>
 <ul>
+<li>github.com/google/cel-go: <a href="https://github.com/google/cel-go/compare/v0.12.5...v0.12.6">v0.12.5 → v0.12.6</a></li>
 <li>github.com/stretchr/objx: <a href="https://github.com/stretchr/objx/compare/v0.2.0...v0.4.0">v0.2.0 → v0.4.0</a></li>
 <li>github.com/stretchr/testify: <a href="https://github.com/stretchr/testify/compare/v1.7.0...v1.8.0">v1.7.0 → v1.8.0</a></li>
 <li>go.uber.org/goleak: v1.1.10 → v1.2.0</li>

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.19.4
+    version: 1.19.5
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -185,7 +185,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents bullseye"
-    version: v1.26.0-go1.19.4-bullseye.1
+    version: v1.26.0-go1.19.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -235,7 +235,7 @@ dependencies:
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "k8s.gcr.io/build-image/kube-cross: dependents (next candidate)"
-    version: v1.26.0-go1.19.4-bullseye.1
+    version: v1.26.0-go1.19.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -252,7 +252,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.19.4
+    version: 1.19.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -269,7 +269,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
-    version: 1.19.4
+    version: 1.19.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,22 +1,13 @@
 variants:
   v1.26-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.4-bullseye.1'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.5-bullseye.0'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.5-bullseye.0'
   v1.24-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.4-bullseye.0'
-  v1.24-cross1.18-bullseye:
-    CONFIG: 'cross1.18'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.18.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.5-bullseye.0'
   v1.23-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.19.4-bullseye.0'
-  v1.23-cross1.17-bullseye:
-    CONFIG: 'cross1.17'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.17.13-bullseye.0'
-  v1.22-cross1.16-buster:
-    CONFIG: 'cross1.16'
-    KUBE_CROSS_VERSION: 'v1.22.0-go1.16.15-buster.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.19.5-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.19.4-${OS_CODENAME} AS builder
+FROM golang:1.19.5-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.19.4
+GO_VERSION ?= 1.19.5
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.19.4'
+    GO_VERSION: '1.19.5'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -13,17 +13,17 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: '1.19.4'
+    GO_VERSION: '1.19.5'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.19.4'
+    GO_VERSION: '1.19.5'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.19.4'
+    GO_VERSION: '1.19.5'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.19.4'
+    GO_VERSION: '1.19.5'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.5
- drop not required images
- 
#### Which issue(s) this PR fixes:

Part of #2851 

#### Does this PR introduce a user-facing change?
```release-note
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.5
```

/assign @saschagrunert @xmudrii @palnabarun @ameukam 
cc @kubernetes/release-engineering 