### PR TITLE
fix array size when creating the assets

### DIFF
--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -308,13 +308,14 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 		}
 	}
 
-	newAssets := make([]string, len(assets)+1)
-	for i, a := range assets {
-		newAssets[i] = a.ReadFrom
+	var newAssets []string //nolint: prealloc,gocritic
+	for _, a := range assets {
+		newAssets = append(newAssets, a.ReadFrom)
 	}
-
 	// add sbom to the path to upload
-	newAssets[len(assets)] = sbomStr
+	if sbomStr != "" {
+		newAssets = append(newAssets, sbomStr)
+	}
 
 	// Build the release page options
 	ghOpts := github.Options{

--- a/pkg/announce/github/impl.go
+++ b/pkg/announce/github/impl.go
@@ -49,6 +49,10 @@ func (i *defaultImpl) github() *githubsdk.GitHub {
 func (i *defaultImpl) processAssetFiles(assetFiles []string) (releaseAssets []map[string]string, err error) {
 	// Check all asset files and get their hashes
 	for _, path := range assetFiles {
+		if path == "" {
+			continue
+		}
+
 		assetData := map[string]string{
 			"rawpath": path,
 			"name":    "",


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
- fix array size when creating the assets

when using the `publish-release` with the `sbom` flag as false we generate a empty entry in the array that fail to parse the assets when trying to upload


/assign @saschagrunert @puerco 
we will need a new release to update the release-actions

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes-sigs/release-actions/issues/107

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix array size when creating the assets
```
