### PR TITLE
add support to manage logs using lumber jack rolling logger

### DIFF
--- a/images/build/go-runner/go.mod
+++ b/images/build/go-runner/go.mod
@@ -1,3 +1,5 @@
 module k8s.io/release/images/build/go-runner
 
 go 1.21
+
+require gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/images/build/go-runner/go.sum
+++ b/images/build/go-runner/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Adding support to go runner to use [lumber jack](https://github.com/natefinch/lumberjack) logger for log rotation.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As per the linux log rotation we have  copy truncate and  create mechanisms to handle log rotation. 

Copy truncate mechanism first copies logs to a backup file then start truncating the original file. During the truncate process our components/application still continues to wright to old file which will be truncated but never copied to the backup file. 

Amount of logs lost is depends on file size during log rotation. If log rotation takes 10 seconds to truncate the log file component/application logs are lost for that 10 seconds. Using Copy truncate mechanism we might loose data as part of log rotation process. It was also mentioned in https://linux.die.net/man/8/logrotate.

Create mechanism renames old log file and creates new log file as part of log rotation process. For the application/component to start writing to the new log file we have to either 
- restart the application/component (we dont want to restart components too many time) 
- or send some kind of signal (like HUP) to the application/component to reopen the log file(which requires code change to handle log file reopen on all kubernetes components running on top of go runner).

Failing to do so the application continues to write logs to the old log file(renamed log file). Both of these mechanisms has some kind of issue to be taken care of.    

This PR introduces using [lumber jack logger](https://github.com/natefinch/lumberjack) as a option to handle log rotation with go runner. 
k8s upstream also use lumber jack to handle [audlit logs](https://github.com/kubernetes/kubernetes/blob/9791f0d1f39f3f1e0796add7833c1059325d5098/staging/src/k8s.io/apiserver/pkg/server/options/audit.go#L496-L516) 
using  lumberjack once current log file reaches ts max-size limit specified by user Lumberjack renames log file and starts writing to new log file without dropping any logs. This way we will not loose logs as part of log rotation.

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
This PR doesn't directly modify current behavior. New change is added as an option. Users can enable it using below flags.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
New flag added. User can set below flags if they want go-runner to handle log rotation using lumberjack logger
    - --log-rotate=true
    - --log-maxsize=100
    - --log-maxbackup=5
    - --log-compress=true
```
