### PR TITLE
Temporarily Run Builds Serially

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -78,6 +78,7 @@ steps:
   - "K8S_REPO=${_K8S_REPO}"
   - "K8S_REF=${_K8S_REF}"
   - GOOGLE_SERVICE_ACCOUNT_NAME=krel-staging@k8s-releng-prod.iam.gserviceaccount.com
+  - "KUBE_PARALLEL_BUILD_MEMORY=64"
   secretEnv:
   - GITHUB_TOKEN
   - DOCKERHUB_TOKEN


### PR DESCRIPTION

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This commit modifies the cloudbuild template to	run the builds serially.

This is just a temporary measure to finish the nov '24 builds while we investigate a memory spike.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
