### PR TITLE
Bump builders to use Go 1.20.5 for branches 1.26/1.25/1.24

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -301,19 +301,19 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.19.10-bullseye.0
+    version: v1.26.0-go1.20.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
-    version: v1.25.0-go1.19.10-bullseye.0
+    version: v1.25.0-go1.20.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.24-cross1.20)"
-    version: v1.24.0-go1.19.10-bullseye.0
+    version: v1.24.0-go1.20.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -2,12 +2,12 @@ variants:
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
     KUBE_CROSS_VERSION: 'v1.27.0-go1.20.5-bullseye.0'
-  v1.26-cross1.19-bullseye:
-    CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.19.10-bullseye.0'
+  v1.26-cross1.20-bullseye:
+    CONFIG: 'cross1.20'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.5-bullseye.0'
   v1.25-cross1.19-bullseye:
-    CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.19.10-bullseye.0'
+    CONFIG: 'cross1.20'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.20.5-bullseye.0'
   v1.24-cross1.19-bullseye:
-    CONFIG: 'cross1.19'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.19.10-bullseye.0'
+    CONFIG: 'cross1.20'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.20.5-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

* Bump k8s-cloud-builder and k8s-ci-builder to Go 1.20.5

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Bump k8s-cloud-builder and k8s-ci-builder to Go 1.20.5
```

/hold for cherry-picks to get merged
/assign @saschagrunert @xmudrii  @puerco @cici37 
cc @kubernetes/release-managers  