### PR TITLE
Drop `arm` arch from `kubepkg`

### DIFF
--- a/pkg/kubepkg/options/options.go
+++ b/pkg/kubepkg/options/options.go
@@ -65,7 +65,7 @@ var (
 		"release", "testing", "nightly",
 	}
 	supportedArchitectures = []string{
-		"amd64", "arm", "arm64", "ppc64le", "s390x",
+		"amd64", "arm64", "ppc64le", "s390x",
 	}
 	latestTemplateDir = filepath.Join(templateRootDir, "latest")
 )


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We dropped the `arm` architecture from the server binaries a while ago so we have to remove it from kubepkg's default architectures as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/kubernetes/issues/118448
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `arm` architecture from `kubepkg` command.
```
