### PR TITLE
bump distroless-iptables to use go 1.22.8/1.23.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -436,7 +436,7 @@ dependencies:
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.23)"
-    version: v0.6.3
+    version: v0.6.4
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -444,7 +444,7 @@ dependencies:
       match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.23)"
-    version: v2.3.1-go1.23.1-bookworm.0
+    version: v2.3.1-go1.23.2-bookworm.0
     refPaths:
     - path: images/build/distroless-iptables/Makefile
       match: GORUNNER_VERSION \?= v\d+\.\d+\.\d+-go\d+.\d+(alpha|beta|rc)?\.?(\d+)?-bookworm\.\d+
@@ -452,13 +452,13 @@ dependencies:
       match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.22)"
-    version: v0.5.8
+    version: v0.5.9
     refPaths:
     - path: images/build/distroless-iptables/variants.yaml
       match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.22)"
-    version: v2.3.1-go1.22.7-bookworm.0
+    version: v2.3.1-go1.22.8-bookworm.0
     refPaths:
     - path: images/build/distroless-iptables/variants.yaml
       match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.6.3
+IMAGE_VERSION ?= v0.6.4
 CONFIG ?= distroless-bookworm
 BASEIMAGE ?= debian:bookworm-slim
-GORUNNER_VERSION ?= v2.3.1-go1.23.1-bookworm.0
+GORUNNER_VERSION ?= v2.3.1-go1.23.2-bookworm.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   distroless-bookworm-go1.23:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.6.3'
+    IMAGE_VERSION: 'v0.6.4'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.3.1-go1.23.1-bookworm.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.23.2-bookworm.0'
   distroless-bookworm-go1.22:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.5.8'
+    IMAGE_VERSION: 'v0.5.9'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.3.1-go1.22.7-bookworm.0'
+    GORUNNER_VERSION: 'v2.3.1-go1.22.8-bookworm.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- bump distroless-iptables to use go 1.23.2/1.22.8

#### Which issue(s) this PR fixes:

xref: #3778

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bump distroless-iptables to use go 1.23.2/1.22.8
```
