### PR TITLE
Fix OBS project substitution in GCB

### DIFF
--- a/gcb/obs-release/cloudbuild.yaml
+++ b/gcb/obs-release/cloudbuild.yaml
@@ -80,7 +80,7 @@ steps:
   - "${_NOMOCK}"
   - "--log-level=${_LOG_LEVEL}"
   - "--packages=${_PACKAGES}"
-  - "--project=${_PROJECT}"
+  - "--project=${_OBS_PROJECT}"
 
 tags:
 - ${_GCP_USER_TAG}
@@ -91,7 +91,7 @@ tags:
 - ${_TYPE_TAG}
 - ${_TYPE}
 - ${_PACKAGES}
-- ${_PROJECT_TAG}
+- ${_OBS_PROJECT_TAG}
 
 options:
   machineType: E2_HIGHCPU_32

--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
   # TODO(xmudrii) - followup: solve problem with delimiter
   # - "--architectures=${_ARCHITECTURES}"
   - "--version=${_VERSION}"
-  - "--project=${_PROJECT}"
+  - "--project=${_OBS_PROJECT}"
   - "--source=${_PACKAGE_SOURCE}"
 
 tags:
@@ -98,7 +98,7 @@ tags:
 - ${_TYPE}
 - ${_PACKAGES}
 - ${_VERSION}
-- ${_PROJECT_TAG}
+- ${_OBS_PROJECT_TAG}
 
 options:
   machineType: E2_HIGHCPU_32

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -108,7 +108,7 @@ type Options struct {
 	Packages         []string
 	Version          string
 	Architectures    []string
-	Project          string
+	OBSProject       string
 	PackageSource    string
 }
 
@@ -395,16 +395,16 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 		//nolint:gocritic // This needs some fixes that will be done in a follow-up
 		// gcbSubs["ARCHITECTURES"] = strings.Join(g.options.Architectures, ",")
 		gcbSubs["VERSION"] = g.options.Version
-		gcbSubs["PROJECT"] = g.options.Project
-		gcbSubs["PROJECT_TAG"] = strings.ReplaceAll(g.options.Project, ":", "-")
+		gcbSubs["OBS_PROJECT"] = g.options.OBSProject
+		gcbSubs["OBS_PROJECT_TAG"] = strings.ReplaceAll(g.options.OBSProject, ":", "-")
 		gcbSubs["PACKAGE_SOURCE"] = g.options.PackageSource
 
 		// Stop here when doing OBS stage
 		return gcbSubs, nil
 	case g.options.OBSRelease:
 		gcbSubs["PACKAGES"] = strings.Join(g.options.Packages, ",")
-		gcbSubs["PROJECT"] = g.options.Project
-		gcbSubs["PROJECT_TAG"] = strings.ReplaceAll(g.options.Project, ":", "-")
+		gcbSubs["OBS_PROJECT"] = g.options.OBSProject
+		gcbSubs["OBS_PROJECT_TAG"] = strings.ReplaceAll(g.options.OBSProject, ":", "-")
 
 		// Stop here when doing OBS release
 		return gcbSubs, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

I made a regression in #3088 by introducing a field called `Project` in GCB's `Options` struct. `Project` field already exists in the embedded struct `build.Options` so this created a conflict between two fields.

This caused the `ci-fast-forward` job to start failing since June 1 (exactly after merging #3088).

#### Does this PR introduce a user-facing change?
```release-note
Replace `PROJECT` and `PROJECT_TAG` GCB substitutions with `OBS_PROJECT` and `OBS_PROJECT_TAG`
```

/assign @ameukam @Verolop @saschagrunert 
cc @kubernetes/release-engineering 