### PR TITLE
Build krel from sources when not using default `TOOL_*` values

### DIFF
--- a/gcb/fast-forward/cloudbuild.yaml
+++ b/gcb/fast-forward/cloudbuild.yaml
@@ -56,6 +56,9 @@ steps:
   dir: go/src/k8s.io/release
   env:
   - KREL_OUTPUT_PATH=/workspace/bin/krel
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
   args:
   - ./hack/get-krel
 

--- a/gcb/obs-release/cloudbuild.yaml
+++ b/gcb/obs-release/cloudbuild.yaml
@@ -56,6 +56,9 @@ steps:
   dir: go/src/k8s.io/release
   env:
   - KREL_OUTPUT_PATH=/workspace/bin/krel
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
   args:
   - ./hack/get-krel
 

--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -56,6 +56,9 @@ steps:
   dir: go/src/k8s.io/release
   env:
   - KREL_OUTPUT_PATH=/workspace/bin/krel
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
   args:
   - ./hack/get-krel
 

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -59,6 +59,9 @@ steps:
   dir: go/src/k8s.io/release
   env:
   - KREL_OUTPUT_PATH=/workspace/bin/krel
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
   args:
   - ./hack/get-krel
 

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -60,6 +60,9 @@ steps:
   dir: go/src/k8s.io/release
   env:
   - KREL_OUTPUT_PATH=/workspace/bin/krel
+  - "TOOL_ORG=${_TOOL_ORG}"
+  - "TOOL_REPO=${_TOOL_REPO}"
+  - "TOOL_REF=${_TOOL_REF}"
   args:
   - ./hack/get-krel
 

--- a/hack/get-krel
+++ b/hack/get-krel
@@ -22,17 +22,29 @@ curl_retry() {
     curl -sSfL --retry 5 --retry-delay 3 "$@"
 }
 
+DEFAULT_TOOL_ORG=kubernetes
+DEFAULT_TOOL_REPO=release
+DEFAULT_TOOL_REF=master
+
+TOOL_ORG=${TOOL_ORG:-${DEFAULT_TOOL_ORG}}
+TOOL_REPO=${TOOL_REPO:-${DEFAULT_TOOL_REPO}}
+TOOL_REF=${TOOL_REF:-${DEFAULT_TOOL_REF}}
 KREL_OUTPUT_PATH=${KREL_OUTPUT_PATH:-bin/krel}
 echo "Using output path: $KREL_OUTPUT_PATH"
 mkdir -p "$(dirname "$KREL_OUTPUT_PATH")"
 
-LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
-echo "Using krel release: $LATEST_RELEASE"
+if [[ "$TOOL_ORG" == "$DEFAULT_TOOL_ORG" && "$TOOL_REPO" == "$DEFAULT_TOOL_REPO" && "$TOOL_REF" == "$DEFAULT_TOOL_REF" ]]; then
+    LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
+    echo "Using krel release: $LATEST_RELEASE"
 
-echo "Downloading krel from GCB bucket…"
-GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
-curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
-chmod +x "$KREL_OUTPUT_PATH"
+    echo "Downloading krel from GCB bucket…"
+    GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
+    curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
+    chmod +x "$KREL_OUTPUT_PATH"
+else
+    echo "Building krel from sources"
+    go build -o "$KREL_OUTPUT_PATH" ./cmd/krel
+fi
 
 echo "Done, output of 'krel version':"
 "$KREL_OUTPUT_PATH" version


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This allos testing GCB by setting one of `TOOL_ORG`, `TOOL_REPO` or `TOOL_REF`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Follow-up on https://github.com/kubernetes/release/pull/3359
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
GCB: build `krel` from sources when not using default `TOOL_*` environment variables.
```
