### PR TITLE
Use package runtime dependencies for CRI-O

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -5,18 +5,23 @@ Name: cri-o
 Version: {{ .RPMVersion }}
 Release: {{ .Revision }}
 Summary: Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
-
-%if "%{_vendor}" == "debbuild"
-Group: admin
-# The _unitdir macro does not exist on debbuild
-%define _unitdir %{_prefix}/lib/systemd/system
-%endif
-
 Packager: Kubernetes Authors <dev@kubernetes.io>
 License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
 BuildRequires: sed
+
+%if "%{_vendor}" == "debbuild"
+Group: admin
+# The _unitdir macro does not exist on debbuild
+%define _unitdir %{_prefix}/lib/systemd/system
+Requires: golang-github-containers-common
+%else
+Requires: containers-common
+%endif
+
+Requires: conmon
+Requires: crun
 Requires: iptables
 Requires: kubernetes-cni
 
@@ -38,9 +43,7 @@ install -dp %{buildroot}%{_sharedstatedir}/crio
 # Binaries
 install -dp %{buildroot}%{_bindir}
 install -p -m 755 %{archive_root}/bin/crio %{buildroot}%{_bindir}/crio
-install -p -m 755 %{archive_root}/bin/conmon %{buildroot}%{_bindir}/conmon
 install -p -m 755 %{archive_root}/bin/pinns %{buildroot}%{_bindir}/pinns
-install -p -m 755 %{archive_root}/bin/crun %{buildroot}%{_bindir}/crun
 
 # Completions
 install -d -m 755 %{buildroot}%{_datadir}/bash-completion/completions
@@ -53,10 +56,7 @@ install -d -m 755 %{buildroot}%{_datadir}/zsh/site-functions
 install -D -m 644 -t %{buildroot}%{_datadir}/zsh/site-functions %{archive_root}/completions/zsh/_crio
 
 # Configurations
-install -dp %{buildroot}%{_sysconfdir}/containers
-install -p -m 644 %{archive_root}/contrib/policy.json %{buildroot}%{_sysconfdir}/containers/policy.json
-install -p -m 644 %{archive_root}/contrib/registries.conf %{buildroot}%{_sysconfdir}/containers/registries.conf
-
+install -dp %{buildroot}%{_sysconfdir}
 install -p -m 644 %{archive_root}/etc/crictl.yaml %{buildroot}%{_sysconfdir}/crictl.yaml
 
 install -dp %{buildroot}%{_sysconfdir}/crio/crio.conf.d
@@ -85,9 +85,7 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 
 # Binaries
 %{_bindir}/crio
-%{_bindir}/conmon
 %{_bindir}/pinns
-%{_bindir}/crun
 
 # Completions
 %{_datadir}/bash-completion/completions/crio
@@ -99,9 +97,6 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 %{_datadir}/zsh/site-functions/_crio
 
 # Configurations
-%dir %{_sysconfdir}/containers
-%config(noreplace) %{_sysconfdir}/containers/policy.json
-%config(noreplace) %{_sysconfdir}/containers/registries.conf
 %config(noreplace) %{_sysconfdir}/crictl.yaml
 %dir %{_sysconfdir}/cni
 %dir %{_sysconfdir}/cni/net.d


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We now use `conmon` and `crun` as package dependencies to not clash with packages like `podman`. We also need a common
(`golang-github-containers-common`/`containers-common`) as dependencie to avoid writing `policy.json` and `registries.conf`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
