### PR TITLE
Use latest krel binary release instead of compilation in cloudbuild

### DIFF
--- a/docs/krel/README.md
+++ b/docs/krel/README.md
@@ -15,16 +15,21 @@ Kubernetes Releases. This includes manually executed tasks like generating the R
 
 ## Installation
 
-Either Compile krel by running the `compile-release-tools` script from the root of this repo:
+Either download the latest version of `krel` by using the `hack/get-krel` script:
+
+```shell
+./hack/get-krel
+```
+
+Or compile `krel` by running the `compile-release-tools` script from the root of this repo:
 
 ```shell
 ./compile-release-tools krel
 ```
-Or
 
-Run the following command in the terminal:
+Or run the following command in the terminal:
 
-```
+```shell
 go install k8s.io/release/cmd/krel@latest
 ```
 

--- a/gcb/fast-forward/cloudbuild.yaml
+++ b/gcb/fast-forward/cloudbuild.yaml
@@ -52,14 +52,12 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
-  dir: "go/src/k8s.io/release"
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: go/src/k8s.io/release
   env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
+  - KREL_OUTPUT_PATH=/workspace/bin/krel
   args:
-  - "./compile-release-tools"
-  - "krel"
+  - ./hack/get-krel
 
 - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "/workspace"

--- a/gcb/obs-release/cloudbuild.yaml
+++ b/gcb/obs-release/cloudbuild.yaml
@@ -52,14 +52,12 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
-  dir: "go/src/k8s.io/release"
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: go/src/k8s.io/release
   env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
+  - KREL_OUTPUT_PATH=/workspace/bin/krel
   args:
-  - "./compile-release-tools"
-  - "krel"
+  - ./hack/get-krel
 
 - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "/workspace"

--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -52,14 +52,12 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
-  dir: "go/src/k8s.io/release"
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: go/src/k8s.io/release
   env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
+  - KREL_OUTPUT_PATH=/workspace/bin/krel
   args:
-  - "./compile-release-tools"
-  - "krel"
+  - ./hack/get-krel
 
 - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "/workspace"

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -55,14 +55,12 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
-  dir: "go/src/k8s.io/release"
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: go/src/k8s.io/release
   env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
+  - KREL_OUTPUT_PATH=/workspace/bin/krel
   args:
-  - "./compile-release-tools"
-  - "krel"
+  - ./hack/get-krel
 
 - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "/workspace"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -56,14 +56,12 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION_LATEST}
-  dir: "go/src/k8s.io/release"
+- name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+  dir: go/src/k8s.io/release
   env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
+  - KREL_OUTPUT_PATH=/workspace/bin/krel
   args:
-  - "./compile-release-tools"
-  - "krel"
+  - ./hack/get-krel
 
 - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
   dir: "/workspace"

--- a/hack/get-krel
+++ b/hack/get-krel
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl_retry() {
+    curl -sSfL --retry 5 --retry-delay 3 "$@"
+}
+
+KREL_OUTPUT_PATH=${KREL_OUTPUT_PATH:-bin/krel}
+echo "Using output path: $KREL_OUTPUT_PATH"
+mkdir -p "$(dirname "$KREL_OUTPUT_PATH")"
+
+LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
+echo "Using krel release: $LATEST_RELEASE"
+
+echo "Downloading krel from GCB bucket…"
+GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
+curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
+chmod +x "$KREL_OUTPUT_PATH"
+
+echo "Done, output of 'krel version':"
+"$KREL_OUTPUT_PATH" version

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -377,21 +377,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 		logrus.Infof("KubeCross version not set for %s, falling back to latest", g.options.Branch)
 	}
 
-	kcVersionLatest := kcVersionBranch
-	if g.options.Branch != git.DefaultBranch {
-		kcVersionLatest, err = kc.Latest()
-		if err != nil {
-			return gcbSubs, fmt.Errorf("retrieve latest kube-cross version: %w", err)
-		}
-
-		// if kcVersionBranch is empty, the branch does not exist yet, we use
-		// the latest kubecross version
-		if kcVersionBranch == "" {
-			kcVersionBranch = kcVersionLatest
-		}
-	}
 	gcbSubs["KUBE_CROSS_VERSION"] = kcVersionBranch
-	gcbSubs["KUBE_CROSS_VERSION_LATEST"] = kcVersionLatest
 
 	switch {
 	case g.options.OBSStage:


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This pins `krel` to the latest available release for all cloudbuild jobs, which usually run in production. It should also speedup the whole process because we do not have to download and compile all those golang dependencies.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
cc @kubernetes/release-engineering 

Example run: https://console.cloud.google.com/cloud-build/builds/2a051d76-08d7-4ba9-a1d6-c90b990889e3
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Pin all cloudbuild jobs to use the latest `krel` release instead of `master`. 
```
