### PR TITLE
Update k8s-cloud-builder to go 1.20.11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -237,25 +237,25 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.20)"
-    version: v1.28.0-go1.20.10-bullseye.0
+    version: v1.28.0-go1.20.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
-    version: v1.27.0-go1.20.10-bullseye.0
+    version: v1.27.0-go1.20.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.20.10-bullseye.0
+    version: v1.26.0-go1.20.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.25-cross1.20)"
-    version: v1.25.0-go1.20.10-bullseye.0
+    version: v1.25.0-go1.20.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,13 +4,13 @@ variants:
     KUBE_CROSS_VERSION: 'v1.29.0-go1.21.4-bullseye.0'
   v1.28-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.28.0-go1.20.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.28.0-go1.20.11-bullseye.0'
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.11-bullseye.0'
   v1.26-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.11-bullseye.0'
   v1.25-cross1.19-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.25.0-go1.20.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.25.0-go1.20.11-bullseye.0'


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Update the cloud-builder images to use go 1.20.11 as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Follow-up on #3356 #3348
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
