### PR TITLE
Set `KUBE_CROSS_VERSION` to latest if required

### DIFF
--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -377,6 +377,18 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) 
 		logrus.Infof("KubeCross version not set for %s, falling back to latest", g.options.Branch)
 	}
 
+	if g.options.Branch != git.DefaultBranch {
+		kcVersionLatest, err := kc.Latest()
+		if err != nil {
+			return gcbSubs, fmt.Errorf("retrieve latest kube-cross version: %w", err)
+		}
+
+		// if kcVersionBranch is empty, the branch does not exist yet, we use
+		// the latest kubecross version
+		if kcVersionBranch == "" {
+			kcVersionBranch = kcVersionLatest
+		}
+	}
 	gcbSubs["KUBE_CROSS_VERSION"] = kcVersionBranch
 
 	switch {


### PR DESCRIPTION


#### What type of PR is this?


/kind regression

#### What this PR does / why we need it:
We should still set the kube-cross version if no branch is specified. 
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
