### PR TITLE
Add `version` subcommand to `release-notes` tool

### DIFF
--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/mdtoc/pkg/mdtoc"
 	"sigs.k8s.io/release-sdk/git"
 	"sigs.k8s.io/release-utils/log"
+	"sigs.k8s.io/release-utils/version"
 )
 
 type releaseNotesOptions struct {
@@ -156,8 +157,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 // versions of release-notes.
 func hackDefaultSubcommand(cmd *cobra.Command) {
 	if len(os.Args) > 1 {
-		// We accept --version and "completion"
-		if os.Args[1] == "completion" || os.Args[1] == "--version" || os.Args[1] == "--help" {
+		if os.Args[1] == "completion" {
 			return
 		}
 
@@ -186,6 +186,8 @@ func main() {
 
 	addGenerate(cmd)
 	addCheckPR(cmd)
+
+	cmd.AddCommand(version.WithFont("slant"))
 
 	hackDefaultSubcommand(cmd)
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
It's not possible to display the version of the `release-notes` right now. This is now being fixed by introducing the `version` subcommand in the same way we do it for `krel`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `version` subcommand to `release-notes` tool.
```
