### PR TITLE
Enable `wsl` and `nlreturn` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
     - nakedret
     - nilerr
     - nilnesserr
+    - nlreturn
     - noctx
     - nolintlint
     - nosprintfhostport
@@ -102,6 +103,7 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
+    - wsl
     - zerologlint
     # - cyclop
     # - depguard
@@ -121,7 +123,6 @@ linters:
     # - mnd
     # - nestif
     # - nilnil
-    # - nlreturn
     # - nonamedreturns
     # - paralleltest
     # - tagliatelle
@@ -129,7 +130,6 @@ linters:
     # - thelper
     # - varnamelen
     # - wrapcheck
-    # - wsl
 linters-settings:
   gci:
     sections:

--- a/cmd/ci-reporter/cmd/testgrid.go
+++ b/cmd/ci-reporter/cmd/testgrid.go
@@ -60,7 +60,9 @@ func (r TestgridReporter) CollectReportData(ctx context.Context, cfg *Config) ([
 	if err != nil {
 		return nil, err
 	}
+
 	records := []*CIReportRecord{}
+
 	for dashboardName, jobData := range testgridReportData {
 		for jobName := range jobData {
 			jobSummary := jobData[jobName]
@@ -77,6 +79,7 @@ func (r TestgridReporter) CollectReportData(ctx context.Context, cfg *Config) ([
 			}
 		}
 	}
+
 	return records, nil
 }
 
@@ -89,17 +92,23 @@ func GetTestgridReportData(ctx context.Context, cfg Config) (testgrid.DashboardD
 			testgrid.DashboardName(fmt.Sprintf("sig-release-%s-informing", cfg.ReleaseVersion)),
 		}...)
 	}
+
 	dashboardData := testgrid.DashboardData{}
+
 	for i := range testgridDashboardNames {
 		d, err := testgrid.ReqTestgridDashboardSummary(ctx, testgridDashboardNames[i])
 		if err != nil {
 			if errors.Is(err, testgrid.ErrDashboardNotFound) {
 				logrus.Warn(fmt.Sprintf("%v for project board %s", err.Error(), testgridDashboardNames[i]))
+
 				continue
 			}
+
 			return nil, err
 		}
+
 		dashboardData[testgridDashboardNames[i]] = d
 	}
+
 	return dashboardData, nil
 }

--- a/cmd/gcbuilder/cmd/root.go
+++ b/cmd/gcbuilder/cmd/root.go
@@ -82,6 +82,7 @@ func run() error {
 	if len(buildErrors) != 0 {
 		logrus.Fatalf("Failed to run some build jobs: %v", buildErrors)
 	}
+
 	logrus.Info("Finished.")
 
 	return nil

--- a/cmd/krel/cmd/announce_build.go
+++ b/cmd/krel/cmd/announce_build.go
@@ -172,6 +172,7 @@ func runBuildBranchAnnounce(opts *buildBranchAnnounceOptions, buildOpts *buildAn
 	if err != nil {
 		return err
 	}
+
 	announcement := bytes.Buffer{}
 	if err := t.Execute(&announcement, struct {
 		Branch string
@@ -232,12 +233,14 @@ func (opts *buildAnnounceOptions) saveAnnouncement(announcement bytes.Buffer) er
 
 	absOutputPath := filepath.Join(opts.workDir, "announcement.html")
 	logrus.Infof("Writing HTML file to %s", absOutputPath)
+
 	err := os.WriteFile(absOutputPath, announcement.Bytes(), os.FileMode(0o644))
 	if err != nil {
 		return fmt.Errorf("saving announcement.html: %w", err)
 	}
 
 	logrus.Info("Kubernetes Announcement created.")
+
 	return nil
 }
 
@@ -248,6 +251,8 @@ func getGoVersion() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get go version: %w", err)
 	}
+
 	versionRegex := regexp.MustCompile(semVerRegex)
+
 	return versionRegex.FindString(strings.TrimSpace(cmdStatus.Output())), nil
 }

--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -113,6 +113,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 	if err := announceRootOpts.Validate(); err != nil {
 		return fmt.Errorf("validating announcement send options: %w", err)
 	}
+
 	logrus.Info("Retrieving release announcement from Google Cloud Bucket")
 
 	tag := util.AddTagPrefix(announceRootOpts.tag)
@@ -132,6 +133,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 	if announceRootOpts.printOnly {
 		logrus.Infof("The email content is:")
 		fmt.Print(string(content))
+
 		return nil
 	}
 
@@ -142,6 +144,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 	}
 
 	logrus.Info("Preparing mail sender")
+
 	m := mail.NewSender(opts.sendgridAPIKey)
 
 	if opts.name != "" && opts.email != "" {
@@ -150,6 +153,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 		}
 	} else {
 		logrus.Info("Retrieving default sender from sendgrid API")
+
 		if err := m.SetDefaultSender(); err != nil {
 			return fmt.Errorf("setting default sender: %w", err)
 		}
@@ -162,6 +166,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 			mail.KubernetesDevGoogleGroup,
 		}
 	}
+
 	logrus.Infof("Using Google Groups as announcement target: %v", groups)
 
 	if err := m.SetGoogleGroupRecipients(groups...); err != nil {
@@ -169,6 +174,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 	}
 
 	logrus.Info("Sending mail")
+
 	subject := fmt.Sprintf("Kubernetes %s is live!", tag)
 
 	yes := true

