### PR TITLE
Add nftables binary to the distroless-iptables image

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -468,7 +468,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.3.3
+    version: v0.4.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.3.3
+IMAGE_VERSION ?= v0.4.0
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bookworm-slim
 GORUNNER_VERSION ?= v2.3.1-go1.21.2-bookworm.0

--- a/images/build/distroless-iptables/distroless/Dockerfile
+++ b/images/build/distroless-iptables/distroless/Dockerfile
@@ -31,6 +31,7 @@ RUN apt -y update && \
     ebtables    \
     ipset       \
     iptables    \
+    nftables    \
     kmod        && \
     `# below binaries and dash are used by iptables-wrapper-installer.sh` \
     /stage-binary-and-deps.sh "${STAGE_DIR}" /bin/dash \

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.3.3'
+    IMAGE_VERSION: 'v0.4.0'
     GORUNNER_VERSION: 'v2.3.1-go1.21.2-bookworm.0'


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds the nftables binary to the (now-somewhat-badly-named) `distroless-iptables` image, so that it will support the new kube-proxy nftables backend ([KEP-3866](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3866-nftables-proxy/README.md)).

#### Which issue(s) this PR fixes:
None
but it unblocks https://github.com/kubernetes/kubernetes/pull/121046

#### Special notes for your reviewer:
We could create separate images for `kube-proxy --proxy-mode iptables` (which would contain iptables and the iptables-wrapper script) and `kube-proxy --proxy-mode nftables` (which would contain nftables and no iptables) but that seems like that would be bad, at least while nftables is in alpha, since it would make it much harder to switch between the two modes.

We could perhaps rename the image to `distroless-kube-proxy-base` or something, though that would imply it contains ipvs too, which I think it doesn't, although in that case I'm not sure how the e2e ipvs job works (but maybe we could just do the same thing for nftables?). It's not _terrible_ to have it be called `distroless-iptables` anyway. At least for now.

#### Does this PR introduce a user-facing change?
```release-note
The distroless-iptables image (and thus by extension, the official kube-proxy image)
now contains the nftables binaries as well as the iptables binaries.
```

cc @aojea @rikatz 