### PR TITLE
Make `--template-dir` work for `krel obs release`

### DIFF
--- a/cmd/krel/cmd/obs_release.go
+++ b/cmd/krel/cmd/obs_release.go
@@ -111,6 +111,14 @@ func init() {
 
 	obsReleaseCmd.PersistentFlags().
 		StringVar(
+			&obsReleaseOptions.SpecTemplatePath,
+			obsSpecTemplatePathFlag,
+			obsReleaseOptions.SpecTemplatePath,
+			"Path to a directory containing templates for specs",
+		)
+
+	obsReleaseCmd.PersistentFlags().
+		StringVar(
 			&obsReleaseOptions.Project,
 			obsProjectFlag,
 			obsReleaseOptions.Project,

--- a/pkg/obs/release.go
+++ b/pkg/obs/release.go
@@ -193,7 +193,7 @@ func (d *DefaultRelease) InitOBSRoot() error {
 		return fmt.Errorf("creating obs config file: %w", err)
 	}
 
-	return d.impl.MkdirAll(obsRoot)
+	return d.impl.MkdirAll(filepath.Join(d.options.Workspace, obsRoot))
 }
 
 // ValidateOptions validates the release options.


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The template dir for `krel obs release` was not configurable before this change.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `--template-dir` for `krel obs release`
```
