### PR TITLE
update setcap image to use bookworm-v1.0.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -425,7 +425,7 @@ dependencies:
         match: "IMAGE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/debian-base: dependents"
-    version: bookworm-v1.0.4
+    version: bookworm-v1.0.6
     refPaths:
       - path: images/build/setcap/Makefile
         match: DEBIAN_BASE_VERSION\ \?=\ bookworm-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -471,7 +471,7 @@ dependencies:
         match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/setcap"
-    version: bookworm-v1.0.4
+    version: bookworm-v1.0.6
     refPaths:
       - path: images/build/setcap/Makefile
         match: IMAGE_VERSION\ \?=\ bookworm-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -486,7 +486,7 @@ dependencies:
         match: "IMAGE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/setcap (next candidate)"
-    version: bookworm-v1.0.4
+    version: bookworm-v1.0.6
     refPaths:
       - path: images/build/setcap/variants.yaml
         match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -18,9 +18,9 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/setcap
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bookworm-v1.0.4
+IMAGE_VERSION ?= bookworm-v1.0.6
 CONFIG ?= bookworm
-DEBIAN_BASE_VERSION ?= bookworm-v1.0.4
+DEBIAN_BASE_VERSION ?= bookworm-v1.0.6
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/setcap/variants.yaml
+++ b/images/build/setcap/variants.yaml
@@ -1,11 +1,6 @@
 variants:
-  # Debian 11 - Kubernetes 1.27 and older
-  bullseye:
-    CONFIG: 'bullseye'
-    IMAGE_VERSION: 'bullseye-v1.4.2'
-    DEBIAN_BASE_VERSION: 'bullseye-v1.4.3'
   # Debian 12 - Kubernetes 1.28 and newer
   bookworm:
     CONFIG: 'bookworm'
-    IMAGE_VERSION: 'bookworm-v1.0.4'
-    DEBIAN_BASE_VERSION: 'bookworm-v1.0.4'
+    IMAGE_VERSION: 'bookworm-v1.0.6'
+    DEBIAN_BASE_VERSION: 'bookworm-v1.0.6'


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update setcap image to use bookworm-v1.0.6
- and drop old config

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update setcap image to use bookworm-v1.0.6
```
