### PR TITLE
Fix number of steps in `krel obs` output

### DIFF
--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -393,7 +393,7 @@ func (s *Stage) Submit(stream bool) error {
 func (s *Stage) Run() error {
 	s.client.InitState()
 
-	logger := log.NewStepLogger(10)
+	logger := log.NewStepLogger(11)
 	v := version.GetVersionInfo()
 	logger.Infof("Using krel version: %s", v.GitVersion)
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We should display the right amount of steps otherwise we'll end up showing:

```
level=info msg="Waiting for OBS build results if required" step=11/10
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed wrong amount of logger steps for `krel obs`.
```
