### PR TITLE
Add `FORCE_BUILD_KREL` GCB env var to build krel from sources

### DIFF
--- a/gcb/fast-forward/cloudbuild.yaml
+++ b/gcb/fast-forward/cloudbuild.yaml
@@ -59,6 +59,7 @@ steps:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
+  - "FORCE_BUILD_KREL=${_FORCE_BUILD_KREL}"
   args:
   - ./hack/get-krel
 

--- a/gcb/obs-release/cloudbuild.yaml
+++ b/gcb/obs-release/cloudbuild.yaml
@@ -59,6 +59,7 @@ steps:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
+  - "FORCE_BUILD_KREL=${_FORCE_BUILD_KREL}"
   args:
   - ./hack/get-krel
 

--- a/gcb/obs-stage/cloudbuild.yaml
+++ b/gcb/obs-stage/cloudbuild.yaml
@@ -59,6 +59,7 @@ steps:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
+  - "FORCE_BUILD_KREL=${_FORCE_BUILD_KREL}"
   args:
   - ./hack/get-krel
 

--- a/gcb/release/cloudbuild.yaml
+++ b/gcb/release/cloudbuild.yaml
@@ -62,6 +62,7 @@ steps:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
+  - "FORCE_BUILD_KREL=${_FORCE_BUILD_KREL}"
   args:
   - ./hack/get-krel
 

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -63,6 +63,7 @@ steps:
   - "TOOL_ORG=${_TOOL_ORG}"
   - "TOOL_REPO=${_TOOL_REPO}"
   - "TOOL_REF=${_TOOL_REF}"
+  - "FORCE_BUILD_KREL=${_FORCE_BUILD_KREL}"
   args:
   - ./hack/get-krel
 

