### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.8

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -335,19 +335,19 @@ dependencies:
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.32-cross1.23)"
-    version: v1.32.0-go1.23.6-bullseye.0
+    version: v1.32.0-go1.23.8-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.23)"
-    version: v1.31.0-go1.23.6-bullseye.0
+    version: v1.31.0-go1.23.8-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.23)"
-    version: v1.30.0-go1.23.6-bullseye.0
+    version: v1.30.0-go1.23.8-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -370,28 +370,21 @@ dependencies:
 
   # Golang (previous release branch: 1.32)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.32)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.31)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.31)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.30)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.30)"
-    version: 1.23.6
-    refPaths:
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
-  # Golang (previous release branch: 1.29)
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.29)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -406,25 +399,19 @@ dependencies:
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.32)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.31)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.30)"
-    version: 1.23.6
-    refPaths:
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
-
-  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.29)"
-    version: 1.23.6
+    version: 1.23.8
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -399,19 +399,19 @@ dependencies:
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.32)"
-    version: 1.23.8
+    version: 1.24.2
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.31)"
-    version: 1.23.8
+    version: 1.24.2
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.30)"
-    version: 1.23.8
+    version: 1.24.2
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -4,13 +4,10 @@ variants:
     KUBE_CROSS_VERSION: 'v1.33.0-go1.24.2-bullseye.0'
   v1.32-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.8-bullseye.0'
   v1.31-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.8-bullseye.0'
   v1.30-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.30.0-go1.23.6-bullseye.0'
-  v1.29-cross1.23-bullseye:
-    CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.29.0-go1.23.6-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.30.0-go1.23.8-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -16,21 +16,16 @@ variants:
     OS_CODENAME: 'bullseye'
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: '1.23.6'
-    GO_VERSION_TOOLING: '1.23.6'
+    GO_VERSION: '1.23.8'
+    GO_VERSION_TOOLING: '1.23.8'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: '1.23.6'
-    GO_VERSION_TOOLING: '1.23.6'
+    GO_VERSION: '1.23.8'
+    GO_VERSION_TOOLING: '1.23.8'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: '1.23.6'
-    GO_VERSION_TOOLING: '1.23.6'
-    OS_CODENAME: 'bullseye'
-  '1.29':
-    CONFIG: '1.29'
-    GO_VERSION: '1.23.6'
-    GO_VERSION_TOOLING: '1.23.6'
+    GO_VERSION: '1.23.8'
+    GO_VERSION_TOOLING: '1.23.8'
     OS_CODENAME: 'bullseye'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -17,15 +17,15 @@ variants:
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: '1.23.8'
-    GO_VERSION_TOOLING: '1.23.8'
+    GO_VERSION_TOOLING: '1.24.2'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'
     GO_VERSION: '1.23.8'
-    GO_VERSION_TOOLING: '1.23.8'
+    GO_VERSION_TOOLING: '1.24.2'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
     GO_VERSION: '1.23.8'
-    GO_VERSION_TOOLING: '1.23.8'
+    GO_VERSION_TOOLING: '1.24.2'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.8


/assign @ameukam @xmudrii @saschagrunert 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/release/issues/3944

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.23.8 for active release branches
```
