### PR TITLE
add GO_VERSION_TOOLING to be able to build the release tooling with another go version

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -391,6 +391,47 @@ dependencies:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
+  # k8s-ci-builder
+  - name: "golang: releng tooling for k8s-ci-builder (master)"
+    version: 1.23.4
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
+  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.32)"
+    version: 1.23.4
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
+  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.31)"
+    version: 1.23.4
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
+  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.30)"
+    version: 1.23.4
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
+  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.29)"
+    version: 1.23.4
+    refPaths:
+    - path: images/releng/k8s-ci-builder/Makefile
+      match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+    - path: images/releng/k8s-ci-builder/variants.yaml
+      match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
   # golangci-lint-version
   - name: "golangci-lint"
     version: v1.62

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION
+ARG GO_VERSION_TOOLING
 ARG OS_CODENAME
 
 # The Release Tooling can be compiled with a different version of Go than the

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -15,9 +15,9 @@
 ARG GO_VERSION
 ARG OS_CODENAME
 
-# The Golang version for the builder image should always be explicitly set to
-# the Golang version of the kubernetes/kubernetes active development branch
-FROM golang:${GO_VERSION}-${OS_CODENAME} AS builder
+# The Release Tooling can be compiled with a different version of Go than the
+# the Go version used in the kubernetes/kubernetes active development branch.
+FROM golang:${GO_VERSION_TOOLING}-${OS_CODENAME} AS builder
 
 WORKDIR /go/src/k8s.io/release
 
@@ -33,7 +33,8 @@ FROM debian:${OS_CODENAME}
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
 
-# arg that specifies the go version to install
+# The Golang version for the builder image should always be explicitly set to
+# the Golang version of the kubernetes/kubernetes active development branch
 ARG GO_VERSION
 
 # arg that specifies docker-buildx version to install

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -25,10 +25,12 @@ TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
 GO_VERSION ?= 1.23.3
+GO_VERSION_TOOLING ?= 1.23.4
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \
+             --build-arg=GO_VERSION_TOOLING=$(GO_VERSION_TOOLING) \
              --build-arg=OS_CODENAME=$(OS_CODENAME) \
 			 --build-arg=IMAGE_ARG=$(IMAGE_ARG)
 

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -15,20 +15,20 @@ steps:
     entrypoint: 'bash'
     dir: ./images/releng/k8s-ci-builder
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - REGISTRY=$_REGISTRY
-    - IMAGE_ARG='$_REGISTRY/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
-    - HOME=/root
-    - TAG=${_GIT_TAG}
-    - PULL_BASE_REF=${_PULL_BASE_REF}
-    - CONFIG=${_CONFIG}
-    - GO_VERSION=${_GO_VERSION}
-    - OS_CODENAME=${_OS_CODENAME}
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - REGISTRY=$_REGISTRY
+      - IMAGE_ARG='$_REGISTRY/k8s-ci-builder:${_GIT_TAG}-${_CONFIG}'
+      - HOME=/root
+      - TAG=${_GIT_TAG}
+      - PULL_BASE_REF=${_PULL_BASE_REF}
+      - CONFIG=${_CONFIG}
+      - GO_VERSION=${_GO_VERSION}
+      - OS_CODENAME=${_OS_CODENAME}
     args:
-    - '-c'
-    - |
-      gcloud auth configure-docker \
-      && make push
+      - '-c'
+      - |
+        gcloud auth configure-docker \
+        && make push
 
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
@@ -37,16 +37,18 @@ substitutions:
   _PULL_BASE_REF: 'dev'
   _CONFIG: 'config'
   _GO_VERSION: '0.0.0'
+  _GO_VERSION_TOOLING: '0.0.0'
   _OS_CODENAME: 'codename'
   _REGISTRY: 'fake.repository/registry-name'
 
 tags:
-- 'k8s-ci-builder'
-- ${_GIT_TAG}
-- ${_PULL_BASE_REF}
-- ${_CONFIG}
-- ${_GO_VERSION}
-- ${_OS_CODENAME}
+  - 'k8s-ci-builder'
+  - ${_GIT_TAG}
+  - ${_PULL_BASE_REF}
+  - ${_CONFIG}
+  - ${_GO_VERSION}
+  - ${_GO_VERSION_TOOLING}
+  - ${_OS_CODENAME}
 
 images:
   - 'gcr.io/$PROJECT_ID/k8s-ci-builder:${_CONFIG}'

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -23,6 +23,7 @@ steps:
       - PULL_BASE_REF=${_PULL_BASE_REF}
       - CONFIG=${_CONFIG}
       - GO_VERSION=${_GO_VERSION}
+      - GO_VERSION_TOOLING=${_GO_VERSION_TOOLING}
       - OS_CODENAME=${_OS_CODENAME}
     args:
       - '-c'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -2,24 +2,30 @@ variants:
   default:
     CONFIG: default
     GO_VERSION: '1.22.9'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
     GO_VERSION: '1.23.3'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bookworm'
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: '1.23.3'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'
     GO_VERSION: '1.22.9'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
     GO_VERSION: '1.22.9'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bullseye'
   '1.29':
     CONFIG: '1.29'
     GO_VERSION: '1.22.9'
+    GO_VERSION_TOOLING: '1.23.4'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

/hold


Our K/Release repo is using Go1.23 and when we need to build the `images/releng/k8s-ci-builder` for older k/k release branches, like release-1.30 that uses go1.22 the image build fails because it needs Go1.23

```
 > [builder 4/4] RUN ./compile-release-tools:
#6 0.079 Setting up environment...
#6 0.084 Compiling default release tools...
#6 0.086 fatal: not a git repository (or any of the parent directories): .git
#6 0.091 go: go.mod requires go >= 1.23.3 (running go 1.22.9; GOTOOLCHAIN=local)
```

the proposed fix is to compile the release tooling with the Go needed and not be attached tot he Go that is used in k/k

Currently is breaking the updates, as we can see in https://github.com/kubernetes/release/pull/3872 / https://github.com/kubernetes/release/pull/3873

/assign @saschagrunert @Verolop @xmudrii 

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:



None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add GO_VERSION_TOOLING to be able to build the release tooling with another go version
```
