### PR TITLE
Add k8s-cloud-builder and k8s-ci-builder for Go 1.23rc2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.22.5
+    version: 1.23rc2
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -266,6 +266,13 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: REVISION:\ '\d+'
 
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.23)"
+    version: v1.31.0-go1.23rc2-bullseye.0
+    refPaths:
+    - path: images/k8s-cloud-builder/variants.yaml
+      match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  # TODO: remove this after upgrade to Go 1.23 is finalized and there's on risk of reverting
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.22)"
     version: v1.31.0-go1.22.5-bullseye.0
     refPaths:

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,8 @@
 variants:
+  v1.31-cross1.23-bullseye:
+    CONFIG: 'cross1.23'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.23rc2-bullseye.0'
+  # TODO: remove this after upgrade to Go 1.23 is finalized and there's on risk of reverting
   v1.31-cross1.22-bullseye:
     CONFIG: 'cross1.22'
     KUBE_CROSS_VERSION: 'v1.31.0-go1.22.5-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.22.5
+GO_VERSION ?= 1.23rc2
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -9,7 +9,7 @@ variants:
     OS_CODENAME: 'bookworm'
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: '1.22.5'
+    GO_VERSION: '1.23rc2'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR updates k8s-cloud-builder and k8s-ci-builder images to Go 1.23rc2.

I didn't remove k8s-cloud-builder for Kubernetes 1.31 based on Go 1.22 until we don't make a decision if we're releasing Kubernetes 1.31.0 with Go 1.23 (see https://github.com/kubernetes/kubernetes/issues/126299). I left TODOs to remove these variants once the decision is made.

#### Which issue(s) this PR fixes:

xref #3650 

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder and k8s-ci-builder images to Go 1.23rc2
```

/assign @saschagrunert @puerco @Verolop 
cc @kubernetes/release-engineering 