### PR TITLE
Update golangci-lint to 2.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.0
+          version: v2.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -431,7 +431,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v2.0
+    version: v2.1
     refPaths:
       - path: .github/workflows/lint.yml
         match: "version: v\\d+.\\d+?\\.?(\\d+)?"


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR supersedes #3999 bumping golangci-lint to v2.1 and also updating the zeitgeist version lock to make the tests pass.

#### Which issue(s) this PR fixes:

Supersedes #3999

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
