### PR TITLE
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.20.1 and 1.19.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.20
+    version: 1.20.1
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -281,38 +281,38 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
-    version: v1.27.0-go1.20-bullseye.0
+    version: v1.27.0-go1.20.1-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.19.5-bullseye.0
+    version: v1.26.0-go1.19.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
-    version: v1.25.0-go1.19.5-bullseye.0
+    version: v1.25.0-go1.19.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.24-cross1.20)"
-    version: v1.24.0-go1.19.5-bullseye.0
+    version: v1.24.0-go1.19.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.23-cross1.20)"
-    version: v1.23.0-go1.19.5-bullseye.0
+    version: v1.23.0-go1.19.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.20
+    version: 1.20.1
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -336,6 +336,40 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
+  # Golang (previous release branches: 1.26)
+  - name: "golang (previous release branches: 1.26)"
+    version: 1.19.6
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.26)"
+    version: 1.19.6
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  # Golang (previous release branches: 1.25)
+  - name: "golang (previous release branches: 1.25)"
+    version: 1.19.6
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.25)"
+    version: 1.19.6
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
   # Golang (previous release branches: 1.24)
   - name: "golang (previous release branches: 1.24)"
     version: 1.19.6
@@ -348,7 +382,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.19.5
+    version: 1.19.6
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -365,7 +399,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.23)"
-    version: 1.19.5
+    version: 1.19.6
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,16 +1,16 @@
 variants:
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.20-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.1-bullseye.0'
   v1.26-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.6-bullseye.0'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.6-bullseye.0'
   v1.24-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.6-bullseye.0'
   v1.23-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.23.0-go1.19.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.23.0-go1.19.6-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.20-${OS_CODENAME} AS builder
+FROM golang:1.20.1-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.20
+GO_VERSION ?= 1.20.1
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,29 +1,29 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.20'
+    GO_VERSION: '1.20.1'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.20'
+    GO_VERSION: '1.20.1'
     OS_CODENAME: 'bullseye'
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: '1.20'
+    GO_VERSION: '1.20.1'
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: '1.19.5'
+    GO_VERSION: '1.19.6'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.19.5'
+    GO_VERSION: '1.19.6'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.19.5'
+    GO_VERSION: '1.19.6'
     OS_CODENAME: 'bullseye'
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: '1.19.5'
+    GO_VERSION: '1.19.6'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency

#### What this PR does / why we need it:

- Bump k8s-cloud-builder and k8s-ci-builder to Go 1.20.1 and 1.19.6


#### Which issue(s) this PR fixes:

Part of #2909 

#### Does this PR introduce a user-facing change?
```release-note
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.20.1 and 1.19.6
```

/assign @saschagrunert @xmudrii @palnabarun @ameukam 
cc @kubernetes/release-engineering 