### PR TITLE
Deprecate release notes website pr

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,8 +33,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
-
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"
@@ -180,7 +179,7 @@ func init() {
 		&releaseNotesOpts.createWebsitePR,
 		"create-website-pr",
 		false,
-		"patch the relnotes.k8s.io sources and generate a PR with the changes",
+		"[DEPRECATED] patch the relnotes.k8s.io sources and generate a PR with the changes",
 	)
 
 	releaseNotesCmd.PersistentFlags().StringSliceVarP(

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,6 +32,8 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
 	"k8s.io/release/pkg/notes/options"

--- a/docs/krel/release-notes.md
+++ b/docs/krel/release-notes.md
@@ -47,7 +47,7 @@ Before running `krel release-notes` export your GitHub token to \$GITHUB_TOKEN:
 ```
 Flags:
       --create-draft-pr     update the Release Notes draft and create a PR in k/sig-release
-      --create-website-pr   patch the relnotes.k8s.io sources and generate a PR with the changes
+      --create-website-pr   [DEPRECATED] patch the relnotes.k8s.io sources and generate a PR with the changes
       --dependencies        add dependency report (default true)
       --fix                 fix release notes
       --fork string         the user's fork in the form org/repo. Used to submit Pull Requests for the website and draft


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

This PR deprecates the `krel release-notes --create-website-pr` command. The process has been automated with https://github.com/kubernetes/release/issues/1087 and is no longer needed.

#### Which issue(s) this PR fixes:

#1087

#### Special notes for your reviewer:

I have just added `[DEPRECATE]` to the usage and docs for the command. Should we also print a warning when an user tries to run the command?

#### Does this PR introduce a user-facing change?

```release-note
Deprecate --create-website-pr on krel release-notes as there is no need to update the repo with latest release notes. They are now fetched automatically from GCS.
```

cc @saschagrunert 