### PR TITLE
build distroless-iptables with go1.24.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -512,6 +512,18 @@ dependencies:
     - path: images/build/setcap/variants.yaml
       match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.24)"
+    version: v0.7.3
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.24)"
+    version: v2.4.0-go1.24.0-bookworm.0
+    refPaths:
+    - path: images/build/distroless-iptables/variants.yaml
+      match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.23)"
     version: v0.6.8
     refPaths:

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,9 +1,9 @@
 variants:
   distroless-bookworm-go1.24:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.7.2'
+    IMAGE_VERSION: 'v0.7.3'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.4.0-go1.24rc3-bookworm.0'
+    GORUNNER_VERSION: 'v2.4.0-go1.24.0-bookworm.0'
   distroless-bookworm-go1.23:
     CONFIG: 'distroless-bookworm'
     IMAGE_VERSION: 'v0.6.8'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- bump distroless-iptables to use go1.24.0

/assign @Verolop  @xmudrii  @saschagrunert   
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3772

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- bump distroless-iptables to use go1.24.0
```
