### PR TITLE
Don't start systemd unit by default

### DIFF
--- a/cmd/krel/templates/latest/cri-o/cri-o.spec
+++ b/cmd/krel/templates/latest/cri-o/cri-o.spec
@@ -15,10 +15,12 @@ BuildRequires: systemd
 
 %if "%{_vendor}" == "debbuild"
 Group: admin
+BuildRequires: systemd-deb-macros
 # The _unitdir macro does not exist on debbuild
 %define _unitdir %{_prefix}/lib/systemd/system
 Replaces: conmon, crun, golang-github-containers-common
 %else
+BuildRequires: systemd-rpm-macros
 Conflicts: conmon, crun, containers-common
 %endif
 
@@ -84,15 +86,6 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man5 %{archive_root}/man/crio.conf.5
 install -D -m 644 -t %{buildroot}%{_mandir}/man5 %{archive_root}/man/crio.conf.d.5
 install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 
-%if "%{_vendor}" == "debbuild"
-# We cannot use the %systemd_ macros here because debbuild does not support them.
-%pre
-/usr/bin/systemctl stop crio.service >/dev/null 2>&1 ||:
-
-%post
-/usr/bin/systemctl daemon-reload
-/usr/bin/systemctl enable --now crio.service
-%else
 %post
 %systemd_post crio.service
 
@@ -101,7 +94,6 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 
 %postun
 %systemd_postun_with_restart crio.service
-%endif
 
 %files
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We should not start the unit by default, just enable it.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
