### PR TITLE
Default `krel obs stage --wait` to `true`

### DIFF
--- a/cmd/krel/cmd/obs_stage.go
+++ b/cmd/krel/cmd/obs_stage.go
@@ -184,7 +184,7 @@ func init() {
 		BoolVar(
 			&obsStageOptions.Wait,
 			obsWaitFlag,
-			false,
+			true,
 			"Wait for the OBS build results to succeed",
 		)
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Defaulting the flag to `true` for providing stronger defaults.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Default `krel obs stage --wait` to `true`
```
