### PR TITLE
comment out temporarily the verify image signatures

### DIFF
--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -208,12 +208,16 @@ func TestPushArtifacts(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // ValidateImages fails
-			prepare: func(mock *anagofakes.FakeReleaseImpl) {
-				mock.ValidateImagesReturns(err)
-			},
-			shouldError: true,
-		},
+		// TODO: bypassing this for now due to the fail in the promotion process
+		// that sign the images. We will release the Feb/2023 patch releases without full
+		// signatures but we will sign those in a near future in a deatached process
+		// revert this change when the patches are out
+		// { // ValidateImages fails
+		// 	prepare: func(mock *anagofakes.FakeReleaseImpl) {
+		// 		mock.ValidateImagesReturns(err)
+		// 	},
+		// 	shouldError: true,
+		// },
 		{ // PusblishVersion fails
 			prepare: func(mock *anagofakes.FakeReleaseImpl) {
 				mock.PublishVersionReturns(err)

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -93,8 +93,13 @@ func (*defaultImageImpl) SignImage(signer *sign.Signer, reference string) error 
 }
 
 func (*defaultImageImpl) VerifyImage(signer *sign.Signer, reference string) error {
-	_, err := signer.VerifyImage(reference)
-	return err
+	// TODO: bypassing this for now due to the fail in the promotion process
+	// that sign the images. We will release the Feb/2023 patch releases without full
+	// signatures but we will sign those in a near future in a deatached process
+	// revert this change when the patches are out
+	// _, err := signer.VerifyImage(reference)
+	// return err
+	return nil
 }
 
 var tagRegex = regexp.MustCompile(`^.+/(.+):.+$`)

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -204,32 +204,36 @@ func TestPublish(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // failure on sign image
-			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-				tempDir := newImagesPath(t)
-				prepareImages(t, tempDir, mock)
-
-				mock.SignImageReturns(errors.New(""))
-
-				return tempDir, func() {
-					require.Nil(t, os.RemoveAll(tempDir))
-				}
-			},
-			shouldError: true,
-		},
-		{ // failure on sign manifest
-			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-				tempDir := newImagesPath(t)
-				prepareImages(t, tempDir, mock)
-
-				mock.SignImageReturnsOnCall(10, errors.New(""))
-
-				return tempDir, func() {
-					require.Nil(t, os.RemoveAll(tempDir))
-				}
-			},
-			shouldError: true,
-		},
+		// TODO: bypassing this for now due to the fail in the promotion process
+		// that sign the images. We will release the Feb/2023 patch releases without full
+		// signatures but we will sign those in a near future in a deatached process
+		// revert this change when the patches are out
+		// { // failure on sign image
+		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+		// 		tempDir := newImagesPath(t)
+		// 		prepareImages(t, tempDir, mock)
+		//
+		// 		mock.SignImageReturns(errors.New(""))
+		//
+		// 		return tempDir, func() {
+		// 			require.Nil(t, os.RemoveAll(tempDir))
+		// 		}
+		// 	},
+		// 	shouldError: true,
+		// },
+		// { // failure on sign manifest
+		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+		// 		tempDir := newImagesPath(t)
+		// 		prepareImages(t, tempDir, mock)
+		//
+		// 		mock.SignImageReturnsOnCall(10, errors.New(""))
+		//
+		// 		return tempDir, func() {
+		// 			require.Nil(t, os.RemoveAll(tempDir))
+		// 		}
+		// 	},
+		// 	shouldError: true,
+		// },
 	} {
 		sut := release.NewImages()
 		clientMock := &releasefakes.FakeImageImpl{}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

- comment out temporarily the verify image signatures

as discussed in the Sig-release meeting today, we will ignore the release signature for the Feb/2023 patch releases and will finish the release for those patches.

We will work in a follow up process to get those images signed in a near future (1-2 weeks from now)

This change will be reverted as soon the finish the current patch releases

for more context:

- https://kubernetes.slack.com/archives/CJH2GBF7Y/p1677093689737729
- https://kubernetes.slack.com/archives/CJH2GBF7Y/p1677597577288549

/assign @puerco @xmudrii @jeremyrickard @ameukam 
cc @kubernetes/release-managers  @kubernetes/sig-release-leads 

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
