### PR TITLE
Switch to `conntrack-tools` as kubelet dependency for RPM's

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -23,14 +23,15 @@ Requires: {{ $dep.Name }} {{ $dep.VersionConstraint }}
 %if "%{_vendor}" == "debbuild"
 Requires: iproute2
 Requires: mount
+Requires: conntrack
 %else
 Requires: iproute
+Requires: conntrack-tools
 %endif
 Requires: socat
 Requires: util-linux
 Requires: ethtool
 Requires: ebtables
-Requires: conntrack
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires: systemd-deb-macros


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The alias `conntrack-tools` should be available for most RPM based distributions, including the mentioned (open)SUSE ones.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/3711
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switch to `conntrack-tools` as kubelet package dependency for RPM's.
```