--- a/cmd/krel/cmd/changelog_test.go
+++ b/cmd/krel/cmd/changelog_test.go
@@ -72,6 +72,7 @@ func TestNewPatchRelease(t *testing.T) {
 	// Verify local results
 	fileContains(t, "CHANGELOG-1.25.html", patchReleaseExpectedHTML)
 	require.NoError(t, os.RemoveAll("CHANGELOG-1.25.html"))
+
 	for _, x := range []struct {
 		branch        string
 		commitMessage string
@@ -202,6 +203,7 @@ func TestNewMinorRelease(t *testing.T) {
 
 	fileContains(t, "CHANGELOG-1.21.html", minorReleaseExpectedHTML)
 	require.NoError(t, os.RemoveAll("CHANGELOG-1.21.html"))
+
 	for _, x := range []struct {
 		branch        string
 		commitMessage string

--- a/cmd/krel/cmd/ci_build.go
+++ b/cmd/krel/cmd/ci_build.go
@@ -58,7 +58,6 @@ var ciBuildCmd = &cobra.Command{
 
 func init() {
 	// Build options
-
 	ciBuildCmd.PersistentFlags().BoolVar(
 		&ciBuildOpts.Fast,
 		"fast",

--- a/cmd/krel/cmd/cve.go
+++ b/cmd/krel/cmd/cve.go
@@ -91,6 +91,7 @@ var argFunc = func(cmd *cobra.Command, args []string) error {
 	if err := cve.NewClient().CheckID(cveOpts.CVE); err != nil {
 		return fmt.Errorf("invalid CVE ID. Format must match %s", cve.CVEIDRegExp)
 	}
+
 	return nil
 }
 
@@ -124,6 +125,7 @@ func writeNewCVE(opts *cveOptions) (err error) {
 	}
 
 	kubeEditor := editor.NewDefaultEditor([]string{"KUBE_EDITOR", "EDITOR"})
+
 	changes, tempFilePath, err := kubeEditor.LaunchTempFile(
 		"cve-datamap-", ".yaml", bytes.NewReader(oldFile),
 	)
@@ -133,6 +135,7 @@ func writeNewCVE(opts *cveOptions) (err error) {
 
 	if bytes.Equal(changes, oldFile) || len(changes) == 0 {
 		logrus.Info("CVE information not modified")
+
 		return nil
 	}
 
@@ -150,12 +153,14 @@ func writeCVEFiles(opts *cveOptions) error {
 			return fmt.Errorf("writing map file %s: %w", mapFile, err)
 		}
 	}
+
 	return nil
 }
 
 // deleteCVE removes an existing map file.
 func deleteCVE(opts *cveOptions) (err error) {
 	client := cve.NewClient()
+
 	return client.Delete(opts.CVE)
 }
 
@@ -186,16 +191,19 @@ func editCVE(opts *cveOptions) (err error) {
 // in the user's default editor.
 func editExistingCVE(opts *cveOptions) (err error) {
 	client := cve.NewClient()
+
 	file, err := client.CopyToTemp(opts.CVE)
 	if err != nil {
 		return fmt.Errorf("copying CVE entry for edting: %w", err)
 	}
+
 	oldFile, err := os.ReadFile(file.Name())
 	if err != nil {
 		return fmt.Errorf("reading local copy of CVE entry: %w", err)
 	}
 
 	kubeEditor := editor.NewDefaultEditor([]string{"KUBE_EDITOR", "EDITOR"})
+
 	changes, tempFilePath, err := kubeEditor.LaunchTempFile(
 		"cve-datamap-", ".yaml", bytes.NewReader(oldFile),
 	)
@@ -205,6 +213,7 @@ func editExistingCVE(opts *cveOptions) (err error) {
 
 	if bytes.Equal(changes, oldFile) || len(changes) == 0 {
 		logrus.Info("CVE information not modified")
+
 		return nil
 	}
 

--- a/cmd/krel/cmd/ff.go
+++ b/cmd/krel/cmd/ff.go
@@ -71,6 +71,7 @@ Google Cloud Build job.
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ffOpts.NoMock = rootOpts.nomock
+
 		return fastforward.New(ffOpts).Run()
 	},
 }

--- a/cmd/krel/cmd/obs_release.go
+++ b/cmd/krel/cmd/obs_release.go
@@ -153,13 +153,16 @@ func init() {
 func runOBSRelease(options *obs.ReleaseOptions) error {
 	options.NoMock = rootOpts.nomock
 	obsRelease := obs.NewRelease(options)
+
 	if submitJob {
 		// Perform a local check of the specified options before launching a
 		// Cloud Build job:
 		if err := options.Validate(&obs.State{}, true); err != nil {
 			return fmt.Errorf("prechecking release options: %w", err)
 		}
+
 		return obsRelease.Submit(stream)
 	}
+
 	return obsRelease.Run()
 }

--- a/cmd/krel/cmd/obs_stage.go
+++ b/cmd/krel/cmd/obs_stage.go
@@ -217,13 +217,16 @@ func runOBSStage(options *obs.StageOptions) error {
 	}
 
 	stage := obs.NewStage(options)
+
 	if submitJob {
 		// Perform a local check of the specified options before launching a
 		// Cloud Build job:
 		if err := options.Validate(&obs.State{}, true); err != nil {
 			return fmt.Errorf("prechecking stage options: %w", err)
 		}
+
 		return stage.Submit(stream)
 	}
+
 	return stage.Run()
 }

--- a/cmd/krel/cmd/release.go
+++ b/cmd/krel/cmd/release.go
@@ -142,7 +142,9 @@ func runRelease(options *anago.ReleaseOptions) error {
 		if err := options.Validate(&anago.State{}); err != nil {
 			return fmt.Errorf("prechecking release options: %w", err)
 		}
+
 		return rel.Submit(stream)
 	}
+
 	return rel.Run()
 }

--- a/cmd/krel/cmd/stage.go
+++ b/cmd/krel/cmd/stage.go
@@ -137,13 +137,16 @@ func init() {
 func runStage(options *anago.StageOptions) error {
 	options.NoMock = rootOpts.nomock
 	stage := anago.NewStage(options)
+
 	if submitJob {
 		// Perform a local check of the specified options before launching a
 		// Cloud Build job:
 		if err := options.Validate(&anago.State{}); err != nil {
 			return fmt.Errorf("prechecking stage options: %w", err)
 		}
+
 		return stage.Submit(stream)
 	}
+
 	return stage.Run()
 }

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -58,7 +58,9 @@ func newSUT(t *testing.T) *sut {
 
 	// The bare repo which is the pseudo remote base
 	bareDir := filepath.Join(tempDir, "bare")
+
 	const url = "https://github.com/kubernetes/kubernetes"
+
 	if _, err := os.Stat(bareDir); os.IsNotExist(err) {
 		require.NoError(t,
 			command.New("git", "clone", "--bare", url, bareDir).RunSuccess(),
@@ -126,5 +128,6 @@ func (s *sut) lastCommit(t *testing.T, branch string) string {
 	res, err := command.NewWithWorkDir(s.repo.Dir(),
 		"git", "log", "-1", branch).RunSilentSuccessOutput()
 	require.NoError(t, err)
+
 	return res.OutputTrimNL()
 }

--- a/cmd/krel/cmd/testgrid.go
+++ b/cmd/krel/cmd/testgrid.go
@@ -112,22 +112,27 @@ func runTestGridShot(opts *TestGridOptions) error {
 	}
 
 	testgridJobs := []TestGridJob{}
+
 	for _, board := range opts.boards {
 		testGridDashboard := fmt.Sprintf("%s/sig-release-%s-%s/summary", opts.testgridURL, opts.branch, board)
+
 		content, err := http.NewAgent().WithTimeout(30 * time.Second).Get(testGridDashboard)
 		if err != nil {
 			return fmt.Errorf("unable to retrieve release announcement form url: %s: %w", testGridDashboard, err)
 		}
 
 		var result map[string]interface{}
+
 		err = json.Unmarshal(content, &result)
 		if err != nil {
 			return fmt.Errorf("unable unmarshal the testgrid response: %w", err)
 		}
 
 		testgridJobsTemp := []TestGridJob{}
+
 		for jobName, jobData := range result {
 			result := TestgridJobInfo{}
+
 			err = mapstructure.Decode(jobData, &result)
 			if err != nil {
 				return fmt.Errorf("decode testgrid data: %w", err)
@@ -143,6 +148,7 @@ func runTestGridShot(opts *TestGridOptions) error {
 				}
 			}
 		}
+
 		testgridJobs = append(testgridJobs, testgridJobsTemp...)
 	}
 
@@ -160,14 +166,17 @@ func generateIssueComment(testgridJobs []TestGridJob, opts *TestGridOptions) err
 	output = append(output, fmt.Sprintf("<!-- ----[ issue comment ]---- -->\n### Testgrid dashboards for %s\n", opts.branch))
 
 	timeNow := time.Now().UTC()
+
 	for _, state := range opts.states {
 		output = append(output, fmt.Sprintf("Boards checked for %s:", state))
 		for _, board := range opts.boards {
 			output = append(output, fmt.Sprintf("- [sig-release-%[1]s-%[2]s](%[3]s/sig-release-%[1]s-%[2]s)", opts.branch, board, opts.testgridURL))
 		}
+
 		output = append(output, "\n")
 
 		haveState := false
+
 		for _, job := range testgridJobs {
 			if state == job.Status {
 				output = append(output,
@@ -198,6 +207,7 @@ func generateIssueComment(testgridJobs []TestGridJob, opts *TestGridOptions) err
 		if err != nil {
 			return fmt.Errorf("creating the GitHub comment: %w", err)
 		}
+
 		logrus.Infof("Comment created in the GitHub Issue https://github.com/%s/%s/issues/%d. Thanks for using krel!", git.DefaultGithubOrg, k8sSigReleaseRepo, opts.gitHubIssue)
 	} else {
 		logrus.Info("Please copy the lines below and paste in the Github Issue for the Release cut. Thanks for using krel!")

--- a/cmd/krel/cmd/validate.go
+++ b/cmd/krel/cmd/validate.go
@@ -100,6 +100,7 @@ func runValidateReleaseNotes(releaseNotesPath string) (err error) {
 
 			fmt.Printf("YAML file %s is valid.\n", path)
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -107,6 +108,7 @@ func runValidateReleaseNotes(releaseNotesPath string) (err error) {
 	}
 
 	fmt.Println("All release notes are valid.")
+
 	return nil
 }
 
@@ -139,6 +141,7 @@ func ValidateYamlMap(filePath string) error {
 	}
 
 	fmt.Printf("File %s is valid YAML.\n", filePath)
+
 	return nil
 }
 

--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -187,15 +187,19 @@ func init() {
 
 func getAssetsFromStrings(assetStrings []string) ([]sbom.Asset, error) {
 	r := []sbom.Asset{}
+
 	var isBucket bool
 	for _, s := range assetStrings {
 		isBucket = false
+
 		if strings.HasPrefix(s, "gs:") {
 			s = strings.TrimPrefix(s, "gs:")
 			isBucket = true
 		}
+
 		parts := strings.Split(s, ":")
 		l := ""
+
 		if len(parts) > 1 {
 			l = parts[1]
 		}
@@ -205,8 +209,10 @@ func getAssetsFromStrings(assetStrings []string) ([]sbom.Asset, error) {
 			if err != nil {
 				return nil, fmt.Errorf("downloading remote asset: %w", err)
 			}
+
 			parts[0] = path
 		}
+
 		r = append(r, sbom.Asset{
 			Path:     filepath.Base(parts[0]),
 			ReadFrom: parts[0],
@@ -224,6 +230,7 @@ func processRemoteAsset(urlString string) (path string, err error) {
 	if err != nil {
 		return path, fmt.Errorf("parsing URL: %w", err)
 	}
+
 	if u.Scheme != "gs" {
 		return path, errors.New("only GCS objects are supported at this time")
 	}
@@ -234,10 +241,12 @@ func processRemoteAsset(urlString string) (path string, err error) {
 	}
 
 	ctx := context.Background()
+
 	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return path, fmt.Errorf("creating storage client: %w", err)
 	}
+
 	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
@@ -276,6 +285,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 	if err != nil {
 		return fmt.Errorf("getting assets: %w", err)
 	}
+
 	sbomStr := ""
 	if opts.sbom {
 		// Generate the assets file
@@ -290,6 +300,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 		if err != nil {
 			return fmt.Errorf("generating sbom: %w", err)
 		}
+
 		opts.assets = append(opts.assets, sbomStr+":SPDX Software Bill of Materials (SBOM)")
 		// Delete the temporary sbom  when we're done
 		if commandLineOpts.nomock {

--- a/cmd/publish-release/cmd/github_test.go
+++ b/cmd/publish-release/cmd/github_test.go
@@ -27,6 +27,7 @@ import (
 func TestProcessRemoteAsset(t *testing.T) {
 	// Remove the fefault app creds temporarily
 	const gacVar = "GOOGLE_APPLICATION_CREDENTIALS"
+
 	prev := os.Getenv(gacVar)
 	defer t.Setenv(gacVar, prev)
 	t.Setenv(gacVar, "")
@@ -37,6 +38,7 @@ func TestProcessRemoteAsset(t *testing.T) {
 			os.RemoveAll(f)
 		}
 	}()
+
 	path, err := processRemoteAsset("gs://kubernetes-release/release/v1.25.1/kubernetes.tar.gz.sha512")
 	require.NoError(t, err)
 	require.FileExists(t, path)

--- a/cmd/release-notes/check.go
+++ b/cmd/release-notes/check.go
@@ -56,6 +56,7 @@ func (o *checkPROptions) ValidateAndFinish() error {
 	for _, n := range o.PullRequests {
 		if n == 0 {
 			prNrErr = errors.New("invalid pull request number (must be an integer larger than 0)")
+
 			break
 		}
 	}
@@ -176,6 +177,7 @@ To generate release notes from these blocks, use release-notes generate.
 
 			if len(errs) > 0 {
 				fmt.Fprintf(os.Stderr, "\nError Checking Release Notes:\n\n"+pullRequestGuidance)
+
 				return errors.Join(errs...)
 			}
 

--- a/cmd/release-notes/check_test.go
+++ b/cmd/release-notes/check_test.go
@@ -27,6 +27,7 @@ import (
 func TestPROptsValidateAndFinish(t *testing.T) {
 	testOrg := "testOrg"
 	testRepo := "testRepo"
+
 	for _, tc := range []struct {
 		name    string
 		sut     checkPROptions

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -88,6 +88,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 			if err := output.Truncate(0); err != nil {
 				return err
 			}
+
 			if _, err := output.Seek(0, 0); err != nil {
 				return err
 			}
@@ -102,6 +103,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
+
 		if err := enc.Encode(releaseNotes.ByPR()); err != nil {
 			return fmt.Errorf("encoding JSON output: %w", err)
 		}
@@ -117,17 +119,20 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 		}
 
 		const nl = "\n"
+
 		if releaseNotesOpts.dependencies {
 			if opts.StartSHA == opts.EndSHA {
 				logrus.Info("Skipping dependency report because start and end SHA are the same")
 			} else {
 				url := git.GetRepoURL(opts.GithubOrg, opts.GithubRepo, false)
+
 				deps, err := notes.NewDependencies().ChangesForURL(
 					url, opts.StartSHA, opts.EndSHA,
 				)
 				if err != nil {
 					return fmt.Errorf("generating dependency report: %w", err)
 				}
+
 				markdown += strings.Repeat(nl, 2) + deps
 			}
 		}
@@ -141,6 +146,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 			if err != nil {
 				return fmt.Errorf("generating table of contents: %w", err)
 			}
+
 			markdown = toc + nl + markdown
 		}
 
@@ -150,6 +156,7 @@ func WriteReleaseNotes(releaseNotes *notes.ReleaseNotes) (err error) {
 	}
 
 	logrus.Infof("Release notes written to file: %s", output.Name())
+
 	return nil
 }
 
@@ -171,6 +178,7 @@ func hackDefaultSubcommand(cmd *cobra.Command) {
 	}
 
 	logrus.Warn("No subcommand specified, running \"generate\" ")
+
 	os.Args = append([]string{os.Args[0], "generate"}, os.Args[1:]...)
 }
 

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -465,6 +465,7 @@ func TestUpdatePatchSchedule(t *testing.T) {
 
 			scheduleYamlBytes, err := os.ReadFile(scheduleFile.Name())
 			require.NoError(t, err)
+
 			patchRes := PatchSchedule{}
 			require.NoError(t, yaml.UnmarshalStrict(scheduleYamlBytes, &patchRes))
 
@@ -472,6 +473,7 @@ func TestUpdatePatchSchedule(t *testing.T) {
 
 			eolYamlBytes, err := os.ReadFile(eolFile.Name())
 			require.NoError(t, err)
+
 			eolRes := EolBranches{}
 			require.NoError(t, yaml.UnmarshalStrict(eolYamlBytes, &eolRes))
 

--- a/cmd/schedule-builder/cmd/root.go
+++ b/cmd/schedule-builder/cmd/root.go
@@ -139,6 +139,7 @@ func run(opts *options) error {
 	if opts.version {
 		info := version.GetVersionInfo()
 		fmt.Print(info.String())
+
 		return nil
 	}
 
@@ -147,6 +148,7 @@ func run(opts *options) error {
 	}
 
 	logrus.Infof("Reading schedule file: %s", opts.configPath)
+
 	data, err := os.ReadFile(opts.configPath)
 	if err != nil {
 		return fmt.Errorf("failed to read the file: %w", err)
@@ -180,6 +182,7 @@ func run(opts *options) error {
 
 		if opts.update {
 			logrus.Info("Updating schedule")
+
 			if err := updatePatchSchedule(
 				time.Now(),
 				patchSchedule,
@@ -191,6 +194,7 @@ func run(opts *options) error {
 			}
 		} else {
 			logrus.Infof("Generating markdown output for type %q", typePatch)
+
 			scheduleOut = parsePatchSchedule(patchSchedule)
 			println(scheduleOut)
 		}
@@ -201,6 +205,7 @@ func run(opts *options) error {
 		}
 
 		logrus.Infof("Generating markdown output for type %q", typeRelease)
+
 		scheduleOut = parseReleaseSchedule(releaseSchedule)
 		println(scheduleOut)
 
@@ -215,6 +220,7 @@ func run(opts *options) error {
 		if err := os.WriteFile(opts.outputFile, []byte(scheduleOut), 0o644); err != nil {
 			return fmt.Errorf("failed to save schedule to the file: %w", err)
 		}
+
 		logrus.Info("File saved")
 	}
 

--- a/gcb/gcb.go
+++ b/gcb/gcb.go
@@ -69,6 +69,7 @@ func (c *CloudBuild) DirForJobType(jobType string) (string, error) {
 	}
 
 	var content []byte
+
 	switch jobType {
 	case JobTypeStage:
 		content = stageCloudBuild

--- a/gcb/gcb_test.go
+++ b/gcb/gcb_test.go
@@ -33,6 +33,7 @@ func TestDirForJobType(t *testing.T) {
 	t.Parallel()
 
 	const testDir = "testDir"
+
 	errTest := errors.New("test")
 
 	for _, tc := range []struct {
@@ -48,6 +49,7 @@ func TestDirForJobType(t *testing.T) {
 				mock.WriteFileCalls(func(name string, content []byte, mode fs.FileMode) error {
 					assert.Contains(t, string(content), "- STAGE")
 					assert.Equal(t, filepath.Join(testDir, build.DefaultCloudbuildFile), name)
+
 					return nil
 				})
 			},
@@ -64,6 +66,7 @@ func TestDirForJobType(t *testing.T) {
 				mock.WriteFileCalls(func(name string, content []byte, mode fs.FileMode) error {
 					assert.Contains(t, string(content), "- RELEASE")
 					assert.Equal(t, filepath.Join(testDir, build.DefaultCloudbuildFile), name)
+
 					return nil
 				})
 			},
@@ -80,6 +83,7 @@ func TestDirForJobType(t *testing.T) {
 				mock.WriteFileCalls(func(name string, content []byte, mode fs.FileMode) error {
 					assert.Contains(t, string(content), "- FAST_FORWARD")
 					assert.Equal(t, filepath.Join(testDir, build.DefaultCloudbuildFile), name)
+
 					return nil
 				})
 			},
@@ -96,6 +100,7 @@ func TestDirForJobType(t *testing.T) {
 				mock.WriteFileCalls(func(name string, content []byte, mode fs.FileMode) error {
 					assert.Contains(t, string(content), "- OBS_STAGE")
 					assert.Equal(t, filepath.Join(testDir, build.DefaultCloudbuildFile), name)
+
 					return nil
 				})
 			},
@@ -112,6 +117,7 @@ func TestDirForJobType(t *testing.T) {
 				mock.WriteFileCalls(func(name string, content []byte, mode fs.FileMode) error {
 					assert.Contains(t, string(content), "- OBS_RELEASE")
 					assert.Equal(t, filepath.Join(testDir, build.DefaultCloudbuildFile), name)
+
 					return nil
 				})
 			},

--- a/pkg/anago/anago.go
+++ b/pkg/anago/anago.go
@@ -120,6 +120,7 @@ func (o *Options) ValidateBuildVersion(state *State) error {
 	if err != nil {
 		return fmt.Errorf("checking for a valid build version: %w", err)
 	}
+
 	if !correct {
 		return errors.New("invalid BuildVersion specified")
 	}
@@ -128,7 +129,9 @@ func (o *Options) ValidateBuildVersion(state *State) error {
 	if err != nil {
 		return fmt.Errorf("invalid build version: %s: %w", o.BuildVersion, err)
 	}
+
 	state.semverBuildVersion = semverBuildVersion
+
 	return nil
 }
 
@@ -137,6 +140,7 @@ func (o *Options) Bucket() string {
 	if o.NoMock {
 		return release.ProductionBucket
 	}
+
 	return release.TestBucket
 }
 
@@ -145,6 +149,7 @@ func (o *Options) ContainerRegistry() string {
 	if o.NoMock {
 		return release.GCRIOPathStaging
 	}
+
 	return release.GCRIOPathMock
 }
 
@@ -249,9 +254,11 @@ func (s *Stage) SetClient(client stageClient) {
 // Submit can be used to submit a staging Google Cloud Build (GCB) job.
 func (s *Stage) Submit(stream bool) error {
 	logrus.Info("Submitting stage GCB job")
+
 	if err := s.client.Submit(stream); err != nil {
 		return fmt.Errorf("submit stage job: %w", err)
 	}
+
 	return nil
 }
 
@@ -269,61 +276,73 @@ func (s *Stage) Run() error {
 	logger.Infof("Using krel version: %s", v.GitVersion)
 
 	logger.WithStep().Info("Validating options")
+
 	if err := s.client.ValidateOptions(); err != nil {
 		return fmt.Errorf("validate options: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
+
 	if err := s.client.CheckPrerequisites(); err != nil {
 		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
+
 	if err := s.client.CheckReleaseBranchState(); err != nil {
 		return fmt.Errorf("check release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
+
 	if err := s.client.GenerateReleaseVersion(); err != nil {
 		return fmt.Errorf("generate release version: %w", err)
 	}
 
 	logger.WithStep().Info("Preparing workspace")
+
 	if err := s.client.PrepareWorkspace(); err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
 
 	logger.WithStep().Info("Tagging repository")
+
 	if err := s.client.TagRepository(); err != nil {
 		return fmt.Errorf("tag repository: %w", err)
 	}
 
 	logger.WithStep().Info("Building release")
+
 	if err := s.client.Build(); err != nil {
 		return fmt.Errorf("build release: %w", err)
 	}
 
 	logger.WithStep().Info("Generating changelog")
+
 	if err := s.client.GenerateChangelog(); err != nil {
 		return fmt.Errorf("generate changelog: %w", err)
 	}
 
 	logger.WithStep().Info("Verifying artifacts")
+
 	if err := s.client.VerifyArtifacts(); err != nil {
 		return fmt.Errorf("verifying artifacts: %w", err)
 	}
 
 	logger.WithStep().Info("Generating bill of materials")
+
 	if err := s.client.GenerateBillOfMaterials(); err != nil {
 		return fmt.Errorf("generating sbom: %w", err)
 	}
 
 	logger.WithStep().Info("Staging artifacts")
+
 	if err := s.client.StageArtifacts(); err != nil {
 		return fmt.Errorf("stage release artifacts: %w", err)
 	}
 
 	logger.Info("Stage done")
+
 	return nil
 }
 
@@ -361,9 +380,11 @@ func (r *ReleaseOptions) Validate(state *State) error {
 	if err := r.Options.Validate(); err != nil {
 		return fmt.Errorf("validating generic options: %w", err)
 	}
+
 	if err := r.Options.ValidateBuildVersion(state); err != nil {
 		return fmt.Errorf("validating build version: %w", err)
 	}
+
 	return nil
 }
 
@@ -385,9 +406,11 @@ func (r *Release) SetClient(client releaseClient) {
 // Submit can be used to submit a releasing Google Cloud Build (GCB) job.
 func (r *Release) Submit(stream bool) error {
 	logrus.Info("Submitting release GCB job")
+
 	if err := r.client.Submit(stream); err != nil {
 		return fmt.Errorf("submit release job: %w", err)
 	}
+
 	return nil
 }
 
@@ -404,31 +427,37 @@ func (r *Release) Run() error {
 	logger.Infof("Using krel version: %s", v.GitVersion)
 
 	logger.WithStep().Info("Validating options")
+
 	if err := r.client.ValidateOptions(); err != nil {
 		return fmt.Errorf("validate options: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
+
 	if err := r.client.CheckPrerequisites(); err != nil {
 		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
+
 	if err := r.client.CheckReleaseBranchState(); err != nil {
 		return fmt.Errorf("check release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
+
 	if err := r.client.GenerateReleaseVersion(); err != nil {
 		return fmt.Errorf("generate release version: %w", err)
 	}
 
 	logger.WithStep().Info("Preparing workspace")
+
 	if err := r.client.PrepareWorkspace(); err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
 
 	logger.WithStep().Info("Checking artifacts provenance")
+
 	if err := r.client.CheckProvenance(); err != nil {
 		// For now, we only notify provenance errors as not to treat
 		// them as fatal while we finish testing SLSA compliance.
@@ -436,25 +465,30 @@ func (r *Release) Run() error {
 	}
 
 	logger.WithStep().Info("Creating announcement")
+
 	if err := r.client.CreateAnnouncement(); err != nil {
 		return fmt.Errorf("create announcement: %w", err)
 	}
 
 	logger.WithStep().Info("Pushing artifacts")
+
 	if err := r.client.PushArtifacts(); err != nil {
 		return fmt.Errorf("push artifacts: %w", err)
 	}
 
 	logger.WithStep().Info("Pushing git objects")
+
 	if err := r.client.PushGitObjects(); err != nil {
 		return fmt.Errorf("push git objects: %w", err)
 	}
 
 	logger.WithStep().Info("Updating GitHub release page")
+
 	if err := r.client.UpdateGitHubPage(); err != nil {
 		return fmt.Errorf("updating github page: %w", err)
 	}
 
 	logger.Info("Release done")
+
 	return nil
 }

--- a/pkg/anago/anago_test.go
+++ b/pkg/anago/anago_test.go
@@ -276,6 +276,7 @@ func TestValidateBuildVersion(t *testing.T) {
 		},
 	} {
 		state := anago.DefaultState()
+
 		err := tc.provided.ValidateBuildVersion(state)
 		if tc.shouldError {
 			require.Error(t, err)
@@ -321,6 +322,7 @@ func TestStagingOptionsValidate(t *testing.T) {
 		},
 	} {
 		state := anago.DefaultState()
+
 		err := tc.provided.Validate(state)
 		if tc.shouldError {
 			require.Error(t, err)

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -187,6 +187,7 @@ func (d *defaultReleaseImpl) PrepareWorkspaceRelease(
 	); err != nil {
 		return err
 	}
+
 	return os.Chdir(gitRoot)
 }
 
@@ -235,6 +236,7 @@ func (d *DefaultRelease) Submit(stream bool) error {
 	options.Branch = d.options.ReleaseBranch
 	options.ReleaseType = d.options.ReleaseType
 	options.BuildVersion = d.options.BuildVersion
+
 	return d.impl.Submit(options)
 }
 
@@ -246,12 +248,15 @@ func (d *DefaultRelease) InitLogFile() error {
 	logrus.SetFormatter(
 		&logrus.TextFormatter{FullTimestamp: true, ForceColors: true},
 	)
+
 	logFile := filepath.Join(os.TempDir(), "release.log")
 	if err := d.impl.ToFile(logFile); err != nil {
 		return fmt.Errorf("setup log file: %w", err)
 	}
+
 	d.state.logFile = logFile
 	logrus.Infof("Additionally logging to file %s", d.state.logFile)
+
 	return nil
 }
 
@@ -280,6 +285,7 @@ func (d *defaultReleaseImpl) PushMainBranch(pusher *release.GitObjectPusher) err
 	if err := pusher.PushMain(); err != nil {
 		return fmt.Errorf("pushing changes in main branch: %w", err)
 	}
+
 	return nil
 }
 
@@ -315,6 +321,7 @@ func (d *defaultReleaseImpl) NewGitPusher(
 	if err != nil {
 		return nil, fmt.Errorf("creating new git object pusher: %w", err)
 	}
+
 	return pusher, nil
 }
 
@@ -322,6 +329,7 @@ func (d *DefaultRelease) ValidateOptions() error {
 	if err := d.options.Validate(d.state.State); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
+
 	return nil
 }
 
@@ -338,7 +346,9 @@ func (d *DefaultRelease) CheckReleaseBranchState() error {
 	if err != nil {
 		return fmt.Errorf("check if release branch needs creation: %w", err)
 	}
+
 	d.state.createReleaseBranch = createReleaseBranch
+
 	return nil
 }
 
@@ -354,6 +364,7 @@ func (d *DefaultRelease) GenerateReleaseVersion() error {
 	}
 	// Set the versions object in the state
 	d.state.versions = versions
+
 	return nil
 }
 
@@ -363,6 +374,7 @@ func (d *DefaultRelease) PrepareWorkspace() error {
 	); err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
+
 	return nil
 }
 
@@ -376,6 +388,7 @@ func (d *DefaultRelease) PushArtifacts() error {
 		)
 		bucket := d.options.Bucket()
 		containerRegistry := d.options.ContainerRegistry()
+
 		pushBuildOptions := &build.Options{
 			Bucket:                     bucket,
 			BuildDir:                   buildDir,
@@ -418,8 +431,10 @@ func (d *DefaultRelease) PushArtifacts() error {
 	}
 
 	logrus.Info("Publishing release notes JSON and announcement")
+
 	objStore := object.NewGCS()
 	objStore.SetOptions(objStore.WithNoClobber(false))
+
 	gcsReleaseRootPath, err := d.impl.NormalizePath(
 		objStore, d.options.Bucket(), gcsRoot,
 	)
@@ -457,6 +472,7 @@ func (d *DefaultRelease) PushArtifacts() error {
 	}
 
 	logrus.Info("Publishing updated release notes index")
+
 	if err := d.impl.PublishReleaseNotesIndex(
 		gcsReleaseRootPath, gcsReleaseNotesPath, d.state.versions.Prime(),
 	); err != nil {
@@ -510,6 +526,7 @@ func (d *DefaultRelease) PushGitObjects() error {
 		"Git objects push complete (%d branches, %d tags & main branch)",
 		len(d.state.versions.Ordered()), len(branchList),
 	)
+
 	return nil
 }
 
@@ -567,6 +584,7 @@ func (d *DefaultRelease) CreateAnnouncement() error {
 	if d.options.NoMock {
 		args += " --nomock"
 	}
+
 	args += " --tag=" + d.state.versions.Prime()
 
 	logrus.Infof(
@@ -606,6 +624,7 @@ func (d *DefaultRelease) UpdateGitHubPage() error {
 	if err := d.impl.UpdateGitHubPage(ghPageOpts); err != nil {
 		return fmt.Errorf("updating GitHub release page: %w", err)
 	}
+
 	return nil
 }
 

--- a/pkg/anago/release_test.go
+++ b/pkg/anago/release_test.go
@@ -36,6 +36,7 @@ func generateTestingReleaseState(params *testStateParameters) *anago.ReleaseStat
 	if params.createReleaseBranch != nil {
 		state.SetCreateReleaseBranch(*params.createReleaseBranch)
 	}
+
 	return state
 }
 
@@ -287,6 +288,7 @@ func TestPrepareWorkspaceRelease(t *testing.T) {
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.PrepareWorkspace()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -317,6 +319,7 @@ func TestSubmitReleaseImpl(t *testing.T) {
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.Submit(false)
 		if tc.shouldError {
 			require.Error(t, err)
@@ -347,9 +350,11 @@ func TestCreateAnnouncement(t *testing.T) {
 		sut.SetState(
 			generateTestingReleaseState(&testStateParameters{versionsTag: &testVersionTag}),
 		)
+
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.CreateAnnouncement()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -398,9 +403,11 @@ func TestPushGitObjects(t *testing.T) {
 		sut.SetState(
 			generateTestingReleaseState(&testStateParameters{versionsTag: &testVersionTag}),
 		)
+
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.PushGitObjects()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -431,9 +438,11 @@ func TestUpdateGitHubPage(t *testing.T) {
 		sut.SetState(
 			generateTestingReleaseState(&testStateParameters{versionsTag: &testVersionTag}),
 		)
+
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.UpdateGitHubPage()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -464,9 +473,11 @@ func TestCheckProvenance(t *testing.T) {
 		sut.SetState(
 			generateTestingReleaseState(&testStateParameters{versionsTag: &testVersionTag}),
 		)
+
 		mock := &anagofakes.FakeReleaseImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.CheckProvenance()
 		if tc.shouldError {
 			require.Error(t, err)

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -41,6 +41,7 @@ func generateTestingStageState(params *testStateParameters) *anago.StageState {
 	if params.createReleaseBranch != nil {
 		state.SetCreateReleaseBranch(*params.createReleaseBranch)
 	}
+
 	return state
 }
 
@@ -184,6 +185,7 @@ func TestGenerateReleaseVersionStage(t *testing.T) {
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.GenerateReleaseVersion()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -219,6 +221,7 @@ func TestPrepareWorkspaceStage(t *testing.T) {
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.PrepareWorkspace()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -235,6 +238,7 @@ func TestTagRepository(t *testing.T) {
 	newBetaVersions := release.NewReleaseVersions(
 		"v1.20.0-beta.1", "", "", "v1.20.0-beta.1", "",
 	)
+
 	for _, tc := range []struct {
 		prepare             func(*anagofakes.FakeStageImpl)
 		versions            *release.Versions
@@ -593,6 +597,7 @@ func TestSubmitStageImpl(t *testing.T) {
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.Submit(false)
 		if tc.shouldError {
 			require.Error(t, err)
@@ -686,9 +691,11 @@ func TestGenerateBillOfMaterials(t *testing.T) {
 		sut.SetState(
 			generateTestingStageState(&testStateParameters{versionsTag: &testVersionTag}),
 		)
+
 		mock := &anagofakes.FakeStageImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.GenerateBillOfMaterials()
 		if tc.shouldError {
 			require.Error(t, err)
@@ -724,6 +731,7 @@ func TestVerifyArtifactsImpl(t *testing.T) {
 				&testStateParameters{versionsTag: &testVersionTag},
 			),
 		)
+
 		err := sut.VerifyArtifacts()
 		if tc.shouldError {
 			require.Error(t, err)

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -96,6 +96,7 @@ func (a *Announce) CreateForBranch() error {
 	// creating an issue for them (see anago)
 
 	logrus.Infof("Branch announcement created")
+
 	return nil
 }
 
@@ -110,9 +111,11 @@ func (a *Announce) CreateForRelease() error {
 		if err != nil {
 			return fmt.Errorf("reading changelog html file: %w", err)
 		}
+
 		if len(changelogData) == 0 {
 			return fmt.Errorf("verifying that changelog html file '%s' is not empty", a.options.changelogFile)
 		}
+
 		changelog = string(changelogData)
 	}
 
@@ -122,13 +125,16 @@ func (a *Announce) CreateForRelease() error {
 	}
 
 	logrus.Infof("Trying to get the Go version used to build %s...", a.options.tag)
+
 	goVersion, err := a.impl.GetGoVersion(a.options.tag)
 	if err != nil {
 		return err
 	}
+
 	if goVersion == "" {
 		return errors.New("verifying Go version is not empty")
 	}
+
 	logrus.Infof("Found the following Go version: %s", goVersion)
 
 	if err := a.impl.Create(
@@ -143,5 +149,6 @@ func (a *Announce) CreateForRelease() error {
 	}
 
 	logrus.Infof("Release announcement created")
+
 	return nil
 }

--- a/pkg/announce/github/impl.go
+++ b/pkg/announce/github/impl.go
@@ -82,6 +82,7 @@ func (i *defaultImpl) processAssetFiles(assetFiles []string) (releaseAssets []ma
 
 		releaseAssets = append(releaseAssets, assetData)
 	}
+
 	return releaseAssets, nil
 }
 

--- a/pkg/announce/github/options.go
+++ b/pkg/announce/github/options.go
@@ -80,9 +80,11 @@ func (o *Options) Validate() error {
 	if o.Tag == "" {
 		return errors.New("cannot update github page without a tag")
 	}
+
 	if o.Repo == "" {
 		return errors.New("cannot update github page, repository not defined")
 	}
+
 	if o.Owner == "" {
 		return errors.New("cannot update github page, github organization not defined")
 	}
@@ -94,13 +96,16 @@ func (o *Options) Validate() error {
 // for the template and parses it as Substitutions in the options.
 func (o *Options) ParseSubstitutions(subs []string) error {
 	o.Substitutions = map[string]string{}
+
 	for _, sString := range subs {
 		p := strings.SplitN(sString, ":", 2)
 		if len(p) != 2 || p[0] == "" {
 			return errors.New("substitution value not well formed: " + sString)
 		}
+
 		o.Substitutions[p[0]] = p[1]
 	}
+
 	return nil
 }
 
@@ -111,8 +116,10 @@ func (o *Options) SetRepository(repoSlug string) error {
 	if err != nil {
 		return fmt.Errorf("parsing repository slug: %w", err)
 	}
+
 	o.Owner = org
 	o.Repo = repo
+
 	return nil
 }
 
@@ -122,6 +129,7 @@ func (o *Options) ReadTemplate(templatePath string) error {
 	// If path is empty, no custom template will be used
 	if templatePath == "" {
 		o.PageTemplate = ""
+
 		return nil
 	}
 
@@ -130,7 +138,10 @@ func (o *Options) ReadTemplate(templatePath string) error {
 	if err != nil {
 		return fmt.Errorf("reading page template text: %w", err)
 	}
+
 	logrus.Infof("Using custom template from %s", templatePath)
+
 	o.PageTemplate = string(templateData)
+
 	return nil
 }

--- a/pkg/announce/impl.go
+++ b/pkg/announce/impl.go
@@ -56,6 +56,7 @@ func (i *defaultImpl) Create(workDir, message string) error {
 			err,
 		)
 	}
+
 	logrus.Debugf("Wrote file %s", announcementFile)
 
 	return nil
@@ -73,6 +74,7 @@ func (i *defaultImpl) GetGoVersion(tag string) (string, error) {
 
 	branch := fmt.Sprintf("release-%d.%d", semver.Major, semver.Minor)
 	kc := kubecross.New()
+
 	kubecrossVer, err := kc.ForBranch(branch)
 	if err != nil {
 		kubecrossVer, err = kc.Latest()
@@ -91,6 +93,7 @@ func (i *defaultImpl) GetGoVersion(tag string) (string, error) {
 	}
 
 	versionRegex := regexp.MustCompile(`^?(\d+)(\.\d+)?(\.\d+)`)
+
 	return versionRegex.FindString(strings.TrimSpace(res.OutputTrimNL())), nil
 }
 

--- a/pkg/announce/options.go
+++ b/pkg/announce/options.go
@@ -42,30 +42,36 @@ func NewOptions() *Options {
 
 func (o *Options) WithWorkDir(workDir string) *Options {
 	o.workDir = workDir
+
 	return o
 }
 
 func (o *Options) WithTag(tag string) *Options {
 	o.tag = tag
+
 	return o
 }
 
 func (o *Options) WithBranch(branch string) *Options {
 	o.branch = branch
+
 	return o
 }
 
 func (o *Options) WithChangelogPath(changelogPath string) *Options {
 	o.changelogPath = changelogPath
+
 	return o
 }
 
 func (o *Options) WithChangelogHTML(changelogHTML string) *Options {
 	o.changelogHTML = changelogHTML
+
 	return o
 }
 
 func (o *Options) WithChangelogFile(changelogFile string) *Options {
 	o.changelogFile = changelogFile
+
 	return o
 }

--- a/pkg/announce/sbom/sbom.go
+++ b/pkg/announce/sbom/sbom.go
@@ -52,6 +52,7 @@ func (s *SBOM) Generate() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("setting up temporary file for SBOM: %w", err)
 	}
+
 	logrus.Infof("SBOM will be temporarily written to %s", sbomFile)
 
 	builder := s.impl.docBuilder()
@@ -73,19 +74,24 @@ func (s *SBOM) Generate() (string, error) {
 	for t := range doc.Packages {
 		doc.Packages[t].Version = s.options.Tag
 		doc.Packages[t].DownloadLocation = "git+" + github.GitHubURL + s.options.Repo + "@" + s.options.Tag
+
 		break
 	}
 
 	// List all artifacts and add them
 	spdxClient := s.impl.spdxClient()
+
 	for _, f := range s.options.Assets {
 		logrus.Infof("Adding file %s to SBOM", f.Path)
+
 		spdxFile, err := spdxClient.FileFromPath(f.ReadFrom)
 		if err != nil {
 			return "", fmt.Errorf("adding %s to SBOM: %w", f.ReadFrom, err)
 		}
+
 		spdxFile.Name = f.Path
 		spdxFile.BuildID() // This is a boog in the spdx pkg, we have to call manually
+
 		spdxFile.DownloadLocation = github.GitHubURL + filepath.Join(
 			s.options.Repo, assetDownloadPath, s.options.Tag, f.Path,
 		)
@@ -95,6 +101,7 @@ func (s *SBOM) Generate() (string, error) {
 	}
 
 	var renderer serialize.Serializer
+
 	switch s.options.Format {
 	case FormatJSON:
 		renderer = &serialize.JSON{}

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -64,8 +64,10 @@ func NewWithOptions(filePath string, opts *Options) (bin *Binary, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting arch implementation: %w", err)
 	}
+
 	bin.options.Path = filePath
 	bin.SetImplementation(impl)
+
 	return bin, nil
 }
 
@@ -77,6 +79,7 @@ func getArchImplementation(filePath string, opts *Options) (impl binaryImplement
 	if err != nil {
 		return nil, fmt.Errorf("checking if file is an ELF binary: %w", err)
 	}
+
 	if elf != nil {
 		return elf, nil
 	}
@@ -86,6 +89,7 @@ func getArchImplementation(filePath string, opts *Options) (impl binaryImplement
 	if err != nil {
 		return nil, fmt.Errorf("checking if file is a Mach-O binary: %w", err)
 	}
+
 	if macho != nil {
 		return macho, nil
 	}
@@ -95,11 +99,13 @@ func getArchImplementation(filePath string, opts *Options) (impl binaryImplement
 	if err != nil {
 		return nil, fmt.Errorf("checking if file is a windows PE binary: %w", err)
 	}
+
 	if pe != nil {
 		return pe, nil
 	}
 
 	logrus.Warnf("File is not a known executable: %s", filePath)
+
 	return nil, errors.New("file is not an executable or is an unknown format")
 }
 
@@ -156,7 +162,9 @@ func (b *Binary) ContainsStrings(s ...string) (match bool, err error) {
 	if err != nil {
 		return match, fmt.Errorf("opening binary to search: %w", err)
 	}
+
 	defer f.Close()
+
 	terms := map[string]bool{}
 	for _, s := range s {
 		terms[s] = true
@@ -172,6 +180,7 @@ func (b *Binary) ContainsStrings(s ...string) (match bool, err error) {
 			if !errors.Is(err, io.EOF) {
 				return match, fmt.Errorf("while reading binary data: %w", err)
 			}
+
 			return false, nil
 		}
 		// If the char is not printable, we assume the string ended
@@ -179,11 +188,14 @@ func (b *Binary) ContainsStrings(s ...string) (match bool, err error) {
 		if !unicode.IsPrint(r) {
 			delete(terms, string(runes))
 			runes = []rune{}
+
 			if len(terms) == 0 {
 				return true, nil
 			}
+
 			continue
 		}
+
 		runes = append(runes, r)
 	}
 }

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -111,6 +111,7 @@ func writeTestBinary(t *testing.T, base64Data string) *os.File {
 func TestOS(t *testing.T) {
 	mock := &binaryfakes.FakeBinaryImplementation{}
 	mock.OSReturns("darwin")
+
 	sut := &binary.Binary{}
 	sut.SetImplementation(mock)
 
@@ -120,6 +121,7 @@ func TestOS(t *testing.T) {
 func TestArch(t *testing.T) {
 	mock := &binaryfakes.FakeBinaryImplementation{}
 	mock.ArchReturns("amd64")
+
 	sut := &binary.Binary{}
 	sut.SetImplementation(mock)
 
@@ -132,6 +134,7 @@ func TestGetELFHeader(t *testing.T) {
 		header, err := binary.GetELFHeader(f.Name())
 		os.Remove(f.Name())
 		require.NoError(t, err)
+
 		if testBin.OS == "linux" {
 			require.NotNil(t, header)
 			require.Equal(t, testBin.Bits, header.WordLength())
@@ -147,6 +150,7 @@ func TestGetMachOHeader(t *testing.T) {
 		header, err := binary.GetMachOHeader(f.Name())
 		os.Remove(f.Name())
 		require.NoError(t, err)
+
 		if testBin.OS == "darwin" {
 			require.NotNil(t, header)
 			require.Equal(t, testBin.Bits, header.WordLength())
@@ -162,6 +166,7 @@ func TestGetPEHeader(t *testing.T) {
 		header, err := binary.GetPEHeader(f.Name())
 		os.Remove(f.Name())
 		require.NoError(t, err)
+
 		if testBin.OS == "windows" {
 			require.NotNil(t, header, "testing binary for %s/%s", testBin.OS, testBin.Arch)
 			require.Equal(t, testBin.Bits, header.WordLength())

--- a/pkg/binary/elf.go
+++ b/pkg/binary/elf.go
@@ -52,8 +52,10 @@ func NewELFBinary(filePath string, opts *Options) (*ELFBinary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("while trying to get ELF header from file: %w", err)
 	}
+
 	if header == nil {
 		logrus.Debug("file is not an ELF binary")
+
 		return nil, nil
 	}
 
@@ -73,10 +75,13 @@ func (eh *ELFHeader) WordLength() int {
 	if eh.WordFlag == 1 {
 		return 32
 	}
+
 	if eh.WordFlag == 2 {
 		return 64
 	}
+
 	logrus.Warn("Cannot determine if ELF binary is 32 or 64 bit")
+
 	return 0
 }
 
@@ -114,7 +119,9 @@ func (eh *ELFHeader) MachineType() string {
 	case 0xF3:
 		return consts.ArchitectureRISCV
 	}
+
 	logrus.Warn("Unknown machine type in elf binary")
+
 	return "arch unknown"
 }
 
@@ -129,6 +136,7 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 	// Read the first 20 bytes of the binary, just enough of the
 	// header for us to get the info we need:
 	reader := bufio.NewReader(f)
+
 	hBytes, err := reader.Peek(6)
 	if err != nil {
 		return nil, fmt.Errorf("reading the binary header: %w", err)
@@ -139,11 +147,13 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 	// Check we're dealing with an elf binary:
 	if string(hBytes[1:4]) != "ELF" {
 		logrus.Debug("Binary is not an ELF executable")
+
 		return nil, nil
 	}
 
 	// Check if binary byte order is big or little endian
 	var endianness binary.ByteOrder
+
 	switch hBytes[5] {
 	case 1:
 		endianness = binary.LittleEndian
@@ -156,12 +166,15 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 	}
 
 	header := &ELFHeader{}
+
 	if _, err := f.Seek(4, 0); err != nil {
 		return nil, fmt.Errorf("seeking past the ELF magic bytes: %w", err)
 	}
+
 	if err := binary.Read(f, endianness, header); err != nil {
 		return nil, fmt.Errorf("reading elf header from binary file: %w", err)
 	}
+
 	return header, nil
 }
 

--- a/pkg/binary/mach-o.go
+++ b/pkg/binary/mach-o.go
@@ -54,10 +54,13 @@ func NewMachOBinary(filePath string, opts *Options) (*MachOBinary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("trying to read a Mach-O header from file: %w", err)
 	}
+
 	if header == nil {
 		logrus.Debug("File is not a Mach-O binary")
+
 		return nil, nil
 	}
+
 	return &MachOBinary{
 		Header:  header,
 		Options: opts,
@@ -83,6 +86,7 @@ func (machoh *MachOHeader) WordLength() int {
 	case MachOFat:
 		return 0
 	}
+
 	return 0
 }
 
@@ -90,7 +94,6 @@ func (machoh *MachOHeader) WordLength() int {
 func (machoh *MachOHeader) MachineType() string {
 	// Interpret the header byte defining the CPU arch. Defined here:
 	// https://opensource.apple.com/source/cctools/cctools-836/include/mach/machine.h
-
 	// Universal Binaries can support many architectures in the same file.
 	if machoh.Magic == MachOFat {
 		return "FAT"
@@ -121,6 +124,7 @@ func (machoh *MachOHeader) MachineType() string {
 	}
 
 	logrus.Warnf("Unable to interpret machine type from mach-o header value %d", machoh.CPU)
+
 	return ""
 }
 
@@ -133,41 +137,52 @@ func GetMachOHeader(path string) (*MachOHeader, error) {
 	defer f.Close()
 
 	reader := bufio.NewReader(f)
+
 	hBytes, err := reader.Peek(4)
 	if err != nil {
 		return nil, fmt.Errorf("reading the binary header: %w", err)
 	}
 
 	var endianness binary.ByteOrder
+
 	magic := binary.BigEndian.Uint32(hBytes)
 	switch magic {
 	case MachO32Magic:
 		logrus.Info("Mach-O 32bit")
+
 		endianness = binary.BigEndian
 	case MachO64Magic:
 		logrus.Info("Mach-O 64bit")
+
 		endianness = binary.BigEndian
 	case MachO32LIMagic:
 		logrus.Info("Mach-O 32bit Little Endian")
+
 		endianness = binary.LittleEndian
 	case MachO64LIMagic:
 		logrus.Info("Mach-O 64bit Little Endian")
+
 		endianness = binary.LittleEndian
 	case MachOFat:
 		logrus.Info("Mach-O Universal Binary")
+
 		endianness = binary.BigEndian
 	default:
 		logrus.Debug("File is not a Mach-O binary")
+
 		return nil, nil
 	}
 
 	header := &MachOHeader{}
+
 	if _, err := f.Seek(0, 0); err != nil {
 		return nil, fmt.Errorf("seeking to the start of the file: %w", err)
 	}
+
 	if err := binary.Read(f, endianness, header); err != nil {
 		return nil, fmt.Errorf("reading Mach-O header from binary file: %w", err)
 	}
+
 	return header, nil
 }
 

--- a/pkg/binary/windows.go
+++ b/pkg/binary/windows.go
@@ -61,10 +61,13 @@ func NewPEBinary(filePath string, opts *Options) (bin *PEBinary, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading header from binary: %w", err)
 	}
+
 	if header == nil {
 		logrus.Infof("file is not a PE executable")
+
 		return nil, nil
 	}
+
 	return &PEBinary{
 		Header:  header,
 		Options: opts,
@@ -113,6 +116,7 @@ func (peh *PEHeader) MachineType() string {
 	}
 
 	logrus.Warn("Could not determine architecture type")
+
 	return ""
 }
 
@@ -127,6 +131,7 @@ func (peh *PEHeader) WordLength() int {
 		return 64
 	default:
 		logrus.Warn("Unable to interpret Magic byte to determine word length")
+
 		return 0
 	}
 }
@@ -144,23 +149,30 @@ func GetPEHeader(path string) (*PEHeader, error) {
 	if _, err := f.ReadAt(dosheader[0:], 0); err != nil {
 		return nil, err
 	}
+
 	var base int64
+
 	if dosheader[0] == 'M' && dosheader[1] == 'Z' {
 		// "At offset 60 (0x3C) from the beginning of the DOS header is a pointer to
 		// the Portable Executable (PE) File header":
 		signoff := int64(binary.LittleEndian.Uint32(dosheader[0x3c:]))
+
 		var sign [4]byte
+
 		if _, err := f.ReadAt(sign[:], signoff); err != nil {
 			return nil, fmt.Errorf("reading the PE file header location: %w", err)
 		}
+
 		if !(sign[0] == 'P' && sign[1] == 'E' && sign[2] == 0 && sign[3] == 0) {
 			return nil, errors.New("invalid PE COFF file signature")
 		}
+
 		base = signoff + 4
 	} else {
 		// If the DOS header signature is not found, then discard the file as a valid
 		// windows executable
 		logrus.Debug("File is not a valid windows PE executable")
+
 		return nil, nil
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -150,6 +150,7 @@ func (bi *Instance) getGCSBuildPath(version string) (string, error) {
 
 func (bi *Instance) setBucket() {
 	bucket := bi.opts.Bucket
+
 	if bi.opts.Bucket == "" {
 		if bi.opts.CI {
 			// TODO: Remove this once all CI and release jobs run on K8s Infra

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestBuildDirFromRepoRoot(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		name             string
 		instance         *Instance
@@ -42,6 +43,7 @@ func TestBuildDirFromRepoRoot(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			setupBuildDir(tc.instance)
+
 			if tc.instance.opts.BuildDir != tc.expectedBuildDir {
 				t.Errorf("buildDir mismatched, got: %v, want: %v", tc.instance.opts.BuildDir, tc.expectedBuildDir)
 			}

--- a/pkg/build/ci.go
+++ b/pkg/build/ci.go
@@ -35,11 +35,13 @@ func (bi *Instance) Build() error {
 	workingDir := bi.opts.RepoRoot
 	if workingDir == "" {
 		var dirErr error
+
 		workingDir, dirErr = os.Getwd()
 		if dirErr != nil {
 			return fmt.Errorf("getting working directory: %w", dirErr)
 		}
 	}
+
 	logrus.Infof("Current working directory: %s", workingDir)
 
 	workingDirRelative := filepath.Base(workingDir)
@@ -95,6 +97,7 @@ func (bi *Instance) Build() error {
 	if bi.opts.KubeBuildPlatforms != "" {
 		cmd.Env("KUBE_BUILD_PLATFORMS=" + bi.opts.KubeBuildPlatforms)
 	}
+
 	if buildErr := cmd.RunSuccess(); buildErr != nil {
 		return fmt.Errorf("running make %s: %w", releaseType, buildErr)
 	}
@@ -114,6 +117,7 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 	bi.opts.Version = version
 	if bi.opts.Version == "" {
 		logrus.Infof("Failed to get a build version from the workspace")
+
 		return false, nil
 	}
 
@@ -141,16 +145,20 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 	// TODO: Do we need to handle the errors more effectively?
 	existErrors := []error{}
 	foundItems := 0
+
 	for _, path := range gcsBuildPaths {
 		logrus.Infof("Checking if GCS build path (%s) exists", path)
+
 		exists, existErr := bi.objStore.PathExists(path)
 		if existErr != nil || !exists {
 			existErrors = append(existErrors, existErr)
 		}
+
 		foundItems++
 	}
 
 	images := release.NewImages()
+
 	imagesExist, imagesExistErr := images.Exists(bi.opts.Registry, version, bi.opts.Fast)
 	if imagesExistErr != nil {
 		existErrors = append(existErrors, imagesExistErr)
@@ -159,6 +167,7 @@ func (bi *Instance) checkBuildExists() (bool, error) {
 	// if bi.opts.AllowDup is false, we want to return this function as true
 	if imagesExist && len(existErrors) == 0 && foundItems >= 3 && !bi.opts.AllowDup {
 		logrus.Infof("Build already exists. Exiting...")
+
 		return true, nil
 	}
 

--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -81,11 +81,13 @@ func (m *Make) MakeCross(version string) error {
 	}
 
 	logrus.Infof("Checking out version %s", version)
+
 	if err := m.impl.Checkout(repo, version); err != nil {
 		return fmt.Errorf("checking out version %s: %w", version, err)
 	}
 
 	logrus.Info("Building binaries")
+
 	if err := m.impl.Command(
 		"make",
 		"cross-in-a-container",
@@ -96,11 +98,13 @@ func (m *Make) MakeCross(version string) error {
 
 	newBuildDir := fmt.Sprintf("%s-%s", release.BuildDir, version)
 	logrus.Infof("Moving build output to %s", newBuildDir)
+
 	if err := m.impl.Rename(release.BuildDir, newBuildDir); err != nil {
 		return fmt.Errorf("move build output: %w", err)
 	}
 
 	logrus.Info("Building package tarballs")
+
 	if err := m.impl.Command(
 		"make",
 		"package-tarballs",

--- a/pkg/build/make_test.go
+++ b/pkg/build/make_test.go
@@ -72,6 +72,7 @@ func TestMakeCross(t *testing.T) {
 		mock := &buildfakes.FakeImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
+
 		err := sut.MakeCross("v1.20.0")
 		if tc.shouldError {
 			require.Error(t, err)

--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestRun(t *testing.T) {
 	err := errors.New("")
+
 	for _, tc := range []struct {
 		prepare   func(*changelogfakes.FakeImpl, *changelog.Options)
 		shouldErr bool

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -212,6 +212,7 @@ func (*defaultImpl) GetURLResponse(url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(content), nil
 }
 
@@ -236,6 +237,7 @@ func (*defaultImpl) CloneCVEData() (cveDir string, err error) {
 
 	// Create a new GCS client
 	gcs := object.NewGCS()
+
 	remoteSrc, err := gcs.NormalizePath(object.GcsPrefix + filepath.Join(cve.Bucket, cve.Directory))
 	if err != nil {
 		return "", fmt.Errorf("normalizing cve bucket path: %w", err)
@@ -245,8 +247,10 @@ func (*defaultImpl) CloneCVEData() (cveDir string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("checking if CVE directory exists: %w", err)
 	}
+
 	if !bucketExists {
 		logrus.Warnf("CVE data maps not found in bucket location: %s", remoteSrc)
+
 		return "", nil
 	}
 
@@ -254,6 +258,8 @@ func (*defaultImpl) CloneCVEData() (cveDir string, err error) {
 	if err := gcs.RsyncRecursive(remoteSrc, tmpdir); err != nil {
 		return "", fmt.Errorf("copying release directory to bucket: %w", err)
 	}
+
 	logrus.Infof("Successfully synchronized CVE data maps from %s", remoteSrc)
+
 	return tmpdir, nil
 }

--- a/pkg/consts/main.go
+++ b/pkg/consts/main.go
@@ -73,9 +73,11 @@ func IsSupported(field string, input, expected []string) bool {
 
 	for _, i := range input {
 		supported := false
+
 		for _, j := range expected {
 			if i == j {
 				supported = true
+
 				break
 			}
 		}
@@ -89,6 +91,7 @@ func IsSupported(field string, input, expected []string) bool {
 		logrus.Infof(
 			"Flag %s has an unsupported option: %v", field, notSupported,
 		)
+
 		return false
 	}
 

--- a/pkg/cve/cve.go
+++ b/pkg/cve/cve.go
@@ -43,27 +43,34 @@ func (cve *CVE) ReadRawInterface(cvedata interface{}) error {
 	if val, ok := cvedata.(map[interface{}]interface{})["id"].(string); ok {
 		cve.ID = val
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["title"].(string); ok {
 		cve.Title = val
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["issue"].(string); ok {
 		cve.TrackingIssue = val
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["vector"].(string); ok {
 		cve.CVSSVector = val
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["score"].(float64); ok {
 		cve.CVSSScore = float32(val)
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["rating"].(string); ok {
 		cve.CVSSRating = val
 	}
+
 	if val, ok := cvedata.(map[interface{}]interface{})["description"].(string); ok {
 		cve.Description = val
 	}
 	// Linked PRs is a list of the PR IDs
 	if val, ok := cvedata.(map[interface{}]interface{})["linkedPRs"].([]interface{}); ok {
 		cve.LinkedPRs = []int{}
+
 		for _, prid := range val {
 			if prid, ok := prid.(int); ok {
 				cve.LinkedPRs = append(cve.LinkedPRs, prid)
@@ -100,9 +107,11 @@ func (cve *CVE) Validate() (err error) {
 	} else {
 		bm, err = cvss.NewTemporal().Decode(cve.CVSSVector)
 	}
+
 	if err != nil {
 		return fmt.Errorf("parsing CVSS vector string: %w", err)
 	}
+
 	cve.CalcLink = fmt.Sprintf(
 		"https://www.first.org/cvss/calculator/%s#%s", bm.BaseMetrics().Ver.String(), cve.CVSSVector,
 	)
@@ -110,6 +119,7 @@ func (cve *CVE) Validate() (err error) {
 	if cve.CVSSScore == 0 {
 		return errors.New("missing CVSS score from CVE data")
 	}
+
 	if cve.CVSSScore < 0 || cve.CVSSScore > 10 {
 		return errors.New("out of range CVSS score, should be 0.0 - 10.0")
 	}

--- a/pkg/cve/cve_unit_test.go
+++ b/pkg/cve/cve_unit_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestCVEValidation(t *testing.T) {
 	var sut CVE
+
 	cve := CVE{
 		ID:            "CVE-2020-8559",
 		Title:         "Privilege escalation from compromised node to cluster",

--- a/pkg/fastforward/fastforward_test.go
+++ b/pkg/fastforward/fastforward_test.go
@@ -44,6 +44,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.AskReturns("", true, nil)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -54,6 +55,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
+
 				return &Options{Branch: branch, NonInteractive: true}
 			},
 			assert: func(err error) {
@@ -65,6 +67,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoCheckoutReturnsOnCall(1, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -76,6 +79,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoCleanupReturns(errTest)
+
 				return &Options{Branch: branch, Cleanup: true}
 			},
 			assert: func(err error) {
@@ -93,6 +97,7 @@ func TestRun(t *testing.T) {
 		{ // success no fast forward required
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.RepoHasRemoteTagReturns(true, nil)
+
 				return &Options{}
 			},
 			assert: func(err error) {
@@ -110,6 +115,7 @@ func TestRun(t *testing.T) {
 		{ // success prepare tool repo
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.ExistsReturns(false)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -137,6 +143,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.ExistsReturns(false)
 				mock.ChdirReturns(errTest)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -147,6 +154,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.ExistsReturns(false)
 				mock.CloneOrOpenGitHubRepoReturns(nil, errTest)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -157,6 +165,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.ExistsReturns(false)
 				mock.RemoveAllReturns(errTest)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -167,6 +176,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.ExistsReturns(false)
 				mock.MkdirTempReturns("", errTest)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -178,6 +188,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.EnvDefaultReturns("token")
+
 				return &Options{Branch: branch, NonInteractive: true}
 			},
 			assert: func(err error) {
@@ -191,6 +202,7 @@ func TestRun(t *testing.T) {
 				mock.EnvDefaultReturns("token")
 				mock.IsDefaultK8sUpstreamReturns(true)
 				mock.RepoSetURLReturns(errTest)
+
 				return &Options{Branch: branch, NonInteractive: true}
 			},
 			assert: func(err error) {
@@ -203,6 +215,7 @@ func TestRun(t *testing.T) {
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.EnvDefaultReturns("token")
 				mock.CloneOrOpenGitHubRepoReturns(nil, errTest)
+
 				return &Options{Branch: branch, NonInteractive: true}
 			},
 			assert: func(err error) {
@@ -212,6 +225,7 @@ func TestRun(t *testing.T) {
 		{ // failure on Submit
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.SubmitReturns(errTest)
+
 				return &Options{Submit: true}
 			},
 			assert: func(err error) {
@@ -221,6 +235,7 @@ func TestRun(t *testing.T) {
 		{ // failure on RepoLatestReleaseBranch
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.RepoLatestReleaseBranchReturns("", errTest)
+
 				return &Options{}
 			},
 			assert: func(err error) {
@@ -230,6 +245,7 @@ func TestRun(t *testing.T) {
 		{ // failure on RepoHasRemoteTag
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.RepoHasRemoteTagReturns(false, errTest)
+
 				return &Options{}
 			},
 			assert: func(err error) {
@@ -239,6 +255,7 @@ func TestRun(t *testing.T) {
 		{ // failure on CloneOrOpenDefaultGitHubRepoSSH
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.CloneOrOpenDefaultGitHubRepoSSHReturns(nil, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -248,6 +265,7 @@ func TestRun(t *testing.T) {
 		{ // failure not a release branch
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.IsReleaseBranchReturns(false)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -258,6 +276,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(false, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -268,6 +287,7 @@ func TestRun(t *testing.T) {
 			prepare: func(mock *fastforwardfakes.FakeImpl) *Options {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(false, nil)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -279,6 +299,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.ListIssuesReturns(nil, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -290,6 +311,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoCurrentBranchReturns("", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -301,6 +323,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoCheckoutReturnsOnCall(0, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -312,6 +335,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.ConfigureGlobalDefaultUserAndEmailReturns(errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -323,6 +347,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoMergeBaseReturns("", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -334,6 +359,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoDescribeReturnsOnCall(0, "", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -345,6 +371,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoDescribeReturnsOnCall(1, "", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -356,6 +383,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoDescribeReturnsOnCall(0, "test", nil)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -367,6 +395,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoHeadReturnsOnCall(0, "", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -378,6 +407,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoMergeReturns(errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -389,6 +419,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.RepoHeadReturnsOnCall(1, "", errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -400,6 +431,7 @@ func TestRun(t *testing.T) {
 				mock.IsReleaseBranchReturns(true)
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.AskReturns("", false, errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {
@@ -412,6 +444,7 @@ func TestRun(t *testing.T) {
 				mock.RepoHasRemoteBranchReturns(true, nil)
 				mock.AskReturns("", true, nil)
 				mock.RepoPushReturns(errTest)
+
 				return &Options{Branch: branch}
 			},
 			assert: func(err error) {

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -225,6 +225,7 @@ func (g *GCB) Submit() error {
 	}
 
 	var jobType string
+
 	switch {
 	// TODO: Consider a '--validate' flag to validate the GCB config without submitting
 	case g.options.Stage:
@@ -242,6 +243,7 @@ func (g *GCB) Submit() error {
 	}
 
 	version := utilsversion.GetVersionInfo().GitVersion
+
 	if err := g.repoClient.Open(); errors.Is(err, gogit.ErrRepositoryNotExists) {
 		// Use the embedded cloudbuild files
 		configDir, err := gcb.New().DirForJobType(jobType)
@@ -300,6 +302,7 @@ func (g *GCB) Submit() error {
 
 		if !g.options.NonInteractive {
 			var err error
+
 			_, submit, err = util.Ask(
 				fmt.Sprintf("Really submit a --nomock release job against the %s branch? (yes/no)", g.options.Branch),
 				"yes",
@@ -320,6 +323,7 @@ func (g *GCB) Submit() error {
 		gcbSubs["NOMOCK"] = ""
 
 		userBucket := strings.ReplaceAll(release.TestBucket, "gcb", gcbSubs["GCP_USER_TAG"])
+
 		userBucketSetErr := os.Setenv("USER_BUCKET", userBucket)
 		if userBucketSetErr != nil {
 			return userBucketSetErr
@@ -332,6 +336,7 @@ func (g *GCB) Submit() error {
 	}
 
 	logrus.Info("Listing GCB substitutions prior to build submission...")
+
 	for k, v := range gcbSubs {
 		logrus.Infof("%s: %s", k, v)
 	}
@@ -375,6 +380,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 	gcpUser := g.options.GcpUser
 	if gcpUser == "" {
 		var gcpUserErr error
+
 		gcpUser, gcpUserErr = auth.GetCurrentGCPUser()
 		if gcpUserErr != nil {
 			return gcbSubs, gcpUserErr
@@ -392,6 +398,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 	gcbSubs["RELEASE_BRANCH"] = g.options.Branch
 
 	kc := kubecross.New()
+
 	kcVersionBranch, err := kc.ForBranch(g.options.Branch)
 	if err != nil {
 		// If the kubecross version is not set, we will get a 404 from GitHub.
@@ -399,6 +406,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 		if g.options.Branch == git.DefaultBranch || !strings.Contains(err.Error(), "404") {
 			return gcbSubs, fmt.Errorf("retrieve kube-cross version: %w", err)
 		}
+
 		logrus.Infof("KubeCross version not set for %s, falling back to latest", g.options.Branch)
 	}
 
@@ -414,6 +422,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 			kcVersionBranch = kcVersionLatest
 		}
 	}
+
 	gcbSubs["KUBE_CROSS_VERSION"] = kcVersionBranch
 
 	switch {
@@ -462,6 +471,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 
 	if buildVersion == "" {
 		var versionErr error
+
 		buildVersion, versionErr = g.versionClient.GetKubeVersionForBranch(
 			release.VersionTypeCILatest, g.options.Branch,
 		)
@@ -483,6 +493,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 	if err != nil {
 		return nil, fmt.Errorf("check if branch needs to be created: %w", err)
 	}
+
 	versions, err := g.releaseClient.GenerateReleaseVersion(
 		g.options.ReleaseType, buildVersion,
 		g.options.Branch, createBranch,
@@ -490,6 +501,7 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 	if err != nil {
 		return nil, fmt.Errorf("generate release version: %w", err)
 	}
+
 	primeSemver, err := util.TagStringToSemver(versions.Prime())
 	if err != nil {
 		return gcbSubs, fmt.Errorf("parse prime version: %w", err)
@@ -511,9 +523,11 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 func (g *GCB) listJobs(project string, lastJobs int64) error {
 	if lastJobs < 0 {
 		logrus.Infof("--list-jobs was set to a negative number, defaulting to 5")
+
 		lastJobs = 5
 	}
 
 	logrus.Infof("Listing last %d GCB jobs:", lastJobs)
+
 	return g.listJobsClient.ListJobs(project, lastJobs)
 }

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -36,12 +36,14 @@ func mockRepo() gcb.Repository {
 	mock.OpenReturns(nil)
 	mock.CheckStateReturns(nil)
 	mock.GetTagReturns("v1.0.0-20201010", nil)
+
 	return mock
 }
 
 func mockVersion(version string) gcb.Version {
 	mock := &gcbfakes.FakeVersion{}
 	mock.GetKubeVersionForBranchReturns(version, nil)
+
 	return mock
 }
 
@@ -50,6 +52,7 @@ func mockRelease(version string) gcb.Release {
 	mock.GenerateReleaseVersionReturns(
 		release.NewReleaseVersions(version, "", "", "", ""), nil,
 	)
+
 	return mock
 }
 
@@ -90,6 +93,7 @@ func TestSubmitList(t *testing.T) {
 			listJobsMock: func() gcb.ListJobs {
 				m := &gcbfakes.FakeListJobs{}
 				m.ListJobsReturns(errors.New(""))
+
 				return m
 			}(),
 			releaseMock: mockRelease("v1.17.0"),
@@ -441,6 +445,7 @@ func TestSetGCBSubstitutionsFailure(t *testing.T) {
 			versionMock: func() gcb.Version {
 				m := &gcbfakes.FakeVersion{}
 				m.GetKubeVersionForBranchReturns("", errors.New(""))
+
 				return m
 			}(),
 		},

--- a/pkg/gcp/gcb/history.go
+++ b/pkg/gcp/gcb/history.go
@@ -114,6 +114,7 @@ func (h *History) Run() error {
 	tagFilter := fmt.Sprintf(
 		"tags=%q create_time>%q create_time<%q", h.opts.Branch, from, to,
 	)
+
 	jobs, err := h.impl.GetJobsByTag(h.opts.Project, tagFilter)
 	if err != nil {
 		return fmt.Errorf("get GCP build jobs by tag: %w", err)
@@ -124,12 +125,15 @@ func (h *History) Run() error {
 	table.SetAutoWrapText(false)
 
 	table.SetHeader([]string{"Step", "Command", "Link", "Start", "Duration", "Succeeded?"})
+
 	for i := len(jobs) - 1; i >= 0; i-- {
 		job := jobs[i]
 		subcommand := ""
+
 		for _, tag := range job.Tags {
 			if tag == "RELEASE" || tag == "STAGE" {
 				subcommand = strings.ToLower(tag)
+
 				break
 			}
 		}
@@ -143,6 +147,7 @@ func (h *History) Run() error {
 		)
 
 		var mock string
+
 		if job.Substitutions["_NOMOCK"] != "" {
 			command = fmt.Sprintf("%s %s`", command, job.Substitutions["_NOMOCK"])
 			mock = ""
@@ -157,19 +162,23 @@ func (h *History) Run() error {
 
 		if start == "" || end == "" {
 			logrus.Infof("Skipping unfinished job from %s with ID: %s", job.CreateTime, job.Id)
+
 			continue
 		}
 
 		// Calculate the duration of the job
 		const layout = "2006-01-02T15:04:05.99Z"
+
 		tStart, err := h.impl.ParseTime(layout, start)
 		if err != nil {
 			return fmt.Errorf("parsing the start job time: %w", err)
 		}
+
 		tEnd, err := h.impl.ParseTime(layout, end)
 		if err != nil {
 			return fmt.Errorf("parsing the end job time: %w", err)
 		}
+
 		diff := tEnd.Sub(tStart)
 		out := time.Time{}.Add(diff)
 
@@ -187,6 +196,7 @@ func (h *History) Run() error {
 	table.Render()
 
 	fmt.Print(tableString.String())
+
 	return nil
 }
 
@@ -199,10 +209,12 @@ func (h *History) parseDateRange() (from, to string, err error) {
 		parseLayout  = "2006-01-02"
 		resultLayout = "2006-01-02T15:04:05.000Z"
 	)
+
 	timeStampFrom, err := h.impl.ParseTime(parseLayout, h.opts.DateFrom)
 	if err != nil {
 		return "", "", fmt.Errorf("convert date from: %w", err)
 	}
+
 	from = timeStampFrom.Format(resultLayout)
 
 	if h.opts.DateTo == "" {

--- a/pkg/gcp/gcb/history_test.go
+++ b/pkg/gcp/gcb/history_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestHistoryRun(t *testing.T) {
 	err := errors.New("error")
+
 	for _, tc := range []struct {
 		options   *gcb.HistoryOptions
 		prepare   func(*gcbfakes.FakeHistoryImpl)

--- a/pkg/kubecross/impl.go
+++ b/pkg/kubecross/impl.go
@@ -36,5 +36,6 @@ func (*defaultImpl) GetURLResponse(url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(bytes.TrimSpace(content)), nil
 }

--- a/pkg/kubecross/kubecross.go
+++ b/pkg/kubecross/kubecross.go
@@ -49,11 +49,13 @@ func (k *KubeCross) ForBranch(branch string) (string, error) {
 	)
 
 	url := fmt.Sprintf("%s/%s/%s", baseURL, branch, versionPath)
+
 	version, err := k.impl.GetURLResponse(url)
 	if err != nil {
 		return "", fmt.Errorf("get URL response: %w", err)
 	}
 
 	logrus.Infof("Retrieved kube-cross version: %s", version)
+
 	return version, nil
 }

--- a/pkg/notes/dependencies_test.go
+++ b/pkg/notes/dependencies_test.go
@@ -75,6 +75,7 @@ const expected = `## Dependencies
 func TestDependencyChangesSuccess(t *testing.T) {
 	moDiff := &notesfakes.FakeMoDiff{}
 	moDiff.RunReturns(expected, nil)
+
 	sut := notes.NewDependencies()
 	sut.SetMoDiff(moDiff)
 
@@ -86,6 +87,7 @@ func TestDependencyChangesSuccess(t *testing.T) {
 func TestDependencyChangesFailure(t *testing.T) {
 	moDiff := &notesfakes.FakeMoDiff{}
 	moDiff.RunReturns("", errors.New(""))
+
 	sut := notes.NewDependencies()
 	sut.SetMoDiff(moDiff)
 

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -256,6 +256,7 @@ func setupTestDir(t *testing.T, dir string) {
 			filepath.Join(dir, file), []byte{1, 2, 3}, os.FileMode(0o644),
 		))
 	}
+
 	for _, arch := range []string{consts.ArchitectureAMD64, consts.ArchitectureARM64, consts.ArchitecturePPC64, consts.ArchitectureS390X} {
 		archDir := filepath.Join(dir, release.ImagesPath, arch)
 		require.NoError(t, os.MkdirAll(archDir, fs.FileMode(0o755)))
@@ -301,6 +302,7 @@ func TestNew(t *testing.T) {
 			func() *notes.ReleaseNotes {
 				n := notes.NewReleaseNotes()
 				n.Set(0, makeReleaseNote("", "No one gave me a kind"))
+
 				return n
 			},
 			&Document{
@@ -320,6 +322,7 @@ func TestNew(t *testing.T) {
 				n.Set(0, makeReleaseNote(notes.KindDeprecation, "C"))
 				n.Set(1, makeReleaseNote(notes.KindDeprecation, "B"))
 				n.Set(2, makeReleaseNote(notes.KindDeprecation, "A"))
+
 				return n
 			},
 			&Document{
@@ -339,6 +342,7 @@ func TestNew(t *testing.T) {
 				n.Set(0, makeReleaseNote(notes.KindFeature, "C"))
 				n.Set(1, makeReleaseNote(notes.KindAPIChange, "B"))
 				n.Set(2, makeReleaseNote(notes.KindDeprecation, "A"))
+
 				return n
 			},
 			&Document{
@@ -368,6 +372,7 @@ func TestNew(t *testing.T) {
 				n.Set(2, makeReleaseNote(notes.KindBug, "* single star"))
 				n.Set(3, makeReleaseNote(notes.KindBug, "** double star"))
 				n.Set(4, makeReleaseNote(notes.KindBug, "- --someflag"))
+
 				return n
 			},
 			&Document{
@@ -398,6 +403,7 @@ func TestNew(t *testing.T) {
 						ActionRequired: false,
 					},
 				)
+
 				return n
 			},
 			&Document{
@@ -422,6 +428,7 @@ func TestNew(t *testing.T) {
 						ActionRequired: false,
 					},
 				)
+
 				return n
 			},
 			&Document{
@@ -440,6 +447,7 @@ func TestNew(t *testing.T) {
 				n := notes.NewReleaseNotes()
 				n.Set(0, makeReleaseNote(notes.KindCleanup, "PR#1"))
 				n.Set(1, makeReleaseNote(notes.KindFlake, "PR#2"))
+
 				return n
 			},
 			&Document{
@@ -514,6 +522,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 
 			actionNeeded := makeReleaseNote(notes.KindAPIChange, "Action required note.")
 			actionNeeded.ActionRequired = true
+
 			testNotes.Set(11, duplicate)
 			testNotes.Set(12, actionNeeded)
 
@@ -521,6 +530,7 @@ func TestDocument_RenderMarkdownTemplate(t *testing.T) {
 			require.NoError(t, err, "Creating test document.")
 
 			templateSpec := tt.templateSpec
+
 			var dir string
 			if tt.hasDownloads || tt.userTemplate {
 				dir = t.TempDir()
@@ -559,11 +569,13 @@ func makeReleaseNote(kind notes.Kind, markdown string) *notes.ReleaseNote {
 	if kind != "" {
 		n.Kinds = []string{string(kind)}
 	}
+
 	return n
 }
 
 func readFile(t *testing.T, path string) string {
 	b, err := os.ReadFile(path)
 	require.NoError(t, err, "Reading file %q", path)
+
 	return strings.TrimSpace(string(b))
 }

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -43,6 +43,7 @@ func TestMain(m *testing.M) {
 
 func TestListCommits(t *testing.T) {
 	t.Parallel()
+
 	const always = -1
 
 	zeroTime := &github.Timestamp{}
@@ -52,6 +53,7 @@ func TestListCommits(t *testing.T) {
 		r  *github.Response
 		e  error
 	}
+
 	type getCommitReturnsList map[int]struct {
 		c *github.Commit
 		r *github.Response
@@ -185,6 +187,7 @@ func TestListCommits(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tc := tc
+
 			t.Parallel()
 
 			client := &githubfakes.FakeClient{}
@@ -226,6 +229,7 @@ func TestListCommits(t *testing.T) {
 					val(t, i, ctx, org, repo, rev)
 				}
 			}
+
 			if val := tc.listCommitsArgValidator; val != nil {
 				for i := range client.ListCommitsCallCount() {
 					ctx, org, repo, clo := client.ListCommitsArgsForCall(i)
@@ -238,7 +242,9 @@ func TestListCommits(t *testing.T) {
 
 func TestGatherNotes(t *testing.T) {
 	t.Parallel()
+
 	type getPullRequestStub func(context.Context, string, string, int) (*github.PullRequest, *github.Response, error)
+
 	type listPullRequestsWithCommitStub func(context.Context, string, string, string, *github.ListOptions) ([]*github.PullRequest, *github.Response, error)
 
 	tests := map[string]struct {
@@ -285,6 +291,7 @@ func TestGatherNotes(t *testing.T) {
 					if e, a := "some-random-sha", sha; e != a {
 						t.Errorf("Expected ListPullRequestsWithCommit(...) to be called for SHA '%s', have been called for '%s'", e, a)
 					}
+
 					return nil, &github.Response{}, nil
 				}
 			},
@@ -308,6 +315,7 @@ func TestGatherNotes(t *testing.T) {
 					if err := seenPRs.Mark(prID); err != nil {
 						t.Errorf("In GetPullRequest: %v", err)
 					}
+
 					return nil, nil, nil
 				}
 			},
@@ -366,6 +374,7 @@ func TestGatherNotes(t *testing.T) {
 					if a, e := callCount+1, len(prsPerCall); a > e {
 						return nil, &github.Response{}, nil
 					}
+
 					return prsPerCall[callCount], &github.Response{}, nil
 				}
 			},
@@ -384,14 +393,17 @@ func TestGatherNotes(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tc := tc
+
 			t.Parallel()
 
 			client := &githubfakes.FakeClient{}
 
 			gatherer := NewGathererWithClient(context.Background(), client)
+
 			if stubber := tc.listPullRequestsWithCommitStubber; stubber != nil {
 				client.ListPullRequestsWithCommitStub = stubber(t)
 			}
+
 			if stubber := tc.getPullRequestStubber; stubber != nil {
 				client.GetPullRequestStub = stubber(t)
 			}
@@ -470,10 +482,13 @@ func (s *intsRecorder) Mark(what int) error {
 	if !ok {
 		return fmt.Errorf("Expected not to get a request to mark %d as seen", what)
 	}
+
 	if seen {
 		return fmt.Errorf("Expected to mark %d as seen only once", what)
 	}
+
 	s.seen[what] = true
+
 	return nil
 }
 
@@ -494,6 +509,7 @@ func checkOrgRepo(t *testing.T, org, repo string) {
 	if org != git.DefaultGithubOrg {
 		t.Errorf("Expected to be called with '%s' as an org, got: %s", git.DefaultGithubOrg, org)
 	}
+
 	if repo != git.DefaultGithubRepo {
 		t.Errorf("Expected to be called with '%s' as a repo, got: %s", git.DefaultGithubRepo, repo)
 	}
@@ -506,11 +522,13 @@ func checkErrMsg(t *testing.T, err error, expectedMsg string) {
 		if err != nil {
 			t.Errorf("Expected no error, got: %#v", err)
 		}
+
 		return
 	}
 
 	if err == nil {
 		t.Errorf("Expected error, but got none")
+
 		return
 	}
 
@@ -527,5 +545,6 @@ func response(statusCode, lastPage int) *github.Response {
 			StatusCode: statusCode,
 		},
 	}
+
 	return res
 }

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -48,6 +48,7 @@ func NewProviderFromInitString(initString string) (MapProvider, error) {
 	if os.IsNotExist(err) {
 		return nil, errors.New("release notes map path does not exist")
 	}
+
 	if !fileStat.IsDir() {
 		return nil, errors.New("release notes map path is not a directory")
 	}
@@ -58,10 +59,12 @@ func NewProviderFromInitString(initString string) (MapProvider, error) {
 // ParseReleaseNotesMap Parses a Release Notes Map.
 func ParseReleaseNotesMap(mapPath string) (*[]ReleaseNotesMap, error) {
 	notemaps := []ReleaseNotesMap{}
+
 	yamlReader, err := os.Open(mapPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening maps: %w", err)
 	}
+
 	defer yamlReader.Close()
 
 	decoder := yaml.NewDecoder(yamlReader)
@@ -73,6 +76,7 @@ func ParseReleaseNotesMap(mapPath string) (*[]ReleaseNotesMap, error) {
 		} else if err != nil {
 			return nil, fmt.Errorf("decoding note map: %w", err)
 		}
+
 		notemaps = append(notemaps, noteMap)
 	}
 
@@ -134,12 +138,14 @@ type DirectoryMapProvider struct {
 // readMaps Open the dir and read dir notes.
 func (mp *DirectoryMapProvider) readMaps() error {
 	var fileList []string
+
 	mp.Maps = map[int][]*ReleaseNotesMap{}
 
 	err := filepath.Walk(mp.Path, func(path string, info os.FileInfo, err error) error {
 		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
 			fileList = append(fileList, path)
 		}
+
 		return nil
 	})
 
@@ -148,14 +154,18 @@ func (mp *DirectoryMapProvider) readMaps() error {
 		if err != nil {
 			return fmt.Errorf("while parsing note map in %s: %w", fileName, err)
 		}
+
 		for i, notemap := range *notemaps {
 			if _, ok := mp.Maps[notemap.PR]; !ok {
 				mp.Maps[notemap.PR] = make([]*ReleaseNotesMap, 0)
 			}
+
 			mp.Maps[notemap.PR] = append(mp.Maps[notemap.PR], &(*notemaps)[i])
 		}
 	}
+
 	logrus.Infof("Successfully parsed release notes maps for %d PRs from %s", len(mp.Maps), mp.Path)
+
 	return err
 }
 
@@ -167,8 +177,10 @@ func (mp *DirectoryMapProvider) GetMapsForPR(pr int) (notesMap []*ReleaseNotesMa
 			return nil, fmt.Errorf("while reading release notes maps: %w", err)
 		}
 	}
+
 	if notesMap, ok := mp.Maps[pr]; ok {
 		return notesMap, nil
 	}
+
 	return nil, nil
 }

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -44,6 +44,7 @@ func githubClient(t *testing.T) (kgithub.Client, context.Context) {
 	}
 
 	c := kgithub.New()
+
 	return c.Client(), context.Background()
 }
 
@@ -185,18 +186,21 @@ func TestClassifyURL(t *testing.T) {
 	// A KEP
 	u, err := url.Parse("http://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kubectl-staging.md")
 	require.NoError(t, err)
+
 	result := classifyURL(u)
 	require.Equal(t, DocTypeKEP, result)
 
 	// An official documentation
 	u, err = url.Parse("https://kubernetes.io/docs/concepts/#kubernetes-objects")
 	require.NoError(t, err)
+
 	result = classifyURL(u)
 	require.Equal(t, DocTypeOfficial, result)
 
 	// An external documentation
 	u, err = url.Parse("https://google.com/")
 	require.NoError(t, err)
+
 	result = classifyURL(u)
 	require.Equal(t, DocTypeExternal, result)
 }
@@ -227,6 +231,7 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected no error to occur but got %v", err)
 			}
+
 			if prs[0] != tc.expectedPRNumber {
 				t.Errorf("Expected PR number to be %d but was %d", tc.expectedPRNumber, prs[0])
 			}
@@ -411,6 +416,7 @@ func testApplyMapHelper(t *testing.T, testDir string, makeNewNote func() *Releas
 	// Read the maps from out test directory
 	testMaps, err := mp.GetMapsForPR(95000)
 	require.NoError(t, err)
+
 	lastProp := ""
 
 	for _, testMap := range testMaps {
@@ -454,9 +460,11 @@ func testApplyMapHelper(t *testing.T, testDir string, makeNewNote func() *Releas
 			// Handle string slice cases
 			actualVal := reflect.Indirect(reflectedNote).FieldByName(property)
 			actualSlice := make([]string, 0)
+
 			for i := range actualVal.Len() {
 				actualSlice = append(actualSlice, actualVal.Index(i).String())
 			}
+
 			require.ElementsMatchf(t, expectedValue, actualSlice, "Failed %s", testName)
 		default:
 			require.FailNowf(t, "Unknown case", "Unable to handle case for %s %T", property, expectedValue)
@@ -585,6 +593,7 @@ func TestReleaseNoteForPullRequest(t *testing.T) {
 		GithubRepo:    "release",
 	})
 	require.NoError(t, err)
+
 	for _, tc := range []struct {
 		name         string
 		prNr         int
@@ -622,13 +631,17 @@ func TestReleaseNoteForPullRequest(t *testing.T) {
 			note, err := g.ReleaseNoteForPullRequest(tc.prNr)
 			if tc.shouldErr {
 				require.Error(t, err)
+
 				return
 			}
+
 			require.NoError(t, err)
 			require.NotNil(t, note)
+
 			if tc.notPublish {
 				require.True(t, note.DoNotPublish)
 			}
+
 			require.Equal(t, tc.expectedNote, note.Markdown)
 		})
 	}

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -54,11 +54,13 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 
 	// load map providers specified in options
 	mapProviders := []MapProvider{}
+
 	for _, initString := range g.options.MapProviderStrings {
 		provider, err := NewProviderFromInitString(initString)
 		if err != nil {
 			return nil, fmt.Errorf("while getting release notes map providers: %w", err)
 		}
+
 		mapProviders = append(mapProviders, provider)
 	}
 
@@ -90,6 +92,7 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 					logrus.WithFields(logrus.Fields{
 						"pr": pair.PrNum,
 					}).Errorf("ignore err: %v", err)
+
 					noteMaps = []*ReleaseNotesMap{}
 				}
 			}
@@ -104,6 +107,7 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 							}).Errorf("ignore err: %v", err)
 						}
 					}
+
 					logrus.WithFields(logrus.Fields{
 						"pr":   pair.PrNum,
 						"note": releaseNote.Text,
@@ -122,6 +126,7 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 					"pr":  pair.PrNum,
 				}).Errorf("err: %v", err)
 			}
+
 			bar.Increment()
 			t.Done(nil)
 		}(pair)
@@ -158,6 +163,7 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 			"sha": pair.Commit.Hash.String(),
 			"pr":  pair.PrNum,
 		}).Debugf("ignore err: %v", err)
+
 		return nil, nil
 	}
 
@@ -184,6 +190,7 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 	indented := strings.ReplaceAll(text, "\n", "\n  ")
 	markdown := fmt.Sprintf("%s (#%d, @%s)",
 		indented, pr.GetNumber(), author)
+
 	if g.options.AddMarkdownLinks {
 		markdown = fmt.Sprintf("%s ([#%d](%s), [@%s](%s))",
 			indented, pr.GetNumber(), prURL, author, authorURL)
@@ -253,14 +260,18 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 	}
 
 	logrus.Debugf("finding merge base (last shared commit) between the two SHAs")
+
 	startTime := time.Now()
+
 	lastSharedCommits, err := endCommit.MergeBase(startCommit)
 	if err != nil {
 		return nil, fmt.Errorf("finding shared commits: %w", err)
 	}
+
 	if len(lastSharedCommits) == 0 {
 		return nil, errors.New("no shared commits between the provided SHAs")
 	}
+
 	logrus.Debugf("found merge base in %v", time.Since(startTime))
 
 	stopHash := lastSharedCommits[0].Hash
@@ -269,6 +280,7 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 	currentTagHash := plumbing.NewHash(opts.EndSHA)
 
 	pairs := []*commitPrPair{}
+
 	hashPointer := currentTagHash
 	for hashPointer != stopHash {
 		hashString := hashPointer.String()
@@ -288,8 +300,10 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 
 			// Advance pointer based on left parent
 			hashPointer = commitPointer.ParentHashes[0]
+
 			continue
 		}
+
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
 				"sha": hashString,
@@ -297,8 +311,10 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 
 			// Advance pointer based on left parent
 			hashPointer = commitPointer.ParentHashes[0]
+
 			continue
 		}
+
 		logrus.WithFields(logrus.Fields{
 			"sha": hashString,
 			"prs": prNums,

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -186,6 +186,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	// Recover for replay if needed
 	if o.ReplayDir != "" {
 		logrus.Info("Using replay mode")
+
 		return nil
 	}
 
@@ -232,6 +233,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 		if err != nil {
 			return err
 		}
+
 		if o.StartRev != "" && o.StartSHA == "" {
 			sha, err := repo.RevParseTag(o.StartRev)
 			if err != nil {
@@ -240,6 +242,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 
 			if o.SkipFirstCommit {
 				logrus.Infof("Skipping first commit: %s", sha)
+
 				sha, err = repo.NextCommit(sha, git.DefaultRemote+"/"+o.Branch)
 				if err != nil {
 					return fmt.Errorf("getting the next repo commit: %w", err)
@@ -249,11 +252,13 @@ func (o *Options) ValidateAndFinish() (err error) {
 			logrus.Infof("Using found start SHA: %s", sha)
 			o.StartSHA = sha
 		}
+
 		if o.EndRev != "" && o.EndSHA == "" {
 			sha, err := repo.RevParseTag(o.EndRev)
 			if err != nil {
 				return fmt.Errorf("resolving %s: %w", o.EndRev, err)
 			}
+
 			logrus.Infof("Using found end SHA: %s", sha)
 			o.EndSHA = sha
 		}
@@ -262,6 +267,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	// Create the record dir
 	if o.RecordDir != "" {
 		logrus.Info("Using record mode")
+
 		if err := os.MkdirAll(o.RecordDir, os.FileMode(0o755)); err != nil {
 			return err
 		}
@@ -275,6 +281,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 	if err := o.checkFormatOptions(); err != nil {
 		return fmt.Errorf("while checking format flags: %w", err)
 	}
+
 	return nil
 }
 
@@ -282,6 +289,7 @@ func (o *Options) ValidateAndFinish() (err error) {
 func (o *Options) checkFormatOptions() error {
 	// Validate the output format and template
 	logrus.Infof("Using output format: %s", o.Format)
+
 	if o.Format == FormatMarkdown && o.GoTemplate != GoTemplateDefault {
 		if !strings.HasPrefix(o.GoTemplate, GoTemplatePrefix) {
 			return fmt.Errorf("go template has to be prefixed with %q", GoTemplatePrefix)
@@ -294,17 +302,21 @@ func (o *Options) checkFormatOptions() error {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("could not find template file (%s)", templatePathOrOnline)
 			}
+
 			if fileStats.Size() == 0 {
 				return fmt.Errorf("template file %s is empty", templatePathOrOnline)
 			}
 		}
 	}
+
 	if o.Format == FormatJSON && o.GoTemplate != GoTemplateDefault {
 		return errors.New("go-template cannot be defined when in JSON mode")
 	}
+
 	if o.Format != FormatJSON && o.Format != FormatMarkdown {
 		return fmt.Errorf("invalid format: %s", o.Format)
 	}
+
 	return nil
 }
 
@@ -315,6 +327,7 @@ func (o *Options) resolveDiscoverMode() error {
 	}
 
 	var result git.DiscoverResult
+
 	switch o.DiscoverMode {
 	case RevisionDiscoveryModeMergeBaseToLatest:
 		result, err = repo.LatestReleaseBranchMergeBaseToLatest()
@@ -360,9 +373,11 @@ func (o *Options) repo() (repo *git.Repo, err error) {
 		logrus.Infof("Re-using local repo %s", o.RepoPath)
 		repo, err = git.OpenRepo(o.RepoPath)
 	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	return repo, nil
 }
 
@@ -377,6 +392,7 @@ func (o *Options) Client() (github.Client, error) {
 	}
 
 	var gh *github.GitHub
+
 	var err error
 	// Create a real GitHub API client
 	if o.GithubBaseURL != "" && o.GithubUploadURL != "" {
@@ -384,6 +400,7 @@ func (o *Options) Client() (github.Client, error) {
 	} else {
 		gh, err = github.NewWithToken(o.githubToken)
 	}
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to create GitHub client: %w", err)
 	}

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -57,6 +57,7 @@ type testRepo struct {
 func newTestOptions(t *testing.T) *testOptions {
 	testRepo := newTestRepo(t)
 	t.Setenv(github.TokenEnvKey, "token")
+
 	return &testOptions{
 		Options: &Options{
 			DiscoverMode: RevisionDiscoveryModeNONE,
@@ -105,6 +106,7 @@ func newTestRepo(t *testing.T) *testRepo {
 
 	// Add the test data set
 	const testFileName = "test-file"
+
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cloneTempDir, testFileName),
 		[]byte("test-content"),
@@ -142,11 +144,13 @@ func newTestRepo(t *testing.T) *testRepo {
 	).RunSuccess())
 
 	const branchTestFileName = "branch-test-file"
+
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cloneTempDir, branchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0o644),
 	))
+
 	_, err = worktree.Add(branchTestFileName)
 	require.NoError(t, err)
 
@@ -166,11 +170,13 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.NoError(t, err)
 
 	const secondBranchTestFileName = "branch-test-file-2"
+
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cloneTempDir, secondBranchTestFileName),
 		[]byte("test-content"),
 		os.FileMode(0o644),
 	))
+
 	_, err = worktree.Add(secondBranchTestFileName)
 	require.NoError(t, err)
 

--- a/pkg/obs/obs.go
+++ b/pkg/obs/obs.go
@@ -205,6 +205,7 @@ func (o *Options) Validate(submit bool) error {
 	if o.ReleaseType != "" || o.ReleaseBranch != "" || o.BuildVersion != "" {
 		foundK8sOption = true
 	}
+
 	if o.Project != "" || o.PackageSource != "" || o.Version != "" {
 		foundManualOption = true
 	}
@@ -212,6 +213,7 @@ func (o *Options) Validate(submit bool) error {
 	if foundK8sOption && foundManualOption {
 		return errors.New("kubernetes and manual options are mutually exclusive")
 	}
+
 	if !foundK8sOption && !foundManualOption {
 		return errors.New("one of kubernetes or manual options are required")
 	}
@@ -248,6 +250,7 @@ func (o *Options) ValidateBuildVersion(state *State) error {
 	if err != nil {
 		return fmt.Errorf("checking for a valid build version: %w", err)
 	}
+
 	if !correct {
 		return errors.New("invalid BuildVersion specified")
 	}
@@ -256,7 +259,9 @@ func (o *Options) ValidateBuildVersion(state *State) error {
 	if err != nil {
 		return fmt.Errorf("invalid build version: %s: %w", o.BuildVersion, err)
 	}
+
 	state.semverBuildVersion = semverBuildVersion
+
 	return nil
 }
 
@@ -265,6 +270,7 @@ func (o *Options) Bucket() string {
 	if o.NoMock {
 		return release.ProductionBucket
 	}
+
 	return release.TestBucket
 }
 
@@ -383,9 +389,11 @@ func (s *Stage) SetClient(client stageClient) {
 // Submit can be used to submit a staging Google Cloud Build (GCB) job.
 func (s *Stage) Submit(stream bool) error {
 	logrus.Info("Submitting OBS stage GCB job")
+
 	if err := s.client.Submit(stream); err != nil {
 		return fmt.Errorf("submit obs stage job: %w", err)
 	}
+
 	return nil
 }
 
@@ -399,26 +407,31 @@ func (s *Stage) Run() error {
 	logger.Infof("Using krel version: %s", v.GitVersion)
 
 	logger.WithStep().Info("Validating options")
+
 	if err := s.client.ValidateOptions(); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
 
 	logger.WithStep().Info("Initializing OBS root and config")
+
 	if err := s.client.InitOBSRoot(); err != nil {
 		return fmt.Errorf("initializing obs root: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
+
 	if err := s.client.CheckPrerequisites(); err != nil {
 		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
+
 	if err := s.client.CheckReleaseBranchState(); err != nil {
 		return fmt.Errorf("checking release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
+
 	if err := s.client.GenerateReleaseVersion(); err != nil {
 		return fmt.Errorf("generating release version: %w", err)
 	}
@@ -427,26 +440,31 @@ func (s *Stage) Run() error {
 	s.client.GeneratePackageVersion()
 
 	logger.WithStep().Info("Generating OBS project name")
+
 	if err := s.client.GenerateOBSProject(); err != nil {
 		return fmt.Errorf("generating obs project name: %w", err)
 	}
 
 	logger.WithStep().Info("Checking out OBS project")
+
 	if err := s.client.CheckoutOBSProject(); err != nil {
 		return fmt.Errorf("checking out obs project: %w", err)
 	}
 
 	logger.WithStep().Info("Generating spec files and artifact archives")
+
 	if err := s.client.GeneratePackageArtifacts(); err != nil {
 		return fmt.Errorf("generating package artifacts: %w", err)
 	}
 
 	logger.WithStep().Info("Pushing packages to OBS")
+
 	if err := s.client.Push(); err != nil {
 		return fmt.Errorf("pushing packages to obs: %w", err)
 	}
 
 	logger.WithStep().Info("Waiting for OBS build results if required")
+
 	if err := s.client.Wait(); err != nil {
 		return fmt.Errorf("wait for OBS build results: %w", err)
 	}
@@ -524,9 +542,11 @@ func (r *Release) SetClient(client releaseClient) {
 // Submit can be used to submit a releasing Google Cloud Build (GCB) job.
 func (r *Release) Submit(stream bool) error {
 	logrus.Info("Submitting release GCB job")
+
 	if err := r.client.Submit(stream); err != nil {
 		return fmt.Errorf("submit release job: %w", err)
 	}
+
 	return nil
 }
 
@@ -539,41 +559,49 @@ func (r *Release) Run() error {
 	logger.Infof("Using krel version: %s", v.GitVersion)
 
 	logger.WithStep().Info("Validating options")
+
 	if err := r.client.ValidateOptions(); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
 
 	logger.WithStep().Info("Initializing OBS root and config")
+
 	if err := r.client.InitOBSRoot(); err != nil {
 		return fmt.Errorf("initializing obs root: %w", err)
 	}
 
 	logger.WithStep().Info("Checking prerequisites")
+
 	if err := r.client.CheckPrerequisites(); err != nil {
 		return fmt.Errorf("check prerequisites: %w", err)
 	}
 
 	logger.WithStep().Info("Checking release branch state")
+
 	if err := r.client.CheckReleaseBranchState(); err != nil {
 		return fmt.Errorf("checking release branch state: %w", err)
 	}
 
 	logger.WithStep().Info("Generating release version")
+
 	if err := r.client.GenerateReleaseVersion(); err != nil {
 		return fmt.Errorf("generating release version: %w", err)
 	}
 
 	logger.WithStep().Info("Generating OBS project name")
+
 	if err := r.client.GenerateOBSProject(); err != nil {
 		return fmt.Errorf("generating obs project name: %w", err)
 	}
 
 	logger.WithStep().Info("Checking out OBS project")
+
 	if err := r.client.CheckoutOBSProject(); err != nil {
 		return fmt.Errorf("checking out obs project: %w", err)
 	}
 
 	logger.WithStep().Info("Releasing packages to OBS")
+
 	if err := r.client.ReleasePackages(); err != nil {
 		return fmt.Errorf("releasing packages: %w", err)
 	}

--- a/pkg/obs/prerequisites.go
+++ b/pkg/obs/prerequisites.go
@@ -107,16 +107,19 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// osc checks
 	logrus.Info("Verifying OpenBuildService access")
+
 	ver, err := p.impl.OSCOutput("version")
 	if err != nil {
 		return fmt.Errorf("running osc version: %w", err)
 	}
+
 	logrus.Infof("Using osc version: %s", ver)
 
 	user, err := p.impl.OSCOutput("whois")
 	if err != nil {
 		return fmt.Errorf("running osc whois: %w", err)
 	}
+
 	logrus.Infof("Using OpenBuildService user: %s", user)
 
 	// Environment checks
@@ -124,6 +127,7 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 		logrus.Infof(
 			"Verifying that %s environment variable is set", OBSPasswordKey,
 		)
+
 		if !p.impl.IsEnvSet(OBSPasswordKey) {
 			return fmt.Errorf("no %s env variable set", OBSPasswordKey)
 		}
@@ -131,13 +135,16 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// Disk space check
 	const minDiskSpaceGiB = 10
+
 	logrus.Infof(
 		"Checking available disk space (%dGB) for %s", minDiskSpaceGiB, workdir,
 	)
+
 	res, err := p.impl.Usage(workdir)
 	if err != nil {
 		return fmt.Errorf("check available disk space: %w", err)
 	}
+
 	diskSpaceGiB := res.Free / 1024 / 1024 / 1024
 	if diskSpaceGiB < minDiskSpaceGiB {
 		return fmt.Errorf(

--- a/pkg/obs/release.go
+++ b/pkg/obs/release.go
@@ -207,6 +207,7 @@ func (d *DefaultRelease) ValidateOptions() error {
 	if err := d.options.Validate(d.state.State, false); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
+
 	return nil
 }
 
@@ -231,7 +232,9 @@ func (d *DefaultRelease) CheckReleaseBranchState() error {
 	if err != nil {
 		return fmt.Errorf("check if release branch needs creation: %w", err)
 	}
+
 	d.state.createReleaseBranch = createReleaseBranch
+
 	return nil
 }
 
@@ -253,6 +256,7 @@ func (d *DefaultRelease) GenerateReleaseVersion() error {
 	}
 	// Set the versions on the state
 	d.state.versions = versions
+
 	return nil
 }
 

--- a/pkg/obs/specs/archive.go
+++ b/pkg/obs/specs/archive.go
@@ -52,6 +52,7 @@ func (s *Specs) BuildArtifactsArchive(pkgDef *PackageDefinition) error {
 		logrus.Infof("Downloading %s %s (%s)...", pkgDef.Name, pkgDef.Version, arch)
 
 		dlRootPath := filepath.Join(pkgDef.SpecOutputPath, pkgDef.Name, arch)
+
 		err := s.impl.MkdirAll(dlRootPath, os.FileMode(0o755))
 		if err != nil {
 			if !s.impl.IsExist(err) {
@@ -62,7 +63,9 @@ func (s *Specs) BuildArtifactsArchive(pkgDef *PackageDefinition) error {
 		logrus.Debugf("Saving downloaded artifacts to temporary location %s...", dlRootPath)
 
 		var dlPath string
+
 		var dlTarGz bool
+
 		switch pkgDef.Name {
 		case consts.PackageKubernetesCNI:
 			dlPath = filepath.Join(dlRootPath, "kubernetes-cni.tar.gz")
@@ -93,6 +96,7 @@ func (s *Specs) BuildArtifactsArchive(pkgDef *PackageDefinition) error {
 	if err := s.impl.Compress(archiveDst, archiveSrc); err != nil {
 		return fmt.Errorf("creating archive: %w", err)
 	}
+
 	if err := s.impl.RemoveAll(archiveSrc); err != nil {
 		return fmt.Errorf("cleaning up archive source: %w", err)
 	}
@@ -122,6 +126,7 @@ func (s *Specs) DownloadArtifactFromGCS(sourcePath, destPath string, extractTgz 
 		if err := s.impl.Extract(destPath, filepath.Dir(destPath)); err != nil {
 			return fmt.Errorf("extracting .tar.gz archive: %w", err)
 		}
+
 		if err := s.impl.RemoveFile(destPath); err != nil {
 			return fmt.Errorf("removing extracted archive: %w", err)
 		}
@@ -142,9 +147,11 @@ func (s *Specs) DownloadArtifactFromURL(downloadURL, destPath string, extractTgz
 	if err != nil {
 		return fmt.Errorf("downloading artifact: %w", err)
 	}
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("downloading artifact: status code %d", resp.StatusCode)
 	}
+
 	defer resp.Body.Close()
 
 	_, err = io.Copy(out, resp.Body)
@@ -156,6 +163,7 @@ func (s *Specs) DownloadArtifactFromURL(downloadURL, destPath string, extractTgz
 		if err := s.impl.Extract(destPath, filepath.Dir(destPath)); err != nil {
 			return fmt.Errorf("extracting .tar.gz archive: %w", err)
 		}
+
 		if err := s.impl.RemoveFile(destPath); err != nil {
 			return fmt.Errorf("removing extracted archive: %w", err)
 		}

--- a/pkg/obs/specs/helpers.go
+++ b/pkg/obs/specs/helpers.go
@@ -41,12 +41,15 @@ func (s *Specs) GetKubernetesChannelForVersion(kubernetesVersion string) (string
 	switch {
 	case len(kubeVersionParts) > 4:
 		logrus.Info("User-supplied Kubernetes version is a CI version, using nightly channel")
+
 		return consts.ChannelTypeNightly, nil
 	case len(kubeVersionParts) == 4:
 		logrus.Info("User-supplied Kubernetes version is a pre-release version, using testing channel")
+
 		return consts.ChannelTypePrerelease, nil
 	default:
 		logrus.Info("User-supplied Kubernetes version is a release version, using release channel")
+
 		return consts.ChannelTypeRelease, nil
 	}
 }
@@ -104,6 +107,7 @@ func (s *Specs) GetKubernetesCIDownloadLink(baseURL, name, version, arch string)
 
 	if version == "" {
 		var err error
+
 		version, err = s.impl.GetKubeVersion(release.VersionTypeCILatestCross)
 		if err != nil {
 			return "", err

--- a/pkg/obs/specs/pkgdef.go
+++ b/pkg/obs/specs/pkgdef.go
@@ -123,6 +123,7 @@ func (s *Specs) ConstructPackageDefinition() (*PackageDefinition, error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting package source download link: %w", err)
 		}
+
 		pkgVar := PackageVariation{
 			Architecture: arch,
 			Source:       sourceURL,
@@ -160,6 +161,7 @@ func (s *Specs) GetMetadataWithVersionConstraint(packageName, packageVersion str
 		if err != nil {
 			return nil, fmt.Errorf("parsing semver range for package %s: %w", packageName, err)
 		}
+
 		kubeSemVer, err := s.impl.TagStringToSemver(packageVersion)
 		if err != nil {
 			return nil, fmt.Errorf("parsing package version %s: %w", packageVersion, err)

--- a/pkg/obs/specs/specs.go
+++ b/pkg/obs/specs/specs.go
@@ -102,6 +102,7 @@ func (o *Options) Validate() error {
 	if o.Version == "" && o.Channel == "" {
 		return errors.New("one of version or channel is required")
 	}
+
 	if o.Channel != "" {
 		if ok := consts.IsSupported("channel", []string{o.Channel}, consts.SupportedChannels); !ok {
 			return errors.New("selected channel is not supported")
@@ -119,6 +120,7 @@ func (o *Options) Validate() error {
 	if _, err := os.Stat(o.SpecTemplatePath); err != nil {
 		return errors.New("templates dir doesn't exist")
 	}
+
 	if _, err := os.Stat(o.SpecOutputPath); err != nil {
 		return errors.New("output dir doesn't exist")
 	}

--- a/pkg/obs/stage.go
+++ b/pkg/obs/stage.go
@@ -169,6 +169,7 @@ func (d *defaultStageImpl) RemovePackageFiles(path string) error {
 		}
 
 		logrus.Infof("Removing path: %s", fullPath)
+
 		return os.RemoveAll(fullPath)
 	})
 }
@@ -272,6 +273,7 @@ func (d *DefaultStage) ValidateOptions() error {
 	if err := d.options.Validate(d.state.State, false); err != nil {
 		return fmt.Errorf("validating options: %w", err)
 	}
+
 	return nil
 }
 
@@ -296,7 +298,9 @@ func (d *DefaultStage) CheckReleaseBranchState() error {
 	if err != nil {
 		return fmt.Errorf("check if release branch needs creation: %w", err)
 	}
+
 	d.state.createReleaseBranch = createReleaseBranch
+
 	return nil
 }
 
@@ -318,6 +322,7 @@ func (d *DefaultStage) GenerateReleaseVersion() error {
 	}
 	// Set the versions on the state
 	d.state.versions = versions
+
 	return nil
 }
 
@@ -380,9 +385,11 @@ func (d *DefaultStage) GeneratePackageArtifacts() error {
 		opts.Version = d.state.packageVersion
 		opts.Architectures = d.options.Architectures
 		opts.PackageSourceBase = d.options.PackageSource
+
 		if d.state.corePackages {
 			opts.PackageSourceBase = fmt.Sprintf("gs://%s/stage/%s/%s/gcs-stage", d.options.Bucket(), d.options.BuildVersion, d.state.versions.Prime())
 		}
+
 		opts.SpecTemplatePath = d.options.SpecTemplatePath
 		opts.SpecOutputPath = filepath.Join(d.options.Workspace, obsRoot, d.state.obsProject, pkg)
 
@@ -423,15 +430,18 @@ func (d *DefaultStage) Push() error {
 func (d *DefaultStage) Wait() error {
 	if !d.options.Wait {
 		logrus.Info("Will not wait for the OBS build results")
+
 		return nil
 	}
 
 	if !d.options.NoMock {
 		logrus.Info("Running stage in mock, skipping waiting for OBS")
+
 		return nil
 	}
 
 	const retries = 3
+
 	for _, pkg := range d.options.Packages {
 		var tryError error
 

--- a/pkg/release/binaries.go
+++ b/pkg/release/binaries.go
@@ -58,6 +58,7 @@ func (ac *ArtifactChecker) CheckBinaryTags() error {
 			return fmt.Errorf("checking tags in %s binaries: %w", tag, err)
 		}
 	}
+
 	return nil
 }
 
@@ -69,6 +70,7 @@ func (ac *ArtifactChecker) CheckBinaryArchitectures() error {
 			return fmt.Errorf("checking tags in %s binaries: %w", tag, err)
 		}
 	}
+
 	return nil
 }
 
@@ -98,7 +100,9 @@ func (impl *defaultArtifactCheckerImpl) CheckVersionTags(
 	if err != nil {
 		return fmt.Errorf("listing binaries for release %s: %w", version, err)
 	}
+
 	logrus.Infof("Checking %d binaries for tag %s", len(binaries), version)
+
 	for _, binData := range binaries {
 		bin, err := binary.New(binData.Path)
 		if err != nil {
@@ -115,12 +119,14 @@ func (impl *defaultArtifactCheckerImpl) CheckVersionTags(
 		if err != nil {
 			return fmt.Errorf("scanning binary %s: %w", binData.Path, err)
 		}
+
 		if !contains {
 			return fmt.Errorf(
 				"tag %s not found in produced binary: %s ", version, binData.Path,
 			)
 		}
 	}
+
 	return nil
 }
 
@@ -133,7 +139,9 @@ func (impl *defaultArtifactCheckerImpl) CheckVersionArch(
 	if err != nil {
 		return fmt.Errorf("listing binaries for release %s: %w", version, err)
 	}
+
 	logrus.Infof("Ensuring architecture of %d binaries for version %s", len(binaries), version)
+
 	for _, binData := range binaries {
 		bin, err := binary.New(binData.Path)
 		if err != nil {
@@ -156,5 +164,6 @@ func (impl *defaultArtifactCheckerImpl) CheckVersionArch(
 			logrus.Warnf("Binary is dynamically linked, which should be nothing we release: %s", binData.Path)
 		}
 	}
+
 	return nil
 }

--- a/pkg/release/branch_checker.go
+++ b/pkg/release/branch_checker.go
@@ -76,11 +76,14 @@ func (r *BranchChecker) NeedsCreation(
 		logrus.Infof("Branch %s does already exist on remote location", branch)
 	} else {
 		logrus.Infof("Branch %s does not yet exist on remote location", branch)
+
 		if releaseType == ReleaseTypeOfficial {
 			return false, errors.New("can't do officials releases when creating a new branch")
 		}
+
 		createReleaseBranch = true
 	}
+
 	logrus.Infof("Release branch needs to be created: %v", createReleaseBranch)
 
 	if branch == git.DefaultBranch {

--- a/pkg/release/branch_checker_test.go
+++ b/pkg/release/branch_checker_test.go
@@ -95,6 +95,7 @@ func TestNeedsCreation(t *testing.T) {
 	} {
 		mock := &releasefakes.FakeBranchCheckerImpl{}
 		sut := release.NewBranchChecker()
+
 		tc.prepare(mock)
 		sut.SetImpl(mock)
 

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestPublish(t *testing.T) {
 	t.Parallel()
+
 	for _, tc := range []struct {
 		name        string
 		prepare     func(*releasefakes.FakeImageImpl) (buildPath string, cleanup func())
@@ -78,6 +79,7 @@ func TestPublish(t *testing.T) {
 			name: "success no images",
 			prepare: func(*releasefakes.FakeImageImpl) (string, func()) {
 				tempDir := newImagesPath(t)
+
 				return tempDir, func() {
 					require.NoError(t, os.RemoveAll(tempDir))
 				}
@@ -181,6 +183,7 @@ func TestPublish(t *testing.T) {
 						return errors.New("")
 					}
 					i++
+
 					return nil
 				})
 
@@ -378,6 +381,7 @@ func TestValidate(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+
 		cleanup()
 	}
 }
@@ -395,6 +399,7 @@ func newImagesPath(t *testing.T) string {
 
 func prepareImages(t *testing.T, tempDir string, mock *releasefakes.FakeImageImpl) {
 	c := 0
+
 	for _, arch := range []string{"amd64", "arm", "arm64"} {
 		archPath := filepath.Join(tempDir, release.ImagesPath, arch)
 		require.NoError(t, os.MkdirAll(archPath, os.FileMode(0o755)))
@@ -414,6 +419,7 @@ func prepareImages(t *testing.T, tempDir string, mock *releasefakes.FakeImageImp
 				),
 				nil,
 			)
+
 			c++
 		}
 	}

--- a/pkg/release/prerequisites.go
+++ b/pkg/release/prerequisites.go
@@ -104,6 +104,7 @@ func (*defaultPrerequisitesChecker) DockerVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return res.OutputTrimNL(), err
 }
 
@@ -127,11 +128,14 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// Docker version checks
 	const minVersion = "18.06.0"
+
 	logrus.Infof("Verifying minimum Docker version %s", minVersion)
+
 	versionOutput, err := p.impl.DockerVersion()
 	if err != nil {
 		return fmt.Errorf("validate docker version: %w", err)
 	}
+
 	if versionOutput < minVersion {
 		return fmt.Errorf(
 			"minimum docker version %s required, got %s",
@@ -141,6 +145,7 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// Google Cloud checks
 	logrus.Info("Verifying Google Cloud access")
+
 	if _, err := p.impl.GCloudOutput(
 		"config", "get-value", "project",
 	); err != nil {
@@ -152,6 +157,7 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 		logrus.Infof(
 			"Verifying that %s environment variable is set", github.TokenEnvKey,
 		)
+
 		if !p.impl.IsEnvSet(github.TokenEnvKey) {
 			return fmt.Errorf("no %s env variable set", github.TokenEnvKey)
 		}
@@ -159,13 +165,16 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// Disk space check
 	const minDiskSpaceGiB = 100
+
 	logrus.Infof(
 		"Checking available disk space (%dGB) for %s", minDiskSpaceGiB, workdir,
 	)
+
 	res, err := p.impl.Usage(workdir)
 	if err != nil {
 		return fmt.Errorf("check available disk space: %w", err)
 	}
+
 	diskSpaceGiB := res.Free / 1024 / 1024 / 1024
 	if diskSpaceGiB < minDiskSpaceGiB {
 		return fmt.Errorf(
@@ -176,6 +185,7 @@ func (p *PrerequisitesChecker) Run(workdir string) error {
 
 	// Git setup check
 	logrus.Info("Configuring git user and email")
+
 	if err := p.impl.ConfigureGlobalDefaultUserAndEmail(); err != nil {
 		return fmt.Errorf("configure git user and email: %w", err)
 	}

--- a/pkg/release/prerequisites_test.go
+++ b/pkg/release/prerequisites_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestCheckPrerequisites(t *testing.T) {
 	err := errors.New("error")
+
 	for _, tc := range []struct {
 		prepare   func(*releasefakes.FakePrerequisitesCheckerImpl)
 		shouldErr bool
@@ -111,6 +112,7 @@ func TestCheckPrerequisites(t *testing.T) {
 	} {
 		mock := &releasefakes.FakePrerequisitesCheckerImpl{}
 		sut := release.NewPrerequisitesChecker()
+
 		tc.prepare(mock)
 		sut.SetImpl(mock)
 

--- a/pkg/release/provenance_test.go
+++ b/pkg/release/provenance_test.go
@@ -117,6 +117,7 @@ func TestGetStagingSubjects(t *testing.T) {
 	for _, sub := range subjects {
 		filename := filepath.Base(sub.Name)
 		require.NotEmpty(t, filename)
+
 		_, ok := testFiles[filepath.Join("second", filename)]
 		if filename == SourcesTar {
 			require.False(t, ok)

--- a/pkg/release/publish_test.go
+++ b/pkg/release/publish_test.go
@@ -144,6 +144,7 @@ func TestPublishVersion(t *testing.T) {
 		sut := release.NewPublisher()
 		clientMock := &releasefakes.FakePublisherClient{}
 		sut.SetClient(clientMock)
+
 		if tc.prepare != nil {
 			tc.prepare(clientMock)
 		}
@@ -162,6 +163,7 @@ func TestPublishVersion(t *testing.T) {
 
 func TestPublishReleaseNotesIndex(t *testing.T) {
 	err := errors.New("")
+
 	for _, tc := range []struct {
 		prepare     func(*releasefakes.FakePublisherClient)
 		shouldError bool

--- a/pkg/release/push_git_objects_test.go
+++ b/pkg/release/push_git_objects_test.go
@@ -38,6 +38,7 @@ func getTestGitObjectPusher() (pusher *GitObjectPusher, repoPath string, err err
 	if err := command.NewWithWorkDir(
 		repoPath, "git", "init").RunSilentSuccess(); err != nil {
 		os.RemoveAll(repoPath)
+
 		return nil, repoPath, fmt.Errorf("initializing test repository: %w", err)
 	}
 
@@ -46,6 +47,7 @@ func getTestGitObjectPusher() (pusher *GitObjectPusher, repoPath string, err err
 		repoPath, "git", "commit", "--allow-empty", "-m", "Root commit",
 	).RunSilentSuccess(); err != nil {
 		os.RemoveAll(repoPath)
+
 		return nil, repoPath, fmt.Errorf("creating first commit: %w", err)
 	}
 
@@ -54,6 +56,7 @@ func getTestGitObjectPusher() (pusher *GitObjectPusher, repoPath string, err err
 	if err != nil {
 		return nil, repoPath, fmt.Errorf("listing branches in test repo: %w", err)
 	}
+
 	if !strings.Contains(out.Output(), git.DefaultBranch) {
 		if err := command.NewWithWorkDir(
 			repoPath, "git", "branch", git.DefaultBranch,
@@ -75,6 +78,7 @@ func TestCheckBranchName(t *testing.T) {
 	if repoPath != "" {
 		defer os.RemoveAll(repoPath)
 	}
+
 	require.NoError(t, err)
 
 	sampleBaranches := []struct {
@@ -99,6 +103,7 @@ func TestCheckTagName(t *testing.T) {
 	if repoPath != "" {
 		defer os.RemoveAll(repoPath)
 	}
+
 	require.NoError(t, err)
 
 	sampleTags := []struct {

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -82,6 +82,7 @@ func TestReadDockerVersion(t *testing.T) {
 		Name: "kubernetes/version",
 		Size: int64(len(versionBytes)),
 	}))
+
 	versionFile, err := os.Open(filepath.Join(baseTmpDir, BuildDir, ReleaseTarsPath, "kubernetes", "version"))
 	require.NoError(t, err)
 	_, err = io.Copy(tw, versionFile)
@@ -97,10 +98,12 @@ func TestReadDockerVersion(t *testing.T) {
 	type args struct {
 		path string
 	}
+
 	type want struct {
 		r    string
 		rErr bool
 	}
+
 	cases := map[string]struct {
 		args args
 		want want
@@ -138,6 +141,7 @@ func TestIsValidReleaseBuild(t *testing.T) {
 		r    bool
 		rErr bool
 	}
+
 	cases := map[string]struct {
 		build string
 		want  want
@@ -448,6 +452,7 @@ func TestWriteChecksums(t *testing.T) {
 			prepare: func() (rootPath string) {
 				tempDir := t.TempDir()
 				require.NoError(t, os.RemoveAll(tempDir))
+
 				return tempDir
 			},
 			validate: func(err error, _ string) {

--- a/pkg/release/release_version.go
+++ b/pkg/release/release_version.go
@@ -83,18 +83,23 @@ func (r *Versions) Alpha() string {
 func (r *Versions) String() string {
 	sb := &strings.Builder{}
 	fmt.Fprintf(sb, "prime: %s", r.prime)
+
 	if r.official != "" {
 		fmt.Fprintf(sb, ", %s: %s", ReleaseTypeOfficial, r.official)
 	}
+
 	if r.rc != "" {
 		fmt.Fprintf(sb, ", %s: %s", ReleaseTypeRC, r.rc)
 	}
+
 	if r.beta != "" {
 		fmt.Fprintf(sb, ", %s: %s", ReleaseTypeBeta, r.beta)
 	}
+
 	if r.alpha != "" {
 		fmt.Fprintf(sb, ", %s: %s", ReleaseTypeAlpha, r.alpha)
 	}
+
 	return sb.String()
 }
 
@@ -103,15 +108,19 @@ func (r *Versions) Ordered() (versions []string) {
 	if r.Official() != "" {
 		versions = append(versions, r.Official())
 	}
+
 	if r.RC() != "" {
 		versions = append(versions, r.RC())
 	}
+
 	if r.Beta() != "" {
 		versions = append(versions, r.Beta())
 	}
+
 	if r.Alpha() != "" {
 		versions = append(versions, r.Alpha())
 	}
+
 	return versions
 }
 
@@ -139,6 +148,7 @@ func GenerateReleaseVersion(
 	}
 
 	var labelID uint64 = 1
+
 	labelIDAvailable := false
 	if len(v.Pre) > 1 && v.Pre[1].IsNum {
 		labelIDAvailable = true
@@ -149,19 +159,23 @@ func GenerateReleaseVersion(
 	// session/type Other labels such as alpha, beta, and rc are set as needed
 	// Index ordering is important here as it's how they are processed
 	releaseVersions := &Versions{}
+
 	if branchFromMaster { //nolint:gocritic // a switch case would not make it better
 		branchMatch := regex.BranchRegex.FindStringSubmatch(branch)
 		if len(branchMatch) < 3 {
 			return nil, fmt.Errorf("invalid formatted branch %s", branch)
 		}
+
 		branchMajor, err := strconv.Atoi(branchMatch[1])
 		if err != nil {
 			return nil, fmt.Errorf("parsing branch major version %q to int: %w", branchMatch[1], err)
 		}
+
 		branchMinor, err := strconv.Atoi(branchMatch[2])
 		if err != nil {
 			return nil, fmt.Errorf("parsing branch minor version %q to int: %w", branchMatch[2], err)
 		}
+
 		releaseBranch := struct{ major, minor int }{
 			major: branchMajor, minor: branchMinor,
 		}
@@ -187,6 +201,7 @@ func GenerateReleaseVersion(
 		if !labelIDAvailable {
 			patch++
 		}
+
 		releaseVersions.prime += fmt.Sprintf(".%d", patch)
 
 		if releaseType == ReleaseTypeOfficial {
@@ -239,5 +254,6 @@ func GenerateReleaseVersion(
 	}
 
 	logrus.Infof("Found release versions: %+v", releaseVersions.String())
+
 	return releaseVersions, nil
 }

--- a/pkg/release/repository_test.go
+++ b/pkg/release/repository_test.go
@@ -51,6 +51,7 @@ func newSUT(t *testing.T) *sut {
 
 	mock := &releasefakes.FakeRepository{}
 	repo.SetRepo(mock)
+
 	return &sut{repo, mock, dir, t}
 }
 

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -46,6 +46,7 @@ func (*versionClient) GetURLResponse(url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(bytes.TrimSpace(c)), nil
 }
 
@@ -90,6 +91,7 @@ func (t VersionType) URL(version string) string {
 	if version != "" {
 		url += "-" + version
 	}
+
 	url += ".txt"
 
 	return url
@@ -98,6 +100,7 @@ func (t VersionType) URL(version string) string {
 // GetKubeVersion retrieves the version of the provided Kubernetes version type.
 func (v *Version) GetKubeVersion(versionType VersionType) (string, error) {
 	logrus.Infof("Retrieving Kubernetes release version for %s", versionType)
+
 	return v.kubeVersionFromURL(versionType.URL(""))
 }
 
@@ -110,12 +113,15 @@ func (v *Version) GetKubeVersionForBranch(versionType VersionType, branch string
 	)
 
 	version := ""
+
 	if branch != git.DefaultBranch {
 		if !git.IsReleaseBranch(branch) {
 			return "", fmt.Errorf("%s is not a valid release branch", branch)
 		}
+
 		version = strings.TrimPrefix(branch, "release-")
 	}
+
 	url := versionType.URL(version)
 
 	return v.kubeVersionFromURL(url)
@@ -125,11 +131,13 @@ func (v *Version) GetKubeVersionForBranch(versionType VersionType, branch string
 // ans strips the tag prefix if `stripTagPrefix` is `true`.
 func (v *Version) kubeVersionFromURL(url string) (string, error) {
 	logrus.Infof("Retrieving Kubernetes build version from %s...", url)
+
 	version, httpErr := v.client.GetURLResponse(url)
 	if httpErr != nil {
 		return "", fmt.Errorf("retrieving kube version: %w", httpErr)
 	}
 
 	logrus.Infof("Retrieved Kubernetes version: %s", version)
+
 	return version, nil
 }

--- a/pkg/testgrid/testgrid-scraper_test.go
+++ b/pkg/testgrid/testgrid-scraper_test.go
@@ -33,7 +33,6 @@ var (
 func TestRequestTestgridSummaryPos(t *testing.T) {
 	// Given
 	// positive dashboard names
-
 	for _, dashboardName := range posDashboardNames {
 		// When
 		summary, err := ReqTestgridDashboardSummary(context.Background(), dashboardName)
@@ -41,6 +40,7 @@ func TestRequestTestgridSummaryPos(t *testing.T) {
 		// Then
 		require.NoError(t, err)
 		assert.NotNil(t, summary)
+
 		for _, jobs := range summary {
 			assert.Equal(t, dashboardName, jobs.DashboardName)
 		}
@@ -50,7 +50,6 @@ func TestRequestTestgridSummaryPos(t *testing.T) {
 func TestRequestTestgridSummaryNeg(t *testing.T) {
 	// Given
 	// negative dashboard names
-
 	for _, dashboardName := range negDashboardNames {
 		// When
 		summary, err := ReqTestgridDashboardSummary(context.Background(), dashboardName)
@@ -64,7 +63,6 @@ func TestRequestTestgridSummaryNeg(t *testing.T) {
 func TestRequestTestgridSummariesPos(t *testing.T) {
 	// Given
 	// positive dashboard names
-
 	// When
 	data, err := ReqTestgridDashboardSummaries(context.Background(), posDashboardNames)
 
@@ -76,7 +74,6 @@ func TestRequestTestgridSummariesPos(t *testing.T) {
 func TestRequestTestgridSummariesNeg(t *testing.T) {
 	// Given
 	// negative dashboard names
-
 	// When
 	data, err := ReqTestgridDashboardSummaries(context.Background(), negDashboardNames)
 
@@ -88,7 +85,6 @@ func TestRequestTestgridSummariesNeg(t *testing.T) {
 func TestRequestTestgridSummariesPosNeg(t *testing.T) {
 	// Given
 	// Request positive and negative dashboard names, expect to get an error and receive positive dashboard name summaries
-
 	// When
 	data, err := ReqTestgridDashboardSummaries(context.Background(), append(negDashboardNames, posDashboardNames...))
 
@@ -116,6 +112,7 @@ func TestOverviewPos(t *testing.T) {
 		{amountOfJobs: staleJobs, overallStatus: Stale},
 	}
 	data := JobData{}
+
 	for _, jobDef := range jobGeneratorDef {
 		for i := range jobDef.amountOfJobs {
 			data[JobName(fmt.Sprintf("%s-%d", jobDef.overallStatus, i))] = JobSummary{

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -69,6 +69,7 @@ func (t *TestGrid) BlockingTests(branch string) (tests []string, err error) {
 
 	dashboardName := "sig-" + branch + "-blocking"
 	dashboard := config.FindDashboard(dashboardName, conf)
+
 	if dashboard == nil {
 		return nil, fmt.Errorf("dashboard %s not found", dashboardName)
 	}
@@ -87,6 +88,7 @@ func (t *TestGrid) configFromURL(url string) (cfg *pb.Configuration, err error) 
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() {
 		if err == nil {
 			err = os.Remove(tmpFile.Name())

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -34,6 +34,7 @@ func newSut() (*testgrid.TestGrid, *testgridfakes.FakeClient) {
 	client := &testgridfakes.FakeClient{}
 	sut := testgrid.New()
 	sut.SetClient(client)
+
 	return sut, client
 }
 

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -24,19 +24,25 @@ import (
 
 func CheckErr(t *testing.T, err error, expectedMsg string) {
 	t.Helper()
+
 	if expectedMsg == "" {
 		require.NoError(t, err)
+
 		return
 	}
+
 	require.EqualError(t, err, expectedMsg)
 }
 
 func CheckErrSub(t *testing.T, err error, expectedSubstring string) {
 	t.Helper()
+
 	if expectedSubstring == "" {
 		require.NoError(t, err)
+
 		return
 	}
+
 	require.Contains(t, err.Error(), expectedSubstring)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The linters come with a new auto-fix function, means we can enable them without any manual effort.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
