### PR TITLE
Remove kubeadm >=1.32 dependency from crictl

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -74,6 +74,8 @@ kubeadm:
     dependencies:
       - name: cri-tools
         versionConstraint: ">= 1.30.0"
+  - versionConstraint: ">= 1.32.0"
+    sourceURLTemplate: "{{ KubernetesURL }}"
 kubectl:
   - versionConstraint: ">= 1.0.0"
     sourceURLTemplate: "{{ KubernetesURL }}"


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
The merge of https://github.com/kubernetes/kubernetes/pull/124685 will make kubeadm work without crictl. We now reflect that in the packaging as well as defined in https://github.com/kubernetes/kubeadm/issues/3064.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/kubeadm/issues/3064
#### Special notes for your reviewer:
cc @neolit123 @carlory 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make kubeadm >= 1.32 independent from crictl due to https://github.com/kubernetes/kubernetes/pull/124685
```
