### PR TITLE
Adding tests for specs in obs package

### DIFF
--- a/pkg/obs/specs/pkgdef_test.go
+++ b/pkg/obs/specs/pkgdef_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs_test
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/obs/metadata"
+	"k8s.io/release/pkg/obs/specs"
+	"k8s.io/release/pkg/obs/specs/specsfakes"
+)
+
+func TestConstructPackageDefinition(t *testing.T) {
+	testcases := []struct {
+		prepare   func(mock *specsfakes.FakeImpl)
+		options   *specs.Options
+		channel   string
+		version   string
+		shouldErr bool
+	}{
+		{ // happy path for core package with version specified
+			shouldErr: false,
+			channel:   "release",
+			version:   "1.0.0",
+			options: &specs.Options{
+				Package:          "kubeadm",
+				Version:          "v1.0.0",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "1.0.0")
+				mock.LoadPackageMetadataReturns(createKubeadmMetadata(), nil)
+			},
+		},
+		{ // specifying non-parsable version should cause
+			//  failure for core packages
+			shouldErr: true,
+			options: &specs.Options{
+				Package:          "kubeadm",
+				Version:          "not-parsable",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mock.TrimTagPrefixReturns("not-parsable")
+				version, _ := semver.New("0.0.0")
+				mock.TagStringToSemverReturns(*version, err)
+			},
+		},
+		{
+			// happy path for core package with channel specified
+			shouldErr: false,
+			channel:   "nightly",
+			version:   "1.0.0",
+			options: &specs.Options{
+				Package:          "kubeadm",
+				Channel:          "nightly",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "1.0.0")
+				mock.LoadPackageMetadataReturns(createKubeadmMetadata(), nil)
+			},
+		},
+		{
+			// can't get a version for core package with channel specified
+			shouldErr: true,
+			channel:   "nightly",
+			version:   "1.0.0",
+			options: &specs.Options{
+				Package:          "kubeadm",
+				Channel:          "nightly",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mock.GetKubeVersionReturns("1.0.0", err)
+				mock.LoadPackageMetadataReturns(createKubeadmMetadata(), nil)
+			},
+		},
+		{ // happy path for cri-tools package
+			shouldErr: false,
+			version:   "2.0.0",
+			options: &specs.Options{
+				Package:          "cri-tools",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "2.0.0")
+				mock.LoadPackageMetadataReturns(createCRIToolsMetadata(), nil)
+				mock.HeadRequestReturns(
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Request:    &http.Request{URL: &url.URL{Scheme: "https", Host: "example.com", Path: "/cri-tools"}},
+						Body:       io.NopCloser(strings.NewReader("response body")),
+					}, nil)
+			},
+		},
+		{ // HTTP head request error should cause failure
+			// for cri-tools package
+			shouldErr: true,
+			version:   "2.0.0",
+			options: &specs.Options{
+				Package:          "cri-tools",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "2.0.0")
+				mock.LoadPackageMetadataReturns(createCRIToolsMetadata(), nil)
+				mock.HeadRequestReturns(&http.Response{}, err)
+			},
+		},
+		{ // happy path for kubernetes-cni package
+			shouldErr: false,
+			version:   "1.0.0",
+			options: &specs.Options{
+				Package:          "kubernetes-cni",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "1.0.0")
+				mock.LoadPackageMetadataReturns(createCNIMetadata(), nil)
+				mock.HeadRequestReturns(
+					&http.Response{
+						StatusCode: http.StatusOK,
+						Request:    &http.Request{URL: &url.URL{Scheme: "https", Host: "example.com", Path: "/kubernetes-cni"}},
+						Body:       io.NopCloser(strings.NewReader("response body")),
+					}, nil)
+			},
+		},
+		{ // HTTP head request error should cause failure
+			// for kubernetes-cni package
+			shouldErr: true,
+			version:   "1.0.0",
+			options: &specs.Options{
+				Package:          "kubernetes-cni",
+				SpecTemplatePath: newSpecPath(t),
+				SpecOutputPath:   t.TempDir(),
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mockVersion(mock, "1.0.0")
+				mock.LoadPackageMetadataReturns(createCNIMetadata(), nil)
+				mock.HeadRequestReturns(&http.Response{}, err)
+			},
+		},
+	}
+	for _, tc := range testcases {
+		createTestMetadataFile(t, tc.options.SpecTemplatePath, "")
+		sut := specs.New(tc.options)
+
+		mock := &specsfakes.FakeImpl{}
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+
+		pkgDef, err := sut.ConstructPackageDefinition()
+
+		if tc.shouldErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, pkgDef)
+			require.Equal(t, tc.options.Package, pkgDef.Name)
+			require.Equal(t, tc.channel, pkgDef.Channel)
+			require.Equal(t, tc.version, pkgDef.Version)
+		}
+	}
+}
+
+func mockVersion(mock *specsfakes.FakeImpl, version string) {
+	mock.GetKubeVersionReturns(version, nil)
+	mock.TrimTagPrefixReturns(version)
+	semverVersion, _ := semver.New(version)
+	mock.TagStringToSemverReturns(*semverVersion, nil)
+}
+
+func createTestMetadataFile(t *testing.T, dir, content string) string {
+	metadataFile := filepath.Join(dir, "metadata.yaml")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(content), 0o600))
+
+	return metadataFile
+}
+
+func createKubeadmMetadata() metadata.PackageMetadataList {
+	return metadata.PackageMetadataList{
+		"kubeadm": {
+			{
+				VersionConstraint: ">=1.0.0",
+			},
+		},
+	}
+}
+
+func createCRIToolsMetadata() metadata.PackageMetadataList {
+	return metadata.PackageMetadataList{
+		"cri-tools": {
+			{
+				VersionConstraint: ">=2.0.0",
+			},
+		},
+	}
+}
+
+func createCNIMetadata() metadata.PackageMetadataList {
+	return metadata.PackageMetadataList{
+		"kubernetes-cni": {
+			{
+				VersionConstraint: ">=1.0.0",
+			},
+		},
+	}
+}

