### PR TITLE
Fix bucket usage, now correctly pointing at GH for Krel release

### DIFF
--- a/hack/get-krel
+++ b/hack/get-krel
@@ -45,9 +45,9 @@ if [[ "$FORCE_BUILD_KREL" == false &&
     LATEST_RELEASE=$(curl_retry https://api.github.com/repos/kubernetes/release/releases/latest | jq -r .tag_name)
     echo "Using krel release: $LATEST_RELEASE"
 
-    echo "Downloading krel from GCB bucket…"
-    GCB_URL="https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$LATEST_RELEASE/krel-amd64-linux"
-    curl_retry "$GCB_URL" -o "$KREL_OUTPUT_PATH"
+    echo "Downloading krel from GitHub releases…"
+    GH_URL="https://github.com/kubernetes/release/releases/download/$LATEST_RELEASE/krel-amd64-linux"
+    curl_retry "$GH_URL" -o "$KREL_OUTPUT_PATH"
     chmod +x "$KREL_OUTPUT_PATH"
 else
     echo "Building krel from sources"


### PR DESCRIPTION
Update get-krel to fix a bug about the bucket used to download the latest krel release

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixing a bug on krel, it is now using the wrong bucket to download krel latest release, ref. https://kubernetes.slack.com/archives/CJH2GBF7Y/p1741090467316019?thread_ts=1741088290.457379&cid=CJH2GBF7Y

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

N/A

```release-note

```
