### PR TITLE
Update builders for release branches to Go 1.20.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -295,19 +295,19 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.20.5-bullseye.0
+    version: v1.26.0-go1.20.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
-    version: v1.25.0-go1.20.5-bullseye.0
+    version: v1.25.0-go1.20.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.24-cross1.20)"
-    version: v1.24.0-go1.20.5-bullseye.0
+    version: v1.24.0-go1.20.6-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -356,7 +356,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.26)"
-    version: 1.20.5
+    version: 1.20.6
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -373,7 +373,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.25)"
-    version: 1.20.5
+    version: 1.20.6
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -390,7 +390,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
-    version: 1.20.5
+    version: 1.20.6
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,10 +4,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.27.0-go1.20.6-bullseye.0'
   v1.26-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.6-bullseye.0'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.20.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.20.6-bullseye.0'
   v1.24-cross1.19-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.20.5-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.24.0-go1.20.6-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -17,13 +17,13 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: '1.20.5'
+    GO_VERSION: '1.20.6'
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.20.5'
+    GO_VERSION: '1.20.6'
     OS_CODENAME: 'bullseye'
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: '1.20.5'
+    GO_VERSION: '1.20.6'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update builders for release branches to Go 1.20.6

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3148

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @cpanato 
cc @kubernetes/release-engineering 