### PR TITLE
schedule-builder: fix wrong log message

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -270,7 +270,7 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 			continue
 		}
 
-		logrus.Infof("Using existing upcoming release for %s (%s)", upcomingRelease.Release, upcomingRelease.TargetDate)
+		logrus.Infof("Using existing upcoming release for %s", upcomingRelease.TargetDate)
 		newUpcomingReleases = append(newUpcomingReleases, upcomingRelease)
 		latestDate = upcomingTargetDate
 	}


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The log message looks like this before applying this patch:

```
INFO Using existing upcoming release for  (2024-05-14)
```

There is no release name existing any more in the `upcoming_releases` section, means we can omit that from the log message.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
