### PR TITLE
Don't set `KUBE_PARALLEL_BUILD_MEMORY` any more

### DIFF
--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -85,12 +85,6 @@ func (m *Make) MakeCross(version string) error {
 		return fmt.Errorf("checking out version %s: %w", version, err)
 	}
 
-	// Unset the build memory requirement for parallel builds
-	// TODO: Remove this once the 1.20 release reaches EOL.
-	const buildMemoryKey = "KUBE_PARALLEL_BUILD_MEMORY"
-	logrus.Infof("Setting %s to force serial build", buildMemoryKey)
-	os.Setenv(buildMemoryKey, "32")
-
 	logrus.Info("Building binaries")
 	if err := m.impl.Command(
 		"make",


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
1.20 is EOL since quite some time so I assume we can just remove that part.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Don't set `KUBE_PARALLEL_BUILD_MEMORY` any more. 
```
