### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.25.6

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -171,6 +171,27 @@ dependencies:
       - path: images/build/go-runner/variants.yaml
         match: REVISION:\ '\d+'
 
+  # kube-cross (Kubernetes v1.36)
+  - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.36-go1.25)"
+    version: go1.25-bullseye
+    refPaths:
+      - path: images/build/cross/variants.yaml
+        match: "CONFIG: 'go\\d+.\\d+-bullseye'"
+
+  - name: "registry.k8s.io/build-image/kube-cross (v1.36-go1.25)"
+    version: v1.36.0-go1.25.6-bullseye.0
+    refPaths:
+      - path: images/build/cross/variants.yaml
+        match: "IMAGE_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+  - name: "registry.k8s.io/build-image/kube-cross: image revision (v1.36-go1.25)"
+    version: 0
+    refPaths:
+      - path: images/build/cross/Makefile
+        match: REVISION \?= \d+
+      - path: images/build/cross/variants.yaml
+        match: REVISION:\ '\d+'
+
   # kube-cross (Kubernetes v1.35)
   - name: "registry.k8s.io/build-image/kube-cross: config variant (v1.35-go1.25)"
     version: go1.25-bullseye
@@ -278,7 +299,7 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.25.5
+    version: 1.25.6
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -308,7 +329,7 @@ dependencies:
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.25.5
+    version: 1.25.6
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,4 +1,7 @@
 variants:
+  v1.36-cross1.25-bullseye:
+    CONFIG: 'cross1.25'
+    KUBE_CROSS_VERSION: 'v1.36.0-go1.25.6-bullseye.0'
   v1.35-cross1.25-bullseye:
     CONFIG: 'cross1.25'
     KUBE_CROSS_VERSION: 'v1.35.0-go1.25.5-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.25.5
-GO_VERSION_TOOLING ?= 1.25.5
+GO_VERSION ?= 1.25.6
+GO_VERSION_TOOLING ?= 1.25.6
 OS_CODENAME ?= bullseye
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,14 +1,19 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.25.5'
-    GO_VERSION_TOOLING: '1.25.5'
+    GO_VERSION: '1.25.6'
+    GO_VERSION_TOOLING: '1.25.6'
     OS_CODENAME: 'bullseye'
   next:
     CONFIG: next
-    GO_VERSION: '1.25.5'
-    GO_VERSION_TOOLING: '1.25.5'
+    GO_VERSION: '1.25.6'
+    GO_VERSION_TOOLING: '1.25.6'
     OS_CODENAME: 'bookworm'
+  '1.36':
+    CONFIG: '1.36'
+    GO_VERSION: '1.25.6'
+    GO_VERSION_TOOLING: '1.25.6'
+    OS_CODENAME: 'bullseye'
   '1.35':
     CONFIG: '1.35'
     GO_VERSION: '1.25.5'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update k8s-cloud-builder and k8s-ci-builder to Go 1.25.6

go updates for k/k in the main branch was merged https://github.com/kubernetes/kubernetes/pull/136465

/assign @xmudrii @saschagrunert  @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/release/issues/4237
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update k8s-cloud-builder and k8s-ci-builder to Go 1.25.6
```
