### PR TITLE
Prevent Docker plugin installation in k8s-cloud-builder

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -83,6 +83,7 @@ ENV PATH="${GOOGLE_DIR}/google-cloud-sdk/bin:${PATH}"
 # https://docs.docker.com/install/linux/docker-ce/debian/
 # Pin to version 24.0.x for API version 1.43 compatibility with DinD in CI
 # See: https://github.com/kubernetes/release/issues/4180
+# Exclude buildx and compose plugins which pull in newer API versions
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && apt-key fingerprint 0EBFCD88 \
     && add-apt-repository \
@@ -91,7 +92,9 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
       stable" \
     && apt-get -y update \
     && apt-get -qqy install \
-        docker-ce-cli=5:24.0.*
+        --no-install-recommends \
+        docker-ce-cli=5:24.0.* \
+    && apt-mark hold docker-ce-cli
 
 # Cleanup a bit
 RUN apt-get -qqy remove \


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The docker-ce-cli package was pulling in buildx and compose plugins as recommended dependencies, which use API version 1.52. This causes incompatibility with GCB's Docker-in-Docker setup that only supports API version 1.43.

Add --no-install-recommends flag to exclude these plugins and use apt-mark hold to prevent accidental upgrades.


#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/release/issues/4180


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
