### PR TITLE
Update distroless-iptables to use go 1.21.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -431,7 +431,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.4.1
+    version: v0.4.2
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -439,7 +439,7 @@ dependencies:
       match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.21.3-bookworm.0
+    version: v2.3.1-go1.21.4-bookworm.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bookworm\.\d+

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.4.1
+IMAGE_VERSION ?= v0.4.2
 CONFIG ?= distroless
 BASEIMAGE ?= debian:bookworm-slim
-GORUNNER_VERSION ?= v2.3.1-go1.21.3-bookworm.0
+GORUNNER_VERSION ?= v2.3.1-go1.21.4-bookworm.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,5 +1,5 @@
 variants:
   distroless:
     CONFIG: 'distroless'
-    IMAGE_VERSION: 'v0.4.1'
-    GORUNNER_VERSION: 'v2.3.1-go1.21.1-bookworm.0'
+    IMAGE_VERSION: 'v0.4.2'
+    GORUNNER_VERSION: 'v2.3.1-go1.21.4-bookworm.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update distroless-iptables to use Go 1.21.4

#### Which issue(s) this PR fixes:

xref #3347

#### Does this PR introduce a user-facing change?
```release-note
Update distroless-iptables to use Go 1.21.4
```

/assign @saschagrunert @xmudrii @Verolop  @puerco 
cc @kubernetes/release-engineering 
