### PR TITLE
Fix publish marker link replacement for production bucket

### DIFF
--- a/hack/get-krel
+++ b/hack/get-krel
@@ -33,18 +33,18 @@ KREL_OUTPUT_PATH=${KREL_OUTPUT_PATH:-bin/krel}
 echo "Using output path: $KREL_OUTPUT_PATH"
 mkdir -p "$(dirname "$KREL_OUTPUT_PATH")"
 
-if [[ "$TOOL_ORG" == "$DEFAULT_TOOL_ORG" && "$TOOL_REPO" == "$DEFAULT_TOOL_REPO" && "$TOOL_REF" == "$DEFAULT_TOOL_REF" ]]; then
-    LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
-    echo "Using krel release: $LATEST_RELEASE"
-
-    echo "Downloading krel from GCB bucket…"
-    GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
-    curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
-    chmod +x "$KREL_OUTPUT_PATH"
-else
-    echo "Building krel from sources"
-    go build -o "$KREL_OUTPUT_PATH" ./cmd/krel
-fi
+#if [[ "$TOOL_ORG" == "$DEFAULT_TOOL_ORG" && "$TOOL_REPO" == "$DEFAULT_TOOL_REPO" && "$TOOL_REF" == "$DEFAULT_TOOL_REF" ]]; then
+#    LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
+#    echo "Using krel release: $LATEST_RELEASE"
+#
+#    echo "Downloading krel from GCB bucket…"
+#    GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
+#    curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
+#    chmod +x "$KREL_OUTPUT_PATH"
+#else
+echo "Building krel from sources"
+go build -o "$KREL_OUTPUT_PATH" ./cmd/krel
+#fi
 
 echo "Done, output of 'krel version':"
 "$KREL_OUTPUT_PATH" version

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -341,10 +341,12 @@ func (p *Publisher) PublishToGcs(
 		return fmt.Errorf("get marker file destination: %w", publishFileDstErr)
 	}
 
+	logrus.Infof("Using marker path: %s", markerPath)
 	publicLink := fmt.Sprintf("%s/%s", URLPrefixForBucket(markerPath), publishFile)
-	if strings.HasPrefix(markerPath, ProductionBucket) {
-		publicLink = fmt.Sprintf("%s/%s", ProductionBucketURL, publishFile)
+	if strings.HasSuffix(markerPath, ProductionBucket+"/release") {
+		publicLink = fmt.Sprintf("%s/release/%s", ProductionBucketURL, publishFile)
 	}
+	logrus.Infof("Using public link: %s", publicLink)
 
 	uploadDir := filepath.Join(releaseStage, "upload")
 	if err := os.MkdirAll(uploadDir, os.FileMode(0o755)); err != nil {


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Fix publink marker link and always build krel from sources to avoid cutting a release after each PR.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed publish marker link replacement for production bucket.
```
