### PR TITLE
Compare original PR body on release notes mapping

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -1154,6 +1154,7 @@ func fixReleaseNotes(workDir string, releaseNotes *notes.ReleaseNotes) error {
 			ActionRequired: note.ActionRequired,
 			Documentation:  note.Documentation,
 			DoNotPublish:   note.DoNotPublish,
+			PRBody:         note.PRBody,
 		}
 
 		if noteMaps != nil {
@@ -1409,6 +1410,8 @@ func editReleaseNote(pr int, workDir string, originalNote, modifiedNote *notes.R
 		logrus.Error("The yaml code does not have a PR number")
 		return true, errors.New("invalid map: the YAML code did not have a PR number")
 	}
+
+	testMap.PRBody = &originalNote.PRBody
 
 	// Remarshall the newyaml to save only the new values
 	newYAML, err := yaml.Marshal(testMap)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/saschagrunert/go-modiff v1.3.5
 	github.com/sendgrid/rest v2.6.9+incompatible
 	github.com/sendgrid/sendgrid-go v3.14.0+incompatible
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2
 	github.com/sirupsen/logrus v1.9.3
@@ -226,7 +227,6 @@ require (
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
-	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	github.com/sigstore/cosign/v2 v2.2.2 // indirect

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -117,6 +117,9 @@ type ReleaseNotesMap struct {
 	} `json:"releasenote"`
 
 	DataFields map[string]ReleaseNotesDataField `json:"datafields,omitempty" yaml:"datafields,omitempty"`
+
+	// PRBody is the full original PR body.
+	PRBody *string `json:"pr_body,omitempty" yaml:"pr_body,omitempty"`
 }
 
 // ReleaseNotesDataField extra data added to a release note


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
When creating a mapping we now preserve the original PR body in the YAML map. This allows us to track modifications to the PR if their values already got mapped during the release cycle and warn the end user in that case.


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3510

#### Special notes for your reviewer:
cc @kubernetes/release-engineering 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Track the original PR body when creating release notes maps. Those will be used to compare the actual PR body against them and warn in case of any differences.
```
