### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.4/1.23.10

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -291,31 +291,31 @@ dependencies:
   # kube-cross dependents (i.e. k8s-cloud-builder)
   # To be updated after kubernetes/kubernetes update)
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.24)"
-    version: v1.34.0-go1.24.3-bullseye.0
+    version: v1.34.0-go1.24.4-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.33-cross1.24)"
-    version: v1.33.0-go1.24.3-bullseye.0
+    version: v1.33.0-go1.24.4-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.32-cross1.23)"
-    version: v1.32.0-go1.23.9-bullseye.0
+    version: v1.32.0-go1.23.10-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.31-cross1.23)"
-    version: v1.31.0-go1.23.9-bullseye.0
+    version: v1.31.0-go1.23.10-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.30-cross1.23)"
-    version: v1.30.0-go1.23.9-bullseye.0
+    version: v1.30.0-go1.23.10-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -329,7 +329,7 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -338,35 +338,35 @@ dependencies:
 
   # Golang (previous release branch: 1.33)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.33)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.32)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.32)"
-    version: 1.23.9
+    version: 1.23.10
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.31)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.31)"
-    version: 1.23.9
+    version: 1.23.10
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.30)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.30)"
-    version: 1.23.9
+    version: 1.23.10
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -374,25 +374,25 @@ dependencies:
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.33)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.32)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.31)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.30)"
-    version: 1.24.3
+    version: 1.24.4
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,16 +1,16 @@
 variants:
   v1.34-cross1.24-bullseye:
     CONFIG: 'cross1.24'
-    KUBE_CROSS_VERSION: 'v1.34.0-go1.24.3-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.34.0-go1.24.4-bullseye.0'
   v1.33-cross1.24-bullseye:
     CONFIG: 'cross1.24'
-    KUBE_CROSS_VERSION: 'v1.33.0-go1.24.3-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.33.0-go1.24.4-bullseye.0'
   v1.32-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.32.0-go1.23.10-bullseye.0'
   v1.31-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.31.0-go1.23.10-bullseye.0'
   v1.30-cross1.23-bullseye:
     CONFIG: 'cross1.23'
-    KUBE_CROSS_VERSION: 'v1.30.0-go1.23.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.30.0-go1.23.10-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.24.3
-GO_VERSION_TOOLING ?= 1.24.3
+GO_VERSION ?= 1.24.4
+GO_VERSION_TOOLING ?= 1.24.4
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,36 +1,36 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.24.3'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.24.4'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.24.3'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.24.4'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: '1.24.3'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.24.4'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: '1.24.3'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.24.4'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: '1.23.9'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.23.10'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: '1.23.9'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.23.10'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: '1.23.9'
-    GO_VERSION_TOOLING: '1.24.3'
+    GO_VERSION: '1.23.10'
+    GO_VERSION_TOOLING: '1.24.4'
     OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.4/1.23.10

/assign @xmudrii @ameukam @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/release/issues/4024

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.4/1.23.10
```
