### PR TITLE
Remove unnecessary `os.Exit` after `logrus.Fatal`

### DIFF
--- a/cmd/ci-reporter/main.go
+++ b/cmd/ci-reporter/main.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/release/cmd/ci-reporter/cmd"
@@ -27,6 +25,5 @@ import (
 func main() {
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatal(err)
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
`logrus.Fatal` already exists, so there is no need to do that twice.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
