### PR TITLE
schedule-builder: don't mention release name for upcoming

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -285,7 +285,7 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 		}
 
 		if refTime.After(upcomingTargetDate) {
-			logrus.Infof("Skipping outdated upcoming release for %s (%s)", upcomingRelease.Release, upcomingRelease.TargetDate)
+			logrus.Infof("Skipping outdated upcoming release for %s", upcomingRelease.TargetDate)
 			continue
 		}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Those releases usually have no single name referring to them, so we just use the date.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
This is just something optical to avoid log lines like:
```
INFO Skipping outdated upcoming release for  (2024-09-10)
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
schedule-builder: don't mention release name for upcoming releases since they don't have a single name.
```
