### PR TITLE
Allow the dependency-review action to access api.deps.dev

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -20,6 +20,7 @@ jobs:
             api.github.com:443
             github.com:443
             api.securityscorecards.dev:443
+            api.deps.dev:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It seems like the `dependency-review` action uses `api.deps.dev` to analyze vulnerabilities in packages: https://github.com/actions/dependency-review-action/blob/df5d74f5d3fc9748a904ea2f1dc6bdddea6439d6/src/scorecard.ts#L71

Given that we only allow specific URLs, it could be that the action can't reach this URL and instead fails with `fetch failed`.

#### Which issue(s) this PR fixes:

xref https://github.com/actions/dependency-review-action/issues/736 and https://github.com/kubernetes/release/pull/3641

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @saschagrunert @cpanato @Verolop 
cc @kubernetes/release-engineering 