### PR TITLE
k8s-ci-builder: install ifconfig through net-tools

### DIFF
--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -76,6 +76,7 @@ RUN echo "Installing Packages ..." \
             kmod \
             lsb-release \
             mercurial \
+            net-tools \
             pkg-config \
             procps \
             python3 \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Install net-tools debian package to have the `ifconfig` command available

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/115605

#### Special notes for your reviewer:

Tested this by manually running inside the image.

```
❯ docker run --entrypoint /bin/bash -it gcr.io/k8s-staging-releng/k8s-ci-builder:v20230206-v0.15.0-50-ga511a4b5-default
root@5405bf78e47e:/# ifconfig
bash: ifconfig: command not found
```

```
❯ docker run --entrypoint /bin/bash -it gcr.io/k8s-staging-releng/k8s-ci-builder:v20230206-v0.15.0-50-ga511a4b5-default
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@a34282332c06:/# apt update && apt install net-tools
Get:1 https://download.docker.com/linux/debian bullseye InRelease [43.3 kB]
Get:2 http://deb.debian.org/debian bullseye InRelease [116 kB]     
Get:3 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
Get:4 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
Get:5 https://download.docker.com/linux/debian bullseye/stable amd64 Packages [18.1 kB]
Get:6 http://deb.debian.org/debian bullseye/main amd64 Packages [8183 kB]
Get:7 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [222 kB]
Get:8 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.6 kB]
Fetched 8689 kB in 8s (1032 kB/s)                                                                                                                      
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  net-tools
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
Need to get 250 kB of archives.
After this operation, 1015 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian bullseye/main amd64 net-tools amd64 1.60+git20181103.0eebece-1 [250 kB]
Fetched 250 kB in 0s (1606 kB/s)  
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package net-tools.
(Reading database ... 19012 files and directories currently installed.)
Preparing to unpack .../net-tools_1.60+git20181103.0eebece-1_amd64.deb ...
Unpacking net-tools (1.60+git20181103.0eebece-1) ...
Setting up net-tools (1.60+git20181103.0eebece-1) ...
root@a34282332c06:/# ifconfig
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.17.0.2  netmask 255.255.0.0  broadcast 172.17.255.255
        ether ab:ab:ab:ab:ab:ab  txqueuelen 0  (Ethernet)
        RX packets 953  bytes 9014257 (8.5 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 331  bytes 24158 (23.5 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

#### Does this PR introduce a user-facing change?

```release-note
k8s-ci-builder: install ifconfig through net-tools
```
