### PR TITLE
allow api.securityscorecards.dev for dependency review job

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,5 +1,7 @@
 name: 'Dependency Review'
-on: [pull_request]
+
+on:
+  pull_request:
 
 permissions:
   contents: read
@@ -7,6 +9,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -16,6 +19,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            api.securityscorecards.dev:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- allow api.securityscorecards.dev

see https://app.stepsecurity.io/github/kubernetes/release/actions/runs/8490141967


/assign @puerco @Verolop @xmudrii 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:



None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
allow api.securityscorecards.dev for dependency review job
```
