### PR TITLE
`pkg/announce`: make interface functions public and add tests

### DIFF
--- a/pkg/announce/announce_test.go
+++ b/pkg/announce/announce_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package announce_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/announce"
+	"k8s.io/release/pkg/announce/announcefakes"
+)
+
+const (
+	workdir       = "/workspace"
+	changelogFile = "/workspace/src/release-notes.html"
+	branch        = "release-1.30"
+)
+
+var err = errors.New("error")
+
+var readChangelogFileStub = func(s string) ([]byte, error) {
+	if s == changelogFile {
+		return []byte("<b>changelog contents</b>"), nil
+	} else {
+		return nil, err
+	}
+}
+
+func TestCreateForBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		workdir     string
+		branch      string
+		prepare     func(*announcefakes.FakeImpl)
+		shouldError bool
+	}{
+		{
+			name:    "create announcement successfully",
+			workdir: workdir,
+			branch:  branch,
+			prepare: func(mock *announcefakes.FakeImpl) {
+			},
+			shouldError: false,
+		},
+		{
+			name:    "fails to create announcement file",
+			workdir: workdir,
+			branch:  branch,
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.CreateReturns(err)
+			},
+			shouldError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := announce.NewOptions().
+				WithWorkDir(tc.workdir).
+				WithBranch(tc.branch)
+
+			an := announce.NewAnnounce(opts)
+			mock := &announcefakes.FakeImpl{}
+			tc.prepare(mock)
+			an.SetImplementation(mock)
+
+			err := an.CreateForBranch()
+			if tc.shouldError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateForRelease(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		workdir       string
+		changelogFile string
+		tag           string
+		prepare       func(*announcefakes.FakeImpl)
+		shouldError   bool
+	}{
+		{
+			name:          "create announcement successfully",
+			workdir:       workdir,
+			changelogFile: changelogFile,
+			tag:           "1.30.0",
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.GetGoVersionReturns("1.22.0", nil)
+				mock.ReadChangelogFileCalls(readChangelogFileStub)
+			},
+			shouldError: false,
+		},
+		{
+			name:          "fails to get go version",
+			workdir:       workdir,
+			changelogFile: changelogFile,
+			tag:           "1.30.0",
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.GetGoVersionReturns("", err)
+				mock.ReadChangelogFileCalls(readChangelogFileStub)
+			},
+			shouldError: true,
+		},
+		{
+			name:          "gets empty go version",
+			workdir:       workdir,
+			changelogFile: changelogFile,
+			tag:           "1.30.0",
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.GetGoVersionReturns("", nil)
+				mock.ReadChangelogFileCalls(readChangelogFileStub)
+			},
+			shouldError: true,
+		},
+		{
+			name:          "fails to create announcement file",
+			workdir:       workdir,
+			changelogFile: changelogFile,
+			tag:           "1.30.0",
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.GetGoVersionReturns("1.22.0", nil)
+				mock.CreateReturns(err)
+				mock.ReadChangelogFileCalls(readChangelogFileStub)
+			},
+			shouldError: true,
+		},
+		{
+			name:          "fails to read changelog file",
+			workdir:       workdir,
+			changelogFile: changelogFile,
+			tag:           "1.30.0",
+			prepare: func(mock *announcefakes.FakeImpl) {
+				mock.GetGoVersionReturns("1.22.0", nil)
+				mock.ReadChangelogFileReturns(nil, err)
+			},
+			shouldError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := announce.NewOptions().
+				WithWorkDir(tc.workdir).
+				WithChangelogFile(tc.changelogFile).
+				WithTag(tc.tag)
+
+			an := announce.NewAnnounce(opts)
+			mock := &announcefakes.FakeImpl{}
+			tc.prepare(mock)
+			an.SetImplementation(mock)
+
+			err := an.CreateForRelease()
+			if tc.shouldError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/announce/announcefakes/fake_impl.go
+++ b/pkg/announce/announcefakes/fake_impl.go
@@ -22,7 +22,7 @@ import (
 )
 
 type FakeImpl struct {
-	createStub        func(string, string, string) error
+	CreateStub        func(string, string, string) error
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 string
@@ -35,7 +35,7 @@ type FakeImpl struct {
 	createReturnsOnCall map[int]struct {
 		result1 error
 	}
-	getGoVersionStub        func(string) (string, error)
+	GetGoVersionStub        func(string) (string, error)
 	getGoVersionMutex       sync.RWMutex
 	getGoVersionArgsForCall []struct {
 		arg1 string
@@ -48,11 +48,24 @@ type FakeImpl struct {
 		result1 string
 		result2 error
 	}
+	ReadChangelogFileStub        func(string) ([]byte, error)
+	readChangelogFileMutex       sync.RWMutex
+	readChangelogFileArgsForCall []struct {
+		arg1 string
+	}
+	readChangelogFileReturns struct {
+		result1 []byte
+		result2 error
+	}
+	readChangelogFileReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) create(arg1 string, arg2 string, arg3 string) error {
+func (fake *FakeImpl) Create(arg1 string, arg2 string, arg3 string) error {
 	fake.createMutex.Lock()
 	ret, specificReturn := fake.createReturnsOnCall[len(fake.createArgsForCall)]
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
@@ -60,9 +73,9 @@ func (fake *FakeImpl) create(arg1 string, arg2 string, arg3 string) error {
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.createStub
+	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("create", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3})
 	fake.createMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -82,7 +95,7 @@ func (fake *FakeImpl) CreateCallCount() int {
 func (fake *FakeImpl) CreateCalls(stub func(string, string, string) error) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
-	fake.createStub = stub
+	fake.CreateStub = stub
 }
 
 func (fake *FakeImpl) CreateArgsForCall(i int) (string, string, string) {
@@ -95,7 +108,7 @@ func (fake *FakeImpl) CreateArgsForCall(i int) (string, string, string) {
 func (fake *FakeImpl) CreateReturns(result1 error) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
-	fake.createStub = nil
+	fake.CreateStub = nil
 	fake.createReturns = struct {
 		result1 error
 	}{result1}
@@ -104,7 +117,7 @@ func (fake *FakeImpl) CreateReturns(result1 error) {
 func (fake *FakeImpl) CreateReturnsOnCall(i int, result1 error) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
-	fake.createStub = nil
+	fake.CreateStub = nil
 	if fake.createReturnsOnCall == nil {
 		fake.createReturnsOnCall = make(map[int]struct {
 			result1 error
@@ -115,15 +128,15 @@ func (fake *FakeImpl) CreateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) getGoVersion(arg1 string) (string, error) {
+func (fake *FakeImpl) GetGoVersion(arg1 string) (string, error) {
 	fake.getGoVersionMutex.Lock()
 	ret, specificReturn := fake.getGoVersionReturnsOnCall[len(fake.getGoVersionArgsForCall)]
 	fake.getGoVersionArgsForCall = append(fake.getGoVersionArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.getGoVersionStub
+	stub := fake.GetGoVersionStub
 	fakeReturns := fake.getGoVersionReturns
-	fake.recordInvocation("getGoVersion", []interface{}{arg1})
+	fake.recordInvocation("GetGoVersion", []interface{}{arg1})
 	fake.getGoVersionMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -143,7 +156,7 @@ func (fake *FakeImpl) GetGoVersionCallCount() int {
 func (fake *FakeImpl) GetGoVersionCalls(stub func(string) (string, error)) {
 	fake.getGoVersionMutex.Lock()
 	defer fake.getGoVersionMutex.Unlock()
-	fake.getGoVersionStub = stub
+	fake.GetGoVersionStub = stub
 }
 
 func (fake *FakeImpl) GetGoVersionArgsForCall(i int) string {
@@ -156,7 +169,7 @@ func (fake *FakeImpl) GetGoVersionArgsForCall(i int) string {
 func (fake *FakeImpl) GetGoVersionReturns(result1 string, result2 error) {
 	fake.getGoVersionMutex.Lock()
 	defer fake.getGoVersionMutex.Unlock()
-	fake.getGoVersionStub = nil
+	fake.GetGoVersionStub = nil
 	fake.getGoVersionReturns = struct {
 		result1 string
 		result2 error
@@ -166,7 +179,7 @@ func (fake *FakeImpl) GetGoVersionReturns(result1 string, result2 error) {
 func (fake *FakeImpl) GetGoVersionReturnsOnCall(i int, result1 string, result2 error) {
 	fake.getGoVersionMutex.Lock()
 	defer fake.getGoVersionMutex.Unlock()
-	fake.getGoVersionStub = nil
+	fake.GetGoVersionStub = nil
 	if fake.getGoVersionReturnsOnCall == nil {
 		fake.getGoVersionReturnsOnCall = make(map[int]struct {
 			result1 string
@@ -179,6 +192,70 @@ func (fake *FakeImpl) GetGoVersionReturnsOnCall(i int, result1 string, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeImpl) ReadChangelogFile(arg1 string) ([]byte, error) {
+	fake.readChangelogFileMutex.Lock()
+	ret, specificReturn := fake.readChangelogFileReturnsOnCall[len(fake.readChangelogFileArgsForCall)]
+	fake.readChangelogFileArgsForCall = append(fake.readChangelogFileArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ReadChangelogFileStub
+	fakeReturns := fake.readChangelogFileReturns
+	fake.recordInvocation("ReadChangelogFile", []interface{}{arg1})
+	fake.readChangelogFileMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) ReadChangelogFileCallCount() int {
+	fake.readChangelogFileMutex.RLock()
+	defer fake.readChangelogFileMutex.RUnlock()
+	return len(fake.readChangelogFileArgsForCall)
+}
+
+func (fake *FakeImpl) ReadChangelogFileCalls(stub func(string) ([]byte, error)) {
+	fake.readChangelogFileMutex.Lock()
+	defer fake.readChangelogFileMutex.Unlock()
+	fake.ReadChangelogFileStub = stub
+}
+
+func (fake *FakeImpl) ReadChangelogFileArgsForCall(i int) string {
+	fake.readChangelogFileMutex.RLock()
+	defer fake.readChangelogFileMutex.RUnlock()
+	argsForCall := fake.readChangelogFileArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) ReadChangelogFileReturns(result1 []byte, result2 error) {
+	fake.readChangelogFileMutex.Lock()
+	defer fake.readChangelogFileMutex.Unlock()
+	fake.ReadChangelogFileStub = nil
+	fake.readChangelogFileReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) ReadChangelogFileReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.readChangelogFileMutex.Lock()
+	defer fake.readChangelogFileMutex.Unlock()
+	fake.ReadChangelogFileStub = nil
+	if fake.readChangelogFileReturnsOnCall == nil {
+		fake.readChangelogFileReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.readChangelogFileReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -186,6 +263,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.createMutex.RUnlock()
 	fake.getGoVersionMutex.RLock()
 	defer fake.getGoVersionMutex.RUnlock()
+	fake.readChangelogFileMutex.RLock()
+	defer fake.readChangelogFileMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/announce/impl.go
+++ b/pkg/announce/impl.go
@@ -37,11 +37,12 @@ type defaultImpl struct{}
 //go:generate /usr/bin/env bash -c "cat ../../hack/boilerplate/boilerplate.generatego.txt announcefakes/fake_impl.go > announcefakes/_fake_impl.go && mv announcefakes/_fake_impl.go announcefakes/fake_impl.go"
 
 type impl interface {
-	create(workDir, subject, message string) error
-	getGoVersion(tag string) (string, error)
+	Create(workDir, subject, message string) error
+	GetGoVersion(tag string) (string, error)
+	ReadChangelogFile(file string) ([]byte, error)
 }
 
-func (i *defaultImpl) create(workDir, subject, message string) error {
+func (i *defaultImpl) Create(workDir, subject, message string) error {
 	subjectFile := filepath.Join(workDir, subjectFile)
 	//nolint:gosec // TODO(gosec): G306: Expect WriteFile permissions to be
 	// 0600 or less
@@ -73,11 +74,11 @@ func (i *defaultImpl) create(workDir, subject, message string) error {
 	return nil
 }
 
-// getGoVersion runs kube-cross container and go version inside it.
+// GetGoVersion runs kube-cross container and go version inside it.
 // We're running kube-cross container because it's not guaranteed that
 // k8s-cloud-builder container will be running the same Go version as
 // the kube-cross container used to build the release.
-func (i *defaultImpl) getGoVersion(tag string) (string, error) {
+func (i *defaultImpl) GetGoVersion(tag string) (string, error) {
 	semver, err := util.TagStringToSemver(tag)
 	if err != nil {
 		return "", fmt.Errorf("parse version tag: %w", err)
@@ -104,4 +105,8 @@ func (i *defaultImpl) getGoVersion(tag string) (string, error) {
 
 	versionRegex := regexp.MustCompile(`^?(\d+)(\.\d+)?(\.\d+)`)
 	return versionRegex.FindString(strings.TrimSpace(res.OutputTrimNL())), nil
+}
+
+func (i *defaultImpl) ReadChangelogFile(file string) ([]byte, error) {
+	return os.ReadFile(file)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

After refactoring `pkg/announce` in #3580, this is the first wave of tests to validate that the new packages work properly. I didn't want to have all tests in one PR (as that will result in a very large diff to review), and I was hoping to get some feedback on my approach before committing to work on additional tests.

In this PR:

- the functions on the implementation interface for `k8s.io/release/pkg/announce.Announce` are made public, because otherwise they can't be used for mock tests. I'm not sure why I chose them to be private in the first place.
- some light validation is added to the `CreateForRelease` method to ensure that empty data (empty changelog HTML or Go version) is caught.
- Reading the changelog file has been moved to the implementation interface, to eliminate the remaining direct filesystem call.
- Tests have been added that make sure creating an announcement fails for various failure scenarios.

Overall, `CreateForBranch` and `CreateForRelease` are very simple methods, but this adds test coverage nonetheless. If this is looking good, I will move on to the sub-packages in `pkg/announce` in future PRs.

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
