### PR TITLE
Ensure `make update-mocks` does not inject existing boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,11 @@ update-deps-go: ## Update all golang dependencies for this repo
 update-mocks: ## Update all generated mocks
 	go generate ./...
 	for f in $(shell find . -name fake_*.go); do \
-		cp hack/boilerplate/boilerplate.generatego.txt tmp ;\
-		cat $$f >> tmp ;\
-		mv tmp $$f ;\
+		if ! grep -q "^`cat hack/boilerplate/boilerplate.generatego.txt`" $$f; then \
+			cp hack/boilerplate/boilerplate.generatego.txt tmp ;\
+			cat $$f >> tmp ;\
+			mv tmp $$f ;\
+		fi \
 	done
 
 ##@ Helpers

--- a/pkg/release/releasefakes/fake_publisher_client.go
+++ b/pkg/release/releasefakes/fake_publisher_client.go
@@ -89,6 +89,7 @@ type FakePublisherClient struct {
 	getMarkerPathArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 bool
 	}
 	getMarkerPathReturns struct {
 		result1 string
@@ -529,10 +530,11 @@ func (fake *FakePublisherClient) GetMarkerPath(arg1 string, arg2 string, arg3 bo
 	fake.getMarkerPathArgsForCall = append(fake.getMarkerPathArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
+		arg3 bool
+	}{arg1, arg2, arg3})
 	stub := fake.GetMarkerPathStub
 	fakeReturns := fake.getMarkerPathReturns
-	fake.recordInvocation("GetMarkerPath", []interface{}{arg1, arg2})
+	fake.recordInvocation("GetMarkerPath", []interface{}{arg1, arg2, arg3})
 	fake.getMarkerPathMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -555,11 +557,11 @@ func (fake *FakePublisherClient) GetMarkerPathCalls(stub func(string, string, bo
 	fake.GetMarkerPathStub = stub
 }
 
-func (fake *FakePublisherClient) GetMarkerPathArgsForCall(i int) (string, string) {
+func (fake *FakePublisherClient) GetMarkerPathArgsForCall(i int) (string, string, bool) {
 	fake.getMarkerPathMutex.RLock()
 	defer fake.getMarkerPathMutex.RUnlock()
 	argsForCall := fake.getMarkerPathArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakePublisherClient) GetMarkerPathReturns(result1 string, result2 error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

I noticed (while working on #3565) that `make update-mocks` always prepended the existing boilerplate header to generated fake clients, so I ended up with the header being injected a second time on existing files that already had it. This PR makes sure that the boilerplate prepend logic in the Makefile is only triggered if the file doesn't already start with the boilerplate.

After adding this and running said make target, it turned out that `FakePublisherClient` wasn't up-to-date, so I'm including that in the PR (we can also extract it if preferred).

/kind bug
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
