### PR TITLE
Do not add release name for upcoming releases

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -286,11 +286,9 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 		nextCherryPickDeadline := time.Date(latestDate.Year(), latestDate.Month(), cherryPickDay, 0, 0, 0, 0, time.UTC)
 		nextTargetDate := time.Date(latestDate.Year(), latestDate.Month(), targetDateDay, 0, 0, 0, 0, time.UTC)
 
-		releaseName := nextTargetDate.Format("January 2006")
-		logrus.Infof("Adding new upcoming release for %s", releaseName)
+		logrus.Infof("Adding new upcoming release for %s", nextTargetDate.Format("January 2006"))
 
 		newUpcomingReleases = append(newUpcomingReleases, &PatchRelease{
-			Release:            releaseName,
 			CherryPickDeadline: nextCherryPickDeadline.Format(refDate),
 			TargetDate:         nextTargetDate.Format(refDate),
 		})

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -31,7 +31,7 @@ const expectedPatchSchedule = `### Upcoming Monthly Releases
 
 | MONTHLY PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
 |-----------------------|----------------------|-------------|
-| June 2020             | 2020-06-12           | 2020-06-17  |
+|                       | 2020-06-12           | 2020-06-17  |
 
 ### Timeline
 
@@ -166,7 +166,6 @@ func TestParsePatchSchedule(t *testing.T) {
 				},
 				UpcomingReleases: []*PatchRelease{
 					{
-						Release:            "June 2020",
 						CherryPickDeadline: "2020-06-12",
 						TargetDate:         "2020-06-17",
 					},
@@ -208,7 +207,6 @@ func TestParsePatchSchedule(t *testing.T) {
 				},
 				UpcomingReleases: []*PatchRelease{
 					{
-						Release:            "June 2020",
 						CherryPickDeadline: "2020-06-12",
 						TargetDate:         "2020-06-17",
 					},
@@ -381,17 +379,14 @@ func TestUpdatePatchSchedule(t *testing.T) {
 				},
 				UpcomingReleases: []*PatchRelease{
 					{
-						Release:            "March 2024",
 						CherryPickDeadline: "2024-03-08",
 						TargetDate:         "2024-03-13",
 					},
 					{
-						Release:            "April 2024",
 						CherryPickDeadline: "2024-04-12",
 						TargetDate:         "2024-04-17",
 					},
 					{
-						Release:            "May 2024",
 						CherryPickDeadline: "2024-05-10",
 						TargetDate:         "2024-05-14",
 					},
@@ -432,17 +427,14 @@ func TestUpdatePatchSchedule(t *testing.T) {
 				},
 				UpcomingReleases: []*PatchRelease{
 					{
-						Release:            "April 2024",
 						CherryPickDeadline: "2024-04-12",
 						TargetDate:         "2024-04-17",
 					},
 					{
-						Release:            "May 2024",
 						CherryPickDeadline: "2024-05-10",
 						TargetDate:         "2024-05-14",
 					},
 					{
-						Release:            "June 2024",
 						CherryPickDeadline: "2024-06-07",
 						TargetDate:         "2024-06-11",
 					},


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
We can infer the release name from the target date by just formatting it to display the month and year.


#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/website/pull/45770

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
schedule-builder: do not add release name for upcoming releases because it can be inferred by the target date.
```
