### PR TITLE
Drop kubelet dependency for kubernetes-cni

### DIFF
--- a/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
+++ b/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
@@ -15,8 +15,6 @@ License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
 
-Requires: kubelet
-
 %description
 %{summary}.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubernetes-cni` is not supposed to depend on `kubelet`, looks like I made some copy-paste mistake

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @puerco @jeremyrickard 
cc @kubernetes/release-engineering 