### PR TITLE
upgrade base image kubepkg-rpm to fedora:39

### DIFF
--- a/Dockerfile-kubepkg-rpm
+++ b/Dockerfile-kubepkg-rpm
@@ -23,7 +23,7 @@ COPY . .
 RUN go build -o . ./cmd/kubepkg/...
 
 
-FROM fedora:30
+FROM fedora:39
 
 RUN dnf install -y \
       rpm-build \


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test


#### What this PR does / why we need it:
follow https://github.com/kubernetes/test-infra/pull/30603/
- but fedora only has some new versions. The latest is 39. 
#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/issues/120591


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


```release-note
None
```
