### PR TITLE
Don't wait for OBS build results if not selected

### DIFF
--- a/pkg/obs/stage.go
+++ b/pkg/obs/stage.go
@@ -421,6 +421,11 @@ func (d *DefaultStage) Push() error {
 
 // Wait waits for the OBS build results to succeed.
 func (d *DefaultStage) Wait() error {
+	if !d.options.Wait {
+		logrus.Info("Will not wait for the OBS build results")
+		return nil
+	}
+
 	if !d.options.NoMock {
 		logrus.Info("Running stage in mock, skipping waiting for OBS")
 		return nil


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
If the option is not enabled, then we should not wait for the OBS build results at all.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to not wait for OBS build results if `krel obs stage --wait=false`.
```
