### PR TITLE
lock docker version to v24.0 fro k8s-ci-builder

### DIFF
--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -106,7 +106,7 @@ RUN echo "Installing Packages ..." \
         && install -m 0755 -d /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
         && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
-        && apt-get install -y --no-install-recommends docker-ce \
+        && apt-get install -y --no-install-recommends docker-ce=5:24.0.* \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && echo "Installing Docker buildx ..." \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Fixes https://github.com/kubernetes/kubernetes/issues/122939

/priority critical-urgent

/sig release
/area release-eng
/assign @saschagrunert @xmudrii

to fix https://testgrid.k8s.io/sig-release-master-blocking#build-master-fast


```release-note
None
```

lock docker version per https://github.com/kubernetes/release/pull/3430#issuecomment-1907964739

Test results:
```
root@23df924d34e4:/# /usr/bin/dockerd --version
Docker version 24.0.7, build 311b9ff
root@23df924d34e4:/# cat /etc/init.d/docker | grep ulimit
		ulimit -n 1048576
			ulimit -u unlimited
			ulimit -p unlimited
root@23df924d34e4:/# service docker start
Starting Docker: docker.
root@23df924d34e4:/#
```