### PR TITLE
Add note about glibc compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/dep-golang.md
+++ b/.github/ISSUE_TEMPLATE/dep-golang.md
@@ -63,7 +63,13 @@ SIG Release Slack thread:
 
 #### After kubernetes/kubernetes (master) has been updated
 
-<!-- Example: https://github.com/kubernetes/release/pull/3390 -->
+<!--
+Notice: Always use the oldest supported distribution release (Debian bullseye as
+time of writing) to achieve maximum glibc compatibility of the kubelet. Other
+images can use the latest available release.
+
+Example: https://github.com/kubernetes/release/pull/3390
+-->
 - [ ] `k8s-cloud-builder` and `k8s-ci-builder` image updates: 
 
 <!-- Example: https://github.com/kubernetes/test-infra/pull/31387 -->
@@ -118,7 +124,13 @@ happened for the 1.20 and 1.19 Kubernetes release branches.
 
 #### After kubernetes/kubernetes (release branches) has been updated
 
-<!-- Example: https://github.com/kubernetes/release/pull/3394 -->
+<!--
+Notice: Always use the oldest supported distribution release (Debian bullseye as
+time of writing) to achieve maximum glibc compatibility of the kubelet. Other
+images can use the latest available release.
+
+Example: https://github.com/kubernetes/release/pull/3394
+-->
 - [ ] `k8s-cloud-builder` and `k8s-ci-builder` image updates: 
 
 <!-- Example: https://github.com/kubernetes/test-infra/pull/31398 -->


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Add a note to the golang update issue template about using the oldest available Debian release for glibc compatibility of the kubelet.


#### Which issue(s) this PR fixes:
Refers to: https://github.com/kubernetes/release/issues/3128#issuecomment-1914615987

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
@kubernetes/release-managers 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
