### PR TITLE
Fix logical `or` in CRI-O rpm spec

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -18,12 +18,13 @@ Group: admin
 # The _unitdir macro does not exist on debbuild
 %define _unitdir %{_prefix}/lib/systemd/system
 Replaces: conmon, crun, golang-github-containers-common
+Requires: kubernetes-cni or containernetworking-plugins
 %else
 Conflicts: conmon, crun, containers-common
+Recommends: kubernetes-cni
 %endif
 
 Requires: iptables
-Requires: kubernetes-cni or containernetworking-plugins
 
 %description
 %{summary}.


### PR DESCRIPTION



#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The spec needs encapsulated by braces, otherwise it won't work.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
