### PR TITLE
Bump ko & goreleaser in releng-ci

### DIFF
--- a/images/releng/ci/Dockerfile
+++ b/images/releng/ci/Dockerfile
@@ -54,8 +54,8 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # install goreleaser
-ARG GORELEASER_VERSION=v2.12.2
-ARG GORELEASER_SHA=b7c923e1ff208a5aa4c800ee0331d9fdc8d3ea434f1126e43088676b34d5717b
+ARG GORELEASER_VERSION=v2.13.3
+ARG GORELEASER_SHA=4b66f2f78f78561330350651ade557b70328664718490f37834749073af21d20
 RUN  \
     GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz && \
     GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE} && \
@@ -66,8 +66,8 @@ RUN  \
     goreleaser -v
 
 # install ko
-ARG KO_VERSION=v0.18.0
-ARG KO_SHA=ce8c8776b243357e0a822c279b06c34302460221e834765dee5f4e9e2c0b7b38
+ARG KO_VERSION=v0.18.1
+ARG KO_SHA=048ab11818089a43b7b74bc554494a79a3fd0d9822c061142e5cd3cf8b30cb27
 RUN  \
     KO_DOWNLOAD_FILE=ko_${KO_VERSION#v}_Linux_x86_64.tar.gz && \
     KO_DOWNLOAD_URL=https://github.com/ko-build/ko/releases/download/${KO_VERSION}/${KO_DOWNLOAD_FILE} && \


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This commit bumps @ko-build to v0.18.1 and goreleaser to v2.13.3 in gcr.io/k8s-staging-releng/releng-ci
 to pick up [a patch in ko](https://github.com/ko-build/ko/commit/c6af5ffd46d2dd0521c6cb875306f5c8464ca0ce) needed to fix some of our ko-based builds that are breaking  ([example](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-bom-push-images/2011552823019311104))

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @cpanato 

#### Does this PR introduce a user-facing change?

```release-note
The releng-ci image now ships with ko v0.18.1 goreleaser to v2.13.3
```
