### PR TITLE
change repo-path default for release-note generate cmd

### DIFF
--- a/cmd/release-notes/generate.go
+++ b/cmd/release-notes/generate.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -120,7 +118,7 @@ func addGenerateFlags(subcommand *cobra.Command) {
 	subcommand.PersistentFlags().StringVar(
 		&opts.RepoPath,
 		"repo-path",
-		env.Default("REPO_PATH", filepath.Join(os.TempDir(), "k8s-repo")),
+		env.Default("REPO_PATH", ""),
 		"Path to a local Kubernetes repository, used only for tag discovery.",
 	)
 

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -192,6 +193,11 @@ func (o *Options) ValidateAndFinish() (err error) {
 			"neither environment variable `%s` nor `replay` option is set",
 			github.TokenEnvKey,
 		)
+	}
+
+	// Set RepoPath to <tempdir>/<gh-org>-<gh-repo> if empty
+	if o.RepoPath == "" {
+		o.RepoPath = filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s", o.GithubOrg, o.GithubRepo))
 	}
 
 	// Check if we want to automatically discover the revisions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes repo-path value from release-note generate command when omitted to use `temp/<gh-org>-<gh-repo>` to prevent issue of trying to clone/update incorrect repo in existing `path`.
cc: @jeremyrickard 

#### Which issue(s) this PR fixes:
Fixes #3444
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
change default value of --repo-path flag from release-note generate to use <tmp>/<gh-org>-<gh-repo>
```
