### PR TITLE
Add go 1.23 cross variants for 1.29 and 1.30

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -44,6 +44,15 @@ variants:
     GO_MAJOR_VERSION: '1.22'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
+  v1.30-go1.23-bullseye:
+    CONFIG: 'go1.23-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.30.0-go1.23.6-bullseye.0'
+    KUBERNETES_VERSION: 'v1.30.0'
+    GO_VERSION: '1.23.6'
+    GO_MAJOR_VERSION: '1.23'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   v1.30-go1.22-bullseye:
     CONFIG: 'go1.22-bullseye'
     TYPE: 'default'
@@ -51,6 +60,15 @@ variants:
     KUBERNETES_VERSION: 'v1.30.0'
     GO_VERSION: '1.22.12'
     GO_MAJOR_VERSION: '1.22'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+  v1.29-go1.23-bullseye:
+    CONFIG: 'go1.23-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.29.0-go1.23.6-bullseye.0'
+    KUBERNETES_VERSION: 'v1.29.0'
+    GO_VERSION: '1.23.6'
+    GO_MAJOR_VERSION: '1.23'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   v1.29-go1.22-bullseye:


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/3650 / https://github.com/kubernetes/release/issues/3914

cc @cpanato 

```release-note
NONE
```