### PR TITLE
Remove deprecated bucket

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,8 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/object"
-
-	"k8s.io/release/pkg/release"
 )
 
 var DefaultExtraVersionMarkers = []string{}
@@ -150,13 +148,6 @@ func (bi *Instance) getGCSBuildPath(version string) (string, error) {
 
 func (bi *Instance) setBucket() {
 	bucket := bi.opts.Bucket
-
-	if bi.opts.Bucket == "" {
-		if bi.opts.CI {
-			// TODO: Remove this once all CI and release jobs run on K8s Infra
-			bucket = release.CIBucketLegacy
-		}
-	}
 
 	bi.opts.Bucket = bucket
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -91,9 +91,6 @@ const (
 	// WindowsLocalPath is the directory where Windows GCE scripts are created.
 	WindowsLocalPath = ReleaseStagePath + "/full/kubernetes/cluster/gce/windows"
 
-	// CIBucketLegacy is the default bucket for Kubernetes CI releases.
-	CIBucketLegacy = "kubernetes-release-dev"
-
 	// CIBucketK8sInfra is the community infra bucket for Kubernetes CI releases.
 	CIBucketK8sInfra = "k8s-release-dev"
 


### PR DESCRIPTION
The bucket is no longer used and replaced by
`gs://k8s-release-dev`

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`CIBucketLegacy` const has been removed as the bucket is no longer used and has been replaced by `gs://k8s-release-dev`
```
