### PR TITLE
Add rpmlintrc file for kubelet

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.rpmlintrc
+++ b/cmd/krel/templates/latest/kubelet/kubelet.rpmlintrc
@@ -1,0 +1,5 @@
+# Ignore "suse-filelist-forbidden-sysconfig" because we can't use "fillup" in
+# our specs. That's because we want to build on SUSE Linux, but use resulting
+# packages on other RPM-based operating systems. This is not possible if
+# "fillup" is used.
+setBadness('suse-filelist-forbidden-sysconfig', 0)

--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -1,13 +1,5 @@
 %global debug_package %{nil}
 
-%if 0%{?suse_version}
-# Needed for SUSE SLE 12 GA used to build s390x package
-## Use the right path for sharedstatedir
-%global _sharedstatedir %{_localstatedir}/lib
-## Use the right path for _fillupdir when not defined
-%{!?_fillupdir:%global _fillupdir %{_localstatedir}/adm/fillup-templates}
-%endif
-
 Name: kubelet
 Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
@@ -21,6 +13,7 @@ Packager: Kubernetes Authors <dev@kubernetes.io>
 License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
+Source1: %{name}.rpmlintrc
 
 BuildRequires: systemd
 Requires: iptables >= 1.4.21
@@ -43,10 +36,6 @@ Requires: conntrack
 BuildRequires: systemd-deb-macros
 %else
 BuildRequires: systemd-rpm-macros
-%endif
-
-%if 0%{?suse_version}
-Requires(post,postun): %fillup_prereq
 %endif
 
 %description
@@ -77,13 +66,8 @@ touch %{buildroot}%{_sharedstatedir}/kubelet/.kubelet-keep
 touch %{buildroot}%{_sysconfdir}/kubernetes/manifests/.kubelet-keep
 %endif
 
-%if 0%{?suse_version}
-mkdir -p %{buildroot}%{_fillupdir}/
-install -p -m 644 -T kubelet.env %{buildroot}%{_fillupdir}/sysconfig.kubelet
-%else
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig/
 install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
-%endif
 
 %files
 %{_bindir}/kubelet
@@ -95,11 +79,7 @@ install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 %{_sharedstatedir}/kubelet/.kubelet-keep
 %{_sysconfdir}/kubernetes/manifests/.kubelet-keep
 %endif
-%if 0%{?suse_version}
-%{_fillupdir}/sysconfig.kubelet
-%else
 %config(noreplace) %{_sysconfdir}/sysconfig/kubelet
-%endif
 %license LICENSE
 %doc README.md
 
@@ -107,9 +87,6 @@ install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 %systemd_preun kubelet.service
 
 %post
-%if 0%{?suse_version}
-%fillup_only kubelet
-%endif
 %systemd_post kubelet.service
 
 %postun

--- a/pkg/obs/specs/template.go
+++ b/pkg/obs/specs/template.go
@@ -62,10 +62,11 @@ func (s *Specs) BuildSpecs(pkgDef *PackageDefinition, specOnly bool) (err error)
 		if f.IsDir() {
 			return s.impl.Mkdir(specFile, f.Mode())
 		}
-		if filepath.Ext(templateFile) == ".spec" {
+		if filepath.Ext(templateFile) == ".spec" || filepath.Ext(templateFile) == ".rpmlintrc" {
 			// Spec is intentionally saved outside package dir, which is later on archived
 			specFile = filepath.Join(pkgDef.SpecOutputPath, templateFile[len(tplDir):])
-		} else if specOnly && filepath.Ext(templateFile) != ".spec" {
+		} else if specOnly {
+			// If we're only building spec files, but encounter a non-spec file, skip it
 			return nil
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

As per advice from the OpenBuildService team, we want to build packages on some of SUSE Enterprise Linux distributions. That way, we can have only one RPM repo with packages for all architectures that we support. For the reference, previously we had two RPM repos: one that was using CentOS 8 Stream for building packages for x86_64, aarch64, ppc64le, and another that was using SUSE SLE 12 SP5 for building packages for s390x.

This was discussed on Slack: https://kubernetes.slack.com/archives/C03U7N0VCGK/p1689770787420149

However, to make this work, we have to ignore some rpmlint errors, concretely `suse-filelist-forbidden-sysconfig`. Ignoring this error is not a problem for us and the OBS team recommended this as a way forward.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @cpanato 
cc @kubernetes/release-engineering 