### PR TITLE
Add tests for specs/template.go file

### DIFF
--- a/pkg/obs/specs/template_test.go
+++ b/pkg/obs/specs/template_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/release/pkg/obs/specs/specsfakes"
+)
+
+var err = errors.New("error")
+
+func TestBuildSpecs(t *testing.T) {
+	testcases := []struct {
+		createPkgDef func(t *testing.T) *PackageDefinition
+		prepare      func(mock *specsfakes.FakeImpl)
+		verifyWrites func(*testing.T, *specsfakes.FakeImpl)
+		shouldErr    bool
+	}{
+		{ // happy path
+			createPkgDef: func(t *testing.T) *PackageDefinition {
+				return &PackageDefinition{
+					Name:             "kubeadm",
+					SpecTemplatePath: "testdata/templates",
+					SpecOutputPath:   t.TempDir(),
+				}
+			},
+			prepare:      func(mock *specsfakes.FakeImpl) {},
+			verifyWrites: func(t *testing.T, fi *specsfakes.FakeImpl) {},
+			shouldErr:    false,
+		},
+		{ // package definition is nil
+			createPkgDef: func(t *testing.T) *PackageDefinition {
+				return nil
+			},
+			prepare:      func(mock *specsfakes.FakeImpl) {},
+			verifyWrites: func(t *testing.T, fi *specsfakes.FakeImpl) {},
+			shouldErr:    true,
+		},
+		{ // spec template path doesn't exist
+			createPkgDef: func(t *testing.T) *PackageDefinition {
+				return &PackageDefinition{
+					Name:             "kubeadm",
+					SpecTemplatePath: "does_not_exist",
+				}
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mock.StatReturns(nil, err)
+			},
+			verifyWrites: func(t *testing.T, fi *specsfakes.FakeImpl) {},
+			shouldErr:    true,
+		},
+		{ // error during walking the template directory
+			createPkgDef: func(t *testing.T) *PackageDefinition {
+				return &PackageDefinition{
+					Name:             "kubeadm",
+					SpecTemplatePath: "testdata/templates",
+					SpecOutputPath:   t.TempDir(),
+				}
+			},
+			prepare: func(mock *specsfakes.FakeImpl) {
+				mock.WalkReturns(err)
+			},
+			verifyWrites: func(t *testing.T, fi *specsfakes.FakeImpl) {},
+			shouldErr:    true,
+		},
+	}
+
+	for _, tc := range testcases {
+		sut := &Specs{}
+
+		pkgDef := tc.createPkgDef(t)
+		mock := &specsfakes.FakeImpl{}
+
+		tc.prepare(mock)
+		sut.SetImpl(mock)
+
+		err := sut.BuildSpecs(pkgDef, false)
+		if tc.shouldErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			tc.verifyWrites(t, mock)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We are missing unit tests for krel obs and this PR attempts to improve coverage
Relevant card from the project board: https://github.com/kubernetes/release/issues/3168

#### Which issue(s) this PR fixes:

It improves unit test coverage for the krel obs

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

PR includes tests for specs/template.go. It is incremental improvement for obs package tests. We need to add tests to 'archive.go' to complete the suite.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
