### PR TITLE
Apply fix for release notes index JSON

### DIFF
--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -372,3 +372,31 @@ func TestIsUpToDate(t *testing.T) {
 		})
 	}
 }
+
+func TestFixPublicReleaseNotesURL(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		input, expected string
+	}{
+		"should not affect correct URL": {
+			input:    "https://dl.k8s.io/release/v1.32.0-beta.0/release-notes.json",
+			expected: "https://dl.k8s.io/release/v1.32.0-beta.0/release-notes.json",
+		},
+		"should fix wrong URL with 1 prefix": {
+			input:    "https://storage.googleapis.com/https://dl.k8s.io/release/v1.32.0-alpha.3/release-notes.json",
+			expected: "https://dl.k8s.io/release/v1.32.0-alpha.3/release-notes.json",
+		},
+		"should fix wrong URL with multiple prefixes": {
+			input:    "https://storage.googleapis.com/https://storage.googleapis.com/https://dl.k8s.io/release/v1.28.1/release-notes.json",
+			expected: "https://dl.k8s.io/release/v1.28.1/release-notes.json",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res := release.FixPublicReleaseNotesURL(tc.input)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The index JSON is broken right now and we should apply this patch to fix it. 
#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/3833

#### Special notes for your reviewer:
Refers to https://github.com/kubernetes-sigs/release-notes/issues/691
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed release notes index generation producing wrong URLs.
```
