### PR TITLE
Add Docker buildx version to `dependencies.yaml`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -479,3 +479,9 @@ dependencies:
       match: QEMUVERSION
     - path: images/build/debian-base/Makefile
       match: QEMUVERSION
+
+  - name: Docker buildx
+    version: 0.10.2
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Dockerfile
+      match: DOCKER_BUILDX_VERSION


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
A slight follow-up on https://github.com/kubernetes/release/pull/2888, where we now track the version for docker buildx in `dependencies.yaml` as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
