### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.5 for main

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -319,7 +319,7 @@ dependencies:
   # kube-cross dependents (i.e. k8s-cloud-builder)
   # To be updated after kubernetes/kubernetes update)
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.24)"
-    version: v1.34.0-go1.24.4-bullseye.0
+    version: v1.34.0-go1.24.5-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -357,7 +357,7 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.24.4
+    version: 1.24.5
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -394,7 +394,7 @@ dependencies:
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.24.4
+    version: 1.24.5
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   v1.34-cross1.24-bullseye:
     CONFIG: 'cross1.24'
-    KUBE_CROSS_VERSION: 'v1.34.0-go1.24.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.34.0-go1.24.5-bullseye.0'
   v1.33-cross1.24-bullseye:
     CONFIG: 'cross1.24'
     KUBE_CROSS_VERSION: 'v1.33.0-go1.24.4-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.24.4
-GO_VERSION_TOOLING ?= 1.24.4
+GO_VERSION ?= 1.24.5
+GO_VERSION_TOOLING ?= 1.24.5
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.24.4'
-    GO_VERSION_TOOLING: '1.24.4'
+    GO_VERSION: '1.24.5'
+    GO_VERSION_TOOLING: '1.24.5'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
@@ -11,8 +11,8 @@ variants:
     OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: '1.24.4'
-    GO_VERSION_TOOLING: '1.24.4'
+    GO_VERSION: '1.24.5'
+    GO_VERSION_TOOLING: '1.24.5'
     OS_CODENAME: 'bullseye'
   '1.33':
     CONFIG: '1.33'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.5

/assign @xmudrii @ameukam @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/release/issues/4055

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.24.5
```
