### PR TITLE
configure *_CROSSPLATFORMS for kube-cross image

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -55,6 +55,9 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 #       not supported in specific architectures
 PLATFORMS ?= linux/amd64 linux/arm64 #linux/arm
 
+KUBE_DYNAMIC_CROSSPLATFORMS ?= "arm64 armhf i386 ppc64el s390x"
+KUBE_CROSSPLATFORMS ?= "linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x darwin/amd64 windows/amd64 windows/386"
+
 # for legacy images only build linux/amd64
 ifeq ($(TYPE), legacy)
   PLATFORMS = linux/amd64
@@ -85,6 +88,8 @@ container: check-env init-docker-buildx
 			--build-arg=PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
 			--build-arg=TARGETPLATFORM=$${platform} \
 			--build-arg=GO_VERSION=$(GO_VERSION) \
+			--build-arg=KUBE_DYNAMIC_CROSSPLATFORMS=$(KUBE_DYNAMIC_CROSSPLATFORMS) \
+			--build-arg=KUBE_CROSSPLATFORMS=$(KUBE_CROSSPLATFORMS) \
 			--file $(TYPE)/Dockerfile \
 			.; \
 	done

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -26,20 +26,14 @@ ARG TARGETPLATFORM
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV GOARM 7
-ENV KUBE_DYNAMIC_CROSSPLATFORMS \
-  arm64 \
-  armhf \
-  i386 \
-  ppc64el \
-  s390x
 
-ENV KUBE_CROSSPLATFORMS \
-  linux/386 \
-  linux/arm linux/arm64 \
-  linux/ppc64le \
-  linux/s390x \
-  darwin/amd64 \
-  windows/amd64 windows/386
+# the default value for KUBE_DYNAMIC_CROSSPLATFORMS and KUBE_CROSSPLATFORMS is set for
+# backward compatibility with the old Dockerfile. 
+ARG KUBE_DYNAMIC_CROSSPLATFORMS="arm64 armhf i386 ppc64el s390x"
+ARG KUBE_CROSSPLATFORMS="linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x darwin/amd64 windows/amd64 windows/386"
+
+ENV KUBE_DYNAMIC_CROSSPLATFORMS=${KUBE_DYNAMIC_CROSSPLATFORMS}
+ENV KUBE_CROSSPLATFORMS=${KUBE_CROSSPLATFORMS}
 
 ##------------------------------------------------------------
 COPY --from=go-source /usr/local/go /usr/local/go


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

add support for configuring the KUBE_CROSSPLATFORMS and KUBE_DYNAMIC_CROSSPLATFORMS in kube cross image build. This helps with reducing the kube-cross image size when not all platforms are required to be built.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
configurable cross-platform builds for kube-cross image
```
