### PR TITLE
add darwin/arm64 to kube-cross

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -36,7 +36,7 @@ ENV KUBE_CROSSPLATFORMS \
   linux/arm linux/arm64 \
   linux/ppc64le \
   linux/s390x \
-  darwin/amd64 \
+  darwin/amd64 darwin/arm64 \
   windows/amd64 windows/386
 
 ##------------------------------------------------------------


### PR DESCRIPTION
Should we build the M1 Macbook kube-cross?

```release-note
None
```