### PR TITLE
Add `-e/--eol-config-path` support to `schedule-builder`

### DIFF
--- a/cmd/schedule-builder/cmd/model.go
+++ b/cmd/schedule-builder/cmd/model.go
@@ -40,6 +40,19 @@ type Schedule struct {
 	PreviousPatches          []*PatchRelease `json:"previousPatches,omitempty"          yaml:"previousPatches,omitempty"`
 }
 
+// EolBranches is main struct to hold the end of life branches.
+type EolBranches struct {
+	Branches []*EolBranch `json:"branches,omitempty" yaml:"branches,omitempty"`
+}
+
+// EolBranch struct to define the end of life release branches.
+type EolBranch struct {
+	Release           string `json:"release,omitempty"           yaml:"release,omitempty"`
+	FinalPatchRelease string `json:"finalPatchRelease,omitempty" yaml:"finalPatchRelease,omitempty"`
+	EndOfLifeDate     string `json:"endOfLifeDate,omitempty"     yaml:"endOfLifeDate,omitempty"`
+	Note              string `json:"note,omitempty"              yaml:"note,omitempty"`
+}
+
 type ReleaseSchedule struct {
 	Releases []Release `yaml:"releases"`
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
It's not possible to specify an optional EOL config path. This file will be updated when a patch release goes end of life when specified.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/3179
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `-e/--eol-config-path` support to `schedule-builder`
```
