### PR TITLE
split release job in two to avoid have token excess permissions in prs 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
     labels:
       - "area/dependency"
       - "release-note-none"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - name: Set up Go
+      id: go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: '1.22'
         check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,9 @@ jobs:
 
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '1.22'
           check-latest: true
@@ -23,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
-          version: v1.56
+          version: v1.57
           args: --timeout=15m

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,18 +1,15 @@
 ---
-name: release
+name: test-snapshot-release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
-      contents: write
+      contents: read
 
     steps:
       - name: Harden Runner
@@ -32,13 +29,10 @@ jobs:
           go-version: '1.22'
           check-latest: true
 
-      - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
-
-      - name: Build and publish release
+      - name: Test release build
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
-        if: contains(github.ref, 'refs/tags')
         with:
-          args: release --clean
+          args: release --clean --snapshot --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -390,7 +390,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v1.56
+    version: v1.57
     refPaths:
     - path: .github/workflows/lint.yml
       match: "version: v\\d+.\\d+?\\.?(\\d+)?"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- split release job in two to avoid have token excess permissions in prs 

/assign @puerco @Verolop @xmudrii 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:



None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
split release job in two to avoid have token excess permissions in prs 
```
