### PR TITLE
Fix monthly patch output for schedule-builder

### DIFF
--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -31,7 +31,7 @@ const expectedPatchSchedule = `### Upcoming Monthly Releases
 
 | MONTHLY PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
 |-----------------------|----------------------|-------------|
-|                       | 2020-06-12           | 2020-06-17  |
+| June 2020             | 2020-06-12           | 2020-06-17  |
 
 ### Timeline
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The output was empty which is now fixed.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed monthly patch output for schedule-builder.
```
