### PR TITLE
Skip unfinished jobs in `krel history`

### DIFF
--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -154,6 +154,11 @@ func (h *History) Run() error {
 		end := job.Timing["BUILD"].EndTime
 		logs := job.LogUrl
 
+		if start == "" || end == "" {
+			logrus.Infof("Skipping unfinished job from %s with ID: %s", job.CreateTime, job.Id)
+			continue
+		}
+
 		// Calculate the duration of the job
 		const layout = "2006-01-02T15:04:05.99Z"
 		tStart, err := h.impl.ParseTime(layout, start)

--- a/pkg/gcp/gcb/history_test.go
+++ b/pkg/gcp/gcb/history_test.go
@@ -104,7 +104,10 @@ func TestHistoryRun(t *testing.T) {
 					{
 						Tags: []string{"RELEASE"},
 						Timing: map[string]cloudbuild.TimeSpan{
-							"BUILD": {StartTime: "wrong"},
+							"BUILD": {
+								StartTime: "wrong",
+								EndTime:   "2020-10-10",
+							},
 						},
 					},
 				}, nil)
@@ -121,7 +124,10 @@ func TestHistoryRun(t *testing.T) {
 					{
 						Tags: []string{"STAGE"},
 						Timing: map[string]cloudbuild.TimeSpan{
-							"BUILD": {EndTime: "wrong"},
+							"BUILD": {
+								StartTime: "2020-10-10",
+								EndTime:   "wrong",
+							},
 						},
 						Substitutions: map[string]string{"_NOMOCK": "true"},
 					},


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We skip those jobs now and don't error-out to still produce usable results.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed `krel history` to still produce output when unfinished jobs are running.
```
