### PR TITLE
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.3 for k/k main

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.22.2
+    version: 1.22.3
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -245,6 +245,12 @@ dependencies:
       match: REVISION \?= \d+
     - path: images/build/cross/variants.yaml
       match: REVISION:\ '\d+'
+
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.22)"
+    version: v1.31.0-go1.22.3-bullseye.0
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.22)"
     version: v1.30.0-go1.22.2-bullseye.0

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,7 @@
 variants:
+  v1.31-cross1.22-bullseye:
+    CONFIG: 'cross1.22'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.22.3-bullseye.0'
   v1.30-cross1.22-bullseye:
     CONFIG: 'cross1.22'
     KUBE_CROSS_VERSION: 'v1.30.0-go1.22.2-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.22.2
+GO_VERSION ?= 1.22.3
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,12 +1,16 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.22.2'
+    GO_VERSION: '1.22.3'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.22.2'
+    GO_VERSION: '1.22.3'
     OS_CODENAME: 'bookworm'
+  '1.31':
+    CONFIG: '1.31'
+    GO_VERSION: '1.22.3'
+    OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
     GO_VERSION: '1.22.2'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.3 for k/k main

/assign @saschagrunert  @ameukam @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3597

#### Does this PR introduce a user-facing change?
```release-note
Build k8s-ci-builder and k8s-cloud-bulider with Go 1.22.3
```
