### PR TITLE
Add registries.conf to CRI-O spec

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -53,6 +53,7 @@ install -D -m 644 -t %{buildroot}%{_datadir}/zsh/site-functions %{archive_root}/
 # Configurations
 install -dp %{buildroot}%{_sysconfdir}/containers
 install -p -m 644 %{archive_root}/contrib/policy.json %{buildroot}%{_sysconfdir}/containers/policy.json
+install -p -m 644 %{archive_root}/contrib/registries.conf %{buildroot}%{_sysconfdir}/containers/registries.conf
 
 install -p -m 644 %{archive_root}/etc/crictl.yaml %{buildroot}%{_sysconfdir}/crictl.yaml
 
@@ -98,6 +99,7 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 # Configurations
 %dir %{_sysconfdir}/containers
 %config(noreplace) %{_sysconfdir}/containers/policy.json
+%config(noreplace) %{_sysconfdir}/containers/registries.conf
 %config(noreplace) %{_sysconfdir}/crictl.yaml
 %dir %{_sysconfdir}/cni
 %dir %{_sysconfdir}/cni/net.d


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The file is required for CRI-O to pull images from public registries if not available on disk.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3214
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
