### PR TITLE
Use production or test bucket when submitting GCB jobs

### DIFF
--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -284,12 +284,9 @@ func (g *GCB) Submit() error {
 	}
 
 	// build the GCS bucket string to be used to sign all the artifacts
-	bucketPrefix := release.BucketPrefix
-	gcsBucket := "gs://" + bucketPrefix
+	gcsBucket := "gs://" + release.TestBucket
 	if g.options.NoMock {
-		gcsBucket = strings.TrimSuffix(gcsBucket, "-")
-	} else {
-		gcsBucket = fmt.Sprintf("%s%s", gcsBucket, "gcb")
+		gcsBucket = strings.ReplaceAll(gcsBucket, release.TestBucket, release.ProductionBucket)
 	}
 
 	gcbSubs, gcbSubsErr := g.SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket)
@@ -321,14 +318,13 @@ func (g *GCB) Submit() error {
 		gcbSubs["NOMOCK_TAG"] = ""
 		gcbSubs["NOMOCK"] = ""
 
-		userBucket := fmt.Sprintf("%s%s", bucketPrefix, gcbSubs["GCP_USER_TAG"])
+		userBucket := strings.ReplaceAll(release.TestBucket, "gcb", gcbSubs["GCP_USER_TAG"])
 		userBucketSetErr := os.Setenv("USER_BUCKET", userBucket)
 		if userBucketSetErr != nil {
 			return userBucketSetErr
 		}
 
-		testBucket := fmt.Sprintf("%s%s", bucketPrefix, "gcb")
-		testBucketSetErr := os.Setenv("BUCKET", testBucket)
+		testBucketSetErr := os.Setenv("BUCKET", release.TestBucket)
 		if testBucketSetErr != nil {
 			return testBucketSetErr
 		}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -55,8 +55,6 @@ const (
 	DefaultRelengStagingTestProject = "k8s-staging-releng-test"
 	DefaultRelengStagingProject     = "k8s-staging-releng"
 	DefaultDiskSize                 = "500"
-	BucketPrefix                    = "kubernetes-release-"
-	BucketPrefixK8sInfra            = "k8s-release-"
 
 	versionReleaseRE   = `v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-?([a-zA-Z0-9]+\.(0|[1-9][0-9]*)\.)?`
 	versionBuildRE     = `([0-9]{1,})\+([0-9a-f]{5,40})`


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Avoid having a substitution and user bucket logic by just referring to the test or production bucket constants.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Only use production or test bucket when submitting GCB jobs.
```
