### PR TITLE
Enable support for building arm64 in krel build

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -105,7 +105,7 @@ type Options struct {
 	// with non-public registries.
 	ConfigureDocker bool
 
-	// Specifies a fast build (linux/amd64 only).
+	// Specifies a fast build.
 	Fast bool
 
 	// Do not exit error if the build already exists on the GCS path.
@@ -123,6 +123,9 @@ type Options struct {
 	// Stage additional files defined by `ExtraGcpStageFiles` and
 	// `ExtraWindowsStageFiles`, otherwise they will be skipped.
 	StageExtraFiles bool
+
+	// This sets the KUBE_BUILD_PLATFORMS value for make release/quick-release commands
+	KubeBuildPlatforms string
 }
 
 // TODO: Refactor so that version is not required as a parameter

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -90,10 +90,11 @@ func (bi *Instance) Build() error {
 		releaseType = "quick-release"
 	}
 
-	if buildErr := command.New(
-		"make",
-		releaseType,
-	).RunSuccess(); buildErr != nil {
+	cmd := command.New("make", releaseType)
+	if bi.opts.KubeBuildPlatforms != "" {
+		cmd.Env(fmt.Sprintf("KUBE_BUILD_PLATFORMS=%s", bi.opts.KubeBuildPlatforms))
+	}
+	if buildErr := cmd.RunSuccess(); buildErr != nil {
 		return fmt.Errorf("running make %s: %w", releaseType, buildErr)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If you are trying to build k/k for arm64, you cant't do something like this:

```go
		if err := rbuild.NewInstance(&rbuild.Options{
			Bucket:         mat[1],
			GCSRoot:        "kubernetes",
			AllowDup:       true,
			CI:             true,
			Version:        version,
			NoUpdateLatest: false,
			RepoRoot:       b.KubeRoot,
                        KubeBuildPlatforms: "linux/arm64",
		}).Build(); err != nil {
			return nil, fmt.Errorf("stage via krel push: %w", err)
		}
```

You'll need to manually build k/k and then use krel to stage it and it looks convoluted. https://github.com/kubernetes/kops/pull/16018/files#diff-4b7f74bf49315195937b0ac8835dcd751c158160c41f787122778517603f82a5R100
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
you can now pass KubeBuildPlatforms field to the pkg/build Options type to enable builds for arm64 and other arches
```

@dims does `make quick-release` work for non linux/amd64 architectures? I see that we use that target in kubetest2-ec2