### PR TITLE
OBS specs: remove source tarball when downloading from GCS

### DIFF
--- a/pkg/obs/specs/archive.go
+++ b/pkg/obs/specs/archive.go
@@ -119,6 +119,9 @@ func (s *Specs) DownloadArtifactFromGCS(sourcePath, destPath string, extractTgz 
 		if err := s.impl.Extract(destPath, filepath.Dir(destPath)); err != nil {
 			return fmt.Errorf("extracting .tar.gz archive: %w", err)
 		}
+		if err := s.impl.RemoveFile(destPath); err != nil {
+			return fmt.Errorf("removing extracted archive: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I forgot to remove the sources tarball that's downloaded when building package tarball upon running `krel obs specs`. For that reason, the package tarball is much larger than it should be. It doesn't affect resulting packages, but we're using storage on OBS side for no reason.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @puerco @jeremyrickard 
cc @kubernetes/release-engineering 