### PR TITLE
Update qemu to v7.2.0-1 for distroless-iptables

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -571,6 +571,8 @@ dependencies:
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: QEMUVERSION
+    - path: images/build/distroless-iptables/Makefile
+      match: QEMUVERSION
     - path: images/build/setcap/Makefile
       match: QEMUVERSION
     - path: images/build/debian-base/Makefile

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -30,7 +30,7 @@ BASE_REGISTRY?=registry.k8s.io/build-image
 
 GORUNNERIMAGE?=$(BASE_REGISTRY)/go-runner:$(GORUNNER_VERSION)
 
-QEMUVERSION=6.1.0-8
+QEMUVERSION=7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static
 
 ifneq ($(ARCH), amd64)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Beside bumping the version, we now track it in `dependencies.yaml` as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated qemu to v7.2.0-1 for distroless-iptables image
```
