### PR TITLE
Fix panic when the `--maps-from` value is smaller than 5 characters

### DIFF
--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -307,7 +307,7 @@ func New(
 		}
 
 		if note.DoNotPublish {
-			logrus.Debugf("skipping PR %d as (marked to not be published)", pr)
+			logrus.Debugf("Skipping PR %d as (marked to not be published)", pr)
 			continue
 		}
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -254,7 +254,7 @@ func GatherReleaseNotes(opts *options.Options) (*ReleaseNotes, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing release notes: %w", err)
 	}
-	logrus.Infof("finished gathering release notes in %v", time.Since(startTime))
+	logrus.Infof("Finished gathering release notes in %v", time.Since(startTime))
 
 	return releaseNotes, nil
 }

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -37,7 +37,7 @@ type MapProvider interface {
 // NewProviderFromInitString creates a new map provider from an initialization string
 func NewProviderFromInitString(initString string) (MapProvider, error) {
 	// If init string starts with gs:// return a CloudStorageProvider
-	if initString[0:5] == object.GcsPrefix {
+	if len(initString) >= 5 && initString[0:5] == object.GcsPrefix {
 		// Currently for illustration purposes
 		return nil, errors.New("CloudStorageProvider is not yet implemented")
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Fixing a runtime panic when the maps value shorter than the gcs prefix we're checking for.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed runtime panic in `release-notes` when the `--maps-from` value is smaller than 5 characters
```
