### PR TITLE
adapt krel/ff to run with other repositories that are not only k/k

### DIFF
--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -75,7 +75,9 @@ Google Cloud Build job.
 }
 
 func init() {
-	ffCmd.PersistentFlags().StringVar(&ffOpts.RepoPath, "repo", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.RepoPath, "repo-path", filepath.Join(os.TempDir(), "k8s"), "the local path to the repository to be used")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.GitHubOrg, "github-org", release.GetK8sOrg(), "the GitHub Organization to be used do the initial clone")
+	ffCmd.PersistentFlags().StringVar(&ffOpts.GitHubRepo, "github-repo", release.GetK8sRepo(), "the GitHub Repository to be used do the initial clone")
 	ffCmd.PersistentFlags().StringVar(&ffOpts.Branch, "branch", "", "branch")
 	ffCmd.PersistentFlags().StringVar(&ffOpts.MainRef, "ref", kgit.Remotify(kgit.DefaultBranch), "ref on the main branch")
 	ffCmd.PersistentFlags().StringVar(&ffOpts.GCPProjectID, "project-id", release.DefaultRelengStagingTestProject, "Google Cloud Project to use to submit the job")

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -188,7 +188,6 @@ func GetK8sRef() string {
 // GetK8sRef() point to their default values.
 func IsDefaultK8sUpstream() bool {
 	return GetK8sOrg() == DefaultK8sOrg &&
-		GetK8sRepo() == DefaultK8sRepo &&
 		GetK8sRef() == DefaultK8sRef
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- adapt krel/ff to run with other repositories that are not only k/k

/assign @saschagrunert @puerco @xmudrii 
cc @kubernetes/release-engineering @katcosgrove 

#### Which issue(s) this PR fixes:

Fixes #3380 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
adapt krel/ff to run with other repositories that are not only k/k
```
