### PR TITLE
Add `--version/-v` flag to `schedule-builder`

### DIFF
--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/release-utils/log"
+	"sigs.k8s.io/release-utils/version"
 	"sigs.k8s.io/yaml"
 )
 
@@ -47,6 +48,7 @@ type options struct {
 	logLevel   string
 	typeFile   string
 	update     bool
+	version    bool
 }
 
 var opts = &options{}
@@ -56,13 +58,10 @@ const (
 	outputFileFlag = "output-file"
 	typeFlag       = "type"
 	updateFlag     = "update"
+	versionFlag    = "version"
 	typePatch      = "patch"
 	typeRelease    = "release"
 )
-
-var requiredFlags = []string{
-	configPathFlag,
-}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -113,11 +112,13 @@ func init() {
 		fmt.Sprintf("update the '--%s' based on the latest available data (or date). Right now only supported if '--%s' is set to '%s'", configPathFlag, typeFlag, typePatch),
 	)
 
-	for _, flag := range requiredFlags {
-		if err := rootCmd.MarkPersistentFlagRequired(flag); err != nil {
-			logrus.Fatal(err)
-		}
-	}
+	rootCmd.PersistentFlags().BoolVarP(
+		&opts.version,
+		versionFlag,
+		"v",
+		false,
+		"print the version and exit",
+	)
 }
 
 func initLogging(*cobra.Command, []string) error {
@@ -125,6 +126,12 @@ func initLogging(*cobra.Command, []string) error {
 }
 
 func run(opts *options) error {
+	if opts.version {
+		info := version.GetVersionInfo()
+		fmt.Print(info.String())
+		return nil
+	}
+
 	if err := opts.SetAndValidate(); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows to print the version and exit.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--version/-v` flag to `schedule-builder`
```
