### PR TITLE
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.22.1
+    version: 1.22.2
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -226,7 +226,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.22)"
-    version: v1.30.0-go1.22.1-bullseye.0
+    version: v1.30.0-go1.22.2-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.30-cross1.22-bullseye:
     CONFIG: 'cross1.22'
-    KUBE_CROSS_VERSION: 'v1.30.0-go1.22.1-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.30.0-go1.22.2-bullseye.0'
   v1.29-cross1.21-bullseye:
     CONFIG: 'cross1.21'
     KUBE_CROSS_VERSION: 'v1.29.0-go1.21.8-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.22.1
+GO_VERSION ?= 1.22.2
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,15 +1,15 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.22.1'
+    GO_VERSION: '1.22.2'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.22.1'
+    GO_VERSION: '1.22.2'
     OS_CODENAME: 'bookworm'
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: '1.22.1'
+    GO_VERSION: '1.22.2'
     OS_CODENAME: 'bullseye'
   '1.29':
     CONFIG: '1.29'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.2

/assign @saschagrunert  @ameukam @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3529

#### Does this PR introduce a user-facing change?
```release-note
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.2
```
