### PR TITLE
Replace go-multierror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/google/go-github/v60 v60.0.0
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.2
@@ -175,6 +174,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/pkg/testgrid/testgrid-scraper.go
+++ b/pkg/testgrid/testgrid-scraper.go
@@ -25,8 +25,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // SummaryLookup this type is used if multiple testgrid summaries are getting requested concurrently.
@@ -72,7 +70,7 @@ func ReqTestgridDashboardSummaries(ctx context.Context, dashboardNames []Dashboa
 	// Collect data from buffered channel
 	for lookups := range requestData(done, dashboardNames...) {
 		if lookups.Error != nil {
-			err = multierror.Append(err, fmt.Errorf("error requesting summary for dashboard %s: %w", lookups.Dashboard, lookups.Error))
+			err = errors.Join(err, fmt.Errorf("error requesting summary for dashboard %s: %w", lookups.Dashboard, lookups.Error))
 		} else {
 			dashboardData[lookups.Dashboard] = lookups.Summary
 		}


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Replace the go-multierr usage with golang native error joining.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
