### PR TITLE
Add `krel push --repo-root` CLI flag

### DIFF
--- a/cmd/krel/cmd/push.go
+++ b/cmd/krel/cmd/push.go
@@ -97,10 +97,7 @@ func init() {
 		&pushBuildOpts.BuildDir,
 		"buildDir",
 		release.BuildDir,
-		fmt.Sprintf(
-			"Specify an alternate build directory (defaults to '%s')",
-			release.BuildDir,
-		),
+		"Specify an alternate build directory",
 	)
 
 	// TODO: Switch to "--registry" once CI no longer uses it
@@ -144,6 +141,13 @@ func init() {
 		"validate-images",
 		false,
 		"Validate that the remote image digests exists",
+	)
+
+	pushBuildCmd.PersistentFlags().StringVar(
+		&pushBuildOpts.RepoRoot,
+		"repo-root",
+		"",
+		"Specify an alternate Kubernetes repository directory",
 	)
 
 	rootCmd.AddCommand(pushBuildCmd)


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Adding the flag to allow setting the repository root on `krel push`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `krel push --repo-root` CLI flag.
```
