### PR TITLE
Ability to build amd64 from arm64 as well

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -71,7 +71,15 @@ RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
 fi
 
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
-  && if [ ${targetArch} = "arm64" ] || [ ${targetArch} = "ppc64le" ] || [ ${targetArch} = "s390x" ]; then \
+  && if [ ${targetArch} = "arm64" ]; then \
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ xenial main" > /etc/apt/sources.list.d/ports.list \
+    && apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+    && apt-get update \
+    && apt-get install -y build-essential gcc-x86-64-linux-gnu; \
+fi
+
+RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
+  && if [ ${targetArch} = "ppc64le" ] || [ ${targetArch} = "s390x" ]; then \
     echo "deb http://ports.ubuntu.com/ubuntu-ports/ xenial main" > /etc/apt/sources.list.d/ports.list \
     && apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
     && apt-get update \


### PR DESCRIPTION
On my MacOS, i want to run quick-release to build amd64 artifacts! for which we need `x86_64-linux-gnu-gcc` in the container image which is present in [gcc-x86-64-linux-gnu package](https://packages.debian.org/search?searchon=names&keywords=gcc-x86-64-linux-gnu].

So just for arm64, install `gcc-x86-64-linux-gnu` as well.

```
[1774:1773 - 0:2095] 09:35:01 [davanum@c889f3bd53ed:o +1] ~/go/src/k8s.io/kubernetes
$ kubetest2 ec2 --build --target-build-arch amd64
I0803 21:36:23.023010   75523 app.go:61] The files in RunDir shall not be part of Artifacts
I0803 21:36:23.023024   75523 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I0803 21:36:23.023032   75523 app.go:64] RunDir for this run: "/Users/davanum/go/src/k8s.io/kubernetes/_rundir/92bf448d-7e83-4bbe-9606-29451edad4af"
I0803 21:36:23.028377   75523 app.go:130] ID for this run: "92bf448d-7e83-4bbe-9606-29451edad4af"
I0803 21:36:23.413123   75523 make.go:48] running build using: KUBE_BUILD_PLATFORMS=linux/amd64
+++ [0803 21:36:23] Verifying Prerequisites....
+++ [0803 21:36:23] Using docker on macOS
+++ [0803 21:36:24] Building Docker image kube-build:build-a65e248211-5-v1.27.0-go1.20.6-bullseye.0
+++ [0803 21:36:25] Syncing sources to container
+++ [0803 21:36:32] Running build command...
go: downloading go.uber.org/automaxprocs v1.5.2
+++ [0803 21:36:47] Setting GOMAXPROCS: 7
+++ [0803 21:36:47] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kube-apiserver (static)
    k8s.io/kubernetes/cmd/kube-controller-manager (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kube-scheduler (static)
    k8s.io/component-base/logs/kube-log-runner (static)
    k8s.io/kube-aggregator (static)
    k8s.io/apiextensions-apiserver (static)
    k8s.io/kubernetes/cluster/gce/gci/mounter (non-static)
# runtime/cgo
cgo: C compiler "x86_64-linux-gnu-gcc" not found: exec: "x86_64-linux-gnu-gcc": executable file not found in $PATH
!!! [0803 21:38:02] Call tree:
!!! [0803 21:38:02]  1: /go/src/k8s.io/kubernetes/hack/lib/golang.sh:783 kube::golang::build_some_binaries(...)
!!! [0803 21:38:02]  2: /go/src/k8s.io/kubernetes/hack/lib/golang.sh:942 kube::golang::build_binaries_for_platform(...)
!!! [0803 21:38:02]  3: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [0803 21:38:02] Call tree:
!!! [0803 21:38:02]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [0803 21:38:02] Call tree:
!!! [0803 21:38:02]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
make[1]: *** [Makefile:92: all] Error 1
make: *** [Makefile:490: cross] Error 1
!!! [0803 21:38:03] Call tree:
!!! [0803 21:38:03]  1: build/../build/common.sh:489 kube::build::run_build_command_ex(...)
!!! [0803 21:38:03]  2: build/release.sh:36 kube::build::run_build_command(...)
make: *** [quick-release] Error 1
Error: exit status 2
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
