### PR TITLE
update golangci-lint to v1.53

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5f1fec7010f6ae3b84ea4f7b2129beb8639b564f # v3.5.0
         with:
-          version: v1.52
+          version: v1.53
           args: --timeout=15m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
     - bodyclose
     - contextcheck
     - decorder
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -404,7 +404,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v1.52
+    version: v1.53
     refPaths:
     - path: .github/workflows/lint.yml
       match: "version: v\\d+.\\d+?\\.?(\\d+)?"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update golangci-lint to v1.53
and drop depguard which now required to setup all imports and that is too expensive to maintain 

/assign @saschagrunert @puerco @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
