### PR TITLE
Fix empty release note parsing

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -627,13 +627,16 @@ func (l *commitList) List() []*gogithub.RepositoryCommit {
 // that do NOT contain release notes. Notably, this is all of the variations of
 // "release note none" that appear in the commit log.
 var noteExclusionFilters = []*regexp.Regexp{
-	// 'none','n/a','na' case insensitive with optional trailing
+	// 'none','n/a','na' case-insensitive with optional trailing
 	// whitespace, wrapped in ``` with/without release-note identifier
 	// the 'none','n/a','na' can also optionally be wrapped in quotes ' or "
 	regexp.MustCompile("(?i)```release-notes?\\s*('\")?(none|n/a|na)('\")?\\s*```"),
 
 	// simple '/release-note-none' tag
 	regexp.MustCompile("/release-note-none"),
+
+	// Matches "release-notes" block with no meaningful content (ex. only whitespace, empty, just newlines)
+	regexp.MustCompile("(?i)```release-notes?\\s*```\\s*"),
 }
 
 // MatchesExcludeFilter returns true if the string matches an excluded release note.

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -372,6 +372,16 @@ func (g *Gatherer) ListReleaseNotes() (*ReleaseNotes, error) {
 // may contain the commit message, the PR description, etc.
 // This is generally the content inside the ```release-note ``` stanza.
 func noteTextFromString(s string) (string, error) {
+	// check release note is not empty
+	// Matches "release-notes" block with no meaningful content (ex. only whitespace, empty, just newlines)
+	emptyExps := []*regexp.Regexp{
+		regexp.MustCompile("(?i)```release-notes?\\s*```\\s*"),
+	}
+
+	if matchesFilter(s, emptyExps) {
+		return "", errors.New("empty release note")
+	}
+
 	exps := []*regexp.Regexp{
 		// (?s) is needed for '.' to be matching on newlines, by default that's disabled
 		// we need to match ungreedy 'U', because after the notes a `docs` block can occur
@@ -634,9 +644,6 @@ var noteExclusionFilters = []*regexp.Regexp{
 
 	// simple '/release-note-none' tag
 	regexp.MustCompile("/release-note-none"),
-
-	// Matches "release-notes" block with no meaningful content (ex. only whitespace, empty, just newlines)
-	regexp.MustCompile("(?i)```release-notes?\\s*```\\s*"),
 }
 
 // MatchesExcludeFilter returns true if the string matches an excluded release note.

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -351,9 +351,11 @@ func TestGatherNotes(t *testing.T) {
 					{pullRequest(9, "release-note /release-note-none", "closed")},       // excluded, the exclusion filters take precedence
 					{pullRequest(10, "```release-note\nNAAAAAAAAAA\n```", "closed")},    // included, does not match the N/A filter, but the 'release-note' check
 					{pullRequest(11, "```release-note\nnone something\n```", "closed")}, // included, does not match the N/A filter, but the 'release-note' check
-					// empty release note block shouldn't be matched
+					// empty release note block should be excluded
 					{pullRequest(12, "```release-note\n\n```", "closed")},
-					{pullRequest(13, "```release-note\n\n```", "open")},
+					{pullRequest(13, "```release-note```", "closed")},
+					{pullRequest(13, "```release-note ```", "closed")},
+					{pullRequest(14, "```release-note\n\n```", "open")},
 				}
 				var callCount int64 = -1
 
@@ -369,7 +371,7 @@ func TestGatherNotes(t *testing.T) {
 			resultsChecker: func(t *testing.T, results []*Result) {
 				// there is not much we can check on the Result, as all the fields are
 				// unexported
-				expectedResultSize := 9
+				expectedResultSize := 12
 				if e, a := expectedResultSize, len(results); e != a {
 					t.Errorf("Expected the result to be of size %d, got %d", e, a)
 				}

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -351,11 +351,11 @@ func TestGatherNotes(t *testing.T) {
 					{pullRequest(9, "release-note /release-note-none", "closed")},       // excluded, the exclusion filters take precedence
 					{pullRequest(10, "```release-note\nNAAAAAAAAAA\n```", "closed")},    // included, does not match the N/A filter, but the 'release-note' check
 					{pullRequest(11, "```release-note\nnone something\n```", "closed")}, // included, does not match the N/A filter, but the 'release-note' check
-					// empty release note block should be excluded
+					// empty release note block should skipped because noteTextFromString returns an error
 					{pullRequest(12, "```release-note\n\n```", "closed")},
 					{pullRequest(13, "```release-note```", "closed")},
-					{pullRequest(13, "```release-note ```", "closed")},
-					{pullRequest(14, "```release-note\n\n```", "open")},
+					{pullRequest(14, "```release-note ```", "closed")},
+					{pullRequest(15, "```release-note\n\n```", "open")},
 				}
 				var callCount int64 = -1
 
@@ -371,7 +371,7 @@ func TestGatherNotes(t *testing.T) {
 			resultsChecker: func(t *testing.T, results []*Result) {
 				// there is not much we can check on the Result, as all the fields are
 				// unexported
-				expectedResultSize := 12
+				expectedResultSize := 9
 				if e, a := expectedResultSize, len(results); e != a {
 					t.Errorf("Expected the result to be of size %d, got %d", e, a)
 				}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -297,6 +297,16 @@ func TestNoteTextFromString(t *testing.T) {
 				require.Equal(t, "item\nitem\n- item\n  item", res)
 			},
 		},
+		{
+			noteBlock(
+				"",
+			),
+			func(res string, err error) {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "empty release note")
+				require.Equal(t, "", res)
+			},
+		},
 	} {
 		tc.expect(noteTextFromString(tc.input))
 	}
@@ -384,7 +394,7 @@ Please use the following format for linking documentation:
 ` + mdSep + `
 
 `,
-			shouldExclude: true,
+			shouldExclude: false, // noteTextFromString will catch empty release notes
 		},
 	} {
 		res := MatchesExcludeFilter(tc.input)

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -328,25 +328,63 @@ func TestMatchesExcludeFilter(t *testing.T) {
 			shouldExclude: false,
 		},
 		{
-			input: `@kubernetes/sig-auth-pr-reviews 
-/milestone v1.19
-/priority important-longterm
-/kind cleanup
-/kind deprecation
+			input: `@kubernetes/sig-auth-pr-reviews
+		/milestone v1.19
+		/priority important-longterm
+		/kind cleanup
+		/kind deprecation
+		
+		xref: #81126
+		xref: #81152
+		xref: https://github.com/kubernetes/website/pull/19630
+		
+		` + mdSep + `release-note
+		Action Required: Support for basic authentication via the --basic-auth-file flag has been removed.  Users should migrate to --token-auth-file for similar functionality.
+		` + mdSep + `
+		
+		` + mdSep + `docs
+		Removed "Static Password File" section from https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-password-file
+		https://github.com/kubernetes/website/pull/19630
+		` + mdSep,
+			shouldExclude: false,
+		},
+		{
+			input: `
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 
-xref: #81126
-xref: #81152
-xref: https://github.com/kubernetes/website/pull/19630
-
+For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
 ` + mdSep + `release-note
-Action Required: Support for basic authentication via the --basic-auth-file flag has been removed.  Users should migrate to --token-auth-file for similar functionality.
+
 ` + mdSep + `
 
+#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
+
+<!--
+This section can be blank if this pull request does not require a release note.
+
+When adding links which point to resources within git repositories, like
+KEPs or supporting documentation, please reference a specific commit and avoid
+linking directly to the master branch. This ensures that links reference a
+specific point in time, rather than a document that may change over time.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+
+Please use the following format for linking documentation:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
 ` + mdSep + `docs
-Removed "Static Password File" section from https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-password-file
-https://github.com/kubernetes/website/pull/19630
-` + mdSep,
-			shouldExclude: false,
+
+` + mdSep + `
+
+`,
+			shouldExclude: true,
 		},
 	} {
 		res := MatchesExcludeFilter(tc.input)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the empty release note parsing when an empty or whitespace-only release note is left on the PR description. 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3516

#### Special notes for your reviewer:

Release notes collection automation has resulted in incorrect text and markdown being collected: https://github.com/kubernetes/sig-release/pull/2449#discussion_r1521495247

You can see examples of this merged in sig-release for 1.30 due to past release notes collection:
- [PR 123082](https://github.com/kubernetes/kubernetes/pull/123082) 
- [PR 121413](https://github.com/kubernetes/kubernetes/pull/121413)
- [PR 122893](https://github.com/kubernetes/kubernetes/pull/122893)

Updated examples from 1.29 that are still in the repo after 1.30 was cleaned up:
- https://github.com/kubernetes/kubernetes/pull/119394, release notes [here](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/release-notes/release-notes-draft.json#L1265). 


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
