### PR TITLE
Remove workdir prefix from SHA*SUMS files

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -372,7 +372,7 @@ func WriteChecksums(rootPath string) error {
 					return fmt.Errorf("get hash from file: %w", err)
 				}
 
-				files = append(files, fmt.Sprintf("%s  %s", sha, path))
+				files = append(files, fmt.Sprintf("%s  %s", sha, strings.TrimPrefix(path, rootPath+"/")))
 				return nil
 			},
 		); err != nil {

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -558,9 +558,19 @@ func TestWriteChecksums(t *testing.T) {
 				tempDir, err := os.MkdirTemp("", "write-checksum-test-")
 				require.Nil(t, err)
 
-				for i, v := range []byte{1, 2, 4, 8, 16, 32, 64, 128} {
+				rootSHAs := []byte{1, 2, 4, 8, 16, 32, 64, 128}
+				for i, v := range rootSHAs {
 					require.Nil(t, os.WriteFile(
 						filepath.Join(tempDir, fmt.Sprintf("%d", i)),
+						[]byte{v}, os.FileMode(0o644),
+					))
+				}
+
+				subTempDir := filepath.Join(tempDir, "test")
+				require.Nil(t, os.MkdirAll(subTempDir, os.FileMode(0o755)))
+				for i, v := range []byte{1, 2} {
+					require.Nil(t, os.WriteFile(
+						filepath.Join(subTempDir, fmt.Sprintf("%d", i+len(rootSHAs))),
 						[]byte{v}, os.FileMode(0o644),
 					))
 				}
@@ -572,40 +582,44 @@ func TestWriteChecksums(t *testing.T) {
 			validate: func(err error, rootPath string) {
 				require.Nil(t, err)
 
-				for digest, shas := range map[int][]string{
+				type shaValue struct{ sha, path string }
+				for digest, shas := range map[int][]shaValue{
 					256: {
-						"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
-						"dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
-						"e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
-						"beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
-						"c555eab45d08845ae9f10d452a99bfcb06f74a50b988fe7e48dd323789b88ee3",
-						"36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068",
-						"c3641f8544d7c02f3580b07c0f9887f0c6a27ff5ab1d4a3e29caf197cfc299ae",
-						"76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71",
+						{sha: "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a", path: "0"},
+						{sha: "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986", path: "1"},
+						{sha: "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71", path: "2"},
+						{sha: "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a", path: "3"},
+						{sha: "c555eab45d08845ae9f10d452a99bfcb06f74a50b988fe7e48dd323789b88ee3", path: "4"},
+						{sha: "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068", path: "5"},
+						{sha: "c3641f8544d7c02f3580b07c0f9887f0c6a27ff5ab1d4a3e29caf197cfc299ae", path: "6"},
+						{sha: "76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71", path: "7"},
+						{sha: "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a", path: "test/8"},
+						{sha: "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986", path: "test/9"},
 					},
 					512: {
-						"7b54b66836c1fbdd13d2441d9e1434dc62ca677fb68f5fe66a464baadecdbd00576f8d6b5ac3bcc80844b7d50b1cc6603444bbe7cfcf8fc0aa1ee3c636d9e339",
-						"fab848c9b657a853ee37c09cbfdd149d0b3807b191dde9b623ccd95281dd18705b48c89b1503903845bba5753945351fe6b454852760f73529cf01ca8f69dcca",
-						"b5b8c725507b5b13158e020d96fe4cfbf6d774e09161e2b599b8f35ae31f16e395825edef8aa69ad304ef80fed9baa0580d247cd84e57a2ae239aec90d2d5869",
-						"f65a6bf8f40b01b87757cde53483d057e1442f3bd67d495d2047b7f7c329e0572e88c18808426706af3b8df2915ca3d527ad49597f211cf89e475a07c901312b",
-						"dc3fee1c29fe441f11008464c18d074dc987dbe02831a4e06c1c4769e4bfce5e78e50f13d786389a577afb2563e306b5d079187e4eccb962e12a5f6c16f62a2e",
-						"f90ddd77e400dfe6a3fcf479b00b1ee29e7015c5bb8cd70f5f15b4886cc339275ff553fc8a053f8ddc7324f45168cffaf81f8c3ac93996f6536eef38e5e40768",
-						"e97b9cc0c1e22c66bff31f6c457c2b95b9f9af955c8a098e043734df7439031fd1c6748a139d99077eb2db5f3d98a0e9d05b6606e3d4010ec107a52cd7e43359",
-						"dfe8ef54110b3324d3b889035c95cfb80c92704614bf76f17546ad4f4b08218a630e16da7df34766a975b3bb85b01df9e99a4ec0a1d0ec3de6bed7b7a40b2f10",
+						{sha: "7b54b66836c1fbdd13d2441d9e1434dc62ca677fb68f5fe66a464baadecdbd00576f8d6b5ac3bcc80844b7d50b1cc6603444bbe7cfcf8fc0aa1ee3c636d9e339", path: "0"},
+						{sha: "fab848c9b657a853ee37c09cbfdd149d0b3807b191dde9b623ccd95281dd18705b48c89b1503903845bba5753945351fe6b454852760f73529cf01ca8f69dcca", path: "1"},
+						{sha: "b5b8c725507b5b13158e020d96fe4cfbf6d774e09161e2b599b8f35ae31f16e395825edef8aa69ad304ef80fed9baa0580d247cd84e57a2ae239aec90d2d5869", path: "2"},
+						{sha: "f65a6bf8f40b01b87757cde53483d057e1442f3bd67d495d2047b7f7c329e0572e88c18808426706af3b8df2915ca3d527ad49597f211cf89e475a07c901312b", path: "3"},
+						{sha: "dc3fee1c29fe441f11008464c18d074dc987dbe02831a4e06c1c4769e4bfce5e78e50f13d786389a577afb2563e306b5d079187e4eccb962e12a5f6c16f62a2e", path: "4"},
+						{sha: "f90ddd77e400dfe6a3fcf479b00b1ee29e7015c5bb8cd70f5f15b4886cc339275ff553fc8a053f8ddc7324f45168cffaf81f8c3ac93996f6536eef38e5e40768", path: "5"},
+						{sha: "e97b9cc0c1e22c66bff31f6c457c2b95b9f9af955c8a098e043734df7439031fd1c6748a139d99077eb2db5f3d98a0e9d05b6606e3d4010ec107a52cd7e43359", path: "6"},
+						{sha: "dfe8ef54110b3324d3b889035c95cfb80c92704614bf76f17546ad4f4b08218a630e16da7df34766a975b3bb85b01df9e99a4ec0a1d0ec3de6bed7b7a40b2f10", path: "7"},
+						{sha: "7b54b66836c1fbdd13d2441d9e1434dc62ca677fb68f5fe66a464baadecdbd00576f8d6b5ac3bcc80844b7d50b1cc6603444bbe7cfcf8fc0aa1ee3c636d9e339", path: "test/8"},
+						{sha: "fab848c9b657a853ee37c09cbfdd149d0b3807b191dde9b623ccd95281dd18705b48c89b1503903845bba5753945351fe6b454852760f73529cf01ca8f69dcca", path: "test/9"},
 					},
 				} {
-					for i, expectedSha := range shas {
-						shaSums, err := os.ReadFile(filepath.Join(
-							rootPath, fmt.Sprintf("SHA%dSUMS", digest),
-						))
-						require.Nil(t, err)
-						require.Contains(t, string(shaSums), expectedSha)
+					shaSums, err := os.ReadFile(filepath.Join(rootPath, fmt.Sprintf("SHA%dSUMS", digest)))
+					require.Nil(t, err)
+
+					for _, expectedSha := range shas {
+						require.Contains(t, string(shaSums), expectedSha.sha)
 
 						sha, err := os.ReadFile(filepath.Join(
-							rootPath, fmt.Sprintf("%d.sha%d", i, digest),
+							rootPath, fmt.Sprintf("%s.sha%d", expectedSha.path, digest),
 						))
 						require.Nil(t, err)
-						require.Equal(t, expectedSha, string(sha))
+						require.Equal(t, expectedSha.sha, string(sha))
 					}
 				}
 			},


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The workdir path is part of the SHA sum files, which breaks most scripts. We now stick to using the relative paths by trimming the root path.


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3222


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed workdir prefix from SHA*SUMS files.
```
