### PR TITLE
Remove duplicate kube-cross image pushes

### DIFF
--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -59,8 +59,3 @@ tags:
 - ${_IMAGE_VERSION}
 - ${_REVISION}
 - ${_PROTOBUF_VERSION}
-
-images:
-  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_IMAGE_VERSION'
-  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:$_GIT_TAG-$_CONFIG-$_TYPE'
-  - 'gcr.io/$PROJECT_ID/kube-cross-amd64:latest-$_CONFIG-$_TYPE'


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`kube-cross` image building tasks have image push twice.
After the commit https://github.com/kubernetes/release/pull/1915/commits/2f73d524ca949d3a13e51ab94f682ac3cb3b3938,  `docker push` commands were added to Makefile at https://github.com/kubernetes/release/blob/master/images/build/cross/Makefile#L95:L97

Hence the `images:` tag in `cloudbuild.yaml` is not needed.
