### PR TITLE
Add upcoming monthly releases support to schedule-builder

### DIFF
--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -27,7 +27,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const expectedPatchSchedule = `### Timeline
+const expectedPatchSchedule = `### Upcoming Monthly Releases
+
+| MONTHLY PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
+|-----------------------|----------------------|-------------|
+| June 2020             | 2020-06-12           | 2020-06-17  |
+
+### Timeline
 
 ### X.Y
 
@@ -158,6 +164,13 @@ func TestParsePatchSchedule(t *testing.T) {
 						},
 					},
 				},
+				UpcomingReleases: []*PatchRelease{
+					{
+						Release:            "June 2020",
+						CherryPickDeadline: "2020-06-12",
+						TargetDate:         "2020-06-17",
+					},
+				},
 			},
 		},
 		{
@@ -191,6 +204,13 @@ func TestParsePatchSchedule(t *testing.T) {
 								TargetDate:         "2020-04-16",
 							},
 						},
+					},
+				},
+				UpcomingReleases: []*PatchRelease{
+					{
+						Release:            "June 2020",
+						CherryPickDeadline: "2020-06-12",
+						TargetDate:         "2020-06-17",
 					},
 				},
 			},
@@ -350,6 +370,23 @@ func TestUpdatePatchSchedule(t *testing.T) {
 						EndOfLifeDate: "2023-01-01",
 					},
 				},
+				UpcomingReleases: []*PatchRelease{
+					{
+						Release:            "March 2024",
+						CherryPickDeadline: "2024-03-08",
+						TargetDate:         "2024-03-13",
+					},
+					{
+						Release:            "April 2024",
+						CherryPickDeadline: "2024-04-12",
+						TargetDate:         "2024-04-17",
+					},
+					{
+						Release:            "May 2024",
+						CherryPickDeadline: "2024-05-10",
+						TargetDate:         "2024-05-14",
+					},
+				},
 			},
 			expectedSchedule: PatchSchedule{
 				Schedules: []*Schedule{
@@ -383,6 +420,23 @@ func TestUpdatePatchSchedule(t *testing.T) {
 					{
 						Release:       "1.20",
 						EndOfLifeDate: "2023-01-01",
+					},
+				},
+				UpcomingReleases: []*PatchRelease{
+					{
+						Release:            "April 2024",
+						CherryPickDeadline: "2024-04-12",
+						TargetDate:         "2024-04-17",
+					},
+					{
+						Release:            "May 2024",
+						CherryPickDeadline: "2024-05-10",
+						TargetDate:         "2024-05-14",
+					},
+					{
+						Release:            "June 2024",
+						CherryPickDeadline: "2024-06-07",
+						TargetDate:         "2024-06-11",
 					},
 				},
 			},

--- a/cmd/schedule-builder/cmd/model.go
+++ b/cmd/schedule-builder/cmd/model.go
@@ -18,7 +18,8 @@ package cmd
 
 // PatchSchedule main struct to hold the schedules.
 type PatchSchedule struct {
-	Schedules []*Schedule `json:"schedules,omitempty" yaml:"schedules,omitempty"`
+	UpcomingReleases []*PatchRelease `json:"upcoming_releases,omitempty" yaml:"upcoming_releases,omitempty"`
+	Schedules        []*Schedule     `json:"schedules,omitempty"         yaml:"schedules,omitempty"`
 }
 
 // PatchRelease struct to define the patch schedules.


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
We now add a new data model to integrate the upcoming monthly releases into schedule builder.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #3179 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added upcoming releases to schedule builder model.
```
