### PR TITLE
Update dependencies.yaml with Kubernetes v1.32

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -99,6 +99,8 @@ dependencies:
   # Example:
   # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
   # - v1.100-go1.17-bullseye.0 does not
+  #
+  # Update after the stable marker has been updated to stable.0
   - name: "Kubernetes version (stable.0)"
     version: v1.31.0
     refPaths:
@@ -107,6 +109,7 @@ dependencies:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  # Update after the stable marker has been updated to stable.0
   - name: "Kubernetes version (next candidate.0)"
     version: v1.32.0
     refPaths:
@@ -178,6 +181,28 @@ dependencies:
   #   refPaths:
   #   - path: images/build/cross/variants.yaml
   #     match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  # kube-cross (Kubernetes v1.32)
+  # To be updated before kubernetes/kubernetes update
+  - name: "registry.k8s.io/build-image/kube-cross (v1.32-go1.23)"
+    version: v1.32.0-go1.23.3-bullseye.0
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.32-go1.23)"
+    version: go1.23-bullseye
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.32-go1.23)"
+    version: 0
+    refPaths:
+    - path: images/build/cross/Makefile
+      match: REVISION \?= \d+
+    - path: images/build/cross/variants.yaml
+      match: REVISION:\ '\d+'
 
   # kube-cross (Kubernetes v1.31)
   # To be updated before kubernetes/kubernetes update
@@ -321,6 +346,13 @@ dependencies:
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
+  # Golang (previous release branch: 1.32)
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.32)"
+    version: 1.23.3
+    refPaths:
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.31)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.31)"


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This is documentation-only PR to add Kubernetes v1.32 to `dependencies.yaml`. All needed images appear to be already built.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @cpanato 
cc @kubernetes/release-engineering @mickeyboxell 