### PR TITLE
Create publishing-bot issue when cutting rc.0

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -546,9 +546,9 @@ func (d *DefaultRelease) CreateAnnouncement() error {
 		return fmt.Errorf("creating the announcement: %w", err)
 	}
 
-	// Check if we are releasing is the initial minor (eg 1.20.0),
+	// Check if we are releasing the initial rc release (eg 1.20.0-rc.0),
 	// and we are working on a release-M.m branch
-	if primeSemver.Patch == 0 && len(primeSemver.Pre) == 0 &&
+	if primeSemver.Patch == 0 && d.options.ReleaseType == release.ReleaseTypeRC &&
 		d.options.ReleaseBranch != git.DefaultBranch {
 		if d.options.NoMock {
 			// Create the publishing bot issue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The issue to remind us to update the publishing-bot rules after creating a new branch has been created upon cutting v1.29.0: https://github.com/kubernetes/sig-release/issues/2398

However, this is too late, the branch is created upon cutting the rc.0 release, and that's when we need to add the new publishing-bot rules. This PR is supposed to ensure that we open this issue upon cutting the rc.0 release.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @puerco @jeremyrickard 
cc @kubernetes/release-engineering 