### PR TITLE
transition ci signal reporter reviewers from 1.26 to 1.27

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,13 +31,13 @@ aliases:
     - leonardpahlke
     - palnabarun
   ci-signal-reporter-reviewers:
-    - bharitwal # 1.26 CI Signal Shadow
+    - drewhagen # 1.27 CI Signal Shadow
+    - gracenng # 1.27 CI Signal Shadow
+    - lauralorenz # 1.27 CI Signal Lead
     - leonardpahlke
-    - mehabhalodiya # 1.26 CI Signal Shadow
-    - Namanl2001 # 1.26 CI Signal Shadow
-    - Nivedita-coder # 1.26 CI Signal Lead
+    - mehabhalodiya # 1.27 CI Signal Shadow
     - palnabarun
-    - shuheiktgw # 1.26 CI Signal Shadow
+    - Vyom-Yadav # 1.27 CI Signal Shadow
   krel-approvers:
     - cpanato
     - puerco


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update CI signal reporting tool reviewers from 1.26 to 1.27

#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
