### PR TITLE
Build k8s-cloud-builder with Go 1.21.7

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -247,32 +247,26 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.21)"
-    version: v1.30.0-go1.21.6-bullseye.0
-    refPaths:
-    - path: images/k8s-cloud-builder/variants.yaml
-      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.21)"
-    version: v1.29.0-go1.21.6-bullseye.0
+    version: v1.29.0-go1.21.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.20)"
-    version: v1.28.0-go1.20.13-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.21)"
+    version: v1.28.0-go1.21.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.20)"
-    version: v1.27.0-go1.20.13-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.21)"
+    version: v1.27.0-go1.21.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.20)"
-    version: v1.26.0-go1.20.13-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.21)"
+    version: v1.26.0-go1.21.7-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -2,18 +2,15 @@ variants:
   v1.30-cross1.22-bullseye:
     CONFIG: 'cross1.22'
     KUBE_CROSS_VERSION: 'v1.30.0-go1.22-bullseye.0'
-  v1.30-cross1.21-bullseye:
-    CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.30.0-go1.21.6-bullseye.0'
   v1.29-cross1.21-bullseye:
     CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.7-bullseye.0'
   v1.28-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.28.0-go1.20.13-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.28.0-go1.21.7-bullseye.0'
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.20.13-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.21.7-bullseye.0'
   v1.26-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.20.13-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.26.0-go1.21.7-bullseye.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Build k8s-cloud-builder with Go 1.21.7

/assign @xmudrii @ameukam @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3451

#### Does this PR introduce a user-facing change?
```release-note
Build k8s-cloud-builder with Go 1.21.7
```
