### PR TITLE
Add SBOM format flag to publish-release 

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -154,7 +154,7 @@ func init() {
 	githubPageCmd.PersistentFlags().StringVar(
 		&ghPageOpts.sbomFormat,
 		"sbom-format",
-		"json",
+		string(announce.FormatJSON),
 		"format to use for the SBOM [json|tag-value]",
 	)
 	githubPageCmd.PersistentFlags().StringVar(
@@ -283,7 +283,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 			RepoDirectory: opts.repoPath,
 			Assets:        assets,
 			Tag:           commandLineOpts.tag,
-			Format:        opts.sbomFormat,
+			Format:        announce.SBOMFormat(opts.sbomFormat),
 		})
 		if err != nil {
 			return fmt.Errorf("generating sbom: %w", err)

--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -86,6 +86,7 @@ type githubPageCmdLineOptions struct {
 	noupdate         bool
 	draft            bool
 	sbom             bool
+	sbomFormat       string
 	name             string
 	repo             string
 	template         string
@@ -150,14 +151,18 @@ func init() {
 		true,
 		"Generate an SPDX bill of materials and attach it to the release",
 	)
-
+	githubPageCmd.PersistentFlags().StringVar(
+		&ghPageOpts.sbomFormat,
+		"sbom-format",
+		"json",
+		"format to use for the SBOM [json|tag-value]",
+	)
 	githubPageCmd.PersistentFlags().StringVar(
 		&ghPageOpts.repoPath,
 		"repo-path",
 		".",
 		"Path to the source code repository",
 	)
-
 	githubPageCmd.PersistentFlags().StringVar(
 		&ghPageOpts.ReleaseNotesFile,
 		"release-notes-file",
@@ -278,6 +283,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 			RepoDirectory: opts.repoPath,
 			Assets:        assets,
 			Tag:           commandLineOpts.tag,
+			Format:        opts.sbomFormat,
 		})
 		if err != nil {
 			return fmt.Errorf("generating sbom: %w", err)

--- a/compile-release-tools
+++ b/compile-release-tools
@@ -22,6 +22,8 @@ RELEASE_TOOLS=(
   krel
   kubepkg
   schedule-builder
+  publish-release
+  release-notes
 )
 
 setup_env() {

--- a/pkg/announce/github_page.go
+++ b/pkg/announce/github_page.go
@@ -105,12 +105,19 @@ type GitHubPageOptions struct {
 	Substitutions map[string]string
 }
 
+type SBOMFormat string
+
+const (
+	FormatJSON     SBOMFormat = "json"
+	FormatTagValue SBOMFormat = "tag-value"
+)
+
 type SBOMOptions struct {
 	ReleaseName   string
 	Repo          string
 	RepoDirectory string
-	Tag           string // Version Tag
-	Format        string // "tag-value"  | "json"
+	Tag           string     // Version Tag
+	Format        SBOMFormat // "tag-value"  | "json"
 	Assets        []Asset
 }
 
@@ -173,12 +180,12 @@ func GenerateReleaseSBOM(opts *SBOMOptions) (string, error) {
 
 	var renderer serialize.Serializer
 	switch opts.Format {
-	case "json":
+	case FormatJSON:
 		renderer = &serialize.JSON{}
-	case "tag-value":
+	case FormatTagValue:
 		renderer = &serialize.TagValue{}
 	default:
-		return "", errors.New("invalid SBOM format, must be one of json, tag-value")
+		return "", fmt.Errorf("invalid SBOM format, must be one of %s, %s", FormatJSON, FormatTagValue)
 	}
 
 	markup, err := renderer.Serialize(doc)


### PR DESCRIPTION

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds a new flag to `publish-release github` to control the format of the generated SBOM and to use JSON as the default.

It also adds targets to the repo Makefile to build publish release along with `release-notes`. 

#### Which issue(s) this PR fixes:

2nd commit related to https://github.com/kubernetes/release/issues/1987

#### Special notes for your reviewer:

/assign @cpanato 

#### Does this PR introduce a user-facing change?


```release-note
The SBOM format can now be controlled in `publish release github` and JSON is now the default.
```
