### PR TITLE
Don't panic if next release is not set

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -173,6 +173,11 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 	removeSchedules := []int{}
 	for i, sched := range schedule.Schedules {
 		for {
+			if sched.Next == nil {
+				logrus.Warnf("Next release not set for %s, skipping", sched.Release)
+				break
+			}
+
 			eolDate, err := time.Parse(refDate, sched.EndOfLifeDate)
 			if err != nil {
 				return fmt.Errorf("parse end of life date: %w", err)

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -366,6 +366,9 @@ func TestUpdatePatchSchedule(t *testing.T) {
 						EndOfLifeDate:            "2025-01-01",
 						MaintenanceModeStartDate: "2024-12-01",
 					},
+					{ // next not set
+						Release: "1.29",
+					},
 					{ // EOL
 						Release:       "1.20",
 						EndOfLifeDate: "2023-01-01",
@@ -422,6 +425,9 @@ func TestUpdatePatchSchedule(t *testing.T) {
 								TargetDate:         "2024-01-09",
 							},
 						},
+					},
+					{
+						Release: "1.29",
 					},
 				},
 				UpcomingReleases: []*PatchRelease{


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Should be usually not the case, but we skip releases from schedule-builder if the `next` field is not available now.

#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes/release/issues/3179
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed crash in `schedule-builder` if `next` field is not set in `schedule.yaml`.
```
