### PR TITLE
update k8s-ci-builder for go1.21 to use bullseye for 1.29 and default for next config keep on bookworm

### DIFF
--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -2,7 +2,7 @@ variants:
   default:
     CONFIG: default
     GO_VERSION: '1.21.0'
-    OS_CODENAME: 'bookworm'
+    OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
     GO_VERSION: '1.21.0'
@@ -10,7 +10,7 @@ variants:
   '1.29':
     CONFIG: '1.29'
     GO_VERSION: '1.21.0'
-    OS_CODENAME: 'bookworm'
+    OS_CODENAME: 'bullseye'
   '1.28':
     CONFIG: '1.28'
     GO_VERSION: '1.20.7'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
- update k8s-ci-builder for go1.21 to use bullseye for 1.29 and default for next config keep on bookworm

/assign @saschagrunert @Verolop @xmudrii 
cc @kubernetes/release-engineering 


#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3076

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update k8s-ci-builder for go1.21 to use bullseye for 1.29 and default for next config keep on bookworm
```
