### PR TITLE
use go1.25 and update golanci-lint

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,8 +62,9 @@ jobs:
       id: go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         check-latest: true
+        cache: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,10 +26,10 @@ jobs:
         id: go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.3
+          version: v2.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,9 @@ jobs:
         id: go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -31,8 +31,9 @@ jobs:
         id: go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - name: Install bom
         uses: kubernetes-sigs/release-actions/setup-bom@a30d93cf2aa029e1e4c8a6c79f766aebf429fddb # v0.3.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -366,7 +366,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v2.3
+    version: v2.5
     refPaths:
       - path: .github/workflows/lint.yml
         match: "version: v\\d+.\\d+?\\.?(\\d+)?"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
   #     match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: 1.<major> (github workflows)"
-    version: 1.24
+    version: 1.25
     refPaths:
       - path: .github/workflows/release.yml
         match: "go-version: '\\d+.\\d+'"

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -102,18 +102,22 @@ func TestListCommits(t *testing.T) {
 			}},
 			getCommitArgValidator: func(t *testing.T, callCount int, ctx context.Context, org, repo, rev string) {
 				checkOrgRepo(t, org, repo)
+
 				if a, e := rev, "the-start"; callCount == 0 && a != e {
 					t.Errorf("Expected to be called with revision '%s' on first call, got: '%s'", e, a)
 				}
+
 				if a, e := rev, "the-end"; callCount == 1 && a != e {
 					t.Errorf("Expected to be called with revision '%s' on second call, got: '%s'", e, a)
 				}
 			},
 			listCommitsArgValidator: func(t *testing.T, callCount int, ctx context.Context, org, repo string, clo *github.CommitsListOptions) {
 				checkOrgRepo(t, org, repo)
+
 				if page, minimum, maximum := clo.Page, 1, 100; page < minimum || page > maximum {
 					t.Errorf("Expected page number to be between %d and %d, got: %d", minimum, maximum, page)
 				}
+
 				if a, e := clo.SHA, "the-branch"; a != e {
 					t.Errorf("Expected SHA to be the branch '%s', got: '%s'", e, a)
 				}
@@ -288,6 +292,7 @@ func TestGatherNotes(t *testing.T) {
 			listPullRequestsWithCommitStubber: func(t *testing.T) listPullRequestsWithCommitStub {
 				return func(_ context.Context, org, repo, sha string, _ *github.ListOptions) ([]*github.PullRequest, *github.Response, error) {
 					checkOrgRepo(t, org, repo)
+
 					if e, a := "some-random-sha", sha; e != a {
 						t.Errorf("Expected ListPullRequestsWithCommit(...) to be called for SHA '%s', have been called for '%s'", e, a)
 					}
@@ -312,6 +317,7 @@ func TestGatherNotes(t *testing.T) {
 
 				return func(_ context.Context, org, repo string, prID int) (*github.PullRequest, *github.Response, error) {
 					checkOrgRepo(t, org, repo)
+
 					if err := seenPRs.Mark(prID); err != nil {
 						t.Errorf("In GetPullRequest: %v", err)
 					}
@@ -357,6 +363,7 @@ func TestGatherNotes(t *testing.T) {
 
 				return func(_ context.Context, org, repo string, prID int) (*github.PullRequest, *github.Response, error) {
 					checkOrgRepo(t, org, repo)
+
 					if err := seenPRs.Mark(prID); err != nil {
 						t.Errorf("In GetPullRequest: %v", err)
 					}
@@ -369,6 +376,7 @@ func TestGatherNotes(t *testing.T) {
 					num    int
 					author string
 				}
+
 				expectMap := map[string]pr{
 					"123": {
 						num:    123,
@@ -385,9 +393,11 @@ func TestGatherNotes(t *testing.T) {
 					if !found {
 						t.Errorf("Unexpected SHA %s", *result.commit.SHA)
 					}
+
 					if expected.num != *result.pullRequest.Number {
 						t.Errorf("Expecting %d got %d for SHA %s", expected.num, *result.pullRequest.Number, *result.commit.SHA)
 					}
+
 					if expected.author != *result.pullRequest.User.Login {
 						t.Errorf("Expecting %s got %s for SHA %s", expected.author, *result.pullRequest.User.Login, *result.commit.SHA)
 					}
@@ -441,6 +451,7 @@ func TestGatherNotes(t *testing.T) {
 					{pullRequest(14, "```release-note ```", "closed")},
 					{pullRequest(15, "```release-note\n\n```", "open")},
 				}
+
 				var callCount int64 = -1
 
 				return func(_ context.Context, _, _, _ string, _ *github.ListOptions) ([]*github.PullRequest, *github.Response, error) {

--- a/pkg/obs/specs/pkgdef_test.go
+++ b/pkg/obs/specs/pkgdef_test.go
@@ -67,6 +67,7 @@ func TestConstructPackageDefinition(t *testing.T) {
 			},
 			prepare: func(mock *specsfakes.FakeImpl) {
 				mock.TrimTagPrefixReturns("not-parsable")
+
 				version, _ := semver.New("0.0.0")
 				mock.TagStringToSemverReturns(*version, err)
 			},


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- use go1.25 and update golanci-lint

/assign @saschagrunert @xmudrii @ameukam 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
use go1.25 and update golanci-lint
```
