### PR TITLE
Add goreleaser actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+---
+name: release
+on:
+  pull_request:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: write
+    steps:
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.21'
+          check-latest: true
+      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
+        with:
+          fetch-depth: 1
+      - name: Build and publish release
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        if: contains(github.ref, 'refs/tags')
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test release build
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        if: "!contains(github.ref, 'refs/tags')"
+        with:
+          args: release --clean --snapshot --skip sign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: artifacts
+          path: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /output*/
 /_output*/
 /_output
+/dist
 
 # Emacs save files
 *~

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,69 @@
+---
+project_name: kubernetes-release
+
+env:
+  - CGO_ENABLED=0
+  - COSIGN_YES=true
+
+before:
+  hooks:
+    - go mod tidy
+    - git diff --exit-code go.mod go.sum
+
+gomod:
+  proxy: true
+
+builds:
+  - id: krel
+    no_unique_dist_dir: true
+    main: ./cmd/krel
+    binary: krel-{{ .Arch }}-{{ .Os }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - id: release-notes
+    no_unique_dist_dir: true
+    main: ./cmd/publish-release
+    binary: release-notes-{{ .Arch }}-{{ .Os }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: krel
+    format: binary
+    allow_different_binary_count: true
+    name_template: krel-{{ .Arch }}-{{ .Os }}
+  - id: release-notes
+    format: binary
+    allow_different_binary_count: true
+    name_template: release-notes-{{ .Arch }}-{{ .Os }}
+
+signs:
+  - id: keyless
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
+    artifacts: all
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+release:
+  github:
+    owner: kubernetes
+    name: release
+  prerelease: auto
+
+changelog:
+  skip: true

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -92,6 +92,8 @@ dependencies:
       match: GO_MAJOR_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/variants.yaml
       match: "GO_MAJOR_VERSION: '\\d+.\\d+'"
+    - path: .github/workflows/release.yml
+      match: "go-version: '\\d+.\\d+'"
 
   - name: "golang: go.mod"
     version: 1.20


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Add a GitHub action to release the `release-notes` tool as well as `krel` via goreleaser.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
