### PR TITLE
Make `--workspace` configurable in `obs stage/release`

### DIFF
--- a/cmd/krel/cmd/obs_release.go
+++ b/cmd/krel/cmd/obs_release.go
@@ -65,6 +65,14 @@ var obsReleaseOptions = obs.DefaultReleaseOptions()
 func init() {
 	obsReleaseCmd.PersistentFlags().
 		StringVar(
+			&obsReleaseOptions.Workspace,
+			"workspace",
+			obsReleaseOptions.Workspace,
+			"Workspace directory for running krel obs",
+		)
+
+	obsReleaseCmd.PersistentFlags().
+		StringVar(
 			&obsReleaseOptions.ReleaseType,
 			"type",
 			obsReleaseOptions.ReleaseType,

--- a/cmd/krel/cmd/obs_stage.go
+++ b/cmd/krel/cmd/obs_stage.go
@@ -79,6 +79,14 @@ const (
 func init() {
 	obsStageCmd.PersistentFlags().
 		StringVar(
+			&obsStageOptions.Workspace,
+			"workspace",
+			obsStageOptions.Workspace,
+			"Workspace directory for running krel obs",
+		)
+
+	obsStageCmd.PersistentFlags().
+		StringVar(
 			&obsStageOptions.ReleaseType,
 			"type",
 			obsStageOptions.ReleaseType,

--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -54,15 +54,15 @@ const (
 
 	// workspaceDir is the global directory where the stage and release process
 	// happens.
-	workspaceDir = "/workspace"
+	defaultWorkspaceDir = "/workspace"
 
 	// defaultSpecTemplatePath is path inside Google Cloud Build where package
 	// specs for kubeadm, kubectl, and kubelet are located.
-	defaultSpecTemplatePath = workspaceDir + "/go/src/k8s.io/release/" + consts.DefaultSpecTemplatePath
+	defaultSpecTemplatePath = defaultWorkspaceDir + "/go/src/k8s.io/release/" + consts.DefaultSpecTemplatePath
 
 	// obsRoot is path inside Google Cloud Build where OBS project and packages
 	// are checked out.
-	obsRoot = workspaceDir + "/src/obs"
+	obsRoot = "/src/obs"
 
 	// obsAPIURL is the URL of openSUSE's OpenBuildService instance.
 	obsAPIURL = "https://api.opensuse.org"
@@ -78,6 +78,9 @@ const (
 // Options are settings which will be used by `StageOptions` as well as
 // `ReleaseOptions`.
 type Options struct {
+	// Workspace is the root workspace.
+	Workspace string
+
 	// Run the whole process in non-mocked mode. Which means that it doesn't
 	// push specs and artifacts to OpenBuildService.
 	NoMock bool
@@ -150,6 +153,7 @@ func DefaultOptions() *Options {
 			consts.ArchitectureS390X,
 		},
 		SpecTemplatePath: defaultSpecTemplatePath,
+		Workspace:        defaultWorkspaceDir,
 	}
 }
 

--- a/pkg/obs/obsfakes/fake_release_impl.go
+++ b/pkg/obs/obsfakes/fake_release_impl.go
@@ -41,9 +41,10 @@ type FakeReleaseImpl struct {
 		result1 bool
 		result2 error
 	}
-	CheckPrerequisitesStub        func() error
+	CheckPrerequisitesStub        func(string) error
 	checkPrerequisitesMutex       sync.RWMutex
 	checkPrerequisitesArgsForCall []struct {
+		arg1 string
 	}
 	checkPrerequisitesReturns struct {
 		result1 error
@@ -51,10 +52,11 @@ type FakeReleaseImpl struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CheckoutProjectStub        func(string) error
+	CheckoutProjectStub        func(string, string) error
 	checkoutProjectMutex       sync.RWMutex
 	checkoutProjectArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	checkoutProjectReturns struct {
 		result1 error
@@ -101,11 +103,12 @@ type FakeReleaseImpl struct {
 	mkdirAllReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ReleasePackageStub        func(string, string) error
+	ReleasePackageStub        func(string, string, string) error
 	releasePackageMutex       sync.RWMutex
 	releasePackageArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	releasePackageReturns struct {
 		result1 error
@@ -194,17 +197,18 @@ func (fake *FakeReleaseImpl) BranchNeedsCreationReturnsOnCall(i int, result1 boo
 	}{result1, result2}
 }
 
-func (fake *FakeReleaseImpl) CheckPrerequisites() error {
+func (fake *FakeReleaseImpl) CheckPrerequisites(arg1 string) error {
 	fake.checkPrerequisitesMutex.Lock()
 	ret, specificReturn := fake.checkPrerequisitesReturnsOnCall[len(fake.checkPrerequisitesArgsForCall)]
 	fake.checkPrerequisitesArgsForCall = append(fake.checkPrerequisitesArgsForCall, struct {
-	}{})
+		arg1 string
+	}{arg1})
 	stub := fake.CheckPrerequisitesStub
 	fakeReturns := fake.checkPrerequisitesReturns
-	fake.recordInvocation("CheckPrerequisites", []interface{}{})
+	fake.recordInvocation("CheckPrerequisites", []interface{}{arg1})
 	fake.checkPrerequisitesMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -218,10 +222,17 @@ func (fake *FakeReleaseImpl) CheckPrerequisitesCallCount() int {
 	return len(fake.checkPrerequisitesArgsForCall)
 }
 
-func (fake *FakeReleaseImpl) CheckPrerequisitesCalls(stub func() error) {
+func (fake *FakeReleaseImpl) CheckPrerequisitesCalls(stub func(string) error) {
 	fake.checkPrerequisitesMutex.Lock()
 	defer fake.checkPrerequisitesMutex.Unlock()
 	fake.CheckPrerequisitesStub = stub
+}
+
+func (fake *FakeReleaseImpl) CheckPrerequisitesArgsForCall(i int) string {
+	fake.checkPrerequisitesMutex.RLock()
+	defer fake.checkPrerequisitesMutex.RUnlock()
+	argsForCall := fake.checkPrerequisitesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeReleaseImpl) CheckPrerequisitesReturns(result1 error) {
@@ -247,18 +258,19 @@ func (fake *FakeReleaseImpl) CheckPrerequisitesReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeReleaseImpl) CheckoutProject(arg1 string) error {
+func (fake *FakeReleaseImpl) CheckoutProject(arg1 string, arg2 string) error {
 	fake.checkoutProjectMutex.Lock()
 	ret, specificReturn := fake.checkoutProjectReturnsOnCall[len(fake.checkoutProjectArgsForCall)]
 	fake.checkoutProjectArgsForCall = append(fake.checkoutProjectArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.CheckoutProjectStub
 	fakeReturns := fake.checkoutProjectReturns
-	fake.recordInvocation("CheckoutProject", []interface{}{arg1})
+	fake.recordInvocation("CheckoutProject", []interface{}{arg1, arg2})
 	fake.checkoutProjectMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -272,17 +284,17 @@ func (fake *FakeReleaseImpl) CheckoutProjectCallCount() int {
 	return len(fake.checkoutProjectArgsForCall)
 }
 
-func (fake *FakeReleaseImpl) CheckoutProjectCalls(stub func(string) error) {
+func (fake *FakeReleaseImpl) CheckoutProjectCalls(stub func(string, string) error) {
 	fake.checkoutProjectMutex.Lock()
 	defer fake.checkoutProjectMutex.Unlock()
 	fake.CheckoutProjectStub = stub
 }
 
-func (fake *FakeReleaseImpl) CheckoutProjectArgsForCall(i int) string {
+func (fake *FakeReleaseImpl) CheckoutProjectArgsForCall(i int) (string, string) {
 	fake.checkoutProjectMutex.RLock()
 	defer fake.checkoutProjectMutex.RUnlock()
 	argsForCall := fake.checkoutProjectArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeReleaseImpl) CheckoutProjectReturns(result1 error) {
@@ -498,19 +510,20 @@ func (fake *FakeReleaseImpl) MkdirAllReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeReleaseImpl) ReleasePackage(arg1 string, arg2 string) error {
+func (fake *FakeReleaseImpl) ReleasePackage(arg1 string, arg2 string, arg3 string) error {
 	fake.releasePackageMutex.Lock()
 	ret, specificReturn := fake.releasePackageReturnsOnCall[len(fake.releasePackageArgsForCall)]
 	fake.releasePackageArgsForCall = append(fake.releasePackageArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.ReleasePackageStub
 	fakeReturns := fake.releasePackageReturns
-	fake.recordInvocation("ReleasePackage", []interface{}{arg1, arg2})
+	fake.recordInvocation("ReleasePackage", []interface{}{arg1, arg2, arg3})
 	fake.releasePackageMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -524,17 +537,17 @@ func (fake *FakeReleaseImpl) ReleasePackageCallCount() int {
 	return len(fake.releasePackageArgsForCall)
 }
 
-func (fake *FakeReleaseImpl) ReleasePackageCalls(stub func(string, string) error) {
+func (fake *FakeReleaseImpl) ReleasePackageCalls(stub func(string, string, string) error) {
 	fake.releasePackageMutex.Lock()
 	defer fake.releasePackageMutex.Unlock()
 	fake.ReleasePackageStub = stub
 }
 
-func (fake *FakeReleaseImpl) ReleasePackageArgsForCall(i int) (string, string) {
+func (fake *FakeReleaseImpl) ReleasePackageArgsForCall(i int) (string, string, string) {
 	fake.releasePackageMutex.RLock()
 	defer fake.releasePackageMutex.RUnlock()
 	argsForCall := fake.releasePackageArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeReleaseImpl) ReleasePackageReturns(result1 error) {

--- a/pkg/obs/obsfakes/fake_stage_impl.go
+++ b/pkg/obs/obsfakes/fake_stage_impl.go
@@ -27,11 +27,12 @@ import (
 )
 
 type FakeStageImpl struct {
-	AddRemoveChangesStub        func(string, string) error
+	AddRemoveChangesStub        func(string, string, string) error
 	addRemoveChangesMutex       sync.RWMutex
 	addRemoveChangesArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	addRemoveChangesReturns struct {
 		result1 error
@@ -54,9 +55,10 @@ type FakeStageImpl struct {
 		result1 bool
 		result2 error
 	}
-	CheckPrerequisitesStub        func() error
+	CheckPrerequisitesStub        func(string) error
 	checkPrerequisitesMutex       sync.RWMutex
 	checkPrerequisitesArgsForCall []struct {
+		arg1 string
 	}
 	checkPrerequisitesReturns struct {
 		result1 error
@@ -64,10 +66,11 @@ type FakeStageImpl struct {
 	checkPrerequisitesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CheckoutProjectStub        func(string) error
+	CheckoutProjectStub        func(string, string) error
 	checkoutProjectMutex       sync.RWMutex
 	checkoutProjectArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	checkoutProjectReturns struct {
 		result1 error
@@ -75,12 +78,13 @@ type FakeStageImpl struct {
 	checkoutProjectReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CommitChangesStub        func(string, string, string) error
+	CommitChangesStub        func(string, string, string, string) error
 	commitChangesMutex       sync.RWMutex
 	commitChangesArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 string
 	}
 	commitChangesReturns struct {
 		result1 error
@@ -164,19 +168,20 @@ type FakeStageImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeStageImpl) AddRemoveChanges(arg1 string, arg2 string) error {
+func (fake *FakeStageImpl) AddRemoveChanges(arg1 string, arg2 string, arg3 string) error {
 	fake.addRemoveChangesMutex.Lock()
 	ret, specificReturn := fake.addRemoveChangesReturnsOnCall[len(fake.addRemoveChangesArgsForCall)]
 	fake.addRemoveChangesArgsForCall = append(fake.addRemoveChangesArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.AddRemoveChangesStub
 	fakeReturns := fake.addRemoveChangesReturns
-	fake.recordInvocation("AddRemoveChanges", []interface{}{arg1, arg2})
+	fake.recordInvocation("AddRemoveChanges", []interface{}{arg1, arg2, arg3})
 	fake.addRemoveChangesMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -190,17 +195,17 @@ func (fake *FakeStageImpl) AddRemoveChangesCallCount() int {
 	return len(fake.addRemoveChangesArgsForCall)
 }
 
-func (fake *FakeStageImpl) AddRemoveChangesCalls(stub func(string, string) error) {
+func (fake *FakeStageImpl) AddRemoveChangesCalls(stub func(string, string, string) error) {
 	fake.addRemoveChangesMutex.Lock()
 	defer fake.addRemoveChangesMutex.Unlock()
 	fake.AddRemoveChangesStub = stub
 }
 
-func (fake *FakeStageImpl) AddRemoveChangesArgsForCall(i int) (string, string) {
+func (fake *FakeStageImpl) AddRemoveChangesArgsForCall(i int) (string, string, string) {
 	fake.addRemoveChangesMutex.RLock()
 	defer fake.addRemoveChangesMutex.RUnlock()
 	argsForCall := fake.addRemoveChangesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStageImpl) AddRemoveChangesReturns(result1 error) {
@@ -292,17 +297,18 @@ func (fake *FakeStageImpl) BranchNeedsCreationReturnsOnCall(i int, result1 bool,
 	}{result1, result2}
 }
 
-func (fake *FakeStageImpl) CheckPrerequisites() error {
+func (fake *FakeStageImpl) CheckPrerequisites(arg1 string) error {
 	fake.checkPrerequisitesMutex.Lock()
 	ret, specificReturn := fake.checkPrerequisitesReturnsOnCall[len(fake.checkPrerequisitesArgsForCall)]
 	fake.checkPrerequisitesArgsForCall = append(fake.checkPrerequisitesArgsForCall, struct {
-	}{})
+		arg1 string
+	}{arg1})
 	stub := fake.CheckPrerequisitesStub
 	fakeReturns := fake.checkPrerequisitesReturns
-	fake.recordInvocation("CheckPrerequisites", []interface{}{})
+	fake.recordInvocation("CheckPrerequisites", []interface{}{arg1})
 	fake.checkPrerequisitesMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -316,10 +322,17 @@ func (fake *FakeStageImpl) CheckPrerequisitesCallCount() int {
 	return len(fake.checkPrerequisitesArgsForCall)
 }
 
-func (fake *FakeStageImpl) CheckPrerequisitesCalls(stub func() error) {
+func (fake *FakeStageImpl) CheckPrerequisitesCalls(stub func(string) error) {
 	fake.checkPrerequisitesMutex.Lock()
 	defer fake.checkPrerequisitesMutex.Unlock()
 	fake.CheckPrerequisitesStub = stub
+}
+
+func (fake *FakeStageImpl) CheckPrerequisitesArgsForCall(i int) string {
+	fake.checkPrerequisitesMutex.RLock()
+	defer fake.checkPrerequisitesMutex.RUnlock()
+	argsForCall := fake.checkPrerequisitesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStageImpl) CheckPrerequisitesReturns(result1 error) {
@@ -345,18 +358,19 @@ func (fake *FakeStageImpl) CheckPrerequisitesReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
-func (fake *FakeStageImpl) CheckoutProject(arg1 string) error {
+func (fake *FakeStageImpl) CheckoutProject(arg1 string, arg2 string) error {
 	fake.checkoutProjectMutex.Lock()
 	ret, specificReturn := fake.checkoutProjectReturnsOnCall[len(fake.checkoutProjectArgsForCall)]
 	fake.checkoutProjectArgsForCall = append(fake.checkoutProjectArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.CheckoutProjectStub
 	fakeReturns := fake.checkoutProjectReturns
-	fake.recordInvocation("CheckoutProject", []interface{}{arg1})
+	fake.recordInvocation("CheckoutProject", []interface{}{arg1, arg2})
 	fake.checkoutProjectMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -370,17 +384,17 @@ func (fake *FakeStageImpl) CheckoutProjectCallCount() int {
 	return len(fake.checkoutProjectArgsForCall)
 }
 
-func (fake *FakeStageImpl) CheckoutProjectCalls(stub func(string) error) {
+func (fake *FakeStageImpl) CheckoutProjectCalls(stub func(string, string) error) {
 	fake.checkoutProjectMutex.Lock()
 	defer fake.checkoutProjectMutex.Unlock()
 	fake.CheckoutProjectStub = stub
 }
 
-func (fake *FakeStageImpl) CheckoutProjectArgsForCall(i int) string {
+func (fake *FakeStageImpl) CheckoutProjectArgsForCall(i int) (string, string) {
 	fake.checkoutProjectMutex.RLock()
 	defer fake.checkoutProjectMutex.RUnlock()
 	argsForCall := fake.checkoutProjectArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeStageImpl) CheckoutProjectReturns(result1 error) {
@@ -406,20 +420,21 @@ func (fake *FakeStageImpl) CheckoutProjectReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeStageImpl) CommitChanges(arg1 string, arg2 string, arg3 string) error {
+func (fake *FakeStageImpl) CommitChanges(arg1 string, arg2 string, arg3 string, arg4 string) error {
 	fake.commitChangesMutex.Lock()
 	ret, specificReturn := fake.commitChangesReturnsOnCall[len(fake.commitChangesArgsForCall)]
 	fake.commitChangesArgsForCall = append(fake.commitChangesArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.CommitChangesStub
 	fakeReturns := fake.commitChangesReturns
-	fake.recordInvocation("CommitChanges", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("CommitChanges", []interface{}{arg1, arg2, arg3, arg4})
 	fake.commitChangesMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -433,17 +448,17 @@ func (fake *FakeStageImpl) CommitChangesCallCount() int {
 	return len(fake.commitChangesArgsForCall)
 }
 
-func (fake *FakeStageImpl) CommitChangesCalls(stub func(string, string, string) error) {
+func (fake *FakeStageImpl) CommitChangesCalls(stub func(string, string, string, string) error) {
 	fake.commitChangesMutex.Lock()
 	defer fake.commitChangesMutex.Unlock()
 	fake.CommitChangesStub = stub
 }
 
-func (fake *FakeStageImpl) CommitChangesArgsForCall(i int) (string, string, string) {
+func (fake *FakeStageImpl) CommitChangesArgsForCall(i int) (string, string, string, string) {
 	fake.commitChangesMutex.RLock()
 	defer fake.commitChangesMutex.RUnlock()
 	argsForCall := fake.commitChangesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeStageImpl) CommitChangesReturns(result1 error) {

--- a/pkg/obs/prerequisites.go
+++ b/pkg/obs/prerequisites.go
@@ -107,9 +107,9 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// osc checks
 	logrus.Info("Verifying OpenBuildService access")
-	ver, err := p.impl.OSCOutput("--version")
+	ver, err := p.impl.OSCOutput("version")
 	if err != nil {
-		return fmt.Errorf("running osc --version: %w", err)
+		return fmt.Errorf("running osc version: %w", err)
 	}
 	logrus.Infof("Using osc version: %s", ver)
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Adding a new `--workspace` flag to allow customizing the previously hard-coded `/workspace` path.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make `--workspace` configurable in `obs stage/release`
```
