### PR TITLE
Fix package versioning and package sources extracting in `krel obs specs` subcommand

### DIFF
--- a/cmd/krel/templates/latest/cri-tools/cri-tools.spec
+++ b/cmd/krel/templates/latest/cri-tools/cri-tools.spec
@@ -2,7 +2,7 @@
 %undefine _missing_build_ids_terminate_build
 
 Name: cri-tools
-Version: {{ .Version }}
+Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Command-line utility for interacting with a container runtime
 

--- a/cmd/krel/templates/latest/kubeadm/kubeadm.spec
+++ b/cmd/krel/templates/latest/kubeadm/kubeadm.spec
@@ -14,8 +14,6 @@ License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
 
-Require: kubectl >= {{ .Version }}
-Require: kubelet >= {{ .Version }}
 {{ range $dep := .Metadata.Dependencies }}
 Requires: {{ $dep.Name }} {{ $dep.VersionConstraint }}
 {{- end }}

--- a/cmd/krel/templates/latest/kubeadm/kubeadm.spec
+++ b/cmd/krel/templates/latest/kubeadm/kubeadm.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: kubeadm
-Version: {{ .Version }}
+Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Command-line utility for administering a Kubernetes cluster
 

--- a/cmd/krel/templates/latest/kubectl/kubectl.spec
+++ b/cmd/krel/templates/latest/kubectl/kubectl.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: kubectl
-Version: {{ .Version }}
+Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Command-line utility for interacting with a Kubernetes cluster
 

--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name: kubelet
-Version: {{ .Version }}
+Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Node agent for Kubernetes clusters
 

--- a/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
+++ b/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
@@ -2,7 +2,7 @@
 %undefine _missing_build_ids_terminate_build
 
 Name: kubernetes-cni
-Version: {{ .Version }}
+Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Binaries required to provision kubernetes container networking
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	sigs.k8s.io/mdtoc v1.1.0
 	sigs.k8s.io/promo-tools/v3 v3.6.0
 	sigs.k8s.io/release-sdk v0.10.2-0.20230526102852-a20f93c51631
-	sigs.k8s.io/release-utils v0.7.5-0.20230526101452-f7d5a1fbd5ad
+	sigs.k8s.io/release-utils v0.7.5-0.20230529163343-ef81b7d025bc
 	sigs.k8s.io/yaml v1.3.0
 	sigs.k8s.io/zeitgeist v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1615,8 +1615,8 @@ sigs.k8s.io/promo-tools/v3 v3.6.0 h1:C2L08ezrWm1aZI8Emd3iZPZQserLPRgzuqQVxvI0PUI
 sigs.k8s.io/promo-tools/v3 v3.6.0/go.mod h1:XJ3jy0hJYs+hWKt8XsLHFzGQV8PUtvllvbxjN/E5RXI=
 sigs.k8s.io/release-sdk v0.10.2-0.20230526102852-a20f93c51631 h1:Nlfp/k1YPaEGjwrK+y3zlnIQcjSmb4g6LH9oXGKeZ+I=
 sigs.k8s.io/release-sdk v0.10.2-0.20230526102852-a20f93c51631/go.mod h1:Go3wt8dMyJOayvZjANFfylamvCauGO4syI73kVHPGTw=
-sigs.k8s.io/release-utils v0.7.5-0.20230526101452-f7d5a1fbd5ad h1:VIkuEZXIvpWG2kJJf4iphoN79zcINjJ6waUy8gAihtw=
-sigs.k8s.io/release-utils v0.7.5-0.20230526101452-f7d5a1fbd5ad/go.mod h1:fsXUqmj1ekJ5sfkmfP3J0x9gh96NwVucQO6sG9STMLM=
+sigs.k8s.io/release-utils v0.7.5-0.20230529163343-ef81b7d025bc h1:hF6rDvDKwf7BJJWjphokRgS6701CppNd6oZUGE3fg4s=
+sigs.k8s.io/release-utils v0.7.5-0.20230529163343-ef81b7d025bc/go.mod h1:fsXUqmj1ekJ5sfkmfP3J0x9gh96NwVucQO6sG9STMLM=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -166,7 +166,7 @@ type State struct {
 // DefaultState returns a new empty State
 func DefaultState() *State {
 	// The default state is empty, it will be initialized after ValidateOptions()
-	// runs in Stage/Release. It will change as the satege/release processes move forward
+	// runs in Stage/Release. It will change as the stage/release processes move forward
 	return &State{
 		startTime: time.Now(),
 	}
@@ -185,7 +185,7 @@ type StageState struct {
 	*State
 }
 
-// DefaultStageState create a new default `ReleaseOptions`.
+// DefaultStageState create a new default `StageState`.
 func DefaultStageState() *StageState {
 	return &StageState{
 		State: DefaultState(),

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -52,7 +52,7 @@ type stageClient interface {
 	// InitLogFile sets up the log file target.
 	InitLogFile() error
 
-	// Validate if the provided `ReleaseOptions` are correctly set.
+	// Validate if the provided `StageOptions` are correctly set.
 	ValidateOptions() error
 
 	// CheckPrerequisites verifies that a valid GITHUB_TOKEN environment

--- a/pkg/obs/specs/archive.go
+++ b/pkg/obs/specs/archive.go
@@ -85,7 +85,7 @@ func (s *Specs) BuildArtifactsArchive(pkgDef *PackageDefinition) error {
 	logrus.Infof("Archiving artifacts for %s %s...", pkgDef.Name, pkgDef.Version)
 
 	archiveSrc := filepath.Join(pkgDef.SpecOutputPath, pkgDef.Name)
-	archiveDst := filepath.Join(pkgDef.SpecOutputPath, fmt.Sprintf("%s_%s.orig.tar.gz", pkgDef.Name, pkgDef.Version))
+	archiveDst := filepath.Join(pkgDef.SpecOutputPath, fmt.Sprintf("%s_%s.orig.tar.gz", pkgDef.Name, pkgDef.RPMVersion()))
 
 	if err := s.impl.Compress(archiveDst, archiveSrc); err != nil {
 		return fmt.Errorf("creating archive: %w", err)

--- a/pkg/obs/specs/pkgdef.go
+++ b/pkg/obs/specs/pkgdef.go
@@ -51,6 +51,14 @@ type PackageVariation struct {
 	Source       string
 }
 
+// RPMVersion returns version that's escaped to be a valid RPM package
+// version. This function currently replaces "-" with "~" as described in
+// the following document:
+// https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret
+func (p *PackageDefinition) RPMVersion() string {
+	return strings.ReplaceAll(p.Version, "-", "~")
+}
+
 // ConstructPackageDefinition creates a new instance of PackageDefinition based
 // on provided options.
 func (s *Specs) ConstructPackageDefinition() (*PackageDefinition, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update release-utils to include https://github.com/kubernetes-sigs/release-utils/pull/84
- Fix some typos in `pkg/anago`
- Fix package versions for prereleases
  - RPM doesn't support semver as package version because `-` is considered as an invalid character
  - The [official guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret) recommend using `~` instead of `-`, so this PR implements this recommendation

#### Does this PR introduce a user-facing change?
```release-note
- Update release-utils to `243952c`
- Replace `-` with `~` in package version for OBS packages to support prereleases
```

/assign @puerco @cpanato @saschagrunert 
cc @kubernetes/release-engineering 