### PR TITLE
Fix link text in release note

### DIFF
--- a/pkg/announce/github/consts.go
+++ b/pkg/announce/github/consts.go
@@ -23,7 +23,7 @@ const ghPageBody = `{{ if .Substitutions.logo }}
 {{ end }}
 {{ .Substitutions.intro }}
 {{ if .Substitutions.changelog }}
-See [the CHANGELOG]({{ .Substitutions.changelog }}) for more details.
+See the [CHANGELOG]({{ .Substitutions.changelog }}) for more details.
 {{ end }}
 {{ if .Substitutions.ReleaseNotes }}
 ### Release Notes


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This fixes the link to the changelog spreading two words "[the changelog](link)" instead of one "the [changelog](link)"
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

If github release notes are considered userfacing, yes.

```release-note
Fix link text to Changelog
```