### PR TITLE
Re-add production bucket fix to release notes index

### DIFF
--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -402,12 +402,10 @@ func (p *Publisher) PublishToGcs(
 	return nil
 }
 
-// TODO: remove this function once https://cdn.dl.k8s.io/release/release-notes-index.json
-// is fixed.
 func FixPublicReleaseNotesURL(gcsPath string) string {
-	const prefix = "https://storage.googleapis.com/"
-	for strings.HasPrefix(gcsPath, prefix) {
-		gcsPath = strings.TrimPrefix(gcsPath, prefix)
+	const prefix = "gs://" + ProductionBucket
+	if strings.HasPrefix(gcsPath, prefix) {
+		gcsPath = ProductionBucketURL + strings.TrimPrefix(gcsPath, prefix)
 	}
 	return gcsPath
 }

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -383,13 +383,9 @@ func TestFixPublicReleaseNotesURL(t *testing.T) {
 			input:    "https://dl.k8s.io/release/v1.32.0-beta.0/release-notes.json",
 			expected: "https://dl.k8s.io/release/v1.32.0-beta.0/release-notes.json",
 		},
-		"should fix wrong URL with 1 prefix": {
-			input:    "https://storage.googleapis.com/https://dl.k8s.io/release/v1.32.0-alpha.3/release-notes.json",
-			expected: "https://dl.k8s.io/release/v1.32.0-alpha.3/release-notes.json",
-		},
-		"should fix wrong URL with multiple prefixes": {
-			input:    "https://storage.googleapis.com/https://storage.googleapis.com/https://dl.k8s.io/release/v1.28.1/release-notes.json",
-			expected: "https://dl.k8s.io/release/v1.28.1/release-notes.json",
+		"should fix URL referring to production bucket": {
+			input:    "gs://767373bbdcb8270361b96548387bf2a9ad0d48758c35/release/v1.29.11/release-notes.json",
+			expected: "https://dl.k8s.io/release/v1.29.11/release-notes.json",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The index still contains entries referring to the production bucket after the recent patches:

```
> curl -sfL https://dl.k8s.io/release/release-notes-index.json | jq . | rg -v dl.k8s.io
{
  "v1.29.11": "gs://767373bbdcb8270361b96548387bf2a9ad0d48758c35/release/v1.29.11/release-notes.json",
  "v1.30.7": "gs://767373bbdcb8270361b96548387bf2a9ad0d48758c35/release/v1.30.7/release-notes.json",
  "v1.31.3": "gs://767373bbdcb8270361b96548387bf2a9ad0d48758c35/release/v1.31.3/release-notes.json",
}
```

We fix that by slightly modifying the existing function and the tests.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes/release/issues/3833
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed release notes index to not refer `gs://` links to the production bucket.
```
