### PR TITLE
Remove socat and ebtables dependencies from the kubelet package

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -28,10 +28,8 @@ Requires: conntrack
 Requires: iproute
 Requires: conntrack-tools
 %endif
-Requires: socat
 Requires: util-linux
 Requires: ethtool
-Requires: ebtables
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires: systemd-deb-macros


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As per https://github.com/kubernetes/release/issues/3707#issuecomment-2301800175 and https://github.com/kubernetes/kubernetes/pull/100679, the `socat` dependency is no longer required.

As per https://github.com/kubernetes/release/pull/3722#discussion_r1726792806, the `ebtables` dependency is no longer required.

This PR removes both dependencies from the kubelet package.

Given that this change is in effect since v1.22, I believe it's okay to just remove it from the spec file without adding special cases in `metadata.yaml`.

#### Which issue(s) this PR fixes:

Fixes #3707

#### Does this PR introduce a user-facing change?
```release-note
Remove `socat` and `ebtables` dependencies from the kubelet deb and rpm packages
```

/assign @saschagrunert
cc @kubernetes/release-engineering @aojea 
/hold
pending the final confirmation https://github.com/kubernetes/release/issues/3707#issuecomment-2304058940