### PR TITLE
Fix release-notes binary path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
       - arm64
   - id: release-notes
     no_unique_dist_dir: true
-    main: ./cmd/publish-release
+    main: ./cmd/release-notes
     binary: release-notes-{{ .Arch }}-{{ .Os }}
     goos:
       - linux


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The binary path is wrong, it should be `release-notes`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed wrong binary path for release-notes tool.
```
