### PR TITLE
Remove Rendertron usage since it is deprecated

### DIFF
--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -68,8 +68,6 @@ const (
 
 	boardInforming = "informing"
 	boardBlocking  = "blocking"
-
-	layoutISO = "2006-01-02"
 )
 
 // testGridCmd represents the base command when called without any subcommands


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PRs removes [Rendertron since it is deprecated](https://github.com/GoogleChrome/rendertron#rendertron-is-deprecated).

With this removal, the `krel testgridshot` tool will no longer take screenshots of the TestGrid boards at adding the GitHub comment to the release cut issue. Also, it will no longer upload any screenshot to the GCS bucket.

We need this removal since every time we run `krel testgridshot` and it tries to get the screenshot, the process fails and does not publish any GitHub comment throwing this error:

```bash
$ krel testgridshot
INFO Starting krel testgrishot...                 
INFO Sending GET request to https://testgrid.k8s.io/sig-release-master-blocking/summary 
INFO Sending GET request to https://testgrid.k8s.io/sig-release-master-informing/summary 
INFO rendertronURL for https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-performance&width=30: https://render-tron.appspot.com/screenshot/https:%2F%2Ftestgrid.k8s.io%2Fsig-release-master-informing%23gce-master-scale-performance&width=30?width=3000&height=2500 
INFO Sending GET request to https://render-tron.appspot.com/screenshot/https:%2F%2Ftestgrid.k8s.io%2Fsig-release-master-informing%23gce-master-scale-performance&width=30?width=3000&height=2500 
FATA processing the dashboards: failed to get the testgrid screenshot: HTTP error 404 Not Found for https://render-tron.appspot.com/screenshot/https:%2F%2Ftestgrid.k8s.io%2Fsig-release-master-informing%23gce-master-scale-performance&width=30?width=3000&height=2500
```

This error has been mentioned a couple of times before at least, see:
- [#issuecomment-1189229139](https://github.com/kubernetes/sig-release/issues/1971#issuecomment-1189229139)
- [#issuecomment-1298967991](https://github.com/kubernetes/sig-release/issues/2066#issuecomment-1298967991)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
