### PR TITLE
Add `rpmlint` to releng-ci image

### DIFF
--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -27,8 +27,9 @@ RUN apt-get update && \
         bsdmainutils \
         build-essential \
         google-cloud-sdk \
-        jq && \
-    rm -rf /var/lib/apt/lists/*
+        jq \
+        rpmlint \
+    && rm -rf /var/lib/apt/lists/*
 
 # install goreleaser
 ARG GORELEASER_VERSION=v1.19.2


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now feature the new tool in the CI image so that we can utilize it in the verify job.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Part of https://github.com/kubernetes/release/issues/3166
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `rpmlint` to releng-ci image `gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm`.
```
