### PR TITLE
update publishing-bot issue repo to k/sig-release

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -130,7 +130,7 @@ const (
 	ArchivePath = "archive"
 
 	// Publishing bot issue repository
-	PubBotRepoOrg  = "k8s-release-robot"
+	PubBotRepoOrg  = "kubernetes"
 	PubBotRepoName = "sig-release"
 
 	DockerHubEnvKey   = "DOCKERHUB_TOKEN" // Env var containing the docker key
@@ -475,6 +475,7 @@ func CreatePubBotBranchIssue(branchName string) error {
 	issueBody += "Please update the publishing-bot's configuration to also publish this new branch.\n\n"
 	issueBody += "/sig release\n"
 	issueBody += "/area release-eng\n"
+	issueBody += "/assign @kubernetes/release-managers\n"
 	issueBody += "/milestone v" + strings.TrimPrefix(branchName, "release-") + "\n"
 
 	// Create the issue on GitHub


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently the issue for updating the branch rules for publishing-bot for a new release are created in [k8s-release-robot/sig-release](https://github.com/k8s-release-robot/sig-release/issues?q=is%3Aissue+is%3Aopen+%22Update+publishing-bot+for+release*%22). Update this to create new issues in k/sig-release.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
publishing-bot issue will now be created in kubernetes/sig-release instead of k8s-release-robot/sig-release
```
