### PR TITLE
Pin docker-ce-cli to version 24.0.x for API 1.43 compatibility

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -81,6 +81,8 @@ ENV PATH="${GOOGLE_DIR}/google-cloud-sdk/bin:${PATH}"
 
 # Install docker cli
 # https://docs.docker.com/install/linux/docker-ce/debian/
+# Pin to version 24.0.x for API version 1.43 compatibility with DinD in CI
+# See: https://github.com/kubernetes/release/issues/4180
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && apt-key fingerprint 0EBFCD88 \
     && add-apt-repository \
@@ -89,7 +91,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
       stable" \
     && apt-get -y update \
     && apt-get -qqy install \
-        docker-ce-cli
+        docker-ce-cli=5:24.0.*
 
 # Cleanup a bit
 RUN apt-get -qqy remove \


### PR DESCRIPTION


#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The latest docker-ce-cli package (API version 1.52) is incompatible with the Docker-in-Docker setup in CI, which supports a maximum API version of 1.43. This causes build failures with the error: "client version 1.52 is too new. Maximum supported API version is 1.43"

Docker 24.0.x uses API version 1.43, making it compatible with the current CI DinD environment.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/release/issues/4180

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
k8s-cloud-builder: pinned docker-ce-cli to version 24.0.x for API 1.43 compatibility
```
