### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder for Kubernetes 1.32 to Go 1.23.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "golang: after kubernetes/kubernetes update"
-    version: 1.23.0
+    version: 1.23.2
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -247,7 +247,7 @@ dependencies:
       match: REVISION:\ '\d+'
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.32-cross1.23)"
-    version: v1.32.0-go1.23.0-bullseye.0
+    version: v1.32.0-go1.23.2-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.32-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.0-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.2-bullseye.0'
   v1.31-cross1.23-bullseye:
     CONFIG: 'cross1.23'
     KUBE_CROSS_VERSION: 'v1.31.0-go1.23.0-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,7 +24,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.23.0
+GO_VERSION ?= 1.23.2
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -5,11 +5,11 @@ variants:
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.23.0'
+    GO_VERSION: '1.23.2'
     OS_CODENAME: 'bookworm'
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: '1.23.0'
+    GO_VERSION: '1.23.2'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR updates k8s-cloud-builder and k8s-ci-builder used by Kubernetes 1.32 to Go 1.23.2. k8s-cloud-builder and k8s-ci-builder for other Kubernetes versions are left untouched at the moment, we'll handle those later as part of #3778.

#### Which issue(s) this PR fixes:

xref #3778 

#### Special notes for your reviewer:

There might be some inconsistencies in `dependencies.yaml`, but that appears to only affect release branches and not 1.32. I'll look into that when we get to update those two images for those branches.

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder and k8s-ci-builder for Kubernetes 1.32 to Go 1.23.2
```

/assign @cpanato @saschagrunert @jeremyrickard
cc @haitch 