### PR TITLE
fix duplicate short hand, remove duplicated flags and mark deprecated the create-website-pr

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -245,10 +245,12 @@ func init() {
 	releaseNotesCmd.PersistentFlags().StringSliceVarP(
 		&releaseNotesOpts.includeLabels,
 		"include-labels",
-		"l",
+		"",
 		[]string{},
 		"only PRs with one of these labels are considered. Set to empty to include all PRs",
 	)
+
+	_ = releaseNotesCmd.PersistentFlags().MarkDeprecated("create-website-pr", "This flag is deprecated and will be removed in a future release. Use --create-draft-pr instead.")
 
 	rootCmd.AddCommand(releaseNotesCmd)
 }

--- a/cmd/release-notes/generate.go
+++ b/cmd/release-notes/generate.go
@@ -243,20 +243,6 @@ func addGenerateFlags(subcommand *cobra.Command) {
 		[]string{},
 		"specify a location to recursively look for release notes *.y[a]ml file mappings",
 	)
-	subcommand.PersistentFlags().BoolVar(
-		&opts.ListReleaseNotesV2,
-		"list-v2",
-		false,
-		"enable experimental implementation to list commits (ListReleaseNotesV2)",
-	)
-
-	subcommand.PersistentFlags().StringSliceVarP(
-		&opts.IncludeLabels,
-		"include-labels",
-		"l",
-		[]string{},
-		"Only PRs with one of these labels are considered. Set to empty to include all PRs",
-	)
 }
 
 // addGenerate adds the generate subcomand to the main release notes cobra cmd.


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

- fix duplicate short hand, remove duplicated flags and mark deprecated the create-website-pr

/assign @saschagrunert @puerco @xmudrii 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/4122


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix duplicate short hand, remove duplicated flags and mark deprecated the create-website-pr
```
