### PR TITLE
Use `%{_arch}` macro for architecture retrieval

### DIFF
--- a/cmd/krel/templates/latest/cri-tools/cri-tools.spec
+++ b/cmd/krel/templates/latest/cri-tools/cri-tools.spec
@@ -25,12 +25,9 @@ Source0: %{name}_%{version}.orig.tar.gz
 # Nothing to build
 
 %install
-# Detect host arch
-KUBE_ARCH="$(uname -m)"
-
 # Install binaries
 mkdir -p %{buildroot}%{_bindir}
-install -p -m 755 ${KUBE_ARCH}/crictl %{buildroot}%{_bindir}/crictl
+install -p -m 755 %{_arch}/crictl %{buildroot}%{_bindir}/crictl
 
 %files
 %{_bindir}/crictl

--- a/cmd/krel/templates/latest/kubeadm/kubeadm.spec
+++ b/cmd/krel/templates/latest/kubeadm/kubeadm.spec
@@ -34,14 +34,11 @@ BuildRequires: systemd-rpm-macros
 # Nothing to build
 
 %install
-# Detect host arch
-KUBE_ARCH="$(uname -m)"
-
 # Install files
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}/kubelet.service.d/
 
-install -p -m 755 ${KUBE_ARCH}/kubeadm %{buildroot}%{_bindir}/kubeadm
+install -p -m 755 %{_arch}/kubeadm %{buildroot}%{_bindir}/kubeadm
 install -p -m 644 10-kubeadm.conf %{buildroot}%{_unitdir}/kubelet.service.d/10-kubeadm.conf
 
 %files

--- a/cmd/krel/templates/latest/kubectl/kubectl.spec
+++ b/cmd/krel/templates/latest/kubectl/kubectl.spec
@@ -24,12 +24,9 @@ Source0: %{name}_%{version}.orig.tar.gz
 # Nothing to build
 
 %install
-# Detect host arch
-KUBE_ARCH="$(uname -m)"
-
 # Install binaries
 mkdir -p %{buildroot}%{_bindir}
-install -p -m 755 ${KUBE_ARCH}/kubectl %{buildroot}%{_bindir}/kubectl
+install -p -m 755 %{_arch}/kubectl %{buildroot}%{_bindir}/kubectl
 
 %files
 %{_bindir}/kubectl

--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -48,16 +48,13 @@ BuildRequires: systemd-rpm-macros
 # Nothing to build
 
 %install
-# Detect host arch
-KUBE_ARCH="$(uname -m)"
-
 # Install files
 mkdir -p %{buildroot}%{_unitdir}/
 mkdir -p %{buildroot}%{_bindir}/
 mkdir -p %{buildroot}%{_sharedstatedir}/kubelet/
 mkdir -p %{buildroot}%{_sysconfdir}/kubernetes/manifests/
 
-install -p -m 755 ${KUBE_ARCH}/kubelet %{buildroot}%{_bindir}/kubelet
+install -p -m 755 %{_arch}/kubelet %{buildroot}%{_bindir}/kubelet
 install -p -m 644 kubelet.service %{buildroot}%{_unitdir}/kubelet.service
 
 # Required because dpkg-deb doesn't keep empty directories

--- a/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
+++ b/cmd/krel/templates/latest/kubernetes-cni/kubernetes-cni.spec
@@ -25,14 +25,11 @@ Source0: %{name}_%{version}.orig.tar.gz
 # Nothing to build
 
 %install
-# Detect host arch
-KUBE_ARCH="$(uname -m)"
-
 # Install files
 mkdir -p %{buildroot}/opt/cni/bin
 mkdir -p %{buildroot}%{_sysconfdir}/cni/net.d/
 
-cp -a ${KUBE_ARCH}/* %{buildroot}/opt/cni/bin/
+cp -a %{_arch}/* %{buildroot}/opt/cni/bin/
 
 %if "%{_vendor}" == "debbuild"
 touch %{buildroot}%{_sysconfdir}/cni/net.d/.kubernetes-cni-keep


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Using the official rpm macro for the arch within the spec files.

```
> rpm --eval '%{_arch}'
x86_64
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
/hold

For review from @xmudrii 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Using `%{_arch}` macro for architecture retrieval in package spec files.
```
