### PR TITLE
Add sig labels to markdown

### DIFF
--- a/pkg/notes/maps/testdata/unit/maps.yaml
+++ b/pkg/notes/maps/testdata/unit/maps.yaml
@@ -48,3 +48,12 @@ datafields:
     - kubectl
     - apiserver
     name: "Modifying release note areas"
+---
+pr: 95000
+releasenote:
+  text: "This test string has been modified"
+datafields:
+  testcase:
+    property: "Markdown"
+    expected: "This test string has been modified (#95000, @arghya88) [SIG Instrumentation and Scheduling]"
+    name: "Modifying release note markdown"

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -478,7 +478,8 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result) (*ReleaseNote, error) {
 	authorURL := pr.GetUser().GetHTMLURL()
 	prURL := pr.GetHTMLURL()
 	isFeature := hasString(labelsWithPrefix(pr, "kind"), "feature")
-	noteSuffix := prettifySIGList(labelsWithPrefix(pr, "sig"))
+	sigLabels := labelsWithPrefix(pr, "sig")
+	noteSuffix := prettifySIGList(sigLabels)
 
 	isDuplicateSIG := false
 	if len(labelsWithPrefix(pr, "sig")) > 1 {
@@ -515,7 +516,7 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result) (*ReleaseNote, error) {
 		AuthorURL:      authorURL,
 		PrURL:          prURL,
 		PrNumber:       pr.GetNumber(),
-		SIGs:           labelsWithPrefix(pr, "sig"),
+		SIGs:           sigLabels,
 		Kinds:          labelsWithPrefix(pr, "kind"),
 		Areas:          labelsWithPrefix(pr, "area"),
 		Feature:        isFeature,
@@ -1223,6 +1224,11 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 		if markdownLinks {
 			markdown = fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
 				indented, rn.PrNumber, rn.PrURL, rn.Author, rn.AuthorURL)
+		}
+		// Add sig labels to markdown
+		if rn.SIGs != nil {
+			noteSuffix := prettifySIGList(rn.SIGs)
+			markdown = fmt.Sprintf("%s [%s]", markdown, noteSuffix)
 		}
 		// Uppercase the first character of the markdown to make it look uniform
 		rn.Markdown = capitalizeString(markdown)

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1227,8 +1227,7 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 		}
 		// Add sig labels to markdown
 		if rn.SIGs != nil {
-			noteSuffix := prettifySIGList(rn.SIGs)
-			markdown = fmt.Sprintf("%s [%s]", markdown, noteSuffix)
+			markdown = fmt.Sprintf("%s [%s]", markdown, prettifySIGList(rn.SIGs))
 		}
 		// Uppercase the first character of the markdown to make it look uniform
 		rn.Markdown = capitalizeString(markdown)

--- a/pkg/notes/notes_map_test.go
+++ b/pkg/notes/notes_map_test.go
@@ -46,7 +46,7 @@ func TestNewProviderFromInitString(t *testing.T) {
 func TestParseReleaseNotesMap(t *testing.T) {
 	maps, err := ParseReleaseNotesMap("maps/testdata/unit/maps.yaml")
 	require.Nil(t, err)
-	require.GreaterOrEqual(t, 5, len(*maps))
+	require.GreaterOrEqual(t, 6, len(*maps))
 
 	maps, err = ParseReleaseNotesMap("maps/testdata/fullmap.yaml")
 	require.Nil(t, err)
@@ -59,7 +59,7 @@ func TestGetMapsForPR(t *testing.T) {
 
 	maps, err := provider.GetMapsForPR(95000)
 	require.Nil(t, err)
-	require.GreaterOrEqual(t, 5, len(maps))
+	require.GreaterOrEqual(t, 6, len(maps))
 
 	maps, err = provider.GetMapsForPR(123)
 	require.Nil(t, err)

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -167,7 +167,8 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 	authorURL := pr.GetUser().GetHTMLURL()
 	prURL := pr.GetHTMLURL()
 	isFeature := hasString(labelsWithPrefix(pr, "kind"), "feature")
-	noteSuffix := prettifySIGList(labelsWithPrefix(pr, "sig"))
+	sigLabels := labelsWithPrefix(pr, "sig")
+	noteSuffix := prettifySIGList(sigLabels)
 
 	isDuplicateSIG := false
 	if len(labelsWithPrefix(pr, "sig")) > 1 {
@@ -204,7 +205,7 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 		AuthorURL:      authorURL,
 		PrURL:          prURL,
 		PrNumber:       pr.GetNumber(),
-		SIGs:           labelsWithPrefix(pr, "sig"),
+		SIGs:           sigLabels,
 		Kinds:          labelsWithPrefix(pr, "kind"),
 		Areas:          labelsWithPrefix(pr, "area"),
 		Feature:        isFeature,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Slack discussion: https://kubernetes.slack.com/archives/CN1KH4K9A/p1721224163843589 

#### Which issue(s) this PR fixes:
When the map file text is replaced, the resulting markdown does not include the SIG labels. See an example of this where the old release notes have the [sig labels removed](https://github.com/kubernetes/sig-release/pull/2561/files#r1681176858).

You can reproduce this by running with the latest krel:
```
go run ./cmd/krel release-notes --create-draft-pr --fork=npolshakova --fix --tag  v1.31.0-alpha.3 --list-v2 --log-level trace --repo=/Users/ninapolshakova/kubernetes/kubernetes
``` 

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?


```release-note
Edited release notes by the release notes team will now have the sig labels included at the end of the markdown.
```
