### PR TITLE
set GOTOOLCHAIN=auto so automatic verison selection can be used

### DIFF
--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=go-source /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOROOT=/usr/local/go
 ENV GOLANG_VERSION=${GO_VERSION}
-ENV GOTOOLCHAIN=local
+ENV GOTOOLCHAIN=auto
 ENV GOPATH=/usr/local/go
 
 # Pre-compile the standard go library when cross-compiling. This is much easier now when we have go1.5+

--- a/images/build/go-runner/Dockerfile
+++ b/images/build/go-runner/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=go-source /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOROOT=/usr/local/go
 ENV GOLANG_VERSION=${GO_VERSION}
-ENV GOTOOLCHAIN=local
+ENV GOTOOLCHAIN=auto
 ENV GOPATH=/usr/local/go
 
 # Copy the sources

--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=go-source /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOROOT=/usr/local/go
 ENV GOLANG_VERSION=${GO_VERSION}
-ENV GOTOOLCHAIN=local
+ENV GOTOOLCHAIN=auto
 ENV GOPATH=/usr/local/go
 
 # Install required packages for adding Google Cloud SDK repository

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=go-source /usr/local/go /go
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOLANG_VERSION=${GO_VERSION_TOOLING}
-ENV GOTOOLCHAIN=local
+ENV GOTOOLCHAIN=auto
 ENV GOPATH=/go
 
 WORKDIR /go/src/k8s.io/release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Ensures when the local desired go version is not aligned we will use that version instead of the version the image contains by default.

`GOTOOLCHAIN=auto` is actually go's default (not the golang image, but the go binary installed locally from upstream)

the upstream golang images set GOTOOLCHAIN=local non-default value so you get the version of the image you selected, but this means if e.g. go.mod desired a different version you won't get it (or the .go-version logic in kubernetes/kubernetes)

I don't think we want to drive the exact go version from the images versus in the code under test anywhere in the project, and auto still means the version in the image is the *default* unless a more specific version is required due to the version selection logic (e.g. you set go.mod to require a higher go version)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
images: use GOTOOLCHAIN=auto for automatic version selection
```
/hold