### PR TITLE
Remove `ETCD_VERSION` refs from base-images

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -83,7 +83,6 @@ container: check-env init-docker-buildx
 			--tag $(IMAGE)-$${platform##*/}:latest-$(CONFIG)-$(TYPE) \
 			--build-arg=BASEIMAGE=$(BASEIMAGE) \
 			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
-			--build-arg=ETCD_VERSION=$(ETCD_VERSION) \
 			--file $(TYPE)/Dockerfile \
 			.; \
 	done

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -20,7 +20,6 @@ steps:
     - OS_CODENAME=$_OS_CODENAME
     - REVISION=$_REVISION
     - PROTOBUF_VERSION=$_PROTOBUF_VERSION
-    - ETCD_VERSION=$_ETCD_VERSION
     - REGISTRY=$_REGISTRY
     # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
     # set the home to /root explicitly to if using docker buildx
@@ -45,7 +44,6 @@ substitutions:
   _OS_CODENAME: 'codename'
   _REVISION: '0'
   _PROTOBUF_VERSION: '0.0.0'
-  _ETCD_VERSION: 'v0.0.0'
   _REGISTRY: 'fake.repository/registry-name'
 
 tags:
@@ -61,7 +59,6 @@ tags:
 - ${_IMAGE_VERSION}
 - ${_REVISION}
 - ${_PROTOBUF_VERSION}
-- ${_ETCD_VERSION}
 
 images:
   - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_IMAGE_VERSION'


### PR DESCRIPTION
This PR will remove `ETCD_VERSION` references from base-image builds since it is unused.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will remove `ETCD_VERSION` references from base-image builds since it is unused.

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/release/pull/2123#issuecomment-862472741
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `ETCD_VERSION` variable references from base-images.
```
