### PR TITLE
go-runner: switch to debian bookworm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -149,13 +149,13 @@ dependencies:
       match: REVISION:\ '\d+'
 
   # go-runner
-  - name: "registry.k8s.io/build-image/go-runner (go1.21-bullseye)"
-    version: v2.3.1-go1.21.0-bullseye.0
+  - name: "registry.k8s.io/build-image/go-runner (go1.21-bookworm)"
+    version: v2.3.1-go1.21.0-bookworm.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
-  - name: "registry.k8s.io/build-image/go-runner: image revision (go1.21-bullseye)"
+  - name: "registry.k8s.io/build-image/go-runner: image revision (go1.21-bookworm)"
     version: 0
     refPaths:
     - path: images/build/go-runner/Makefile
@@ -428,8 +428,8 @@ dependencies:
     # - path: images/build/debian-base/variants.yaml
     #   match: "CONFIG: 'bullseye'"
     # Must match distroless Debian version as well
-    - path: images/build/go-runner/Makefile
-      match: OS_CODENAME\ \?=\ bullseye
+    # - path: images/build/go-runner/Makefile
+    #   match: OS_CODENAME\ \?=\ bullseye
     - path: images/build/go-runner/variants.yaml
       match: "OS_CODENAME: 'bullseye'"
     # TODO: revert once all images are on bookworm

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -20,11 +20,11 @@ APP_VERSION = $(shell cat VERSION)
 GO_MAJOR_VERSION ?= 1.21
 REVISION ?= 0
 GO_VERSION ?= 1.21.0
-OS_CODENAME ?= bullseye
+OS_CODENAME ?= bookworm
 
 # Build args
 DISTROLESS_REGISTRY ?= gcr.io/distroless
-DISTROLESS_IMAGE ?= static-debian11
+DISTROLESS_IMAGE ?= static-debian12
 BUILDER_IMAGE ?= golang:$(GO_VERSION)-$(OS_CODENAME)
 
 # Configuration

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,12 +1,12 @@
 variants:
-  go1.21-bullseye:
-    CONFIG: 'go1.21-bullseye'
-    IMAGE_VERSION: 'v2.3.1-go1.21.0-bullseye.0'
+  go1.21-bookworm:
+    CONFIG: 'go1.21-bookworm'
+    IMAGE_VERSION: 'v2.3.1-go1.21.0-bookworm.0'
     GO_MAJOR_VERSION: '1.21'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
     REVISION: '0'
     GO_VERSION: '1.21.0'
-    DISTROLESS_IMAGE: 'static-debian11'
+    DISTROLESS_IMAGE: 'static-debian12'
   go1.20-bullseye:
     CONFIG: 'go1.20-bullseye'
     IMAGE_VERSION: 'v2.3.1-go1.20.7-bullseye.0'


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Use debian 12 for go runner image.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3128
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use debian 12 for go-runner 1.21 image.
```
