### PR TITLE
Update version constraint for kubernetes-cni package

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -24,6 +24,6 @@ kubelet:
       - name: kubernetes-cni
         versionConstraint: ">= 1.2.0"
 kubernetes-cni:
-  - versionConstraint: ">= 1.0.0"
+  - versionConstraint: ">= 0.8.7"
     sourceURLTemplate: "gs://k8s-artifacts-cni/release/v{{ .PackageVersion }}/cni-plugins-linux-{{ .Architecture }}-v{{ .PackageVersion }}.tgz"
     sourceTarGz: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update version constraint for the `kubernetes-cni` package to allow building `kubernetes-cni` v0.8.7

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc @kubernetes/release-engineering 