### PR TITLE
CRI-O: handle systemd unit file

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -10,6 +10,8 @@ License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
 BuildRequires: sed
+BuildRequires: systemd
+%{?systemd_requires}
 
 %if "%{_vendor}" == "debbuild"
 Group: admin
@@ -81,6 +83,25 @@ install -D -m 644 -t %{buildroot}%{_unitdir} %{archive_root}/contrib/crio.servic
 install -D -m 644 -t %{buildroot}%{_mandir}/man5 %{archive_root}/man/crio.conf.5
 install -D -m 644 -t %{buildroot}%{_mandir}/man5 %{archive_root}/man/crio.conf.d.5
 install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
+
+%if "%{_vendor}" == "debbuild"
+# We cannot use the %systemd_ macros here because debbuild does not support them.
+%pre
+/usr/bin/systemctl stop crio.service >/dev/null 2>&1 ||:
+
+%post
+/usr/bin/systemctl daemon-reload
+/usr/bin/systemctl enable --now crio.service
+%else
+%post
+%systemd_post crio.service
+
+%preun
+%systemd_preun crio.service
+
+%postun
+%systemd_postun_with_restart crio.service
+%endif
 
 %files
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Allow systemd unit file handling per installation method.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
