### PR TITLE
Do not exclude mapped notes

### DIFF
--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -306,7 +306,7 @@ func New(
 			doc.CVEList = append(doc.CVEList, newcve)
 		}
 
-		if note.DoNotPublish {
+		if !note.IsMapped && note.DoNotPublish {
 			logrus.Debugf("Skipping PR %d as (marked to not be published)", pr)
 			continue
 		}

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -136,6 +136,9 @@ type ReleaseNote struct {
 
 	// DataFields a key indexed map of data fields
 	DataFields map[string]ReleaseNotesDataField `json:"-"`
+
+	// IsMapped is set if the note got modified from a map
+	IsMapped bool `json:"is_mapped,omitempty"`
 }
 
 type Documentation struct {
@@ -1146,6 +1149,8 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 	logrus.WithFields(logrus.Fields{
 		"pr": rn.PrNumber,
 	}).Debugf("Applying map to note")
+	rn.IsMapped = true
+
 	reRenderMarkdown := false
 	if noteMap.ReleaseNote.Author != nil {
 		rn.Author = *noteMap.ReleaseNote.Author


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If a note PR get's modified to remove the release note, then the label `release-note-none` will get applied to it. If a map for that note exists, then it will excluded based on that. We now still provide the mapped value to ensure a higher priority over the original PR.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not exclude mapped notes if they got modified to contain the `release-note-none` label.
```
