### PR TITLE
add configs for 1.29 and 1.28 for k8s-cloudbuilder and drop 1.24

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -286,12 +286,17 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: REVISION:\ '\d+'
 
-  # TODO: uncomment when we have the cross available and then need to build this one as well
-  # - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.20)"
-  #   version: v1.28.0-go1.20.7-bullseye.0
-  #   refPaths:
-  #   - path: images/k8s-cloud-builder/variants.yaml
-  #     match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.21)"
+    version: v1.29.0-go1.21.0-bullseye.0
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.20)"
+    version: v1.28.0-go1.20.7-bullseye.0
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
     version: v1.27.0-go1.20.7-bullseye.0
@@ -352,6 +357,12 @@ dependencies:
     - path: images/build/go-runner/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/releng/ci/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: master)"
+    version: 1.21.0
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.28)"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,10 @@
 variants:
+  v1.29-cross1.21-bullseye:
+    CONFIG: 'cross1.20'
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.0-bullseye.0'
+  v1.28-cross1.20-bullseye:
+    CONFIG: 'cross1.20'
+    KUBE_CROSS_VERSION: 'v1.28.0-go1.20.7-bullseye.0'
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
     KUBE_CROSS_VERSION: 'v1.27.0-go1.20.7-bullseye.0'
@@ -8,6 +14,3 @@ variants:
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.20'
     KUBE_CROSS_VERSION: 'v1.25.0-go1.20.7-bullseye.0'
-  v1.24-cross1.19-bullseye:
-    CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.24.0-go1.20.7-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- add configs for 1.29 and 1.28 for k8s-cloudbuilder and drop 1.24

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3076

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add configs for 1.29 and 1.28 for k8s-cloudbuilder and drop 1.24
```
