### PR TITLE
update debian-iptables and distroless-iptables to go 1.20.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -450,7 +450,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/debian-iptables"
-    version: bullseye-v1.5.5
+    version: bullseye-v1.5.6
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ bullseye-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -458,13 +458,13 @@ dependencies:
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.2.3
+    version: v0.2.4
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.20.3-bullseye.0
+    version: v2.3.1-go1.20.4-bullseye.0
     refPaths:
     - path: images/build/debian-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+
@@ -495,7 +495,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/debian-iptables (next candidate)"
-    version: bullseye-v1.5.5
+    version: bullseye-v1.5.6
     refPaths:
     - path: images/build/debian-iptables/variants.yaml
       match: "IMAGE_VERSION: 'bullseye-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/debian-iptables/Makefile
+++ b/images/build/debian-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bullseye-v1.5.5
+IMAGE_VERSION ?= bullseye-v1.5.6
 CONFIG ?= bullseye
 DEBIAN_BASE_VERSION ?= bullseye-v1.4.3
-GORUNNER_VERSION ?= v2.3.1-go1.20.3-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.20.4-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/debian-iptables/variants.yaml
+++ b/images/build/debian-iptables/variants.yaml
@@ -2,6 +2,6 @@ variants:
   # Debian 11 - Kubernetes 1.23 and newer
   bullseye:
     CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.5.5'
+    IMAGE_VERSION: 'bullseye-v1.5.6'
     DEBIAN_BASE_VERSION: 'bullseye-v1.4.3'
-    GORUNNER_VERSION: 'v2.3.1-go1.20.3-bullseye.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.20.4-bullseye.0'

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.2.3
+IMAGE_VERSION ?= v0.2.4
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bullseye-slim
-GORUNNER_VERSION ?= v2.3.1-go1.20.3-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.20.4-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.2.3'
-    GORUNNER_VERSION: 'v2.3.1-go1.20.3-bullseye.0'
+    IMAGE_VERSION: 'v0.2.4'
+    GORUNNER_VERSION: 'v2.3.1-go1.20.4-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

* update debian-iptables and distroless-iptables

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3025

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @cpanato 
cc @kubernetes/release-engineering 