### PR TITLE
Fix CRI-O unitdir macro on debbuild

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -8,6 +8,8 @@ Summary: Open Container Initiative-based implementation of Kubernetes Container 
 
 %if "%{_vendor}" == "debbuild"
 Group: admin
+# The _unitdir macro does not exist on debbuild
+%define _unitdir %{_prefix}/lib/systemd/system
 %endif
 
 Packager: Kubernetes Authors <dev@kubernetes.io>


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The unitdir macro does not seem to exist, so we just redefine it on debbuild.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3214
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
