### PR TITLE
feat: add includeLabels option to release-notes

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -138,6 +138,7 @@ type releaseNotesOptions struct {
 	githubOrg          string
 	draftRepo          string
 	mapProviders       []string
+	includeLabels      []string
 }
 
 type releaseNotesResult struct {
@@ -239,6 +240,14 @@ func init() {
 		"",
 		true,
 		"update the cloned repository to fetch any upstream change (default: true)",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringSliceVarP(
+		&releaseNotesOpts.includeLabels,
+		"include-labels",
+		"l",
+		[]string{},
+		"specify one or more PR labels to include in release notes",
 	)
 
 	rootCmd.AddCommand(releaseNotesCmd)
@@ -909,6 +918,7 @@ func releaseNotesJSON(repoPath, tag string) (jsonString string, err error) {
 	notesOptions.Debug = logrus.StandardLogger().Level >= logrus.DebugLevel
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 	notesOptions.AddMarkdownLinks = true
+	notesOptions.IncludeLabels = releaseNotesOpts.includeLabels
 
 	// If the release for the tag we are using has a mapping directory,
 	// add it to the mapProviders array to read the edits from the release team:
@@ -964,6 +974,7 @@ func gatherNotesFrom(repoPath, startTag string) (*notes.ReleaseNotes, error) {
 	notesOptions.MapProviderStrings = releaseNotesOpts.mapProviders
 	notesOptions.ListReleaseNotesV2 = releaseNotesOpts.listReleaseNotesV2
 	notesOptions.AddMarkdownLinks = true
+	notesOptions.IncludeLabels = releaseNotesOpts.includeLabels
 
 	if err := notesOptions.ValidateAndFinish(); err != nil {
 		return nil, err

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -247,7 +247,7 @@ func init() {
 		"include-labels",
 		"l",
 		[]string{},
-		"specify one or more PR labels to include in release notes",
+		"only PRs with one of these labels are considered. Set to empty to include all PRs",
 	)
 
 	rootCmd.AddCommand(releaseNotesCmd)

--- a/cmd/release-notes/generate.go
+++ b/cmd/release-notes/generate.go
@@ -255,7 +255,7 @@ func addGenerateFlags(subcommand *cobra.Command) {
 		"include-labels",
 		"l",
 		[]string{},
-		"specify one or more PR labels to include in release notes",
+		"Only PRs with one of these labels are considered. Set to empty to include all PRs",
 	)
 }
 

--- a/cmd/release-notes/generate.go
+++ b/cmd/release-notes/generate.go
@@ -249,6 +249,14 @@ func addGenerateFlags(subcommand *cobra.Command) {
 		false,
 		"enable experimental implementation to list commits (ListReleaseNotesV2)",
 	)
+
+	subcommand.PersistentFlags().StringSliceVarP(
+		&opts.IncludeLabels,
+		"include-labels",
+		"l",
+		[]string{},
+		"specify one or more PR labels to include in release notes",
+	)
 }
 
 // addGenerate adds the generate subcomand to the main release notes cobra cmd.

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -37,19 +37,20 @@ import (
 
 // Options are the main settings for generating the changelog.
 type Options struct {
-	RepoPath     string
-	Tag          string
-	Branch       string
-	Bucket       string
-	Tars         string
-	Images       string
-	HTMLFile     string
-	JSONFile     string
-	RecordDir    string
-	ReplayDir    string
-	CVEDataDir   string
-	CloneCVEMaps bool
-	Dependencies bool
+	RepoPath      string
+	Tag           string
+	Branch        string
+	Bucket        string
+	Tars          string
+	Images        string
+	HTMLFile      string
+	JSONFile      string
+	RecordDir     string
+	ReplayDir     string
+	CVEDataDir    string
+	CloneCVEMaps  bool
+	Dependencies  bool
+	IncludeLabels []string
 }
 
 // Changelog can be used to generate the changelog for a release.
@@ -278,6 +279,7 @@ func (c *Changelog) generateReleaseNotes(
 	notesOptions.ReplayDir = c.options.ReplayDir
 	notesOptions.Pull = false
 	notesOptions.AddMarkdownLinks = true
+	notesOptions.IncludeLabels = c.options.IncludeLabels
 
 	if c.options.CVEDataDir != "" {
 		notesOptions.MapProviderStrings = append(

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -682,6 +682,19 @@ func MatchesExcludeFilter(msg string) bool {
 	return matchesFilter(msg, noteExclusionFilters)
 }
 
+// matchesLabelFilter returns true if any of PR labels match the includeLabels.
+func matchesLabelFilter(prLabels []*gogithub.Label, includeLabels []string) bool {
+	for _, include := range includeLabels {
+		for _, label := range prLabels {
+			if label.GetName() == include {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func matchesFilter(msg string, filters []*regexp.Regexp) bool {
 	for _, filter := range filters {
 		if filter.MatchString(msg) {

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -157,6 +157,10 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 		return nil, nil
 	}
 
+	if len(g.options.IncludeLabels) > 0 && !matchesLabelFilter(pr.Labels, g.options.IncludeLabels) {
+		return nil, nil
+	}
+
 	text, err := noteTextFromString(prBody)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -133,6 +133,9 @@ type Options struct {
 	// This is useful when the release notes are outputted to a file. When using the GitHub release page to publish release notes,
 	// this option should be set to false to take advantage of Github's autolinked references.
 	AddMarkdownLinks bool
+
+	// IncludeLabels enables including only PRs that have one or more specific labels.
+	IncludeLabels []string
 }
 
 type RevisionDiscoveryMode string
@@ -167,6 +170,7 @@ func New() *Options {
 		gitCloneFn:         git.CloneOrOpenGitHubRepo,
 		MapProviderStrings: []string{},
 		AddMarkdownLinks:   false,
+		IncludeLabels:      []string{},
 	}
 }
 

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -134,7 +134,7 @@ type Options struct {
 	// this option should be set to false to take advantage of Github's autolinked references.
 	AddMarkdownLinks bool
 
-	// IncludeLabels enables including only PRs that have one or more specific labels.
+	// IncludeLabels can be used to filter PRs by labels so only PRs with one or more specified labels are included.
 	IncludeLabels []string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

For monorepo github repositories in the Kubernetes ecosystem that share a common master/main branch, we need a way to differentiate commits in order to use `release-notes` in a fully automated way.

This PR introduces a user-configurable labels filter that can be used to instruct release-notes "only include commits that originate from PRs w/ one of these labels" in the generated output.

In particular, this would enable SIG Autoscaling to leverage `release-notes` for the variety of projects under a common repository (e.g., Cluster Autoscaler, Vertical Pod Autoscaling).

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
feat: add includeLabels option to release-notes
```
