### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.22.4 for active release branches

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -258,20 +258,20 @@ dependencies:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.21)"
-    version: v1.29.0-go1.21.11-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.22)"
+    version: v1.29.0-go1.22.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.21)"
-    version: v1.28.0-go1.21.11-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.28-cross1.22)"
+    version: v1.28.0-go1.22.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.21)"
-    version: v1.27.0-go1.21.11-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.27-cross1.22)"
+    version: v1.27.0-go1.22.4-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -337,7 +337,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.29)"
-    version: 1.21.11
+    version: 1.22.4
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -360,7 +360,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.28)"
-    version: 1.21.11
+    version: 1.22.4
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -377,7 +377,7 @@ dependencies:
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.27)"
-    version: 1.21.11
+    version: 1.22.4
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -5,12 +5,12 @@ variants:
   v1.30-cross1.22-bullseye:
     CONFIG: 'cross1.22'
     KUBE_CROSS_VERSION: 'v1.30.0-go1.22.4-bullseye.0'
-  v1.29-cross1.21-bullseye:
+  v1.29-cross1.22-bullseye:
     CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.21.11-bullseye.0'
-  v1.28-cross1.20-bullseye:
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.22.4-bullseye.0'
+  v1.28-cross1.22-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.28.0-go1.21.11-bullseye.0'
-  v1.27-cross1.20-bullseye:
+    KUBE_CROSS_VERSION: 'v1.28.0-go1.22.4-bullseye.0'
+  v1.27-cross1.22-bullseye:
     CONFIG: 'cross1.20'
-    KUBE_CROSS_VERSION: 'v1.27.0-go1.21.11-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.27.0-go1.22.4-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -17,13 +17,13 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: '1.21.11'
+    GO_VERSION: '1.22.4'
     OS_CODENAME: 'bullseye'
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: '1.21.11'
+    GO_VERSION: '1.22.4'
     OS_CODENAME: 'bullseye'
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: '1.21.11'
+    GO_VERSION: '1.22.4'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update k8s-cloud-builder and k8s-ci-builder to Go 1.22.4 for active release branches

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3280

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.22.4 for active release branches
```

/assign @saschagrunert @xmudrii 
cc @kubernetes/release-engineering 