### PR TITLE
fix link to example go-template for release tool

### DIFF
--- a/cmd/release-notes/README.md
+++ b/cmd/release-notes/README.md
@@ -121,5 +121,4 @@ Check out the rendering of 1.11's release notes [here](https://gist.github.com/m
 Right now the tool can output release notes in Markdown and JSON. The tool
 also supports arbitrary formats using go-templates. The template has access
 to fields in the `Document` struct. For an example, see the default markdown
-template (`pkg/notes/internal/template.go`) used to render the stock format.
-
+template ([pkg/notes/document/template.go](../../pkg/notes/document/template.go)) used to render the stock format.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
I was looking into using the release-notes tool in this repo and noticed that the documentation pointed to an example template that has since been moved.

#### Which issue(s) this PR fixes:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
