### PR TITLE
Mark text/template usage safe from yaml injection.

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
 	"time"
+
+	// Mark text/template as not to be checked for producing yaml.
+	"text/template" // NOLINT
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
A google internal scanner incorrectly flags this
usage of text/template as being vulnerable to yaml injection.

Add a NOLINT to mark this usage as safe.

/kind cleanup

```release-note
NONE
```
