### PR TITLE
releng-ci: switch to debian bookworm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -436,8 +436,8 @@ dependencies:
     #  match: CONFIG\ \?=\ bullseye
     # - path: images/build/setcap/variants.yaml
     #   match: "CONFIG: 'bullseye'"
-    - path: images/releng/ci/variants.yaml
-      match: "OS_CODENAME: 'bullseye'"
+    # - path: images/releng/ci/variants.yaml
+    #   match: "OS_CODENAME: 'bullseye'"
     - path: images/releng/k8s-ci-builder/Makefile
       match: OS_CODENAME\ \?=\ bullseye
     - path: images/releng/k8s-ci-builder/variants.yaml

--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -31,8 +31,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install goreleaser
-ARG GORELEASER_VERSION=v1.16.0
-ARG GORELEASER_SHA=498193112465ba149b55684d75d40a94649b5ba031021e82d9aa3df420f7c5a6
+ARG GORELEASER_VERSION=v1.19.2
+ARG GORELEASER_SHA=27c7397b816c43098f88cbccc5aeec3df929fb857f28b2cb8e885d09458ada1e
 RUN  \
     GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz && \
     GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE} && \
@@ -43,8 +43,8 @@ RUN  \
     goreleaser -v
 
 # install ko
-ARG KO_VERSION=v0.13.0
-ARG KO_SHA=80f3e3148fabd5b839cc367ac56bb4794f90e7262b01911316c670b210b574cc
+ARG KO_VERSION=v0.14.1
+ARG KO_SHA=3f8f8e3fb4b78a4dfc0708df2b58f202c595a66c34195786f9a279ea991f4eae
 RUN  \
     KO_DOWNLOAD_FILE=ko_${KO_VERSION#v}_Linux_x86_64.tar.gz && \
     KO_DOWNLOAD_URL=https://github.com/ko-build/ko/releases/download/${KO_VERSION}/${KO_DOWNLOAD_FILE} && \

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,16 +1,16 @@
 variants:
-  go1.21-bullseye:
-    CONFIG: 'go1.21-bullseye'
+  go1.21-bookworm:
+    CONFIG: 'go1.21-bookworm'
     GO_VERSION: '1.21rc2'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
     REVISION: '0'
-  go1.20-bullseye:
-    CONFIG: 'go1.20-bullseye'
+  go1.20-bookworm:
+    CONFIG: 'go1.20-bookworm'
     GO_VERSION: '1.20.5'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
     REVISION: '0'
-  go1.19-bullseye:
-    CONFIG: 'go1.19-bullseye'
+  go1.19-bookworm:
+    CONFIG: 'go1.19-bookworm'
     GO_VERSION: '1.19.10'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
     REVISION: '0'


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Updated releng-ci image to use debian bookworm.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3128
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated releng-ci image to use debian bookworm.

```
