### PR TITLE
Update Dockerfile-kubepkg to use bookworm debian

### DIFF
--- a/Dockerfile-kubepkg
+++ b/Dockerfile-kubepkg
@@ -23,7 +23,7 @@ COPY . .
 RUN go build -o . ./cmd/kubepkg/...
 
 
-FROM debian:buster
+FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test


#### What this PR does / why we need it:
follow https://github.com/kubernetes/test-infra/pull/30603/
#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/120588


#### Special notes for your reviewer:
Bookworm uses a newer version of glibc compared to bullseye.

#### Does this PR introduce a user-facing change?


```release-note
None
```
