### PR TITLE
distroless-iptables: provide debian 12 bookworm variant

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -483,10 +483,10 @@ dependencies:
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.20.7-bullseye.0
+    version: v2.3.1-go1.21.0-bookworm.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
-      match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bullseye\.\d+
+      match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bookworm\.\d+
 
   - name: "registry.k8s.io/build-image/setcap"
     version: bookworm-v1.0.0

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -20,8 +20,8 @@ IMAGE=$(REGISTRY)/distroless-iptables
 TAG ?= $(shell git describe --tags --always --dirty)
 IMAGE_VERSION ?= v0.2.7
 CONFIG ?= distroless
-BASEIMAGE ?= debian:bullseye-slim
-GORUNNER_VERSION ?= v2.3.1-go1.20.7-bullseye.0
+BASEIMAGE ?= debian:bookworm-slim
+GORUNNER_VERSION ?= v2.3.1-go1.21.0-bookworm.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/distroless/package-utils.sh
+++ b/images/build/distroless-iptables/distroless/package-utils.sh
@@ -19,7 +19,7 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
+    (dpkg-query --search "$(realpath "${1}")" || true) | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1
@@ -37,10 +37,14 @@ stage_file() {
     fi
     # get the package so we can stage package metadata as well
     package="$(file_to_package "${1}")"
-    # stage the copyright for the file
-    cp -a --parents "$(package_to_copyright "${package}")" "${2}"
-    # stage the package status mimicking bazel
-    # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
-    # instead of parsing the control file, we can just get the actual package status with dpkg
-    dpkg -s "${package}" > "${2}/var/lib/dpkg/status.d/${package}"
+
+    # files like /usr/lib/x86_64-linux-gnu/libc.so.6 will return no package
+    if [[ "$package" != "" ]]; then
+        # stage the copyright for the file
+        cp -a --parents "$(package_to_copyright "${package}")" "${2}"
+        # stage the package status mimicking bazel
+        # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
+        # instead of parsing the control file, we can just get the actual package status with dpkg
+        dpkg -s "${package}" > "${2}/var/lib/dpkg/status.d/${package}"
+    fi
 }

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -2,4 +2,4 @@ variants:
   distroless:
     CONFIG: 'distroless'
     IMAGE_VERSION: 'v0.2.7'
-    GORUNNER_VERSION: 'v2.3.1-go1.20.6-bullseye.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.21.0-bookworm.0'


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Provide debian 12 bookworm variant or distroless-iptables image.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3128
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
