### PR TITLE
Use only public URLS for release notes index

### DIFF
--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -299,15 +299,9 @@ func TestPublishReleaseNotesIndex(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // failure NormalizePath 0
+		{ // failure NormalizePath
 			prepare: func(mock *releasefakes.FakePublisherClient) {
 				mock.NormalizePathReturnsOnCall(0, "", err)
-			},
-			shouldError: true,
-		},
-		{ // failure NormalizePath 1
-			prepare: func(mock *releasefakes.FakePublisherClient) {
-				mock.NormalizePathReturnsOnCall(1, "", err)
 			},
 			shouldError: true,
 		},
@@ -318,12 +312,12 @@ func TestPublishReleaseNotesIndex(t *testing.T) {
 		tc.prepare(clientMock)
 
 		err := sut.PublishReleaseNotesIndex(
-			"", "", "",
+			"gs://foo-bar/release", "gs://foo-bar/release/v1.2.3/index.json", "v1.2.3",
 		)
 		if tc.shouldError {
-			require.NotNil(t, err)
+			require.Error(t, err)
 		} else {
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 	}
 }

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -246,7 +246,8 @@ func GetWorkspaceVersion() (string, error) {
 func URLPrefixForBucket(bucket string) string {
 	bucket = strings.TrimPrefix(bucket, object.GcsPrefix)
 	urlPrefix := "https://storage.googleapis.com/" + bucket
-	if bucket == ProductionBucket {
+	const legacyBucket = "kubernetes-release"
+	if bucket == ProductionBucket || bucket == legacyBucket {
 		urlPrefix = ProductionBucketURL
 	}
 	return urlPrefix


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now switch over to use only the public urls for the index.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/3720
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
