### PR TITLE
distroless-iptables: remove dependency from conntrack binary

### DIFF
--- a/images/build/distroless-iptables/distroless-bookworm/Dockerfile
+++ b/images/build/distroless-iptables/distroless-bookworm/Dockerfile
@@ -27,8 +27,7 @@ RUN apt -y update && \
     apt -y dist-upgrade && \
     apt -y install bash curl && \
     mkdir -p "${STAGE_DIR}" && \
-    /stage-binaries-from-package.sh "${STAGE_DIR}" conntrack \
-    ipset       \
+    /stage-binaries-from-package.sh "${STAGE_DIR}" ipset \
     iptables    \
     nftables    \
     kmod        && \

--- a/images/build/distroless-iptables/distroless-bullseye/Dockerfile
+++ b/images/build/distroless-iptables/distroless-bullseye/Dockerfile
@@ -27,8 +27,7 @@ RUN apt -y update && \
     apt -y dist-upgrade && \
     apt -y install bash curl && \
     mkdir -p "${STAGE_DIR}" && \
-    /stage-binaries-from-package.sh "${STAGE_DIR}" conntrack \
-    ipset       \
+    /stage-binaries-from-package.sh "${STAGE_DIR}" ipset \
     iptables    \
     kmod        && \
     `# below binaries and dash are used by iptables-wrapper-installer.sh` \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
With https://github.com/kubernetes/kubernetes/pull/126847 kube-proxy will no longer depend on `conntrack` binary to be present on the image, this PR removes the conntrack binary from the distroless-iptables image.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The distroless iptables binary will no longer have conntrack binary
```
