### PR TITLE
Add osc to k8s-cloud-builder image

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get -q update \
         lsb-release \
         make \
         net-tools \
+        osc \
         pandoc \
         rsync \
         software-properties-common \

--- a/images/k8s-cloud-builder/test.yaml
+++ b/images/k8s-cloud-builder/test.yaml
@@ -43,6 +43,8 @@ commandTests:
   - yq
   # for multiarch support / cross building
   - gcc
+  # CLI for OpenBuildService (OBS)
+  - osc
   - arm-linux-gnueabihf-gcc
   - aarch64-linux-gnu-gcc
   - powerpc64le-linux-gnu-gcc


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds `osc` to k8s-cloud-builder image. `osc` is CLI for OpenBuildService (OBS) and we're going to use it for building and publishing packages. `osc` is available as a package in Debian repositories out of the box.

The list of packages that are added with the `osc` package:

```
The following additional packages will be installed:
  arch-test bash-completion cpio dbus debootstrap debugedit libapparmor1 libarchive-tools libarchive13
  libbytes-random-secure-perl libcrypt-random-seed-perl libcrypt-ssleay-perl libdbus-1-3 libdw1 liblua5.2-0
  libmath-random-isaac-perl libmath-random-isaac-xs-perl librpm9 librpmbuild9 librpmio9 librpmsign9 obs-build
  python3-cffi-backend python3-chardet python3-cryptography python3-jeepney python3-keyring python3-m2crypto
  python3-parameterized python3-pkg-resources python3-rpm python3-secretstorage python3-six python3-websocket rpm
  rpm-common rpm2cpio sudo wget xzdec
Suggested packages:
  libarchive1 default-dbus-session-bus | dbus-session-bus ubuntu-archive-keyring squid-deb-proxy-client rpm-i18n lrzip
  xfsprogs btrfs-progs python-cryptography-doc python3-cryptography-vectors gnome-keyring libkf5wallet-bin python3-dbus
  python3-keyrings.alt python-m2crypto-doc python3-setuptools python-secretstorage-doc alien elfutils rpmlint rpm2html
The following NEW packages will be installed:
  arch-test bash-completion cpio dbus debootstrap debugedit libapparmor1 libarchive-tools libarchive13
  libbytes-random-secure-perl libcrypt-random-seed-perl libcrypt-ssleay-perl libdbus-1-3 libdw1 liblua5.2-0
  libmath-random-isaac-perl libmath-random-isaac-xs-perl librpm9 librpmbuild9 librpmio9 librpmsign9 obs-build osc
  python3-cffi-backend python3-chardet python3-cryptography python3-jeepney python3-keyring python3-m2crypto
  python3-parameterized python3-pkg-resources python3-rpm python3-secretstorage python3-six python3-websocket rpm
  rpm-common rpm2cpio sudo wget xzdec
0 upgraded, 41 newly installed, 0 to remove and 16 not upgraded.
```

#### Special notes for your reviewer:

I have some concerns regarding the number of dependencies that are installed:

- How much is that going to affect the image size?
- How much is that going to affect the security of that image in term of number of vulnerabilities potentially affecting those packages now and in the future?

I decided to go with k8s-cloud-bulider because that's what we use in stage and release for krel. We'll extend stage and release steps with OBS workflow, so I wanted to keep the same image. Alternative is to create a new image or repurpose the kubepkg image, but I'm opening this PR to collect ideas and feedback.

#### Does this PR introduce a user-facing change?
```release-note
Add `osc` (OpenBuildService CLI) to k8s-cloud-builder image
```

/assign @saschagrunert @cpanato @jeremyrickard 
cc @kubernetes/release-engineering 
/hold
for discussion