### PR TITLE
Create publishing-bot issue only for rc.0 release

### DIFF
--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -545,7 +545,10 @@ func (d *DefaultRelease) CreateAnnouncement() error {
 
 	// Check if we are releasing the initial rc release (eg 1.20.0-rc.0),
 	// and we are working on a release-M.m branch
-	if primeSemver.Patch == 0 && d.options.ReleaseType == release.ReleaseTypeRC &&
+	if primeSemver.Patch == 0 &&
+		len(primeSemver.Pre) == 2 &&
+		primeSemver.Pre[0].String() == "rc" &&
+		primeSemver.Pre[1].VersionNum == 0 &&
 		d.options.ReleaseBranch != git.DefaultBranch {
 		if d.options.NoMock {
 			// Create the publishing bot issue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The publishing-bot reminder issue is supposed to be created only when we cut the rc.0 release. At the moment, it's created for any pre-release rc release, i.e. `*.0-rc.*`.

e.g. https://github.com/kubernetes/sig-release/issues/2674 is a duplicate of https://github.com/kubernetes/sig-release/issues/2669

The logic in this PR has been based on https://github.com/kubernetes/release/blob/7aef8df9397b146e8727e6f3e67e72ad10f55c31/cmd/krel/cmd/release_notes.go#L841-L847

#### Does this PR introduce a user-facing change?
```release-note
Create the publishing-bot reminder issue only when cutting `*.0-rc.0` release
```

/assign @saschagrunert @cpanato @puerco @Verolop 
cc @kubernetes/release-engineering 