### PR TITLE
rebuild debian-base - bump to bookworm-v1.0.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -420,7 +420,7 @@ dependencies:
       match: "OS_CODENAME: 'bookworm'"
 
   - name: "registry.k8s.io/build-image/debian-base"
-    version: bookworm-v1.0.3
+    version: bookworm-v1.0.4
     refPaths:
     - path: images/build/debian-base/Makefile
       match: IMAGE_VERSION\ \?=\ bookworm-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -473,20 +473,16 @@ dependencies:
 
   # Base images (next candidate)
   - name: "registry.k8s.io/build-image/debian-base (next candidate)"
-    version: bookworm-v1.0.3
+    version: bookworm-v1.0.4
     refPaths:
     - path: images/build/debian-base/variants.yaml
       match: "IMAGE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/debian-base: dependents (next candidate)"
+  - name: "registry.k8s.io/build-image/setcap (next candidate)"
     version: bookworm-v1.0.3
     refPaths:
     - path: images/build/setcap/variants.yaml
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
-  - name: "registry.k8s.io/build-image/setcap (next candidate)"
-    version: bookworm-v1.0.3
-    refPaths:
     - path: images/build/setcap/variants.yaml
       match: "IMAGE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,7 +19,7 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bookworm-v1.0.3
+IMAGE_VERSION ?= bookworm-v1.0.4
 CONFIG ?= bookworm
 
 TAR_FILE ?= rootfs.tar

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -1,4 +1,4 @@
 variants:
   bookworm:
     CONFIG: 'bookworm'
-    IMAGE_VERSION: 'bookworm-v1.0.3'
+    IMAGE_VERSION: 'bookworm-v1.0.4'


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

- rebuild debian-base - bump to bookworm-v1.0.4

/assign @saschagrunert @puerco @xmudrii 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
rebuild debian-base - bump to bookworm-v1.0.4
```
