### PR TITLE
Use GitHub release for cri-tools and CNI plugins

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -1,6 +1,6 @@
 cri-tools:
   - versionConstraint: ">= 1.0.0"
-    sourceURLTemplate: "gs://k8s-artifacts-cri-tools/release/v{{ .PackageVersion }}/crictl-v{{ .PackageVersion }}-linux-{{ .Architecture }}.tar.gz"
+    sourceURLTemplate: "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ .PackageVersion }}/crictl-v{{ .PackageVersion }}-linux-{{ .Architecture }}.tar.gz"
     sourceTarGz: true
 kubeadm:
   - versionConstraint: ">= 1.24.0 < 1.24.2"
@@ -107,5 +107,5 @@ kubelet:
         versionConstraint: ">= 1.2.0"
 kubernetes-cni:
   - versionConstraint: ">= 0.8.7"
-    sourceURLTemplate: "gs://k8s-artifacts-cni/release/v{{ .PackageVersion }}/cni-plugins-linux-{{ .Architecture }}-v{{ .PackageVersion }}.tgz"
+    sourceURLTemplate: "https://github.com/containernetworking/plugins/releases/download/v{{ .PackageVersion }}/cni-plugins-linux-{{ .Architecture }}-v{{ .PackageVersion }}.tgz"
     sourceTarGz: true


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Use the GitHub release download links instead of the buckets to save resources.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use GitHub release for cri-tools and CNI plugins package builds.
```
