### PR TITLE
use google/safetext for yaml templating.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # repo infra
   - name: "repo-infra"
-    version: 0.1.1
+    version: 0.2.5
     refPaths:
     - path: hack/verify-boilerplate.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/go-github/v50 v50.2.0
+	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,8 @@ github.com/google/pprof v0.0.0-20221103000818-d260c55eee4c h1:lvddKcYTQ545ADhBuj
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp5GZKyvYY6MkjvPE8CIMlkvXFF8gA=
+github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/tink/go v1.7.0 h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v0.1.1
+VERSION=v0.2.5
 URL_BASE=https://raw.githubusercontent.com/kubernetes/repo-infra
 URL=$URL_BASE/$VERSION/hack/verify_boilerplate.py
 BIN_DIR=bin

--- a/images/build/go-runner/go-runner.go
+++ b/images/build/go-runner/go-runner.go
@@ -54,7 +54,7 @@ func configureAndRun() error {
 	}
 
 	if logFilePath != nil && *logFilePath != "" {
-		logFile, err := os.OpenFile(*logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		logFile, err := os.OpenFile(*logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return fmt.Errorf("failed to create log file %v: %w", *logFilePath, err)
 		}

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/packages/deb/build.go
+++ b/packages/deb/build.go
@@ -79,6 +79,7 @@ type stringList []string
 func (ss *stringList) String() string {
 	return strings.Join(*ss, ",")
 }
+
 func (ss *stringList) Set(v string) error {
 	*ss = strings.Split(v, ",")
 	return nil
@@ -206,7 +207,7 @@ func (c cfg) run() error {
 	dstParts := []string{"bin", string(c.Channel), c.DistroName}
 
 	dstPath := filepath.Join(dstParts...)
-	os.MkdirAll(dstPath, 0777)
+	os.MkdirAll(dstPath, 0o777)
 
 	fileName := fmt.Sprintf("%s_%s-%s_%s.deb", c.Package, c.Version, c.Revision, c.DebArch)
 	err = runCommand("", "mv", filepath.Join("/tmp", fileName), dstPath)

--- a/packages/deb/build_test.go
+++ b/packages/deb/build_test.go
@@ -105,5 +105,4 @@ func TestGetKubeadmDependencies(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/obs/specs/pkgdef.go
+++ b/pkg/obs/specs/pkgdef.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
I think `krel` is used only with trusted inputs.

However, this should be a safe drop in replacement that blocks yaml injection attacks via package metadata templates.

/kind cleanup

#### What this PR does / why we need it:

use google/safetext (a drop-in replacement for text/template) to generate yaml. 
This prevents certain yaml injection attacks.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
