### PR TITLE
Update package dependencies for 1.28

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -47,7 +47,7 @@ kubeadm:
         versionConstraint: ">= 0.8.7"
       - name: cri-tools
         versionConstraint: ">= 1.24.2"
-  - versionConstraint: ">= 1.25.1"
+  - versionConstraint: ">= 1.25.1 < 1.28.0"
     sourceURLTemplate: "{{ KubernetesURL }}"
     dependencies:
       - name: kubelet
@@ -58,6 +58,17 @@ kubeadm:
         versionConstraint: ">= 1.1.1"
       - name: cri-tools
         versionConstraint: ">= 1.25.0"
+  - versionConstraint: ">= 1.28.0"
+    sourceURLTemplate: "{{ KubernetesURL }}"
+    dependencies:
+      - name: kubelet
+        versionConstraint: ">= 1.19.0"
+      - name: kubectl
+        versionConstraint: ">= 1.19.0"
+      - name: kubernetes-cni
+        versionConstraint: ">= 1.2.0"
+      - name: cri-tools
+        versionConstraint: ">= 1.28.0"
 kubectl:
   - versionConstraint: ">= 1.0.0"
     sourceURLTemplate: "{{ KubernetesURL }}"
@@ -77,11 +88,16 @@ kubelet:
     dependencies:
       - name: kubernetes-cni
         versionConstraint: ">= 0.8.7"
-  - versionConstraint: ">= 1.25.1"
+  - versionConstraint: ">= 1.25.1 < 1.28.0"
     sourceURLTemplate: "{{ KubernetesURL }}"
     dependencies:
       - name: kubernetes-cni
         versionConstraint: ">= 1.1.1"
+  - versionConstraint: ">= 1.28.0"
+    sourceURLTemplate: "{{ KubernetesURL }}"
+    dependencies:
+      - name: kubernetes-cni
+        versionConstraint: ">= 1.2.0"
 kubernetes-cni:
   - versionConstraint: ">= 0.8.7"
     sourceURLTemplate: "gs://k8s-artifacts-cni/release/v{{ .PackageVersion }}/cni-plugins-linux-{{ .Architecture }}-v{{ .PackageVersion }}.tgz"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Kubernetes 1.28+ packages hosted on `pkgs.k8s.io` require kubernetes-cni 1.2.0 and cri-tools 1.28.0.

We already tried this in #2863 and #2821, but this affected all minor versions and not only the latest one. This is now fixed for `pkgs.k8s.io` so I believe it's a good time to update dependencies at least for packages hosted on `pkgs.k8s.io`.

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes 1.28+ packages hosted on `pkgs.k8s.io` require kubernetes-cni 1.2.0 and cri-tools 1.28.0
```

/assign @saschagrunert @cpanato @jeremyrickard @puerco 
cc @kubernetes/release-engineering 
/hold
Remove hold only after cri-tools 1.28.0 is released