### PR TITLE
allow objects.githubusercontent.com

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,7 @@ jobs:
           storage.googleapis.com:443
           sum.golang.org:443
           uploads.github.com:443
+          objects.githubusercontent.com:443
 
     - name: Checkout repository
       uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v2


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

CodeQL action was not running because it was blocked by the hardener, allowing `objects.githubusercontent.com:443`

https://github.com/kubernetes/release/actions/runs/4530836989

/assign @saschagrunert @xmudrii @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
