### PR TITLE
Update packages in distroless-iptables build

### DIFF
--- a/images/build/distroless-iptables/distroless/Dockerfile
+++ b/images/build/distroless-iptables/distroless/Dockerfile
@@ -24,6 +24,7 @@ COPY package-utils.sh /
 # TODO: /bin/sleep is used by a specific e2e test
 ARG STAGE_DIR="/opt/stage"
 RUN apt -y update && \
+    apt -y dist-upgrade && \
     apt -y install bash curl && \
     mkdir -p "${STAGE_DIR}" && \
     /stage-binaries-from-package.sh "${STAGE_DIR}" conntrack \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Update system packages as part of the build. This is similar to what we already do for `debian-base`. 

I noticed that there were a number of relatively minor CVEs in the `distroless-iptables` in openssl. It appears it's coming in through the bae image - `debian:bullseye-slim`. The openssl version has an upgrade available but is not installed by default:

```
root@2d264ed7da9b:/# apt update
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8183 kB]
Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [245 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.8 kB]
Fetched 8651 kB in 2s (4759 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.

root@2d264ed7da9b:/# apt list --upgradeable
Listing... Done
libssl1.1/stable-security 1.1.1n-0+deb11u5 amd64 [upgradable from: 1.1.1n-0+deb11u4]
N: There is 1 additional version. Please use the '-a' switch to see it
```

This happens because there is a delay between when the new library is made available in stable, e.g.:

- https://tracker.debian.org/news/1432726/accepted-openssl-111n-0deb11u5-source-into-stable-security/

And when a new base image is actually updated / released in the dockerhub repo:

- https://github.com/docker-library/official-images/blob/master/library/debian

This change just makes sure that if there is an available fix from the repo it will get installed even if it hasn't made it into the image. I built a new one for amd64 and scanned it, this takes care of the 4 CVEs I previously detected.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
