### PR TITLE
Fix EnvironmentFile path for kubeadm deb package

### DIFF
--- a/cmd/krel/templates/latest/kubeadm/kubeadm.spec
+++ b/cmd/krel/templates/latest/kubeadm/kubeadm.spec
@@ -20,6 +20,7 @@ Requires: {{ $dep.Name }} {{ $dep.VersionConstraint }}
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires: systemd-deb-macros
+BuildRequires: sed
 %else
 BuildRequires: systemd-rpm-macros
 %endif
@@ -40,6 +41,10 @@ KUBE_ARCH="$(uname -m)"
 # Install files
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}/kubelet.service.d/
+
+%if "%{_vendor}" == "debbuild"
+sed -i 's;/etc/sysconfig/kubelet;/etc/default/kubelet;g' 10-kubeadm.conf
+%endif
 
 install -p -m 755 ${KUBE_ARCH}/kubeadm %{buildroot}%{_bindir}/kubeadm
 install -p -m 644 10-kubeadm.conf %{buildroot}%{_unitdir}/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Debian packages published to the legacy repos have EnvironmentFile in `10-kubeadm.conf` set to `/etc/default/kubelet`. However, Debian packages published to `pkgs.k8s.io` have this variable set to `/etc/sysconfig/kubelet`

This is wrong as described in https://github.com/kubernetes/release/issues/3276 and https://kubernetes.slack.com/archives/C09NXKJKA/p1694790202990129

Moreover, this is breaking some clusters as described in https://github.com/kubernetes/release/issues/3219#issuecomment-1717015276

This PR is supposed to fix this issue by applying some `sed` magic when building packages ✨ 🧙 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3276

#### Special notes for your reviewer:

I'll properly test this change after the PR is merged because I can't run a nomock job on a non-master branch. This fix only applies on packages published after the fix is merged, we don't have a way to alter existing packages.

/priority critical-urgent

#### Does this PR introduce a user-facing change?
```release-note
EnvironmentFile is changed from `/etc/sysconfig/kubelet` to `/etc/default/kubelet` for `kubeadm` Debian packages published to `pkgs.k8s.io`
```

/assign @saschagrunert 
cc @kubernetes/release-engineering 