### PR TITLE
Include revert PR instead of the reverted one in release notes

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1136,6 +1136,13 @@ func prsNumForCommitFromMessage(commitMessage string) (prs []int, err error) {
 		prs = append(prs, pr)
 	}
 
+	regex = regexp.MustCompile(`\(#(?P<number>\d+)\)\s*\n\nThis reverts commit`)
+
+	pr = prForRegex(regex, commitMessage)
+	if pr != 0 {
+		prs = append(prs, pr)
+	}
+
 	// If the PR was squash merged, the regexp is different
 	regex = regexp.MustCompile(`\(#(?P<number>\d+)\)`)
 

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -223,6 +223,14 @@ func TestGetPRNumberFromCommitMessage(t *testing.T) {
 			commitMessage:    "Add swapoff to centos so kubelet starts (#504)",
 			expectedPRNumber: 504,
 		},
+		{
+			name: "Get PR number from revert commit",
+			commitMessage: `Revert "some pr (#1000)" (#1234)
+
+
+This reverts commit abcdef1234567890abcdef1234567890abcdef12.`,
+			expectedPRNumber: 1234,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
As described in #3966, the release notes include the reverted PRs instead of the revert PRs.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #3966 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix release notes to include the revert PR instead of the reverted one.
```
