### PR TITLE
Set GitHub release as latest if target release is highest semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	google.golang.org/api v0.152.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.29.3
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/bom v0.6.0
 	sigs.k8s.io/mdtoc v1.3.0
 	sigs.k8s.io/promo-tools/v3 v3.6.0
@@ -294,7 +295,6 @@ require (
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	modernc.org/libc v1.37.6 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.7.2 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR attempts to implement heuristics to determine if a GitHub release created by `krel` (and other tools using `pkg/announce`?) should be marked as "latest". It's an overdue follow-up to the extension of release-sdk in https://github.com/kubernetes-sigs/release-sdk/pull/288 that added a field to mark a GitHub release as latest.

The idea here is: Unless a release is a pre-release, we start with the assumption that "our" release _is_ the latest one. Since we already query the first page of GitHub releases for determining if this is an existing or new release, my changes now extend that loop and compare our version to the already existing releases by doing a semver parse and comparison. 

As soon as we have determined our release is **not** the latest, this check will be skipped.

Since there doesn't seem to be an easy way to test `krel`, I think this makes sense but I hope it gets scrutinised appropriately during review.

#### Which issue(s) this PR fixes:

Towards https://github.com/kubernetes/kubernetes/issues/119472

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mark GitHub release as latest if no newer releases were found
```
