### PR TITLE
Allow setting OBS_USERNAME for a specific user

### DIFF
--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -73,6 +73,10 @@ const (
 	// OBSPasswordKey is name of the environment variable with password for
 	// Kubernetes Release Bot account.
 	OBSPasswordKey = "OBS_PASSWORD"
+
+	// OBSUsernameKey is name of the environment variable containing the
+	// username for the OBS account. If empty, obsK8sUsername will be used.
+	OBSUsernameKey = "OBS_USERNAME"
 )
 
 // Options are settings which will be used by `StageOptions` as well as

--- a/pkg/obs/release.go
+++ b/pkg/obs/release.go
@@ -189,7 +189,12 @@ func (d *DefaultRelease) InitOBSRoot() error {
 		return fmt.Errorf("%s environment variable not set", OBSPasswordKey)
 	}
 
-	if err := d.impl.CreateOBSConfigFile(obsK8sUsername, password); err != nil {
+	username := os.Getenv(OBSUsernameKey)
+	if username == "" {
+		username = obsK8sUsername
+	}
+
+	if err := d.impl.CreateOBSConfigFile(username, password); err != nil {
 		return fmt.Errorf("creating obs config file: %w", err)
 	}
 

--- a/pkg/obs/stage.go
+++ b/pkg/obs/stage.go
@@ -244,7 +244,12 @@ func (d *DefaultStage) InitOBSRoot() error {
 		return fmt.Errorf("%s environment variable not set", OBSPasswordKey)
 	}
 
-	if err := d.impl.CreateOBSConfigFile(obsK8sUsername, password); err != nil {
+	username := os.Getenv(OBSUsernameKey)
+	if username == "" {
+		username = obsK8sUsername
+	}
+
+	if err := d.impl.CreateOBSConfigFile(username, password); err != nil {
 		return fmt.Errorf("creating obs config file: %w", err)
 	}
 


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows setting a specific username for OBS.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow setting `OBS_USERNAME` for a specific `krel obs` user
```
