### PR TITLE
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.21.9

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -232,25 +232,19 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.21)"
-    version: v1.29.0-go1.21.8-bullseye.0
+    version: v1.29.0-go1.21.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.21)"
-    version: v1.28.0-go1.21.8-bullseye.0
+    version: v1.28.0-go1.21.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.21)"
-    version: v1.27.0-go1.21.8-bullseye.0
-    refPaths:
-    - path: images/k8s-cloud-builder/variants.yaml
-      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.26-cross1.21)"
-    version: v1.26.0-go1.21.8-bullseye.0
+    version: v1.27.0-go1.21.9-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -299,7 +293,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.29)"
-    version: 1.21.8
+    version: 1.21.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -322,7 +316,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.28)"
-    version: 1.21.8
+    version: 1.21.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -339,13 +333,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.27)"
-    version: 1.21.8
-    refPaths:
-    - path: images/releng/k8s-ci-builder/variants.yaml
-      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.26)"
-    version: 1.21.8
+    version: 1.21.9
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,13 +4,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.30.0-go1.22.2-bullseye.0'
   v1.29-cross1.21-bullseye:
     CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.9-bullseye.0'
   v1.28-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.28.0-go1.21.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.28.0-go1.21.9-bullseye.0'
   v1.27-cross1.20-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.21.8-bullseye.0'
-  v1.26-cross1.20-bullseye:
-    CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.26.0-go1.21.8-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.21.9-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -13,17 +13,13 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: '1.21.8'
+    GO_VERSION: '1.21.9'
     OS_CODENAME: 'bullseye'
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: '1.21.8'
+    GO_VERSION: '1.21.9'
     OS_CODENAME: 'bullseye'
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: '1.21.8'
-    OS_CODENAME: 'bullseye'
-  '1.26':
-    CONFIG: '1.26'
-    GO_VERSION: '1.21.8'
+    GO_VERSION: '1.21.9'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Build k8s-ci-builder and k8s-cloud-bulider with Go 1.21.9

/assign @puerco @Verolop @jeremyrickard 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3529

#### Does this PR introduce a user-facing change?
```release-note
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.21.9
```
