### PR TITLE
krel/templates: remove kubeadm's deps on kubelet and kubectl

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -58,7 +58,7 @@ kubeadm:
         versionConstraint: ">= 1.1.1"
       - name: cri-tools
         versionConstraint: ">= 1.25.0"
-  - versionConstraint: ">= 1.28.0"
+  - versionConstraint: ">= 1.28.0 < 1.30.0"
     sourceURLTemplate: "{{ KubernetesURL }}"
     dependencies:
       - name: kubelet
@@ -69,6 +69,11 @@ kubeadm:
         versionConstraint: ">= 1.2.0"
       - name: cri-tools
         versionConstraint: ">= 1.28.0"
+  - versionConstraint: ">= 1.30.0"
+    sourceURLTemplate: "{{ KubernetesURL }}"
+    dependencies:
+      - name: cri-tools
+        versionConstraint: ">= 1.30.0"
 kubectl:
   - versionConstraint: ">= 1.0.0"
     sourceURLTemplate: "{{ KubernetesURL }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

we should remove kubeadm's dependencies on kubelet and kubectl:

kubeadm - only cri-tools (needed for crictl)
kubelet - kuberentes-cni, iptables, other
kubectl - no dependencies

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3480

#### Special notes for your reviewer:

please LMK if i need to update something else.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
remove kubeadm's dependencies for kubelet and kubectl for kubeadm versions >= 1.30.0
```
