### PR TITLE
`krel obs specs`: Stronger defaults

### DIFF
--- a/pkg/obs/consts/consts.go
+++ b/pkg/obs/consts/consts.go
@@ -57,6 +57,7 @@ var (
 const (
 	DefaultReleaseDownloadLinkBase = "gs://kubernetes-release/release"
 	DefaultRevision                = "0"
+	DefaultSpecTemplatePath        = "cmd/krel/templates/latest"
 )
 
 func IsSupported(field string, input, expected []string) bool {

--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -58,7 +58,7 @@ const (
 
 	// defaultSpecTemplatePath is path inside Google Cloud Build where package
 	// specs for kubeadm, kubectl, and kubelet are located.
-	defaultSpecTemplatePath = workspaceDir + "/go/src/k8s.io/release/cmd/krel/templates/latest"
+	defaultSpecTemplatePath = workspaceDir + "/go/src/k8s.io/release/" + consts.DefaultSpecTemplatePath
 
 	// obsRoot is path inside Google Cloud Build where OBS project and packages
 	// are checked out.

--- a/pkg/obs/specs/specs.go
+++ b/pkg/obs/specs/specs.go
@@ -78,6 +78,9 @@ func DefaultOptions() *Options {
 			consts.ArchitecturePPC64,
 			consts.ArchitectureS390X,
 		},
+		Channel:          consts.ChannelTypeRelease,
+		SpecOutputPath:   ".",
+		SpecTemplatePath: consts.DefaultSpecTemplatePath,
 	}
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Use stronger CLI defaults to be able to omit the channel, output path as well as spec template then just running `go run ./cmd/krel obs specs …`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`krel obs specs`: use default `--channel release`, `--output .` and `--template-dir cmd/krel/templates/latest`.
```
