### PR TITLE
build go imagesd for k8s 1.33

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -111,7 +111,7 @@ dependencies:
 
   # Update after the stable marker has been updated to stable.0
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.32.0
+    version: v1.33.0
     refPaths:
     - path: images/build/cross/variants.yaml
       match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -181,6 +181,28 @@ dependencies:
   #   refPaths:
   #   - path: images/build/cross/variants.yaml
   #     match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  # kube-cross (Kubernetes v1.33)
+  # To be updated before kubernetes/kubernetes update
+  - name: "registry.k8s.io/build-image/kube-cross (v1.33-go1.23)"
+    version: v1.33.0-go1.23.4-bullseye.0
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.33-go1.23)"
+    version: go1.23-bullseye
+    refPaths:
+    - path: images/build/cross/variants.yaml
+      match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.33-go1.23)"
+    version: 0
+    refPaths:
+    - path: images/build/cross/Makefile
+      match: REVISION \?= \d+
+    - path: images/build/cross/variants.yaml
+      match: REVISION:\ '\d+'
 
   # kube-cross (Kubernetes v1.32)
   # To be updated before kubernetes/kubernetes update

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,4 +1,13 @@
 variants:
+  v1.33-go1.23-bullseye:
+    CONFIG: 'go1.23-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.33.0-go1.23.4-bullseye.0'
+    KUBERNETES_VERSION: 'v1.33.0'
+    GO_VERSION: '1.23.4'
+    GO_MAJOR_VERSION: '1.23'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   v1.32-go1.23-bullseye:
     CONFIG: 'go1.23-bullseye'
     TYPE: 'default'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- build go imagesd for k8s 1.33

forgot that one 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3848

/assign @saschagrunert @puerco @Verolop 
cc @kubernetes/release-managers 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build go imagesd for k8s 1.33
```
