### PR TITLE
Fix version comparison in VerifyLatestUpdate

### DIFF
--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -282,7 +282,17 @@ func (p *Publisher) VerifyLatestUpdate(
 		return false, fmt.Errorf("invalid GCS version format %s", gcsVersion)
 	}
 
-	if sv.LTE(gcsSemverVersion) {
+	// The version format that we use is:
+	//   - Stable: "v<major>.<minor>.<patch>-<number-of-commits>+<build-number>"
+	//   - Prerelease: "v<major>.<minor>.<patch>-<prerelease>.<number-of-commits>+<build-number>"
+	// blang/semver library considers "-<number-of-commits>" part as the prerelease part even though
+	// the version is stable. This is causing issues when we're supposed to bump the version marker
+	// from rc to stable.
+	// blang/semver models prerelease as a slice of prereleases, so stable releases
+	// are going to have one element (the number of commits), and prereleases are going to have three elements
+	// (alpha/beta/rc, number of prerelease, number of commits).
+	// We can use this to determine when we're switching from rc to stable and act accordingly.
+	if sv.LTE(gcsSemverVersion) && len(sv.Pre) >= len(gcsSemverVersion.Pre) {
 		logrus.Infof(
 			"Not updating version, because %s <= %s", version, gcsVersion,
 		)

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -325,3 +325,181 @@ func TestPublishReleaseNotesIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestVerifyLatestUpdate(t *testing.T) {
+	// err := errors.New("")
+	for _, tc := range []struct {
+		prepare     func(*releasefakes.FakePublisherClient, string)
+		version     string
+		gcsVersion  string
+		needsUpdate bool
+		shouldError bool
+	}{
+		{ // success same version
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.24.0",
+			gcsVersion:  "v1.24.0",
+			needsUpdate: false,
+			shouldError: false,
+		},
+
+		{ // success version > gcsVersion (patch)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.24.1",
+			gcsVersion:  "v1.24.0",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version < gcsVersion (patch)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.24.0",
+			gcsVersion:  "v1.24.1",
+			needsUpdate: false,
+			shouldError: false,
+		},
+
+		{ // success version > gcsVersion (minor)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.25.0",
+			gcsVersion:  "v1.24.0",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version < gcsVersion (minor)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.23.0",
+			gcsVersion:  "v1.24.0",
+			needsUpdate: false,
+			shouldError: false,
+		},
+
+		{ // success version = gcsVersion (with build version)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-7+c4e17abb04728e",
+			gcsVersion:  "v1.28.0-7+c4e17abb04728e",
+			needsUpdate: false,
+			shouldError: false,
+		},
+		{ // success version > gcsVersion (with build version)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-9+aaaaaabb04728e",
+			gcsVersion:  "v1.28.0-7+c4e17abb04728e",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version < gcsVersion (with build version)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-7+c4e17abb04728e",
+			gcsVersion:  "v1.28.0-9+aaaaaabb04728e",
+			needsUpdate: false,
+			shouldError: false,
+		},
+		{ // success version > gcsVersion (with build version)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.1-1+aaaaaabb04728e",
+			gcsVersion:  "v1.28.0-7+c4e17abb04728e",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version = gcsVersion (with build version, prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
+			gcsVersion:  "v1.28.0-rc.1.9+3fb5377b25ec51",
+			needsUpdate: false,
+			shouldError: false,
+		},
+		{ // success version > gcsVersion (with build version, prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-rc.1.10+3fb5377b25ec51",
+			gcsVersion:  "v1.28.0-rc.1.9+3fb5377b25ec51",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version < gcsVersion (with build version, prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
+			gcsVersion:  "v1.28.0-rc.1.10+3fb5377b25ec51",
+			needsUpdate: false,
+			shouldError: false,
+		},
+		{ // success version < gcsVersion (with build version, prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-beta.1.9+3fb5377b25ec51",
+			gcsVersion:  "v1.28.0-rc.1.9+3fb5377b25ec51",
+			needsUpdate: false,
+			shouldError: false,
+		},
+		{ // success version > gcsVersion (with build version, prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
+			gcsVersion:  "v1.28.0-beta.1.9+3fb5377b25ec51",
+			needsUpdate: true,
+			shouldError: false,
+		},
+		{ // success version > gcsVersion (with build version, stable and prerelease)
+			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
+				mock.NormalizePath("", "")
+				mock.GSUtilOutputReturns(gcsVersion, nil)
+			},
+			version:     "v1.28.0-7+c4e17abb04728e",
+			gcsVersion:  "v1.28.0-rc.1.9+3fb5377b25ec51",
+			needsUpdate: true,
+			shouldError: false,
+		},
+	} {
+		sut := release.NewPublisher()
+		clientMock := &releasefakes.FakePublisherClient{}
+		sut.SetClient(clientMock)
+		tc.prepare(clientMock, tc.gcsVersion)
+
+		needsUpdate, err := sut.VerifyLatestUpdate("", "", tc.version)
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+			require.Equal(t, tc.needsUpdate, needsUpdate)
+		}
+	}
+}

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -327,7 +327,6 @@ func TestPublishReleaseNotesIndex(t *testing.T) {
 }
 
 func TestVerifyLatestUpdate(t *testing.T) {
-	// err := errors.New("")
 	for _, tc := range []struct {
 		prepare     func(*releasefakes.FakePublisherClient, string)
 		version     string
@@ -337,7 +336,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 	}{
 		{ // success same version
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.24.0",
@@ -348,7 +347,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 
 		{ // success version > gcsVersion (patch)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.24.1",
@@ -358,7 +357,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version < gcsVersion (patch)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.24.0",
@@ -369,7 +368,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 
 		{ // success version > gcsVersion (minor)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.25.0",
@@ -379,7 +378,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version < gcsVersion (minor)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.23.0",
@@ -390,7 +389,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 
 		{ // success version = gcsVersion (with build version)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-7+c4e17abb04728e",
@@ -400,7 +399,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version > gcsVersion (with build version)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-9+aaaaaabb04728e",
@@ -410,7 +409,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version < gcsVersion (with build version)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-7+c4e17abb04728e",
@@ -420,7 +419,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version > gcsVersion (with build version)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.1-1+aaaaaabb04728e",
@@ -430,7 +429,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version = gcsVersion (with build version, prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
@@ -440,7 +439,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version > gcsVersion (with build version, prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-rc.1.10+3fb5377b25ec51",
@@ -450,7 +449,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version < gcsVersion (with build version, prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
@@ -460,7 +459,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version < gcsVersion (with build version, prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-beta.1.9+3fb5377b25ec51",
@@ -470,7 +469,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version > gcsVersion (with build version, prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-rc.1.9+3fb5377b25ec51",
@@ -480,7 +479,7 @@ func TestVerifyLatestUpdate(t *testing.T) {
 		},
 		{ // success version > gcsVersion (with build version, stable and prerelease)
 			prepare: func(mock *releasefakes.FakePublisherClient, gcsVersion string) {
-				mock.NormalizePath("", "")
+				mock.NormalizePathReturns("", nil)
 				mock.GSUtilOutputReturns(gcsVersion, nil)
 			},
 			version:     "v1.28.0-7+c4e17abb04728e",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We observed that version markers are not getting updated properly on many occasions which is documented in https://github.com/kubernetes/kubernetes/issues/117115

This issue appears when the version marker is supposed to switch from prerelease (rc) to stable. For example: `v1.28.0-rc.1.9+3fb5377b25ec51` -> `v1.28.0-7+c4e17abb04728e` is not going to happen even though left version is lower than right version.

The reason for that is that both `v1.28.0-rc.1.9+3fb5377b25ec51` and `v1.28.0-7+c4e17abb04728e` are considered as "prereleases" by `blang/semver` library. Version is modeled as:

| Version Part | `v1.28.0-rc.1.9+3fb5377b25ec51` | `v1.28.0-7+c4e17abb04728e` |
| ------------ | ---------------------------------- | ------------------------------  |
| Major            | 1                                                          | 1                                                     |
| Minor            | 28                                                       | 28                                                  |
| Patch            | 0                                                         | 0                                                    |
| Prerelease   | [rc, 1, 9]                                              | [7]                                                 |
| Build             | 3fb5377b25ec51                              | c4e17abb04728e                        |

Comparing versions includes comparing elements in both prerelease slices and that doesn't behave as we would expect in this case.

Given this logic, we always know that:

- Stable releases are going to have only one element in the `prerelease` slice
- Prereleases are going to have two or three elements in the `prerelease` slice

This can be used when comparing the version to properly switch from prerelease (rc) to stable.

There might be a better approach, but I didn't find such an approach from [the `blang/semver` documentation](https://pkg.go.dev/github.com/blang/semver/v4). Unit tests are added to cover various cases and ensure that this still works as expected.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/117115

#### Does this PR introduce a user-facing change?
```release-note
Fix version comparison in VerifyLatestUpdate
```

/assign @saschagrunert @puerco @jeremyrickard 
cc @kubernetes/release-engineering 
/hold for discussion