### PR TITLE
kube-cross v1.28: switch to debian bookworm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -195,16 +195,16 @@ dependencies:
 
   # kube-cross
   - name: "registry.k8s.io/build-image/kube-cross (v1.28-go1.21)"
-    version: v1.28.0-go1.21rc2-bullseye.0
+    version: v1.28.0-go1.21rc2-bookworm.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.28-go1.21)"
-    version: go1.21-bullseye
+    version: go1.21-bookworm
     refPaths:
     - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+      match: "CONFIG: 'go\\d+.\\d+-bookworm'"
 
   - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.28-go1.21)"
     version: 0
@@ -339,10 +339,10 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: config variant (next candidate)"
-    version: go1.21-bullseye
+    version: go1.21-bookworm
     refPaths:
     - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+      match: "CONFIG: 'go\\d+.\\d+-bookworm'"
 
   # Golang (previous release branches: 1.26)
   - name: "golang (previous release branches: 1.26)"

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,12 +1,12 @@
 variants:
-  v1.28-go1.21-bullseye:
-    CONFIG: 'go1.21-bullseye'
+  v1.28-go1.21-bookworm:
+    CONFIG: 'go1.21-bookworm'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.28.0-go1.21rc2-bullseye.0'
+    IMAGE_VERSION: 'v1.28.0-go1.21rc2-bookworm.0'
     KUBERNETES_VERSION: 'v1.28.0'
     GO_VERSION: '1.21rc2'
     GO_MAJOR_VERSION: '1.21'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
     REVISION: '0'
     PROTOBUF_VERSION: '3.19.4'
   v1.27-go1.20-bullseye:


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Update the kube-cross v1.28 image to use debian bookworm.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3128
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated the kube-cross v1.28 image to use debian bookworm.
```
