### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.5/1.22.11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -357,32 +357,32 @@ dependencies:
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.32-cross1.23)"
-    version: v1.32.0-go1.23.4-bullseye.0
+    version: v1.32.0-go1.23.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.23)"
-    version: v1.31.0-go1.23.4-bullseye.0
+    version: v1.31.0-go1.23.5-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   # TODO: remove this after upgrade to Go 1.23 is finalized and there's on risk of reverting
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.22)"
-    version: v1.31.0-go1.22.10-bullseye.0
+    version: v1.31.0-go1.22.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.22)"
-    version: v1.30.0-go1.22.10-bullseye.0
+    version: v1.30.0-go1.22.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.29-cross1.22)"
-    version: v1.29.0-go1.22.10-bullseye.0
+    version: v1.29.0-go1.22.11-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -405,28 +405,28 @@ dependencies:
 
   # Golang (previous release branch: 1.32)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.32)"
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.31)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.31)"
-    version: 1.22.10
+    version: 1.22.11
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.30)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.30)"
-    version: 1.22.10
+    version: 1.22.11
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.29)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.29)"
-    version: 1.22.10
+    version: 1.22.11
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -441,25 +441,25 @@ dependencies:
       match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.32)"
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.31)"
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.30)"
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.29)"
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: images/releng/k8s-ci-builder/variants.yaml
       match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,17 +4,17 @@ variants:
     KUBE_CROSS_VERSION: 'v1.33.0-go1.23.5-bullseye.0'
   v1.32-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.5-bullseye.0'
   v1.31-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.5-bullseye.0'
   # TODO: remove this after upgrade to Go 1.23 is finalized and there's on risk of reverting
   v1.31-cross1.22-bullseye:
     CONFIG: 'cross1.22'
-    KUBE_CROSS_VERSION: 'v1.31.0-go1.22.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.22.11-bullseye.0'
   v1.30-cross1.22-bullseye:
     CONFIG: 'cross1.22'
-    KUBE_CROSS_VERSION: 'v1.30.0-go1.22.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.30.0-go1.22.11-bullseye.0'
   v1.29-cross1.22-bullseye:
     CONFIG: 'cross1.21'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.22.10-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.29.0-go1.22.11-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.22.10'
+    GO_VERSION: '1.22.11'
     GO_VERSION_TOOLING: '1.23.5'
     OS_CODENAME: 'bullseye'
   next:
@@ -16,21 +16,21 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: '1.23.4'
-    GO_VERSION_TOOLING: '1.23.4'
+    GO_VERSION: '1.23.5'
+    GO_VERSION_TOOLING: '1.23.5'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: '1.22.10'
-    GO_VERSION_TOOLING: '1.23.4'
+    GO_VERSION: '1.22.11'
+    GO_VERSION_TOOLING: '1.23.5'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: '1.22.10'
-    GO_VERSION_TOOLING: '1.23.4'
+    GO_VERSION: '1.22.11'
+    GO_VERSION_TOOLING: '1.23.5'
     OS_CODENAME: 'bullseye'
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: '1.22.10'
-    GO_VERSION_TOOLING: '1.23.4'
+    GO_VERSION: '1.22.11'
+    GO_VERSION_TOOLING: '1.23.5'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.5/1.22.11


#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3901

#### Does this PR introduce a user-facing change?
```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.5/1.22.11
```

/assign @Verolop @xmudrii @saschagrunert  
cc @kubernetes/release-engineering 