### PR TITLE
Fix schedule builder to reflect current format

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -36,8 +36,11 @@ func parseSchedule(patchSchedule PatchSchedule) string {
 	output = append(output, "### Timeline\n")
 	for _, releaseSchedule := range patchSchedule.Schedules {
 		output = append(output, fmt.Sprintf("### %s\n", releaseSchedule.Release),
-			fmt.Sprintf("Next patch release is **%s**\n", releaseSchedule.Next),
-			fmt.Sprintf("End of Life for **%s** is **%s**\n", releaseSchedule.Release, releaseSchedule.EndOfLifeDate))
+			fmt.Sprintf("Next patch release is **%s**\n", releaseSchedule.Next.Release),
+			fmt.Sprintf("**%s** enters maintenance mode on **%s** and End of Life is on **%s**.\n",
+				releaseSchedule.Release, releaseSchedule.MaintenanceModeStartDate, releaseSchedule.EndOfLifeDate,
+			),
+		)
 
 		tableString := &strings.Builder{}
 		table := tablewriter.NewWriter(tableString)
@@ -45,8 +48,8 @@ func parseSchedule(patchSchedule PatchSchedule) string {
 		table.SetHeader([]string{"Patch Release", "Cherry Pick Deadline", "Target Date", "Note"})
 
 		// Check if the next patch release is in the Previous Patch list, if yes dont read in the output
-		if !patchReleaseInPreviousList(releaseSchedule.Next, releaseSchedule.PreviousPatches) {
-			table.Append([]string{strings.TrimSpace(releaseSchedule.Next), strings.TrimSpace(releaseSchedule.CherryPickDeadline), strings.TrimSpace(releaseSchedule.TargetDate), ""})
+		if !patchReleaseInPreviousList(releaseSchedule.Next.Release, releaseSchedule.PreviousPatches) {
+			table.Append([]string{strings.TrimSpace(releaseSchedule.Next.Release), strings.TrimSpace(releaseSchedule.Next.CherryPickDeadline), strings.TrimSpace(releaseSchedule.Next.TargetDate), ""})
 		}
 
 		for _, previous := range releaseSchedule.PreviousPatches {
@@ -113,7 +116,7 @@ func parseReleaseSchedule(releaseSchedule ReleaseSchedule) string {
 	return scheduleOut
 }
 
-func patchReleaseInPreviousList(a string, previousPatches []PreviousPatches) bool {
+func patchReleaseInPreviousList(a string, previousPatches []PatchRelease) bool {
 	for _, b := range previousPatches {
 		if b.Release == a {
 			return true

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -29,7 +29,7 @@ const expectedPatchSchedule = `### Timeline
 
 Next patch release is **X.Y.ZZZ**
 
-End of Life for **X.Y** is **NOW**
+**X.Y** enters maintenance mode on **THEN** and End of Life is on **NOW**.
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE |
 |---------------|----------------------|-------------|------|
@@ -131,12 +131,15 @@ func TestParseSchedule(t *testing.T) {
 			schedule: PatchSchedule{
 				Schedules: []Schedule{
 					{
-						Release:            "X.Y",
-						Next:               "X.Y.ZZZ",
-						CherryPickDeadline: "2020-06-12",
-						TargetDate:         "2020-06-17",
-						EndOfLifeDate:      "NOW",
-						PreviousPatches: []PreviousPatches{
+						Release: "X.Y",
+						Next: &PatchRelease{
+							Release:            "X.Y.ZZZ",
+							CherryPickDeadline: "2020-06-12",
+							TargetDate:         "2020-06-17",
+						},
+						EndOfLifeDate:            "NOW",
+						MaintenanceModeStartDate: "THEN",
+						PreviousPatches: []PatchRelease{
 							{
 								Release:            "X.Y.XXX",
 								CherryPickDeadline: "2020-05-15",
@@ -158,12 +161,15 @@ func TestParseSchedule(t *testing.T) {
 			schedule: PatchSchedule{
 				Schedules: []Schedule{
 					{
-						Release:            "X.Y",
-						Next:               "X.Y.ZZZ",
-						CherryPickDeadline: "2020-06-12",
-						TargetDate:         "2020-06-17",
-						EndOfLifeDate:      "NOW",
-						PreviousPatches: []PreviousPatches{
+						Release: "X.Y",
+						Next: &PatchRelease{
+							Release:            "X.Y.ZZZ",
+							CherryPickDeadline: "2020-06-12",
+							TargetDate:         "2020-06-17",
+						},
+						EndOfLifeDate:            "NOW",
+						MaintenanceModeStartDate: "THEN",
+						PreviousPatches: []PatchRelease{
 							{
 								Release:            "X.Y.ZZZ",
 								CherryPickDeadline: "2020-06-12",

--- a/cmd/schedule-builder/cmd/model.go
+++ b/cmd/schedule-builder/cmd/model.go
@@ -21,8 +21,8 @@ type PatchSchedule struct {
 	Schedules []Schedule `yaml:"schedules"`
 }
 
-// PreviousPatches struct to define the old patch schedules
-type PreviousPatches struct {
+// PatchRelease struct to define the patch schedules
+type PatchRelease struct {
 	Release            string `yaml:"release"`
 	CherryPickDeadline string `yaml:"cherryPickDeadline"`
 	TargetDate         string `yaml:"targetDate"`
@@ -31,12 +31,12 @@ type PreviousPatches struct {
 
 // Schedule struct to define the release schedule for a specific version
 type Schedule struct {
-	Release            string            `yaml:"release"`
-	Next               string            `yaml:"next"`
-	CherryPickDeadline string            `yaml:"cherryPickDeadline"`
-	TargetDate         string            `yaml:"targetDate"`
-	EndOfLifeDate      string            `yaml:"endOfLifeDate"`
-	PreviousPatches    []PreviousPatches `yaml:"previousPatches"`
+	Release                  string         `yaml:"release"`
+	ReleaseDate              string         `yaml:"releaseDate"`
+	Next                     *PatchRelease  `yaml:"next"`
+	EndOfLifeDate            string         `yaml:"endOfLifeDate"`
+	MaintenanceModeStartDate string         `yaml:"maintenanceModeStartDate"`
+	PreviousPatches          []PatchRelease `yaml:"previousPatches"`
 }
 
 type ReleaseSchedule struct {

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -58,7 +58,6 @@ const (
 
 var requiredFlags = []string{
 	configPathFlag,
-	typeFlag,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/schedule-builder/cmd/root_test.go
+++ b/cmd/schedule-builder/cmd/root_test.go
@@ -35,7 +35,7 @@ const expectedPatchOut = `### Timeline
 
 Next patch release is **1.18.4**
 
-End of Life for **1.18** is **TBD**
+**1.18** enters maintenance mode on **TBD** and End of Life is on **TBD**.
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE |
 |---------------|----------------------|-------------|------|
@@ -47,7 +47,7 @@ End of Life for **1.18** is **TBD**
 
 Next patch release is **1.17.7**
 
-End of Life for **1.17** is **TBD**
+**1.17** enters maintenance mode on **TBD** and End of Life is on **TBD**.
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE |
 |---------------|----------------------|-------------|------|
@@ -58,7 +58,7 @@ End of Life for **1.17** is **TBD**
 
 Next patch release is **1.16.11**
 
-End of Life for **1.16** is **TBD**
+**1.16** enters maintenance mode on **TBD** and End of Life is on **TBD**.
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE |
 |---------------|----------------------|-------------|------|

--- a/cmd/schedule-builder/cmd/testdata/schedule.yaml
+++ b/cmd/schedule-builder/cmd/testdata/schedule.yaml
@@ -1,9 +1,11 @@
 schedules:
 - release: 1.18
-  next: 1.18.4
-  cherryPickDeadline: 2020-06-12
-  targetDate: 2020-06-17
+  next:
+    release: 1.18.4
+    cherryPickDeadline: 2020-06-12
+    targetDate: 2020-06-17
   endOfLifeDate: TBD
+  maintenanceModeStartDate: TBD
   previousPatches:
     - release: 1.18.3
       cherryPickDeadline: 2020-05-15
@@ -12,19 +14,23 @@ schedules:
       cherryPickDeadline: 2020-04-13
       targetDate: 2020-04-16
 - release: 1.17
-  next: 1.17.7
-  cherryPickDeadline: 2020-06-12
-  targetDate: 2020-06-17
+  next:
+    release: 1.17.7
+    cherryPickDeadline: 2020-06-12
+    targetDate: 2020-06-17
   endOfLifeDate: TBD
+  maintenanceModeStartDate: TBD
   previousPatches:
     - release: 1.17.6
       cherryPickDeadline: 2020-05-15
       targetDate: 2020-05-20
 - release: 1.16
-  next: 1.16.11
-  cherryPickDeadline: 2020-06-12
-  targetDate: 2020-06-17
+  next:
+    release: 1.16.11
+    cherryPickDeadline: 2020-06-12
+    targetDate: 2020-06-17
   endOfLifeDate: TBD
+  maintenanceModeStartDate: TBD
   previousPatches:
     - release: 1.16.10
       cherryPickDeadline: 2020-05-15


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The format used in https://github.com/kubernetes/website/blob/main/data/releases/schedule.yaml diverged from the format schedule builder is using. This is now fixed and test cases have been changed to match the new format.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed schedule-builder to match the current format from k/website.
```
