### PR TITLE
Build Go 1.22 (1.22.0) images

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # Golang
   - name: "golang"
-    version: 1.21.7
+    version: 1.22
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -41,7 +41,7 @@ dependencies:
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
   - name: "golang: 1.<major>"
-    version: 1.21
+    version: 1.22
     refPaths:
     - path: images/build/cross/Makefile
       match: GO_MAJOR_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -51,6 +51,10 @@ dependencies:
       match: GO_MAJOR_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/build/go-runner/variants.yaml
       match: "GO_MAJOR_VERSION: '\\d+.\\d+'"
+
+  - name: "golang: 1.<major> (github workflows)"
+    version: 1.21
+    refPaths:
     - path: .github/workflows/release.yml
       match: "go-version: '\\d+.\\d+'"
 
@@ -109,7 +113,7 @@ dependencies:
 
   # go-runner
   - name: "registry.k8s.io/build-image/go-runner (go1.22-bookworm)"
-    version: v2.3.1-go1.22rc2-bookworm.0
+    version: v2.3.1-go1.22-bookworm.0
     refPaths:
     - path: images/build/go-runner/variants.yaml
       match: v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -160,7 +164,7 @@ dependencies:
 
   # kube-cross
   - name: "registry.k8s.io/build-image/kube-cross (v1.30-go1.22)"
-    version: v1.30.0-go1.22rc2-bullseye.0
+    version: v1.30.0-go1.22-bullseye.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -303,7 +307,7 @@ dependencies:
 
   # Golang (next candidate)
   - name: "golang (next candidate)"
-    version: 1.22rc2
+    version: 1.22
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -28,8 +28,8 @@ IMGNAME = kube-cross
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
 KUBERNETES_VERSION ?= v1.30.0
-GO_VERSION ?= 1.21.7
-GO_MAJOR_VERSION ?= 1.21
+GO_VERSION ?= 1.22
+GO_MAJOR_VERSION ?= 1.22
 OS_CODENAME ?= bullseye
 REVISION ?= 0
 TYPE ?= default

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -2,9 +2,9 @@ variants:
   v1.30-go1.22-bullseye:
     CONFIG: 'go1.22-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.30.0-go1.22rc2-bullseye.0'
+    IMAGE_VERSION: 'v1.30.0-go1.22-bullseye.0'
     KUBERNETES_VERSION: 'v1.30.0'
-    GO_VERSION: '1.22rc2'
+    GO_VERSION: '1.22'
     GO_MAJOR_VERSION: '1.22'
     OS_CODENAME: 'bullseye'
     REVISION: '0'

--- a/images/build/go-runner/Makefile
+++ b/images/build/go-runner/Makefile
@@ -17,9 +17,9 @@ include $(CURDIR)/../../Makefile.common-image
 
 IMGNAME = go-runner
 APP_VERSION = $(shell cat VERSION)
-GO_MAJOR_VERSION ?= 1.21
+GO_MAJOR_VERSION ?= 1.22
 REVISION ?= 0
-GO_VERSION ?= 1.21.7
+GO_VERSION ?= 1.22
 OS_CODENAME ?= bookworm
 
 # Build args

--- a/images/build/go-runner/variants.yaml
+++ b/images/build/go-runner/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   go1.22-bookworm:
     CONFIG: 'go1.22-bookworm'
-    IMAGE_VERSION: 'v2.3.1-go1.22rc2-bookworm.0'
+    IMAGE_VERSION: 'v2.3.1-go1.22-bookworm.0'
     GO_MAJOR_VERSION: '1.22'
     OS_CODENAME: 'bookworm'
     REVISION: '0'
-    GO_VERSION: '1.22rc2'
+    GO_VERSION: '1.22'
     DISTROLESS_IMAGE: 'static-debian12'
   go1.21-bookworm:
     CONFIG: 'go1.21-bookworm'

--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -32,8 +32,8 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # install goreleaser
-ARG GORELEASER_VERSION=v1.19.2
-ARG GORELEASER_SHA=27c7397b816c43098f88cbccc5aeec3df929fb857f28b2cb8e885d09458ada1e
+ARG GORELEASER_VERSION=v1.24.0
+ARG GORELEASER_SHA=99709684e3f543ed32a771e1565055e43d2ec524e631bcd8d331c2d8ed6a584f
 RUN  \
     GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz && \
     GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE} && \
@@ -44,8 +44,8 @@ RUN  \
     goreleaser -v
 
 # install ko
-ARG KO_VERSION=v0.14.1
-ARG KO_SHA=3f8f8e3fb4b78a4dfc0708df2b58f202c595a66c34195786f9a279ea991f4eae
+ARG KO_VERSION=v0.15.1
+ARG KO_SHA=5b06079590371954cceadf0ddcfa8471afb039c29a2e971043915957366a2f39
 RUN  \
     KO_DOWNLOAD_FILE=ko_${KO_VERSION#v}_Linux_x86_64.tar.gz && \
     KO_DOWNLOAD_URL=https://github.com/ko-build/ko/releases/download/${KO_VERSION}/${KO_DOWNLOAD_FILE} && \

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   go1.22-bookworm:
     CONFIG: 'go1.22-bookworm'
-    GO_VERSION: '1.22rc2'
+    GO_VERSION: '1.22'
     OS_CODENAME: 'bookworm'
     REVISION: '0'
   go1.21-bookworm:


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup
/kind feature


#### What this PR does / why we need it:

- Build Go 1.22 (1.22.0) images
- update ko and goreleaser

/assign @saschagrunert @xmudrii @puerco 
cc @kubernetes/release-managers 


#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3280

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Build Go 1.22 (1.22.0) images
- update ko and goreleaser
```
