### PR TITLE
build k8s-cloud-builder and k8s-ci-builder for go1.24

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -350,8 +350,8 @@ dependencies:
 
   # kube-cross dependents (i.e. k8s-cloud-builder)
   # To be updated after kubernetes/kubernetes update)
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.33-cross1.23)"
-    version: v1.33.0-go1.23.6-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.33-cross1.24)"
+    version: v1.33.0-go1.24.0-bullseye.0
     refPaths:
     - path: images/k8s-cloud-builder/variants.yaml
       match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -389,7 +389,7 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.23.6
+    version: 1.24.0
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -426,7 +426,7 @@ dependencies:
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.23.6
+    version: 1.24.0
     refPaths:
     - path: images/releng/k8s-ci-builder/Makefile
       match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
-  v1.33-cross1.23-bullseye:
+  v1.33-cross1.24-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.33.0-go1.23.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.33.0-go1.24.0-bullseye.0'
   v1.32-cross1.23-bullseye:
     CONFIG: 'cross1.23'
     KUBE_CROSS_VERSION: 'v1.32.0-go1.23.6-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.23.6
-GO_VERSION_TOOLING ?= 1.23.6
+GO_VERSION ?= 1.24.0
+GO_VERSION_TOOLING ?= 1.24.0
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.23.6'
-    GO_VERSION_TOOLING: '1.23.6'
+    GO_VERSION: '1.24.0'
+    GO_VERSION_TOOLING: '1.24.0'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- build k8s-cloud-builder and k8s-ci-builder for go1.24

/assign @saschagrunert @puerco @Verolop 
cc @kubernetes/release-managers 


#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3772

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
build k8s-cloud-builder and k8s-ci-builder for go1.24
```
