### PR TITLE
distroless-iptables: fix `grep` command

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -478,7 +478,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.3.0
+    version: v0.3.1
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.3.0
+IMAGE_VERSION ?= v0.3.1
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bookworm-slim
 GORUNNER_VERSION ?= v2.3.1-go1.21.0-bookworm.0

--- a/images/build/distroless-iptables/distroless/Dockerfile
+++ b/images/build/distroless-iptables/distroless/Dockerfile
@@ -52,7 +52,7 @@ FROM ${GORUNNERIMAGE} as gorunner
 
 # We need to use distroless:base here as tzdata, glibc and some other base packages
 # are required
-FROM gcr.io/distroless/base as intermediate
+FROM gcr.io/distroless/base-debian12 as intermediate
 
 ARG SKIP_WRAPPER_CHECK
 

--- a/images/build/distroless-iptables/distroless/package-utils.sh
+++ b/images/build/distroless-iptables/distroless/package-utils.sh
@@ -30,13 +30,19 @@ package_to_copyright() {
 # stage_file stages the filepath $1 to $2, following symlinks
 # and staging copyrights
 stage_file() {
-    cp -a --parents "${1}" "${2}"
+    # /lib is a symlink to /usr/lib in debian 12, means we just stick to
+    # /usr/lib for all libraries to avoid separating symlinks with the actual binaries
+    from="${1}"
+    if [[ $from = /lib/*  ]]; then
+        from="/usr$from"
+    fi
+    cp -a --parents "${from}" "${2}"
     # recursively follow symlinks
-    if [[ -L "${1}" ]]; then
-        stage_file "$(cd "$(dirname "${1}")" || exit; realpath -s "$(readlink "${1}")")" "${2}"
+    if [[ -L "${from}" ]]; then
+        stage_file "$(cd "$(dirname "${from}")" || exit; realpath -s "$(readlink "${from}")")" "${2}"
     fi
     # get the package so we can stage package metadata as well
-    package="$(file_to_package "${1}")"
+    package="$(file_to_package "${from}")"
 
     # files like /usr/lib/x86_64-linux-gnu/libc.so.6 will return no package
     if [[ "$package" != "" ]]; then


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The issue was that libaries from /usr/lib get symlinked from /lib, which is just a symlink to /usr/lib in debian 12. To avoid that, we now always refer to /usr/lib. To avoid wrong glibc versions we also have to use distroless/base-debian12.

Bumped the version of the image to v0.3.1.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to  https://github.com/kubernetes/release/issues/3128
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `grep` usage in distroless-iptables, which is now on version v0.3.1.
```
