### PR TITLE
Update `osc` binary in k8s-cloud-builder

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get -q update \
         lsb-release \
         make \
         net-tools \
-        osc \
         pandoc \
         rsync \
         software-properties-common \
@@ -65,6 +64,7 @@ RUN apt-get -qqy purge ".*python2.*" \
 RUN pip3 install --no-cache-dir \
       # for gcloud https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
       crcmod \
+      osc \
       yq
 
 # common::set_cloud_binaries() looks for it in this path


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The dist version is pretty old (0.169.1) compared to the latest 0.3.1 release. We now stick to pip to get the recent version in.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Upgrade `osc` binary in k8s-cloud-builder image.
```
