### PR TITLE
Remove ACL ownership change on release publish

### DIFF
--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -371,25 +371,6 @@ func (p *Publisher) PublishToGcs(
 
 	var content string
 	if !privateBucket {
-		// New Kubernetes infra buckets, like k8s-staging-kubernetes, have a
-		// bucket-only ACL policy set, which means attempting to set the ACL on
-		// an object will fail. We should skip this ACL change in those
-		// instances, as new buckets already default to being publicly
-		// readable.
-		//
-		// Ref:
-		// - https://cloud.google.com/storage/docs/bucket-policy-only
-		// - https://github.com/kubernetes/release/issues/904
-		if !strings.HasPrefix(markerPath, object.GcsPrefix+"k8s-") {
-			aclOutput, err := p.client.GSUtilOutput(
-				"acl", "ch", "-R", "-g", "all:R", publishFileDst,
-			)
-			if err != nil {
-				return fmt.Errorf("change %s permissions: %w", publishFileDst, err)
-			}
-			logrus.Infof("Making uploaded version file public: %s", aclOutput)
-		}
-
 		// If public, validate public link
 		response, err := p.client.GetURLResponse(publicLink)
 		if err != nil {


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Remove that ownership change which is not required for the new release bucket and others.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel release: removed ACL ownership change on release publish.
```