--- a/hack/get-krel
+++ b/hack/get-krel
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 curl_retry() {
     curl -sSfL --retry 5 --retry-delay 3 "$@"
@@ -29,11 +30,18 @@ DEFAULT_TOOL_REF=master
 TOOL_ORG=${TOOL_ORG:-${DEFAULT_TOOL_ORG}}
 TOOL_REPO=${TOOL_REPO:-${DEFAULT_TOOL_REPO}}
 TOOL_REF=${TOOL_REF:-${DEFAULT_TOOL_REF}}
+
+FORCE_BUILD_KREL=${FORCE_BUILD_KREL:-false}
+
 KREL_OUTPUT_PATH=${KREL_OUTPUT_PATH:-bin/krel}
 echo "Using output path: $KREL_OUTPUT_PATH"
 mkdir -p "$(dirname "$KREL_OUTPUT_PATH")"
 
-if [[ "$TOOL_ORG" == "$DEFAULT_TOOL_ORG" && "$TOOL_REPO" == "$DEFAULT_TOOL_REPO" && "$TOOL_REF" == "$DEFAULT_TOOL_REF" ]]; then
+if [[ "$FORCE_BUILD_KREL" == false &&
+    "$TOOL_ORG" == "$DEFAULT_TOOL_ORG" &&
+    "$TOOL_REPO" == "$DEFAULT_TOOL_REPO" &&
+    "$TOOL_REF" == "$DEFAULT_TOOL_REF" ]]; then
+
     LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
     echo "Using krel release: $LATEST_RELEASE"
 

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -218,6 +218,7 @@ func (g *GCB) Submit() error {
 	toolOrg := release.GetToolOrg()
 	toolRepo := release.GetToolRepo()
 	toolRef := release.GetToolRef()
+	forceBuildKrel := release.GetForceBuildKrel()
 
 	if err := gcli.PreCheck(); err != nil {
 		return fmt.Errorf("pre-checking for GCP package usage: %w", err)
@@ -289,7 +290,7 @@ func (g *GCB) Submit() error {
 		gcsBucket = strings.ReplaceAll(gcsBucket, release.TestBucket, release.ProductionBucket)
 	}
 
-	gcbSubs, gcbSubsErr := g.SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket)
+	gcbSubs, gcbSubsErr := g.SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBuildKrel)
 	if gcbSubs == nil || gcbSubsErr != nil {
 		return gcbSubsErr
 	}
@@ -351,12 +352,13 @@ func (g *GCB) Submit() error {
 
 // SetGCBSubstitutions takes a set of `Options` and returns a map of GCB
 // substitutions.
-func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket string) (map[string]string, error) {
+func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBuildKrel string) (map[string]string, error) {
 	gcbSubs := map[string]string{}
 
 	gcbSubs["TOOL_ORG"] = toolOrg
 	gcbSubs["TOOL_REPO"] = toolRepo
 	gcbSubs["TOOL_REF"] = toolRef
+	gcbSubs["FORCE_BUILD_KREL"] = forceBuildKrel
 
 	gcbSubs["K8S_ORG"] = release.GetK8sOrg()
 	if g.options.CustomK8sOrg != "" {

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -157,15 +157,16 @@ func TestSubmitGcbFailure(t *testing.T) {
 
 func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 	testcases := []struct {
-		name        string
-		gcbOpts     *gcb.Options
-		toolOrg     string
-		toolRepo    string
-		toolRef     string
-		expected    map[string]string
-		repoMock    gcb.Repository
-		versionMock gcb.Version
-		releaseMock gcb.Release
+		name           string
+		gcbOpts        *gcb.Options
+		toolOrg        string
+		toolRepo       string
+		toolRef        string
+		forceBuildKrel string
+		expected       map[string]string
+		repoMock       gcb.Repository
+		versionMock    gcb.Version
+		releaseMock    gcb.Release
 	}{
 		{
 			name: "main branch alpha - stage",
@@ -183,6 +184,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "",
 				"TYPE":                   release.ReleaseTypeAlpha,
 				"TYPE_TAG":               release.ReleaseTypeAlpha,
 				"MAJOR_VERSION_TAG":      "1",
@@ -211,6 +213,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "",
 				"TYPE":                   release.ReleaseTypeBeta,
 				"TYPE_TAG":               release.ReleaseTypeBeta,
 				"MAJOR_VERSION_TAG":      "1",
@@ -239,6 +242,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -266,6 +270,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "",
 				"TYPE":                   release.ReleaseTypeOfficial,
 				"TYPE_TAG":               release.ReleaseTypeOfficial,
 				"MAJOR_VERSION_TAG":      "1",
@@ -285,12 +290,13 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				ReleaseType: release.ReleaseTypeOfficial,
 				GcpUser:     "test-user",
 			},
-			repoMock:    mockRepo(),
-			versionMock: mockVersion("v1.16.0"),
-			releaseMock: mockRelease("v1.16.0"),
-			toolOrg:     "honk",
-			toolRepo:    "best-tools",
-			toolRef:     "tool-branch",
+			repoMock:       mockRepo(),
+			versionMock:    mockVersion("v1.16.0"),
+			releaseMock:    mockRelease("v1.16.0"),
+			toolOrg:        "honk",
+			toolRepo:       "best-tools",
+			toolRef:        "tool-branch",
+			forceBuildKrel: "true",
 			expected: map[string]string{
 				"RELEASE_BRANCH":         "release-1.16",
 				"TOOL_ORG":               "honk",
@@ -298,6 +304,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_REF":               "tool-branch",
 				"TYPE":                   release.ReleaseTypeOfficial,
 				"TYPE_TAG":               release.ReleaseTypeOfficial,
+				"FORCE_BUILD_KREL":       "true",
 				"MAJOR_VERSION_TAG":      "1",
 				"MINOR_VERSION_TAG":      "16",
 				"PATCH_VERSION_TAG":      "0",
@@ -315,17 +322,19 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				ReleaseType: release.ReleaseTypeBeta,
 				GcpUser:     "test-user",
 			},
-			repoMock:    mockRepo(),
-			versionMock: mockVersion("v1.19.0-alpha.2.763+2da917d3701904"),
-			releaseMock: mockRelease("1.19.0-beta.0"),
-			toolOrg:     "honk",
-			toolRepo:    "best-tools",
-			toolRef:     "tool-branch",
+			repoMock:       mockRepo(),
+			versionMock:    mockVersion("v1.19.0-alpha.2.763+2da917d3701904"),
+			releaseMock:    mockRelease("1.19.0-beta.0"),
+			toolOrg:        "honk",
+			toolRepo:       "best-tools",
+			toolRef:        "tool-branch",
+			forceBuildKrel: "true",
 			expected: map[string]string{
 				"RELEASE_BRANCH":         "release-1.19",
 				"TOOL_ORG":               "honk",
 				"TOOL_REPO":              "best-tools",
 				"TOOL_REF":               "tool-branch",
+				"FORCE_BUILD_KREL":       "true",
 				"TYPE":                   release.ReleaseTypeBeta,
 				"TYPE_TAG":               release.ReleaseTypeBeta,
 				"MAJOR_VERSION_TAG":      "1",
@@ -345,14 +354,16 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				ReleaseType: release.ReleaseTypeRC,
 				GcpUser:     "test-user",
 			},
-			repoMock:    mockRepo(),
-			versionMock: mockVersion("v1.18.6-rc.0.15+e38139724f8f00"),
-			releaseMock: mockRelease("1.18.6-rc.1"),
+			repoMock:       mockRepo(),
+			versionMock:    mockVersion("v1.18.6-rc.0.15+e38139724f8f00"),
+			releaseMock:    mockRelease("1.18.6-rc.1"),
+			forceBuildKrel: "false",
 			expected: map[string]string{
 				"RELEASE_BRANCH":         "release-1.18",
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "false",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -380,6 +391,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"TOOL_ORG":               "",
 				"TOOL_REPO":              "",
 				"TOOL_REF":               "",
+				"FORCE_BUILD_KREL":       "",
 				"TYPE":                   release.ReleaseTypeRC,
 				"TYPE_TAG":               release.ReleaseTypeRC,
 				"MAJOR_VERSION_TAG":      "1",
@@ -402,7 +414,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 		sut.SetReleaseClient(tc.releaseMock)
 
 		subs, err := sut.SetGCBSubstitutions(
-			tc.toolOrg, tc.toolRepo, tc.toolRef, "gs://test-bucket",
+			tc.toolOrg, tc.toolRepo, tc.toolRef, "gs://test-bucket", tc.forceBuildKrel,
 		)
 		require.Nil(t, err)
 
@@ -449,7 +461,7 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 		sut := gcb.New(tc.gcbOpts)
 		sut.SetRepoClient(tc.repoMock)
 		sut.SetVersionClient(tc.versionMock)
-		_, err := sut.SetGCBSubstitutions("", "", "", "")
+		_, err := sut.SetGCBSubstitutions("", "", "", "", "")
 		require.Error(t, err)
 	}
 }

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -159,6 +159,13 @@ func GetToolRef() string {
 	return env.Default("TOOL_REF", DefaultToolRef)
 }
 
+// GetForceBuildKrel checks if the 'FORCE_BUILD_KREL' environment variable is
+// set.  If 'FORCE_BUILD_KREL' is non-empty, it returns the value. Otherwise,
+// it returns "false".
+func GetForceBuildKrel() string {
+	return env.Default("FORCE_BUILD_KREL", "false")
+}
+
 // GetK8sOrg checks if the 'K8S_ORG' environment variable is set.
 // If 'K8S_ORG' is non-empty, it returns the value. Otherwise, it returns DefaultK8sOrg.
 func GetK8sOrg() string {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows changing something in `master` and using that krel sources without having a need for a new release.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `FORCE_BUILD_KREL` GCB env var to build `krel` from sources if requested.
```
