### PR TITLE
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.9

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -267,19 +267,19 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.19.8-bullseye.0
+    version: v1.26.0-go1.19.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
-    version: v1.25.0-go1.19.8-bullseye.0
+    version: v1.25.0-go1.19.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.24-cross1.20)"
-    version: v1.24.0-go1.19.8-bullseye.0
+    version: v1.24.0-go1.19.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -322,7 +322,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.26)"
-    version: 1.19.8
+    version: 1.19.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -339,7 +339,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.25)"
-    version: 1.19.8
+    version: 1.19.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -356,7 +356,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.19.8
+    version: 1.19.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,10 +4,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.27.0-go1.20.4-bullseye.0'
   v1.26-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.9-bullseye.0'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.9-bullseye.0'
   v1.24-cross1.19-bullseye:
     CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.9-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -13,13 +13,13 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: '1.19.8'
+    GO_VERSION: '1.19.9'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.19.8'
+    GO_VERSION: '1.19.9'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.19.8'
+    GO_VERSION: '1.19.9'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

* Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.9

Go 1.20.4 bump has been already merged as part of #3032 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3025

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.19.9
```

/hold for cherry-picks to get merged
/assign @saschagrunert @cpanato @puerco @cici37 
cc @kubernetes/release-engineering 