### PR TITLE
use fedora:36 for RPM builds

### DIFF
--- a/packages/rpm/Dockerfile
+++ b/packages/rpm/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:24
+FROM fedora:36
 MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 
-RUN dnf install -y rpm-build rpmdevtools createrepo && dnf clean all
+RUN dnf install -y rpm-build rpmdevtools createrepo systemd && dnf clean all
 
 RUN rpmdev-setuptree
 

--- a/packages/rpm/entry.sh
+++ b/packages/rpm/entry.sh
@@ -42,7 +42,7 @@ for ARCH in ${ARCHS[@]}; do
   sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/kubelet.spec
   # Download sources if not already available
   cd ${SRC_PATH} && spectool -gf kubelet.spec
-  /usr/bin/rpmbuild --target ${RPMARCH} --define "_sourcedir ${SRC_PATH}" -bb ${SRC_PATH}/kubelet.spec
+  /usr/bin/rpmbuild --target ${RPMARCH} --define "_sourcedir ${SRC_PATH}" --define "_smp_build_ncpus 1" --define "__os_install_post %{nil}" -bb ${SRC_PATH}/kubelet.spec
   mkdir -p /root/rpmbuild/RPMS/${RPMARCH}
   createrepo -o /root/rpmbuild/RPMS/${RPMARCH}/ /root/rpmbuild/RPMS/${RPMARCH}
 done


### PR DESCRIPTION
This addresses the file digest algorithm changing to SHA256 in RPM 4.14, which
was first included in Fedora 27 [1].  A few different sources outline the
details, see [2] and [3].  These digests must be included in the RPMs to be
installed on FIPS-enabled systems, as typically required by US government
organizations.

The Kubernetes RPMs are still being built with a Fedora 24 image, which doesn't
support the SHA256 algorithm.  It's a pretty trivial change to swap the container
image used for building the RPMs, since the RPMs are just consuming the already
published binary artifacts from elsewhere.

Note, this does not have anything to do with package signatures or trying to
make the code FIPS-compliant.  This is solely addressing the issue of
installing the binary RPMs onto FIPS-enabled systems without having to alter
anything at the system-level.  This includes just the kubectl RPM on client
systems.

I also noted that there was effort to modernize the RPM package building
process in https://github.com/kubernetes/release/issues/1027, but that effort
seems to have stalled?

# built with fedora:24
```
$ rpm -Kv /tmp/release/packages/rpm/output/x86_64/kubectl-1.19.0-0.x86_64.rpm
/tmp/release/packages/rpm/output/x86_64/kubectl-1.19.0-0.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
```

# built with fedora:36
```
$ rpm -Kv /tmp/release/packages/rpm/output/x86_64/kubectl-1.19.0-0.x86_64.rpm
/tmp/release/packages/rpm/output/x86_64/kubectl-1.19.0-0.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```

[1] - https://fedoraproject.org/wiki/Changes/RPM-4.14
[2] - https://www.starlab.io/blog/adding-sha256-digests-to-rpms
[3] - https://bugzilla.cendio.com/show_bug.cgi?id=7809#c2

/kind bug