### PR TITLE
kubelet.spec: Remove deps: conntrack*/iproute*/ethtool

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -21,15 +21,9 @@ Requires: iptables >= 1.4.21
 Requires: {{ $dep.Name }} {{ $dep.VersionConstraint }}
 {{ end }}
 %if "%{_vendor}" == "debbuild"
-Requires: iproute2
 Requires: mount
-Requires: conntrack
-%else
-Requires: iproute
-Requires: conntrack-tools
 %endif
 Requires: util-linux
-Requires: ethtool
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires: systemd-deb-macros


### PR DESCRIPTION
kubelet.spec: Remove deps: conntrack*/iproute*/ethtool

According to [1] & [2], the kubelet is no longer relying on the
following binaries:
- conntrack since Kubernetes 1.24.
- iproute / iproute2
- ethtool

Thus drop the dependencies.

[1] https://github.com/coreos/rhel-coreos-config/pull/42
[2] https://github.com/kubernetes/release/pull/4106

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove a dependency on a package that is no longer used.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Remove the dependency on conntrack and conntrack-tools for the kubelet package.
```