### PR TITLE
Fix path for kubelet.env file in kubelet deb package

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -66,8 +66,13 @@ touch %{buildroot}%{_sharedstatedir}/kubelet/.kubelet-keep
 touch %{buildroot}%{_sysconfdir}/kubernetes/manifests/.kubelet-keep
 %endif
 
+%if "%{_vendor}" == "debbuild"
+mkdir -p %{buildroot}%{_sysconfdir}/default/
+install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/default/kubelet
+%else
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig/
 install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
+%endif
 
 %files
 %{_bindir}/kubelet
@@ -78,8 +83,10 @@ install -p -m 644 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 %if "%{_vendor}" == "debbuild"
 %{_sharedstatedir}/kubelet/.kubelet-keep
 %{_sysconfdir}/kubernetes/manifests/.kubelet-keep
-%endif
+%config(noreplace) %{_sysconfdir}/default/kubelet
+%else
 %config(noreplace) %{_sysconfdir}/sysconfig/kubelet
+%endif
 %license LICENSE
 %doc README.md
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We received two reports that our `kubelet` Debian package installs `kubelet.env` file in a wrong location:

- https://github.com/kubernetes/release/pull/3279#issuecomment-2099865359
- https://github.com/kubernetes/release/issues/3276#issuecomment-2099862981

I was able to confirm these reports. As per some guidelines:

- `/etc/default` should be used on Debian-based operating systems
- `/etc/sysconfig` should be used on RPM-based operating systems

We partially fixed the issue a while ago with #3279, by ensuring that `kubeadm` is going to read the file from the correct path, but we didn't ensure that we install the file in the correct location. This is now fixed with this PR.

I tried building and installing the package locally to make sure the file is created in the correct location. This change will be applied to all `kubelet` packages that we build (for all minor releases) once this PR is merged. I don't expect this to regress in any way. 🤞 

#### Does this PR introduce a user-facing change?
```release-note
`kubelet.env` file is now installed in `/etc/default` instead of `/etc/sysconfig` on Debian-based systems by the `kubelet` package
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes/release-engineering 