### PR TITLE
Update distroless-iptables to use Go 1.20.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -473,13 +473,13 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.2.5
+    version: v0.2.6
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.20.5-bullseye.0
+    version: v2.3.1-go1.20.6-bullseye.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.2.5
+IMAGE_VERSION ?= v0.2.6
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bullseye-slim
-GORUNNER_VERSION ?= v2.3.1-go1.20.5-bullseye.0
+GORUNNER_VERSION ?= v2.3.1-go1.20.6-bullseye.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.2.5'
-    GORUNNER_VERSION: 'v2.3.1-go1.20.5-bullseye.0'
+    IMAGE_VERSION: 'v0.2.6'
+    GORUNNER_VERSION: 'v2.3.1-go1.20.6-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update distroless-iptables to use Go 1.20.6

#### Which issue(s) this PR fixes:

xref #3148 

#### Does this PR introduce a user-facing change?
```release-note
Update distroless-iptables to use Go 1.20.6
```

/assign @saschagrunert @cpanato
cc @kubernetes/release-engineering 