--- a/pkg/obs/specs/specs_test.go
+++ b/pkg/obs/specs/specs_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/consts"
+	"k8s.io/release/pkg/obs/specs"
+)
+
+var err = errors.New("error")
+
+func TestValidate(t *testing.T) {
+	testcases := []struct {
+		prepare   func(options *specs.Options)
+		shouldErr bool
+	}{
+		{ // default options
+			prepare:   func(options *specs.Options) {},
+			shouldErr: false,
+		},
+		{ // specs for package doesn't exist
+			prepare: func(options *specs.Options) {
+				options.SpecTemplatePath = "does_not_exist"
+			},
+			shouldErr: true,
+		},
+		{ // one of version or channel is required
+			prepare: func(options *specs.Options) {
+				options.Version = ""
+				options.Channel = ""
+			},
+			shouldErr: true,
+		},
+		{ // selected channel is not supported
+			prepare: func(options *specs.Options) {
+				options.Channel = "not_supported"
+			},
+			shouldErr: true,
+		},
+		{ // revision is required
+			prepare: func(options *specs.Options) {
+				options.Revision = ""
+			},
+			shouldErr: true,
+		},
+		{ // architectures selection is not supported
+			prepare: func(options *specs.Options) {
+				options.Architectures = []string{"not_supported"}
+			},
+			shouldErr: true,
+		},
+		{ // output path dir doesn't exist
+			prepare: func(options *specs.Options) {
+				options.SpecOutputPath = "does_not_exist"
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		options := specs.DefaultOptions()
+
+		tc.prepare(options)
+
+		newSpecPath(t)
+
+		err = options.Validate()
+
+		if tc.shouldErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}
+
+func newSpecPath(t *testing.T) string {
+	tempDir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(
+		consts.DefaultSpecTemplatePath,
+		os.FileMode(0o755),
+	))
+
+	return tempDir
+}


### PR DESCRIPTION
Adding top level tests for spec.go file and also
tests for pkgdef file.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We are missing unit tests for krel obs and this PR attempts to improve coverage  
Relevant card from the project board: [#3168](https://github.com/kubernetes/release/issues/3168)

This is part 4 of the tests, previously tests we added for obs.go file [here](https://github.com/kubernetes/release/pull/3953) and [here](https://github.com/kubernetes/release/pull/4019) and [here](https://github.com/kubernetes/release/pull/4025)

#### Which issue(s) this PR fixes:

It improves unit test coverage for the `krel obs`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

PR includes tests for `obs/specs/spec.go` and helper function in `obs/specs/pkgdef.go`. 
We will need tests for `obs/specs/template.go` and `obs/specs/archive.go`
I'll add those tests in the follow-up PR to keep this PR small-ish.

I'll also add test coverage for `Run` function in `spec.go` later. From 'Run` function we call `BuildSpecs` and `BuildArtifactsArchive` which are defined in `template.go` and `archive.go` mentioned above (they are still missing tests). They don't have fakes, so to set up tests I need some implementation knowledge.

 It will be easier to add tests for 'Run()' after I added tests for `template.go` and `archive.go`.

#### Does this PR introduce a user-facing change?
no

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

cc @xmudrii  for feedback