### PR TITLE
Revert bumping kubernetes-cni to v1.2.0 and cri-tools to v1.26.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -34,7 +34,7 @@ dependencies:
 
   # CRI Tools
   - name: "crictl"
-    version: 1.26.0
+    version: 1.25.0
     refPaths:
     - path: packages/deb/build.go
       match: criToolsVersion\s+= "\d+\.\d+.\d+"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,7 +15,7 @@ dependencies:
 
   # CNI plugins
   - name: "CNI plugins"
-    version: 1.2.0
+    version: 1.1.1
     refPaths:
     - path: packages/deb/build.go
       match: currentCNIVersion\s+= "\d+\.\d+.\d+"

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -41,7 +41,7 @@ const (
 	ChannelUnstable ChannelType = "unstable"
 	ChannelNightly  ChannelType = "nightly"
 
-	currentCNIVersion  = "1.2.0"
+	currentCNIVersion  = "1.1.1"
 	criToolsVersion    = "1.26.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -42,7 +42,7 @@ const (
 	ChannelNightly  ChannelType = "nightly"
 
 	currentCNIVersion  = "1.1.1"
-	criToolsVersion    = "1.26.0"
+	criToolsVersion    = "1.25.0"
 	pre180kubeadmconf  = "pre-1.8/10-kubeadm.conf"
 	pre1110kubeadmconf = "post-1.8/10-kubeadm.conf"
 	latestkubeadmconf  = "post-1.10/10-kubeadm.conf"

--- a/packages/deb/build_test.go
+++ b/packages/deb/build_test.go
@@ -74,7 +74,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.26.0)",
+				"cri-tools (>= 1.25.0)",
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestGetKubeadmDependencies(t *testing.T) {
 				"kubectl (>= 1.19.0)",
 				"kubernetes-cni (>= 0.8.7)",
 				"${misc:Depends}",
-				"cri-tools (>= 1.26.0)",
+				"cri-tools (>= 1.25.0)",
 			},
 		},
 	}

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -12,7 +12,7 @@
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
 %global CNI_VERSION 1.1.1
-%global CRI_TOOLS_VERSION 1.26.0
+%global CRI_TOOLS_VERSION 1.25.0
 
 Name: kubelet
 Version: %{KUBE_VERSION}
@@ -157,6 +157,12 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
+* Wed Jan 25 2023 Marko Mudrinić <mudrinic.mare@gmail.com> - 1.26.2
+- Revert updating CNI plugins to v1.2.0 and cri-tools to v1.26.0
+
+* Tue Jan 17 2023 Sascha Grunert <sgrunert@redhat.com> - 1.26.0
+- Update CNI plugins to v1.2.0
+
 * Thu Dec 14 2022 Sascha Grunert <sgrunert@redhat.com> - 1.26.0
 - Update cri-tools to v1.26.0
 

--- a/packages/rpm/kubelet.spec
+++ b/packages/rpm/kubelet.spec
@@ -11,7 +11,7 @@
 %define semver() (%1 * 256 * 256 + %2 * 256 + %3)
 %global KUBE_SEMVER %{semver %{KUBE_MAJOR} %{KUBE_MINOR} %{KUBE_PATCH}}
 
-%global CNI_VERSION 1.2.0
+%global CNI_VERSION 1.1.1
 %global CRI_TOOLS_VERSION 1.26.0
 
 Name: kubelet
@@ -157,9 +157,6 @@ mv cni-plugins/* %{buildroot}/opt/cni/bin/
 
 
 %changelog
-* Tue Jan 17 2023 Sascha Grunert <sgrunert@redhat.com> - 1.26.0
-- Update CNI plugins to v1.2.0
-
 * Thu Dec 14 2022 Sascha Grunert <sgrunert@redhat.com> - 1.26.0
 - Update cri-tools to v1.26.0
 

--- a/pkg/kubepkg/kubepkg.go
+++ b/pkg/kubepkg/kubepkg.go
@@ -44,7 +44,7 @@ const (
 	ChannelNightly ChannelType = "nightly"
 
 	minimumKubernetesVersion = "1.13.0"
-	CurrentCNIVersion        = "1.2.0"
+	CurrentCNIVersion        = "1.1.1"
 	MinimumCNIVersion        = "0.8.6"
 
 	kubeadmConf = "10-kubeadm.conf"


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

We bumped the minimum kubernetes-cni version to v1.2.0 in #2863, and cri-tools to v1.26.0 in #2821. However, this affects all kubelet and kubeadm packages, including v1.23.16, v1.24.10, v1.25.6, and v1.26.1.

This brings two major problems:
* cri-tools v1.26.0 requires containerd 1.6, but many users are still using containerd 1.5, so they are now forced to upgrade
* users are confused are cni-plugins v1.2.0 compatible with older minor releases
  * I'm also not sure that we properly or at all tested that

Therefore, we think it might be better to revert those bumps. This problem will be solved in the future with the KEP-1731 (https://github.com/kubernetes/enhancements/issues/1731).

#### Which issue(s) this PR fixes:

Fixes #2866 

#### Does this PR introduce a user-facing change?
```release-note
Revert increasing the minimum kubernetes-cni and cri-tools versions
```

/assign @saschagrunert 
cc @kubernetes/release-engineering 