### PR TITLE
build go images for 1.35 and 1.34 k8s releases and update releng-ci

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -102,7 +102,7 @@ dependencies:
   #
   # Update after the stable marker has been updated to stable.0
   - name: "Kubernetes version (stable.0)"
-    version: v1.34.0
+    version: v1.35.0
     refPaths:
       - path: images/build/cross/Makefile
         match: KUBERNETES_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -111,7 +111,7 @@ dependencies:
 
   # Update after the stable marker has been updated to stable.0
   - name: "Kubernetes version (next candidate.0)"
-    version: v1.34.0
+    version: v1.35.0
     refPaths:
       - path: images/build/cross/variants.yaml
         match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -187,20 +187,20 @@ dependencies:
       - path: images/build/go-runner/variants.yaml
         match: REVISION:\ '\d+'
 
-  # kube-cross (next candidate)
-  - name: "registry.k8s.io/build-image/kube-cross: config variant (next candidate)"
-    version: go1.25-bullseye
+  # kube-cross (Kubernetes v1.34)
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.34-go1.24)"
+    version: go1.24-bullseye
     refPaths:
       - path: images/build/cross/variants.yaml
         match: "CONFIG: 'go\\d+.\\d+-bullseye'"
 
-  - name: "registry.k8s.io/build-image/kube-cross (v1.34-go1.25)"
-    version: v1.34.0-go1.25.1-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross (v1.34-go1.24)"
+    version: v1.34.0-go1.24.7-bullseye.0
     refPaths:
       - path: images/build/cross/variants.yaml
         match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.34-go1.25)"
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.34-go1.24)"
     version: 0
     refPaths:
       - path: images/build/cross/Makefile

--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -27,7 +27,7 @@ IMGNAME = kube-cross
 # Example:
 # - v1.100.0-go1.17-bullseye.0 satisfies SemVer regex, while:
 # - v1.100-go1.17-bullseye.0 does not
-KUBERNETES_VERSION ?= v1.34.0
+KUBERNETES_VERSION ?= v1.35.0
 GO_VERSION ?= 1.25.1
 GO_MAJOR_VERSION ?= 1.25
 OS_CODENAME ?= bullseye

--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -1,11 +1,20 @@
 variants:
-  v1.34-go1.25-bullseye:
+  v1.35-go1.25-bullseye:
     CONFIG: 'go1.25-bullseye'
     TYPE: 'default'
-    IMAGE_VERSION: 'v1.34.0-go1.25.1-bullseye.0'
-    KUBERNETES_VERSION: 'v1.34.0'
+    IMAGE_VERSION: 'v1.35.0-go1.25.1-bullseye.0'
+    KUBERNETES_VERSION: 'v1.35.0'
     GO_VERSION: '1.25.1'
     GO_MAJOR_VERSION: '1.25'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+  v1.34-go1.24-bullseye:
+    CONFIG: 'go1.24-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.34.0-go1.24.7-bullseye.0'
+    KUBERNETES_VERSION: 'v1.34.0'
+    GO_VERSION: '1.24.7'
+    GO_MAJOR_VERSION: '1.24'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   v1.33-go1.24-bullseye:

--- a/images/releng/ci/variants.yaml
+++ b/images/releng/ci/variants.yaml
@@ -1,8 +1,8 @@
 variants:
-  go1.25-bookworm:
-    CONFIG: 'go1.25-bookworm'
+  go1.25-trixie:
+    CONFIG: 'go1.25-trixie'
     GO_VERSION: '1.25.1'
-    OS_CODENAME: 'bookworm'
+    OS_CODENAME: 'trixie'
     REVISION: '0'
   go1.24-bookworm:
     CONFIG: 'go1.24-bookworm'


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- build go images for 1.35 and 1.34 k8s releases and update releng-ci

k/k master branch (1.35) is on go1.25 but release 1.34 is on 1.24

doing some clean up and update to the correct references
I will update everything and make all in sync, notice that some follow ups after the k/k go 1.25 merged was not done

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes/release-managers 


#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build go images for 1.35 and 1.34 k8s releases and update releng-ci
```
