### PR TITLE
build go1.21 images with base debian bookworm

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.21.0-bookworm AS builder
 
 ENV GO111MODULE=on
 

--- a/Dockerfile-kubepkg-rpm
+++ b/Dockerfile-kubepkg-rpm
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.21.0-bookworm AS builder
 
 ENV GO111MODULE=on
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,12 +57,12 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.20.7
+    version: 1.21
     refPaths:
     - path: Dockerfile-kubepkg
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bookworm|bullseye) AS builder
     - path: Dockerfile-kubepkg-rpm
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bullseye|buster) AS builder
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bookworm|bullseye) AS builder
     - path: images/build/cross/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/cross/variants.yaml
@@ -74,7 +74,7 @@ dependencies:
     - path: images/releng/ci/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
     - path: packages/deb/Dockerfile
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-bullseye
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-(bookworm|bullseye)
 
   # Golang pre-releases are denoted as `1.y<pre-release stage>.z`
   # Example: go1.17rc1
@@ -82,7 +82,7 @@ dependencies:
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.20
+    version: 1.21
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_MAJOR_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -129,7 +129,7 @@ dependencies:
   # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
   # - v1.100-go1.17-bullseye.0 does not
   - name: "Kubernetes version (stable.0)"
-    version: v1.27.0
+    version: v1.28.0
     refPaths:
     - path: images/build/cross/Makefile
       match: KUBERNETES_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -137,7 +137,7 @@ dependencies:
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.27.0
+    version: v1.28.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -150,7 +150,7 @@ dependencies:
 
   # go-runner
   - name: "registry.k8s.io/build-image/go-runner (go1.21-bullseye)"
-    version: v2.3.1-go1.21rc4-bullseye.0
+    version: v2.3.1-go1.21.0-bullseye.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -187,7 +187,7 @@ dependencies:
 
   # kube-cross
   - name: "registry.k8s.io/build-image/kube-cross (v1.28-go1.21)"
-    version: v1.28.0-go1.21rc4-bookworm.0
+    version: v1.28.0-go1.21.0-bookworm.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -318,7 +318,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.21rc4
+    version: 1.21
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
@@ -408,11 +408,18 @@ dependencies:
       match: "version: v\\d+.\\d+?\\.?(\\d+)?"
 
   # Base images
+  # split until all are set to bookworm
+  - name: "Debian: codename (bookworm)"
+    version: bookworm
+    refPaths:
+    - path: images/build/cross/Makefile
+      match: OS_CODENAME\ \?=\ bookworm
+    - path: packages/deb/Dockerfile
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-bookworm
+
   - name: "Debian: codename (default)"
     version: bullseye
     refPaths:
-    - path: images/build/cross/Makefile
-      match: OS_CODENAME\ \?=\ bullseye
     - path: images/build/cross/variants.yaml
       match: "OS_CODENAME: 'bullseye'"
     # TODO: revert once all images are on bookworm
@@ -436,8 +443,7 @@ dependencies:
       match: OS_CODENAME\ \?=\ bullseye
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "OS_CODENAME: 'bullseye'"
-    - path: packages/deb/Dockerfile
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-bullseye
+
 
   - name: "Debian: codename (next candidate)"
     version: bookworm

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -27,10 +27,10 @@ IMGNAME = kube-cross
 # Example:
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
-KUBERNETES_VERSION ?= v1.27.0
-GO_VERSION ?= 1.20.7
-GO_MAJOR_VERSION ?= 1.20
-OS_CODENAME ?= bullseye
+KUBERNETES_VERSION ?= v1.28.0
+GO_VERSION ?= 1.21.0
+GO_MAJOR_VERSION ?= 1.21
+OS_CODENAME ?= bookworm
 REVISION ?= 0
 TYPE ?= default
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,9 +2,9 @@ variants:
   v1.28-go1.21-bookworm:
     CONFIG: 'go1.21-bookworm'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.28.0-go1.21rc4-bookworm.0'
+    IMAGE_VERSION: 'v1.28.0-go1.21.0-bookworm.0'
     KUBERNETES_VERSION: 'v1.28.0'
-    GO_VERSION: '1.21rc4'
+    GO_VERSION: '1.21.0'
     GO_MAJOR_VERSION: '1.21'
     OS_CODENAME: 'bookworm'
     REVISION: '0'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -17,9 +17,9 @@ include $(CURDIR)/../../Makefile.common-image
 
 IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)
-GO_MAJOR_VERSION ?= 1.20
+GO_MAJOR_VERSION ?= 1.21
 REVISION ?= 0
-GO_VERSION ?= 1.20.7
+GO_VERSION ?= 1.21.0
 OS_CODENAME ?= bullseye
 
 # Build args

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   go1.21-bullseye:
     CONFIG: 'go1.21-bullseye'
-    IMAGE_VERSION: 'v2.3.1-go1.21rc4-bullseye.0'
+    IMAGE_VERSION: 'v2.3.1-go1.21.0-bullseye.0'
     GO_MAJOR_VERSION: '1.21'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
-    GO_VERSION: '1.21rc4'
+    GO_VERSION: '1.21.0'
     DISTROLESS_IMAGE: 'static-debian11'
   go1.20-bullseye:
     CONFIG: 'go1.20-bullseye'

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   go1.21-bookworm:
-    CONFIG: 'go1.21-bookworm'
-    GO_VERSION: '1.21rc4'
+    CONFIG: 'go1.21.0-bookworm'
+    GO_VERSION: '1.21.0'
     OS_CODENAME: 'bookworm'
     REVISION: '0'
   go1.20-bookworm:

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,15 +1,15 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.20.7'
-    OS_CODENAME: 'bullseye'
+    GO_VERSION: '1.21.0'
+    OS_CODENAME: 'bookworm'
   next:
     CONFIG: next
-    GO_VERSION: '1.21rc4'
+    GO_VERSION: '1.21.0'
     OS_CODENAME: 'bookworm'
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: '1.21rc4'
+    GO_VERSION: '1.21.0'
     OS_CODENAME: 'bookworm'
   '1.27':
     CONFIG: '1.27'

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.7-bullseye
+FROM golang:1.21.0-bookworm
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- golang: Build 1.21 images

/hold
/assign @saschagrunert @ameukam @Verolop @palnabarun  
cc @kubernetes/release-managers @liggitt 


#### Which issue(s) this PR fixes:

Related to https://github.com/kubernetes/release/issues/3076

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- golang: Build 1.21 images
```
