### PR TITLE
Bump k8s-cloud-builder and golang refs to 1.20.5 after k/k update

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.20.4
+    version: 1.20.5
     refPaths:
     - path: images/releng/k8s-ci-builder/Dockerfile
       match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-\${OS_CODENAME} AS builder
@@ -261,7 +261,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
-    version: v1.27.0-go1.20.4-bullseye.0
+    version: v1.27.0-go1.20.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.5-bullseye.0'
   v1.26-cross1.19-bullseye:
     CONFIG: 'cross1.19'
     KUBE_CROSS_VERSION: 'v1.26.0-go1.19.9-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -17,7 +17,7 @@ ARG OS_CODENAME
 
 # The Golang version for the builder image should always be explicitly set to
 # the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:1.20.4-${OS_CODENAME} AS builder
+FROM golang:1.20.5-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.20.4
+GO_VERSION ?= 1.20.5
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,15 +1,15 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.20.4'
+    GO_VERSION: '1.20.5'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.20.4'
+    GO_VERSION: '1.20.5'
     OS_CODENAME: 'bullseye'
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: '1.20.4'
+    GO_VERSION: '1.20.5'
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Bump k8s-cloud-builder and cube-cross to go 1.20.5 after updating k/k

#### Which issue(s) this PR fixes:

ref: #3099 

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

/assign @saschagrunert @xmudrii @cpanato @puerco 
/cc: @kubernetes/release-engineering 
