### PR TITLE
Update k8s-cloud-builder to Go 1.20.7 after updating k/k master

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.20.6
+    version: 1.20.7
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -287,7 +287,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
-    version: v1.27.0-go1.20.6-bullseye.0
+    version: v1.27.0-go1.20.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.7-bullseye.0'
   v1.26-cross1.20-bullseye:
     CONFIG: 'cross1.20'
     KUBE_CROSS_VERSION: 'v1.26.0-go1.20.6-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.20.6
+GO_VERSION ?= 1.20.7
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.20.6'
+    GO_VERSION: '1.20.7'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -13,7 +13,7 @@ variants:
     OS_CODENAME: 'bookworm'
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: '1.20.6'
+    GO_VERSION: '1.20.7'
     OS_CODENAME: 'bullseye'
   '1.26':
     CONFIG: '1.26'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update k8s-cloud-builder to Go 1.20.7 after updating k/k master

#### Which issue(s) this PR fixes:

xref #3181

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder to Go 1.20.7
```

/assign @saschagrunert @cpanato @puerco @Verolop 
cc @kubernetes/release-engineering 