### PR TITLE
reverting parallel builds freal

### DIFF
--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -86,8 +86,8 @@ func (m *Make) MakeCross(version string) error {
 	// Unset the build memory requirement for parallel builds
 	// TODO: Remove this once the 1.20 release reaches EOL.
 	const buildMemoryKey = "KUBE_PARALLEL_BUILD_MEMORY"
-	logrus.Infof("Unsetting %s to force parallel build", buildMemoryKey)
-	os.Setenv(buildMemoryKey, "0")
+	logrus.Infof("Setting %s to force serial build", buildMemoryKey)
+	os.Setenv(buildMemoryKey, "32")
 
 	logrus.Info("Building binaries")
 	if err := m.impl.Command(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In an attempt to release 1.29 alpha, parallel builds result in cloud build OOM. This PR removes the parallelism as far as I can tell.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Slack conversation: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1695250323844399?thread_ts=1695230356.037239&cid=CJH2GBF7Y

#### Does this PR introduce a user-facing change?

```release-note
NONE
```