### PR TITLE
Update k8s-cloud-builder/k8s-ci-builder to Go 1.21.3

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.21.2
+    version: 1.21.3
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -251,7 +251,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.21)"
-    version: v1.29.0-go1.21.2-bullseye.0
+    version: v1.29.0-go1.21.3-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -324,7 +324,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: master)"
-    version: 1.21.2
+    version: 1.21.3
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.29-cross1.21-bullseye:
     CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.2-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.3-bullseye.0'
   v1.28-cross1.20-bullseye:
     CONFIG: 'cross1.20'
     KUBE_CROSS_VERSION: 'v1.28.0-go1.20.9-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.21.2
+GO_VERSION ?= 1.21.3
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,15 +1,15 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.21.2'
+    GO_VERSION: '1.21.3'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.21.2'
+    GO_VERSION: '1.21.3'
     OS_CODENAME: 'bookworm'
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: '1.21.2'
+    GO_VERSION: '1.21.3'
     OS_CODENAME: 'bullseye'
   '1.28':
     CONFIG: '1.28'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update k8s-cloud-builder/k8s-ci-builder to Go 1.21.3

#### Which issue(s) this PR fixes:

xref #3311

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder/k8s-ci-builder to Go 1.21.3
```

/assign @cpanato @saschagrunert @jeremyrickard @marosset 
cc @kubernetes/release-engineering 