### PR TITLE
Allow string slices as `krel obs` arguments

### DIFF
--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -82,8 +82,7 @@ steps:
   - "--log-level=${_LOG_LEVEL}"
   - "--template-dir=${_SPEC_TEMPLATE_PATH}"
   - "--packages=${_PACKAGES}"
-  # TODO(xmudrii) - followup: solve problem with delimiter
-  # - "--architectures=${_ARCHITECTURES}"
+  - "--architectures=${_ARCHITECTURES}"
   - "--version=${_VERSION}"
   - "--project=${_OBS_PROJECT}"
   - "--source=${_PACKAGE_SOURCE}"
@@ -97,6 +96,7 @@ tags:
 - ${_TYPE_TAG}
 - ${_TYPE}
 - ${_PACKAGES}
+- ${_ARCHITECTURES}
 - ${_VERSION}
 - ${_OBS_PROJECT_TAG}
 

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -42,6 +42,10 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
+// StringSliceSeparator is the separator used for passing string slices as GCB
+// substitutions.
+const StringSliceSeparator = "..."
+
 // GCB is the main structure of this package.
 type GCB struct {
 	options        *Options
@@ -391,9 +395,8 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 	switch {
 	case g.options.OBSStage:
 		gcbSubs["SPEC_TEMPLATE_PATH"] = g.options.SpecTemplatePath
-		gcbSubs["PACKAGES"] = strings.Join(g.options.Packages, ",")
-		//nolint:gocritic // This needs some fixes that will be done in a follow-up
-		// gcbSubs["ARCHITECTURES"] = strings.Join(g.options.Architectures, ",")
+		gcbSubs["PACKAGES"] = strings.Join(g.options.Packages, StringSliceSeparator)
+		gcbSubs["ARCHITECTURES"] = strings.Join(g.options.Architectures, StringSliceSeparator)
 		gcbSubs["VERSION"] = g.options.Version
 		gcbSubs["OBS_PROJECT"] = g.options.OBSProject
 		gcbSubs["OBS_PROJECT_TAG"] = strings.ReplaceAll(g.options.OBSProject, ":", "-")
@@ -402,7 +405,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 		// Stop here when doing OBS stage
 		return gcbSubs, nil
 	case g.options.OBSRelease:
-		gcbSubs["PACKAGES"] = strings.Join(g.options.Packages, ",")
+		gcbSubs["PACKAGES"] = strings.Join(g.options.Packages, StringSliceSeparator)
 		gcbSubs["OBS_PROJECT"] = g.options.OBSProject
 		gcbSubs["OBS_PROJECT_TAG"] = strings.ReplaceAll(g.options.OBSProject, ":", "-")
 


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This fixes the usage of packages and architectures as mentioned in https://github.com/kubernetes/release/issues/3224 by using a custom separator.

We cannot use the GCB separator substitution (see `gcloud topic escaping`) because GCB complains that a 'build tag must match format "^[\\w][\\w.-]{0,127}$"'.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/3224
#### Special notes for your reviewer:
Tested via:

```
> export TOOL_ORG=saschagrunert TOOL_REF=arches && go run ./cmd/krel obs stage --architectures amd64,arm64,ppc64le --packages cri-o --version 1.28.1 --project isv:kubernetes:core:shared:build --stream
```
https://console.cloud.google.com/cloud-build/builds/8480b7dd-2b36-44c2-87c1-f2af0caeaac6?project=648026197307

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow string slices (`architectures` and `packages`) as `krel obs` arguments.
```
