### PR TITLE
Pin docker-ce-cli to version 24.0.x for API 1.43 compatibility in k8s-ci-builder

### DIFF
--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -121,7 +121,7 @@ RUN echo "Installing Packages ..." \
         && install -m 0755 -d /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
         && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
-        && apt-get install -y --no-install-recommends docker-ce=5:24.0.* \
+        && apt-get install -y --no-install-recommends docker-ce=5:24.0.* docker-ce-cli=5:24.0.* \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && echo "Installing Docker buildx ..." \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR pins `docker-ce-cli` to version 24.0.x in the k8s-ci-builder image to ensure API version 1.43 compatibility with Docker-in-Docker in CI environments.

While `docker-ce` was already pinned to 24.0.x, the `docker-ce` package has an unversioned dependency on `docker-ce-cli`. This allows APT to install the latest available `docker-ce-cli` (currently 29.0.0 with API 1.52), which is incompatible with the DinD setup that only supports API 1.43.


#### Which issue(s) this PR fixes:

Follow-up to #4183

#### Special notes for your reviewer:

This is the same fix as #4183, but applied to the k8s-ci-builder image instead of k8s-cloud-builder. The k8s-ci-builder image installs `docker-ce` (full daemon) while k8s-cloud-builder only installs `docker-ce-cli`, but both suffer from the same issue where the CLI can be upgraded to an incompatible version.

#### Does this PR introduce a user-facing change?

```release-note
Pin docker-ce-cli to version 24.0.x in k8s-ci-builder image for API 1.43 compatibility with CI DinD environments
```