### PR TITLE
Add `--update` flag to `schedule-builder`

### DIFF
--- a/cmd/schedule-builder/cmd/model.go
+++ b/cmd/schedule-builder/cmd/model.go
@@ -16,27 +16,27 @@ limitations under the License.
 
 package cmd
 
-// PatchSchedule main struct to hold the schedules
+// PatchSchedule main struct to hold the schedules.
 type PatchSchedule struct {
-	Schedules []Schedule `yaml:"schedules"`
+	Schedules []*Schedule `json:"schedules,omitempty" yaml:"schedules,omitempty"`
 }
 
-// PatchRelease struct to define the patch schedules
+// PatchRelease struct to define the patch schedules.
 type PatchRelease struct {
-	Release            string `yaml:"release"`
-	CherryPickDeadline string `yaml:"cherryPickDeadline"`
-	TargetDate         string `yaml:"targetDate"`
-	Note               string `yaml:"note"`
+	Release            string `json:"release,omitempty"            yaml:"release,omitempty"`
+	CherryPickDeadline string `json:"cherryPickDeadline,omitempty" yaml:"cherryPickDeadline,omitempty"`
+	TargetDate         string `json:"targetDate,omitempty"         yaml:"targetDate,omitempty"`
+	Note               string `json:"note,omitempty"               yaml:"note,omitempty"`
 }
 
-// Schedule struct to define the release schedule for a specific version
+// Schedule struct to define the release schedule for a specific version.
 type Schedule struct {
-	Release                  string         `yaml:"release"`
-	ReleaseDate              string         `yaml:"releaseDate"`
-	Next                     *PatchRelease  `yaml:"next"`
-	EndOfLifeDate            string         `yaml:"endOfLifeDate"`
-	MaintenanceModeStartDate string         `yaml:"maintenanceModeStartDate"`
-	PreviousPatches          []PatchRelease `yaml:"previousPatches"`
+	Release                  string          `json:"release,omitempty"                  yaml:"release,omitempty"`
+	ReleaseDate              string          `json:"releaseDate,omitempty"              yaml:"releaseDate,omitempty"`
+	Next                     *PatchRelease   `json:"next,omitempty"                     yaml:"next,omitempty"`
+	EndOfLifeDate            string          `json:"endOfLifeDate,omitempty"            yaml:"endOfLifeDate,omitempty"`
+	MaintenanceModeStartDate string          `json:"maintenanceModeStartDate,omitempty" yaml:"maintenanceModeStartDate,omitempty"`
+	PreviousPatches          []*PatchRelease `json:"previousPatches,omitempty"          yaml:"previousPatches,omitempty"`
 }
 
 type ReleaseSchedule struct {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
The schedule builder is now able to update the schedule based on the current date. The logic is also able to backfill missed releases and will stop adding more if the next target date is in the future.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3179
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--update` flag to `schedule-builder` to update the patch release `schedule.yaml`.
```
