### PR TITLE
Add `--wait` flag for `krel obs stage`

### DIFF
--- a/cmd/krel/cmd/obs_stage.go
+++ b/cmd/krel/cmd/obs_stage.go
@@ -74,6 +74,7 @@ const (
 	obsVersionFlag          = "version"
 	obsProjectFlag          = "project"
 	obsSourceFlag           = "source"
+	obsWaitFlag             = "wait"
 )
 
 func init() {
@@ -177,6 +178,14 @@ func init() {
 			streamFlag,
 			false,
 			"Run the Google Cloud Build job synchronously",
+		)
+
+	obsStageCmd.PersistentFlags().
+		BoolVar(
+			&obsStageOptions.Wait,
+			obsWaitFlag,
+			false,
+			"Wait for the OBS build results to succeed",
 		)
 
 	for _, flag := range []string{buildVersionFlag, submitJobFlag} {

--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -86,6 +86,7 @@ steps:
   - "--version=${_VERSION}"
   - "--project=${_OBS_PROJECT}"
   - "--source=${_PACKAGE_SOURCE}"
+  - "--wait=${_WAIT}"
 
 tags:
 - ${_GCP_USER_TAG}
@@ -99,6 +100,7 @@ tags:
 - ${_ARCHITECTURES}
 - ${_VERSION}
 - ${_OBS_PROJECT_TAG}
+- ${_WAIT}
 
 options:
   machineType: E2_HIGHCPU_32

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -114,6 +114,7 @@ type Options struct {
 	Architectures    []string
 	OBSProject       string
 	PackageSource    string
+	OBSWait          bool
 }
 
 // NewDefaultOptions returns a new default `*Options` instance.
@@ -401,6 +402,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 		gcbSubs["OBS_PROJECT"] = g.options.OBSProject
 		gcbSubs["OBS_PROJECT_TAG"] = strings.ReplaceAll(g.options.OBSProject, ":", "-")
 		gcbSubs["PACKAGE_SOURCE"] = g.options.PackageSource
+		gcbSubs["WAIT"] = fmt.Sprint(g.options.OBSWait)
 
 		// Stop here when doing OBS stage
 		return gcbSubs, nil

--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -140,6 +140,9 @@ type Options struct {
 	// Mutually exclusive with `ReleaseType`, `ReleaseBranch`, and
 	// `BuildVersion`.
 	PackageSource string
+
+	// Wait can be used to wait for the OBS build results.
+	Wait bool
 }
 
 // DefaultOptions returns a new `Options` instance.
@@ -440,6 +443,11 @@ func (s *Stage) Run() error {
 	logger.WithStep().Info("Pushing packages to OBS")
 	if err := s.client.Push(); err != nil {
 		return fmt.Errorf("pushing packages to obs: %w", err)
+	}
+
+	logger.WithStep().Info("Waiting for OBS build results if required")
+	if err := s.client.Wait(); err != nil {
+		return fmt.Errorf("wait for OBS build results: %w", err)
 	}
 
 	return nil

--- a/pkg/obs/obsfakes/fake_stage_client.go
+++ b/pkg/obs/obsfakes/fake_stage_client.go
@@ -131,6 +131,16 @@ type FakeStageClient struct {
 	validateOptionsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	WaitStub        func() error
+	waitMutex       sync.RWMutex
+	waitArgsForCall []struct {
+	}
+	waitReturns struct {
+		result1 error
+	}
+	waitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -721,6 +731,59 @@ func (fake *FakeStageClient) ValidateOptionsReturnsOnCall(i int, result1 error) 
 	}{result1}
 }
 
+func (fake *FakeStageClient) Wait() error {
+	fake.waitMutex.Lock()
+	ret, specificReturn := fake.waitReturnsOnCall[len(fake.waitArgsForCall)]
+	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
+	}{})
+	stub := fake.WaitStub
+	fakeReturns := fake.waitReturns
+	fake.recordInvocation("Wait", []interface{}{})
+	fake.waitMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageClient) WaitCallCount() int {
+	fake.waitMutex.RLock()
+	defer fake.waitMutex.RUnlock()
+	return len(fake.waitArgsForCall)
+}
+
+func (fake *FakeStageClient) WaitCalls(stub func() error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = stub
+}
+
+func (fake *FakeStageClient) WaitReturns(result1 error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = nil
+	fake.waitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageClient) WaitReturnsOnCall(i int, result1 error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = nil
+	if fake.waitReturnsOnCall == nil {
+		fake.waitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.waitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -748,6 +811,8 @@ func (fake *FakeStageClient) Invocations() map[string][][]interface{} {
 	defer fake.submitMutex.RUnlock()
 	fake.validateOptionsMutex.RLock()
 	defer fake.validateOptionsMutex.RUnlock()
+	fake.waitMutex.RLock()
+	defer fake.waitMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/obs/obsfakes/fake_stage_impl.go
+++ b/pkg/obs/obsfakes/fake_stage_impl.go
@@ -164,6 +164,18 @@ type FakeStageImpl struct {
 	submitReturnsOnCall map[int]struct {
 		result1 error
 	}
+	WaitStub        func(string, string) error
+	waitMutex       sync.RWMutex
+	waitArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	waitReturns struct {
+		result1 error
+	}
+	waitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -857,6 +869,68 @@ func (fake *FakeStageImpl) SubmitReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeStageImpl) Wait(arg1 string, arg2 string) error {
+	fake.waitMutex.Lock()
+	ret, specificReturn := fake.waitReturnsOnCall[len(fake.waitArgsForCall)]
+	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.WaitStub
+	fakeReturns := fake.waitReturns
+	fake.recordInvocation("Wait", []interface{}{arg1, arg2})
+	fake.waitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) WaitCallCount() int {
+	fake.waitMutex.RLock()
+	defer fake.waitMutex.RUnlock()
+	return len(fake.waitArgsForCall)
+}
+
+func (fake *FakeStageImpl) WaitCalls(stub func(string, string) error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = stub
+}
+
+func (fake *FakeStageImpl) WaitArgsForCall(i int) (string, string) {
+	fake.waitMutex.RLock()
+	defer fake.waitMutex.RUnlock()
+	argsForCall := fake.waitArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStageImpl) WaitReturns(result1 error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = nil
+	fake.waitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) WaitReturnsOnCall(i int, result1 error) {
+	fake.waitMutex.Lock()
+	defer fake.waitMutex.Unlock()
+	fake.WaitStub = nil
+	if fake.waitReturnsOnCall == nil {
+		fake.waitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.waitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -882,6 +956,8 @@ func (fake *FakeStageImpl) Invocations() map[string][][]interface{} {
 	defer fake.removePackageFilesMutex.RUnlock()
 	fake.submitMutex.RLock()
 	defer fake.submitMutex.RUnlock()
+	fake.waitMutex.RLock()
+	defer fake.waitMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Add the ability for wait for the build results in `krel obs stage`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--wait` flag for `krel obs stage` to wait for OBS build results.
```
