### PR TITLE
WIP: Test OBS credentials in cloudbuild

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -16,8 +16,24 @@ secrets:
   secretEnv:
     GITHUB_TOKEN: CiQAIkWjMHZABAFJqEFQir1WipsO3rAGkhw1pwhp1er/m3px/kESUQBLz1D+hzzlrovRVuetP+sCqzjfKZl/iB0aiQIT36imOk8j7laYDZjprxGGQQQiUVaqYvstroJH3D53f4JKQHzXUvWziSSnhH3HFZz++RT/yQ==
     DOCKERHUB_TOKEN: CiQAIkWjMJDKU6Hu3pJIBf31dIl7xJQQEiccN7k1cCzGadGoT2gSTQBLz1D+uc9PMusYnFvXtJi25OqEUktDJs28d09jDyj9gcyTx9iX/JvOE3Dn2qnhrjwrUMk5bBhFjR7dHCr4mJgEVD5dXrd6yLGbDBu2
+- kmsKeyName: projects/k8s-releng-prod/locations/global/keyRings/release/cryptoKeys/obs
+  secretEnv:
+    OBS_PASSWORD: CiQAXrrgPTLzLId8sRADEJYdBeOCBv7djdomvYV/9cdEbNKUBrMSPAA2Zz9jrArtxsYUKk1if2nZE6w0wPosrAKDpko8c/WErfYajTQ/yF88gZd3DdllDHmYzTqHCA0eLbie9A==
 
 steps:
+- name: docker.io/opensuse/tumbleweed
+  entrypoint: bash
+  args:
+  - '-c'
+  - |
+    zypper in -y osc
+    mkdir -p ~/.config/osc
+    printf "[general]\n[https://api.opensuse.org]\nuser=k8s-release-bot\npass=$$OBS_PASSWORD\n" > ~/.config/osc/oscrc
+    osc ls
+    exit 1
+  secretEnv:
+  - OBS_PASSWORD
+
 - name: gcr.io/cloud-builders/git
   dir: "go/src/k8s.io"
   args:


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

Testing the OBS credentials in Google Cloud build via:

```bash
export TOOL_ORG=saschagrunert TOOL_REF=cloudbuild-test && go run ./cmd/krel stage
```

The test run successfully lists available OBS projects: https://console.cloud.google.com/cloud-build/builds;region=global/7c4fd9f4-7aba-4388-93de-200a860233ea?project=kubernetes-release-test
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
PTAL @xmudrii 
cc @kubernetes/sig-release-admins 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
