### PR TITLE
Fix env substitution in release/cloudbuild.yaml

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
   - "bin/krel"
   - "sign"
   - "blobs"
-  - "--certificate-identity=${GOOGLE_SERVICE_ACCOUNT_NAME}"
+  - "--certificate-identity=$${GOOGLE_SERVICE_ACCOUNT_NAME}"
   - "--certificate-oidc-issuer=https://accounts.google.com"
   - "--log-level=${_LOG_LEVEL}"
   - "${_KUBERNETES_GCS_BUCKET}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

We added a new environment variable `GOOGLE_SERVICE_ACCOUNT_NAME` for release GCB in #3078 and we reference that environment variable in args for the same step where that env variable is defined. However, that is a static environment variable, not a substitution. That said, trying to use `$` will result in a failure because `GOOGLE_SERVICE_ACCOUNT_NAME` is not provided in a substitution map.

From what I found, we can use `$$` to avoid substitution, so this hopefully should fix the problem.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @ameukam @puerco @cpanato 
cc @kubernetes/release-engineering 