### PR TITLE
comment out temporarily the verify image signatures

### DIFF
--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -208,12 +208,16 @@ func TestPushArtifacts(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // ValidateImages fails
-			prepare: func(mock *anagofakes.FakeReleaseImpl) {
-				mock.ValidateImagesReturns(err)
-			},
-			shouldError: true,
-		},
+		// TODO: bypassing this for now due to the fail in the promotion process
+		// that sign the images. We will release the Feb/2023 patch releases without full
+		// signatures but we will sign those in a near future in a deatached process
+		// revert this change when the patches are out
+		// { // ValidateImages fails
+		// 	prepare: func(mock *anagofakes.FakeReleaseImpl) {
+		// 		mock.ValidateImagesReturns(err)
+		// 	},
+		// 	shouldError: true,
+		// },
 		{ // PusblishVersion fails
 			prepare: func(mock *anagofakes.FakeReleaseImpl) {
 				mock.PublishVersionReturns(err)

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -93,8 +93,13 @@ func (*defaultImageImpl) SignImage(signer *sign.Signer, reference string) error 
 }
 
 func (*defaultImageImpl) VerifyImage(signer *sign.Signer, reference string) error {
-	_, err := signer.VerifyImage(reference)
-	return err
+	// TODO: bypassing this for now due to the fail in the promotion process
+	// that sign the images. We will release the Feb/2023 patch releases without full
+	// signatures but we will sign those in a near future in a deatached process
+	// revert this change when the patches are out
+	// _, err := signer.VerifyImage(reference)
+	// return err
+	return nil
 }
 
 var tagRegex = regexp.MustCompile(`^.+/(.+):.+$`)

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -204,32 +204,36 @@ func TestPublish(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // failure on sign image
-			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-				tempDir := newImagesPath(t)
-				prepareImages(t, tempDir, mock)
-
-				mock.SignImageReturns(errors.New(""))
-
-				return tempDir, func() {
-					require.Nil(t, os.RemoveAll(tempDir))
-				}
-			},
-			shouldError: true,
-		},
-		{ // failure on sign manifest
-			prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
-				tempDir := newImagesPath(t)
-				prepareImages(t, tempDir, mock)
-
-				mock.SignImageReturnsOnCall(10, errors.New(""))
-
-				return tempDir, func() {
-					require.Nil(t, os.RemoveAll(tempDir))
-				}
-			},
-			shouldError: true,
-		},
+		// TODO: bypassing this for now due to the fail in the promotion process
+		// that sign the images. We will release the Feb/2023 patch releases without full
+		// signatures but we will sign those in a near future in a deatached process
+		// revert this change when the patches are out
+		// { // failure on sign image
+		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+		// 		tempDir := newImagesPath(t)
+		// 		prepareImages(t, tempDir, mock)
+		//
+		// 		mock.SignImageReturns(errors.New(""))
+		//
+		// 		return tempDir, func() {
+		// 			require.Nil(t, os.RemoveAll(tempDir))
+		// 		}
+		// 	},
+		// 	shouldError: true,
+		// },
+		// { // failure on sign manifest
+		// 	prepare: func(mock *releasefakes.FakeImageImpl) (string, func()) {
+		// 		tempDir := newImagesPath(t)
+		// 		prepareImages(t, tempDir, mock)
+		//
+		// 		mock.SignImageReturnsOnCall(10, errors.New(""))
+		//
+		// 		return tempDir, func() {
+		// 			require.Nil(t, os.RemoveAll(tempDir))
+		// 		}
+		// 	},
+		// 	shouldError: true,
+		// },
 	} {
 		sut := release.NewImages()
 		clientMock := &releasefakes.FakeImageImpl{}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR reapplies #2935 because the container images for March patch releases not properly signed.

The root cause is different this time. We had failed promotion because we reached Artifact Registry (AR) ratelimits. The signatures were not properly replicated, so not all images are signed properly. The issue with AR ratelimits has already been fixed by @puerco.

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2962

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @puerco @jeremyrickard 
cc @kubernetes/release-engineering 