### PR TITLE
Revert "comment out temporarily the verify image signatures"

### DIFF
--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -208,16 +208,12 @@ func TestPushArtifacts(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		// TODO: bypassing this for now due to the fail in the promotion process
-		// that sign the images. We will release the Feb/2023 patch releases without full
-		// signatures but we will sign those in a near future in a deatached process
-		// revert this change when the patches are out
-		// { // ValidateImages fails
-		// 	prepare: func(mock *anagofakes.FakeReleaseImpl) {
-		// 		mock.ValidateImagesReturns(err)
-		// 	},
-		// 	shouldError: true,
-		// },
+		{ // ValidateImages fails
+			prepare: func(mock *anagofakes.FakeReleaseImpl) {
+				mock.ValidateImagesReturns(err)
+			},
+			shouldError: true,
+		},
 		{ // PusblishVersion fails
 			prepare: func(mock *anagofakes.FakeReleaseImpl) {
 				mock.PublishVersionReturns(err)

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -93,13 +93,8 @@ func (*defaultImageImpl) SignImage(signer *sign.Signer, reference string) error 
 }
 
 func (*defaultImageImpl) VerifyImage(signer *sign.Signer, reference string) error {
-	// TODO: bypassing this for now due to the fail in the promotion process
-	// that sign the images. We will release the Feb/2023 patch releases without full
-	// signatures but we will sign those in a near future in a deatached process
-	// revert this change when the patches are out
-	// _, err := signer.VerifyImage(reference)
-	// return err
-	return nil
+	_, err := signer.VerifyImage(reference)
+	return err
 }
 
 var tagRegex = regexp.MustCompile(`^.+/(.+):.+$`)

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -204,36 +204,32 @@ func TestPublish(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		// TODO: bypassing this for now due to the fail in the promotion process
-		// that sign the images. We will release the Feb/2023 patch releases without full
-		// signatures but we will sign those in a near future in a deatached process
-		// revert this change when the patches are out
-		// { // failure on sign image
-		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-		// 		tempDir := newImagesPath(t)
-		// 		prepareImages(t, tempDir, mock)
-		//
-		// 		mock.SignImageReturns(errors.New(""))
-		//
-		// 		return tempDir, func() {
-		// 			require.Nil(t, os.RemoveAll(tempDir))
-		// 		}
-		// 	},
-		// 	shouldError: true,
-		// },
-		// { // failure on sign manifest
-		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-		// 		tempDir := newImagesPath(t)
-		// 		prepareImages(t, tempDir, mock)
-		//
-		// 		mock.SignImageReturnsOnCall(10, errors.New(""))
-		//
-		// 		return tempDir, func() {
-		// 			require.Nil(t, os.RemoveAll(tempDir))
-		// 		}
-		// 	},
-		// 	shouldError: true,
-		// },
+		{ // failure on sign image
+			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+				tempDir := newImagesPath(t)
+				prepareImages(t, tempDir, mock)
+
+				mock.SignImageReturns(errors.New(""))
+
+				return tempDir, func() {
+					require.Nil(t, os.RemoveAll(tempDir))
+				}
+			},
+			shouldError: true,
+		},
+		{ // failure on sign manifest
+			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+				tempDir := newImagesPath(t)
+				prepareImages(t, tempDir, mock)
+
+				mock.SignImageReturnsOnCall(10, errors.New(""))
+
+				return tempDir, func() {
+					require.Nil(t, os.RemoveAll(tempDir))
+				}
+			},
+			shouldError: true,
+		},
 	} {
 		sut := release.NewImages()
 		clientMock := &releasefakes.FakeImageImpl{}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR reverts temporary fix implemented in #2935. We don't need it any longer as February patch releases are out.

#### Which issue(s) this PR fixes:

xref #2935 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @cpanato @puerco @jeremyrickard 
cc @kubernetes/release-engineering 