### PR TITLE
update go images for 1.29 and 1.28 release branches and drop 1.24 config

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -129,7 +129,7 @@ dependencies:
   # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
   # - v1.100-go1.17-bullseye.0 does not
   - name: "Kubernetes version (stable.0)"
-    version: v1.28.0
+    version: v1.29.0
     refPaths:
     - path: images/build/cross/Makefile
       match: KUBERNETES_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -137,7 +137,7 @@ dependencies:
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.28.0
+    version: v1.29.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -186,19 +186,39 @@ dependencies:
       match: REVISION:\ '\d+'
 
   # kube-cross
-  - name: "registry.k8s.io/build-image/kube-cross (v1.28-go1.21)"
-    version: v1.28.0-go1.21.0-bookworm.0
+  - name: "registry.k8s.io/build-image/kube-cross (v1.29-go1.21)"
+    version: v1.29.0-go1.21.0-bookworm.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.28-go1.21)"
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.29-go1.21)"
     version: go1.21-bookworm
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-bookworm'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.28-go1.21)"
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.29-go1.21)"
+    version: 0
+    refPaths:
+    - path: images/build/cross/Makefile
+      match: REVISION \?= \d+
+    - path: images/build/cross/variants.yaml
+      match: REVISION:\ '\d+'
+
+  - name: "registry.k8s.io/build-image/kube-cross (v1.28-go1.20)"
+    version: v1.28.0-go1.20.7-bullseye.0
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.28-go1.20)"
+    version: go1.20-bullseye
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.28-go1.20)"
     version: 0
     refPaths:
     - path: images/build/cross/Makefile
@@ -266,25 +286,12 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: REVISION:\ '\d+'
 
-  - name: "registry.k8s.io/build-image/kube-cross (v1.24-go1.20)"
-    version: v1.24.0-go1.20.7-bullseye.0
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.24-go1.20)"
-    version: go1.20-bullseye
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
-
-  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.24-go1.20)"
-    version: 0
-    refPaths:
-    - path: images/build/cross/Makefile
-      match: REVISION \?= \d+
-    - path: images/build/cross/variants.yaml
-      match: REVISION:\ '\d+'
+  # TODO: uncomment when we have the cross available and then need to build this one as well
+  # - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.20)"
+  #   version: v1.28.0-go1.20.7-bullseye.0
+  #   refPaths:
+  #   - path: images/k8s-cloud-builder/variants.yaml
+  #     match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
     version: v1.27.0-go1.20.7-bullseye.0
@@ -300,12 +307,6 @@ dependencies:
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
     version: v1.25.0-go1.20.7-bullseye.0
-    refPaths:
-    - path: images/k8s-cloud-builder/variants.yaml
-      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.24-cross1.20)"
-    version: v1.24.0-go1.20.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -342,6 +343,40 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: "CONFIG: 'go\\d+.\\d+-bookworm'"
 
+  # Golang (previous release branches: 1.28)
+  - name: "golang (previous release branches: 1.28)"
+    version: 1.20.7
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.28)"
+    version: 1.20.7
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  # Golang (previous release branches: 1.27)
+  - name: "golang (previous release branches: 1.27)"
+    version: 1.20.7
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/build/go-runner/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.27)"
+    version: 1.20.7
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
   # Golang (previous release branches: 1.26)
   - name: "golang (previous release branches: 1.26)"
     version: 1.20.7
@@ -354,40 +389,6 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.26)"
-    version: 1.20.7
-    refPaths:
-    - path: images/releng/k8s-ci-builder/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  # Golang (previous release branches: 1.25)
-  - name: "golang (previous release branches: 1.25)"
-    version: 1.20.7
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/build/go-runner/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/releng/ci/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.25)"
-    version: 1.20.7
-    refPaths:
-    - path: images/releng/k8s-ci-builder/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  # Golang (previous release branches: 1.24)
-  - name: "golang (previous release branches: 1.24)"
-    version: 1.20.7
-    refPaths:
-    - path: images/build/cross/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/build/go-runner/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-    - path: images/releng/ci/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.24)"
     version: 1.20.7
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -27,7 +27,7 @@ IMGNAME = kube-cross
 # Example:
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
-KUBERNETES_VERSION ?= v1.28.0
+KUBERNETES_VERSION ?= v1.29.0
 GO_VERSION ?= 1.21.0
 GO_MAJOR_VERSION ?= 1.21
 OS_CODENAME ?= bookworm

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,12 +1,21 @@
 variants:
-  v1.28-go1.21-bookworm:
+  v1.29-go1.21-bookworm:
     CONFIG: 'go1.21-bookworm'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.28.0-go1.21.0-bookworm.0'
-    KUBERNETES_VERSION: 'v1.28.0'
+    IMAGE_VERSION: 'v1.29.0-go1.21.0-bookworm.0'
+    KUBERNETES_VERSION: 'v1.29.0'
     GO_VERSION: '1.21.0'
     GO_MAJOR_VERSION: '1.21'
     OS_CODENAME: 'bookworm'
+    REVISION: '0'
+  v1.28-go1.20-bullseye:
+    CONFIG: 'go1.20-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.28.0-go1.20.7-bullseye.0'
+    KUBERNETES_VERSION: 'v1.28.0'
+    GO_VERSION: '1.20.7'
+    GO_MAJOR_VERSION: '1.20'
+    OS_CODENAME: 'bullseye'
     REVISION: '0'
   v1.27-go1.20-bullseye:
     CONFIG: 'go1.20-bullseye'
@@ -31,15 +40,6 @@ variants:
     TYPE: 'default'
     IMAGE_VERSION: 'v1.25.0-go1.20.7-bullseye.0'
     KUBERNETES_VERSION: 'v1.25.0'
-    GO_VERSION: '1.20.7'
-    GO_MAJOR_VERSION: '1.20'
-    OS_CODENAME: 'bullseye'
-    REVISION: '0'
-  v1.24-go1.20-bullseye:
-    CONFIG: 'go1.20-bullseye'
-    TYPE: 'default'
-    IMAGE_VERSION: 'v1.24.0-go1.20.7-bullseye.0'
-    KUBERNETES_VERSION: 'v1.24.0'
     GO_VERSION: '1.20.7'
     GO_MAJOR_VERSION: '1.20'
     OS_CODENAME: 'bullseye'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -7,10 +7,14 @@ variants:
     CONFIG: next
     GO_VERSION: '1.21.0'
     OS_CODENAME: 'bookworm'
-  '1.28':
-    CONFIG: '1.28'
+  '1.29':
+    CONFIG: '1.29'
     GO_VERSION: '1.21.0'
     OS_CODENAME: 'bookworm'
+  '1.28':
+    CONFIG: '1.28'
+    GO_VERSION: '1.20.7'
+    OS_CODENAME: 'bullseye'
   '1.27':
     CONFIG: '1.27'
     GO_VERSION: '1.20.7'
@@ -21,9 +25,5 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: '1.20.7'
-    OS_CODENAME: 'bullseye'
-  '1.24':
-    CONFIG: '1.24'
     GO_VERSION: '1.20.7'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
- update go images for 1.29 and 1.28 release branches and drop 1.24 config

First of a few PRs to update and put in sync all go images for the active release branches

/assign @saschagrunert @Verolop @xmudrii @ameukam 
cc @kubernetes/release-engineering 

#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update go images for 1.29 and 1.28 release branches and drop 1.24 config
```
