### PR TITLE
Require iptables and CNI plugins for CRI-O

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -15,6 +15,8 @@ License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
 BuildRequires: sed
+Requires: iptables
+Requires: kubernetes-cni
 
 %description
 %{summary}.


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add the requirements to both packages since they're required at runtime.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3214
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
