### PR TITLE
chore: Port to sigs.k8s.io/yaml

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -34,13 +34,13 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/release-sdk/git"
 	"sigs.k8s.io/release-sdk/github"
 	"sigs.k8s.io/release-utils/command"
 	"sigs.k8s.io/release-utils/editor"
 	"sigs.k8s.io/release-utils/util"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/text v0.25.0
 	google.golang.org/api v0.221.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.33.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/bom v0.6.0
@@ -306,6 +305,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.28.4 // indirect
 	k8s.io/client-go v0.28.4 // indirect

--- a/pkg/cve/impl.go
+++ b/pkg/cve/impl.go
@@ -27,9 +27,9 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/release-sdk/object"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/release/pkg/notes"
 )

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -41,9 +41,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/release-sdk/github"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/release/pkg/notes/options"
 )

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -24,9 +24,9 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/release-sdk/object"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // MapProvider interface that obtains release notes maps from a source.


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

/kind deprecation

#### What this PR does / why we need it:
Ports from unmaintained gopkg.in/yaml.v2 to sigs.k8s.io/yaml.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
