### PR TITLE
kube-cross: install gcc-x86-64-linux-gnu on non amd64 platform

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -78,6 +78,12 @@ RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
     && apt-get install -y build-essential; \
 fi
 
+# To build amd64 from arm64 host platform, gcc-x86-64-linux-gnu is needed.
+RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
+  && if [ ${targetArch} = "arm64" ]; then \
+    apt-get install -y gcc-x86-64-linux-gnu; \
+fi
+
 ARG PROTOBUF_VERSION
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
   && if [ ${targetArch} = "amd64" ]; then \


### PR DESCRIPTION
As also reported in [kubernetes/kubernetes#116989][1], it is not possible to cross build amd64 binaries from arm64 host architecture. The build fails with messages like below:

```
cgo: C compiler "x86_64-linux-gnu-gcc" not found: exec: "x86_64-linux-gnu-gcc": executable file not found in $PATH
!!! [0329 14:22:44] Call tree:
!!! [0329 14:22:44]  1: /go/src/k8s.io/kubernetes/hack/lib/golang.sh:767 kube::golang::build_some_binaries(...)
!!! [0329 14:22:44]  2: /go/src/k8s.io/kubernetes/hack/lib/golang.sh:929 kube::golang::build_binaries_for_platform(...)
!!! [0329 14:22:44]  3: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [0329 14:22:44] Call tree:
!!! [0329 14:22:44]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [0329 14:22:44] Call tree:
!!! [0329 14:22:44]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
```

It is needed to install `gcc-x86-64-linux-gnu` in this case.

/kind feature

```release-note
kube-cross: support linux/amd64 build from arm64 host platform
```
