### PR TITLE
use go1.24 and remove deprecated lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
         id: go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.63
+          version: v1.64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
 
       - uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -26,7 +26,7 @@ jobs:
         id: go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
 
       - name: Install bom

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,6 @@ linters:
     - staticcheck
     - stylecheck
     - tagalign
-    - tenv
     - testableexamples
     - testifylint
     - tparallel

--- a/cmd/krel/cmd/sut_test.go
+++ b/cmd/krel/cmd/sut_test.go
@@ -49,7 +49,7 @@ func newSUT(t *testing.T) *sut {
 	// global .gitconfig. This means we're silently assuming that we're running
 	// inside a container with the actual $HOME of `/root`.
 	if !env.IsSet("HOME") {
-		os.Setenv("HOME", "/root")
+		t.Setenv("HOME", "/root")
 	}
 
 	// A local k/k repo will be our test base

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
   #     match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: 1.<major> (github workflows)"
-    version: 1.23
+    version: 1.24
     refPaths:
     - path: .github/workflows/release.yml
       match: "go-version: '\\d+.\\d+'"
@@ -459,7 +459,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v1.63
+    version: v1.64
     refPaths:
     - path: .github/workflows/lint.yml
       match: "version: v\\d+.\\d+?\\.?(\\d+)?"

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -52,7 +52,7 @@ func TestGetToolRefSuccess(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Logf("Test case: %s", tc.name)
-		require.NoError(t, os.Setenv("TOOL_REF", tc.ref))
+		t.Setenv("TOOL_REF", tc.ref)
 
 		actual := GetToolRef()
 		require.Equal(t, tc.expected, actual)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

- use go1.24 and remove deprecated lint

/assign @saschagrunert @Verolop @xmudrii 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
use go1.24 and remove deprecated lint
```
