### PR TITLE
Improve CVSS parsing performances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cheggaaa/pb/v3 v3.1.2
 	github.com/go-git/go-git/v5 v5.7.0
-	github.com/goark/go-cvss v1.6.6
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/go-github/v50 v50.2.0
@@ -21,6 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pandatix/go-cvss v0.5.2
 	github.com/psampaz/go-mod-outdated v0.9.0
 	github.com/saschagrunert/go-modiff v1.3.3
 	github.com/sendgrid/rest v2.6.9+incompatible
@@ -160,7 +160,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
-	github.com/goark/errs v1.1.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -456,10 +456,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
-github.com/goark/errs v1.1.0 h1:FKnyw4LVyRADIjM8Nj0Up6r0/y5cfADvZAd1E+tthXE=
-github.com/goark/errs v1.1.0/go.mod h1:TtaPEoadm2mzqzfXdkkfpN2xuniCFm2q4JH+c1qzaqw=
-github.com/goark/go-cvss v1.6.6 h1:WJFuIWqmAw1Ilb9USv0vuX+nYzOWJp8lIujseJ/y3sU=
-github.com/goark/go-cvss v1.6.6/go.mod h1:H3qbfUSUlV7XtA3EwWNunvXz6OySwWHOuO+R6ZPMQPI=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -835,6 +831,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a h1:tkTSd1nhioPqi5Whu3CQ79UjPtaGOytqyNnSCVOqzHM=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
+github.com/pandatix/go-cvss v0.5.2 h1:9441i+Sn/P/TP9kNBl3kI7mwYtNYFr1eN8JdsiybiMM=
+github.com/pandatix/go-cvss v0.5.2/go.mod h1:u4HcNBqA9IY6PZHuH8Pac4VaGv5iAMyiXMex/FIfxcg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
-	cvss "github.com/goark/go-cvss/v3/metric"
+	gocvss30 "github.com/pandatix/go-cvss/30"
+	gocvss31 "github.com/pandatix/go-cvss/31"
 )
 
 // CVE Information of a linked CVE vulnerability
@@ -91,18 +93,23 @@ func (cve *CVE) Validate() (err error) {
 		return errors.New("string CVSS vector missing from CVE data")
 	}
 
-	var bm cvss.Metrics
 	// Parse the vector string to make sure it is well formed
-	if len(cve.CVSSVector) == 44 {
-		bm, err = cvss.NewBase().Decode(cve.CVSSVector)
-	} else {
-		bm, err = cvss.NewTemporal().Decode(cve.CVSSVector)
+	var ver string
+	switch {
+	case strings.HasPrefix(cve.CVSSVector, "CVSS:3.0"):
+		_, err = gocvss30.ParseVector(cve.CVSSVector)
+		ver = "3.0"
+	case strings.HasPrefix(cve.CVSSVector, "CVSS:3.1"):
+		_, err = gocvss31.ParseVector(cve.CVSSVector)
+		ver = "3.1"
+	default:
+		return errors.New("invalid CVSS prefix")
 	}
 	if err != nil {
 		return fmt.Errorf("parsing CVSS vector string: %w", err)
 	}
 	cve.CalcLink = fmt.Sprintf(
-		"https://www.first.org/cvss/calculator/%s#%s", bm.BaseMetrics().Ver.String(), cve.CVSSVector,
+		"https://www.first.org/cvss/calculator/%s#%s", ver, cve.CVSSVector,
 	)
 
 	if cve.CVSSScore == 0 {


### PR DESCRIPTION
CVSS parsing is not a big part of the release process, so if parsing it takes a long time, it only reduces the overall performances.

In this PR, I propose to use my implementation of CVSS which performs better (see [benchmarks results](https://github.com/pandatiX/go-cvss#comparison)) to avoid this.
This implementation is also tested and fuzzed according to the best practices, what was not achieved by goark.

#### What type of PR is this?

/kind cleanup

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
