### PR TITLE
Avoid parent process if no log redirection is used

### DIFF
--- a/images/build/go-runner/go-runner.go
+++ b/images/build/go-runner/go-runner.go
@@ -46,6 +46,7 @@ func configureAndRun() error {
 	var (
 		outputStream io.Writer = os.Stdout
 		errStream    io.Writer = os.Stderr
+		err          error
 	)
 
 	args := flag.Args()
@@ -79,7 +80,11 @@ func configureAndRun() error {
 	cmd.Stderr = errStream
 
 	log.Printf("Running command:\n%v", cmdInfo(cmd))
-	err := cmd.Start()
+	if cmd.Stdout == os.Stdout && cmd.Stderr == os.Stderr {
+		err = syscall.Exec(cmd.Path, cmd.Args, syscall.Environ())
+	} else {
+		err = cmd.Start()
+	}
 	if err != nil {
 		return fmt.Errorf("starting command: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind design

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Exec the command without forking in case go-runner does not need to perform log output redirection.

The idea here is to save resources by exec'ing instead of fork'ing the subprocess to avoid an unnecessary process lingering around.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Not sure if this is a desired change, please review and decide if generally useful or not. Thanks!

#### Does this PR introduce a user-facing change?
Yes

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Avoid parent go-runner process if no log redirection is used, action required: may impact process-based monitoring solutions.
```
