### PR TITLE
Inline value for certificate-identity in GCB release

### DIFF
--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
   - "bin/krel"
   - "sign"
   - "blobs"
-  - "--certificate-identity=$${GOOGLE_SERVICE_ACCOUNT_NAME}"
+  - "--certificate-identity=krel-staging@k8s-releng-prod.iam.gserviceaccount.com"
   - "--certificate-oidc-issuer=https://accounts.google.com"
   - "--log-level=${_LOG_LEVEL}"
   - "${_KUBERNETES_GCS_BUCKET}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

My fix in #3092 didn't work, so let's try what @cpanato proposed in https://github.com/kubernetes/release/pull/3092#discussion_r1210706312

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @ameukam @cpanato @puerco 
cc @kubernetes/release-engineering 