### PR TITLE
fix: updated `publish-packages.sh` to use `dl.k8s.io` bucket

### DIFF
--- a/hack/rapture/publish-packages.sh
+++ b/hack/rapture/publish-packages.sh
@@ -57,7 +57,7 @@ fatal() {
 version="$1"
 
 download_packages() {
-  local bucket="gs://kubernetes-release/release"
+  local bucket="https://dl.k8s.io/release"
   log "Downloading packages from bucket $bucket"
 
   declare -A locations=(
@@ -68,7 +68,7 @@ download_packages() {
   for package in "${!locations[@]}"; do
     rm -rf "${locations[$package]}" || true
     mkdir -p "${locations[$package]}"
-    gsutil -m cp -r "$bucket/v$version/$package/*" "${locations[$package]}"
+    curl -L "$bucket/v$version/$package/*" -o "${locations[$package]}"
   done
 
   log "Got all packages"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to gs://kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396