### PR TITLE
Make krel obs stage/release use correct OBSProject field

### DIFF
--- a/pkg/obs/release.go
+++ b/pkg/obs/release.go
@@ -171,7 +171,7 @@ func (d *DefaultRelease) Submit(stream bool) error {
 	// Required to determine kube-cross version
 	options.Branch = d.options.ReleaseBranch
 	options.Packages = d.options.Packages
-	options.Project = d.options.Project
+	options.OBSProject = d.options.Project
 
 	return d.impl.Submit(options)
 }

--- a/pkg/obs/stage.go
+++ b/pkg/obs/stage.go
@@ -227,7 +227,7 @@ func (d *DefaultStage) Submit(stream bool) error {
 	options.Packages = d.options.Packages
 	options.Architectures = d.options.Architectures
 	options.Version = d.options.Version
-	options.Project = d.options.Project
+	options.OBSProject = d.options.Project
 	options.PackageSource = d.options.PackageSource
 
 	return d.impl.Submit(options)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#3174 changed the field that's used for passing OBS project name to GCB, but I forgot to update references in `pkg/obs`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes/release-engineering 