### PR TITLE
update distroless iptables to use go1.21.7 and go1.20.14

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -470,19 +470,46 @@ dependencies:
     - path: images/build/setcap/variants.yaml
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/distroless-iptables"
-    version: v0.4.4
+  - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.22)"
+    version: v0.5.0
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.22)"
+    version: v2.3.1-go1.22rc2-bookworm.0
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.21)"
+    version: v0.4.5
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: images/build/distroless-iptables/variants.yaml
       match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
-  - name: "registry.k8s.io/build-image/go-runner: dependents"
-    version: v2.3.1-go1.21.6-bookworm.0
+  - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.21)"
+    version: v2.3.1-go1.21.7-bookworm.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bookworm\.\d+
+    - path: images/build/distroless-iptables/variants.yaml
+      match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.20)"
+    version: v0.2.10
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.20)"
+    version: v2.3.1-go1.20.14-bullseye.0
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+  
 
   - name: "registry.k8s.io/build-image/setcap"
     version: bookworm-v1.0.1

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.4.4
+IMAGE_VERSION ?= v0.4.5
 CONFIG ?= distroless-bookworm
 BASEIMAGE ?= debian:bookworm-slim
-GORUNNER_VERSION ?= v2.3.1-go1.21.6-bookworm.0
+GORUNNER_VERSION ?= v2.3.1-go1.21.7-bookworm.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -6,11 +6,11 @@ variants:
     GORUNNER_VERSION: 'v2.3.1-go1.22rc2-bookworm.0'
   distroless-bookworm-go1.21:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.4.4'
+    IMAGE_VERSION: 'v0.4.5'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.3.1-go1.21.6-bookworm.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.21.7-bookworm.0'
   distroless-bullseye-go1.20:
     CONFIG: 'distroless-bullseye'
-    IMAGE_VERSION: 'v0.2.9'
+    IMAGE_VERSION: 'v0.2.10'
     BASEIMAGE: 'debian:bullseye-slim'
-    GORUNNER_VERSION: 'v2.3.1-go1.20.13-bullseye.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.20.14-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- update distroless iptables to use go1.21.7 and go1.20.14

/assign @puerco @xmudrii @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3451

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update distroless iptables to use go1.21.7 and go1.20.14
```
