### PR TITLE
build distroless-iptables with go1.23rc1

### DIFF
--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  distroless-bookworm-go1.23:
+    CONFIG: 'distroless-bookworm'
+    IMAGE_VERSION: 'v0.6.0'
+    BASEIMAGE: 'debian:bookworm-slim'
+    GORUNNER_VERSION: 'v2.3.1-go1.23rc1-bookworm.0'
   distroless-bookworm-go1.22:
     CONFIG: 'distroless-bookworm'
     IMAGE_VERSION: 'v0.5.6'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- build distroless-iptables with go1.23rc1

/assign @Verolop @saschagrunert @puerco 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3650


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build distroless-iptables with go1.23rc1
```
