### PR TITLE
Fix krel announcement --print-only

### DIFF
--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -131,7 +131,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 
 	if announceRootOpts.printOnly {
 		logrus.Infof("The email content is:")
-		fmt.Print(content)
+		fmt.Print(string(content))
 		return nil
 	}
 


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This corrects a bug that was causing the release announcement to be spit out as bytes.

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where `krel announce` would spit out the release announcement as the raw bytes
```
