### PR TITLE
Switch to bullseye for kube-cross

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -187,16 +187,16 @@ dependencies:
 
   # kube-cross
   - name: "registry.k8s.io/build-image/kube-cross (v1.29-go1.21)"
-    version: v1.29.0-go1.21.0-bookworm.0
+    version: v1.29.0-go1.21.0-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.29-go1.21)"
-    version: go1.21-bookworm
+    version: go1.21-bullseye
     refPaths:
     - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-bookworm'"
+      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.29-go1.21)"
     version: 0
@@ -338,10 +338,10 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: config variant (next candidate)"
-    version: go1.21-bookworm
+    version: go1.21-bullseye
     refPaths:
     - path: images/build/cross/variants.yaml
-      match: "CONFIG: 'go\\d+.\\d+-bookworm'"
+      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
   # Golang (previous release branches: 1.28)
   - name: "golang (previous release branches: 1.28)"
@@ -409,14 +409,14 @@ dependencies:
       match: "version: v\\d+.\\d+?\\.?(\\d+)?"
 
   # Base images
-  # split until all are set to bookworm
-  - name: "Debian: codename (bookworm)"
-    version: bookworm
+  # # Use bullseye for kube-cross to achieve maximum glibc compatibility.
+  - name: "Debian: codename (bullseye)"
+    version: bullseye
     refPaths:
     - path: images/build/cross/Makefile
-      match: OS_CODENAME\ \?=\ bookworm
+      match: OS_CODENAME\ \?=\ bullseye
     - path: packages/deb/Dockerfile
-      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-bookworm
+      match: FROM golang:\d+.\d+(alpha|beta|rc)?\.?(\d+)-bullseye
 
   - name: "Debian: codename (default)"
     version: bullseye

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -30,7 +30,7 @@ IMGNAME = kube-cross
 KUBERNETES_VERSION ?= v1.29.0
 GO_VERSION ?= 1.21.0
 GO_MAJOR_VERSION ?= 1.21
-OS_CODENAME ?= bookworm
+OS_CODENAME ?= bullseye
 REVISION ?= 0
 TYPE ?= default
 

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,12 +1,12 @@
 variants:
-  v1.29-go1.21-bookworm:
-    CONFIG: 'go1.21-bookworm'
+  v1.29-go1.21-bullseye:
+    CONFIG: 'go1.21-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.29.0-go1.21.0-bookworm.0'
+    IMAGE_VERSION: 'v1.29.0-go1.21.0-bullseye.0'
     KUBERNETES_VERSION: 'v1.29.0'
     GO_VERSION: '1.21.0'
     GO_MAJOR_VERSION: '1.21'
-    OS_CODENAME: 'bookworm'
+    OS_CODENAME: 'bullseye'
     REVISION: '0'
   v1.28-go1.20-bullseye:
     CONFIG: 'go1.20-bullseye'

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.0-bookworm
+FROM golang:1.21.0-bullseye
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
To achieve maximum glibc compatibility for the kubelet binary.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #3076 

Required for https://github.com/kubernetes/kubernetes/pull/118996
#### Special notes for your reviewer:
cc @kubernetes/release-managers 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
