### PR TITLE
Reintroduce docker-buildx plugin to k8s-cloud-builder image

### DIFF
--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -96,6 +96,15 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
         docker-ce-cli=5:24.0.* \
     && apt-mark hold docker-ce-cli
 
+# Install docker-buildx plugin manually to avoid apt pulling in newer API versions
+# Buildx v0.14.1 supports Docker API 1.41+ (Docker Engine 20.10+)
+# See: https://github.com/docker/buildx/releases
+ARG BUILDX_VERSION=0.14.1
+RUN mkdir -p /usr/lib/docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64" \
+        -o /usr/lib/docker/cli-plugins/docker-buildx \
+    && chmod +x /usr/lib/docker/cli-plugins/docker-buildx
+
 # Cleanup a bit
 RUN apt-get -qqy remove \
       wget \

--- a/images/k8s-cloud-builder/test.yaml
+++ b/images/k8s-cloud-builder/test.yaml
@@ -32,6 +32,10 @@ commandTests:
   - -c
   - |
     pip list | grep '^crcmod\b'
+- name:           docker buildx is installed
+  command:        docker
+  args:           [ "buildx", "version" ]
+  expectedOutput: [ "github.com/docker/buildx" ]
 
 - name:    commands are available
   command: /test.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

A history of the issues we faced today:
1. https://console.cloud.google.com/cloud-build/builds;region=global/34046c12-350f-429a-9e72-c94814c742c0?project=kubernetes-release-test

```
ERROR: failed to build: Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41: driver not connecting
```

An attempt to fix this was made in https://github.com/kubernetes/release/commit/ee1a65f3ceeb7157ec030930a36fafc378a91272

2. https://console.cloud.google.com/cloud-build/builds/14880a62-6ae7-4932-83f1-d6d807c560de;step=2?project=kubernetes-release-test

```
ERROR: docker buildx not available. Docker 19.03 or higher is required with experimental features enabled
```

Install docker-buildx v0.14.1 as a standalone binary to support
multi-platform builds while maintaining compatibility with Docker
API 1.41+. The plugin is installed manually from GitHub releases
to avoid apt dependency conflicts with newer API versions.

In a previous commit (https://github.com/kubernetes/release/commit/ee1a65f3ceeb7157ec030930a36fafc378a91272), --no-install-recommends was added to the apt
install of docker-ce-cli which resulted in docker-buildx to be
skipped entirely.

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

#### Which issue(s) this PR fixes:

Fixes bugs due to #4254 which attempts to fix consequence of #4180

#### Special notes for your reviewer:

Before:
```
❯ docker run --rm -it --platform linux/amd64 gcr.io/k8s-staging-releng/k8s-cloud-builder:v1.35.0-go1.25.6-bullseye.0 docker buildx version
docker: 'buildx' is not a docker command.
See 'docker --help'
```

After:
```
❯ docker run -v --rm -it --platform linux/amd64 k8s-cloud-builder:test docker buildx version
github.com/docker/buildx v0.14.1 59582a88fca7858dbe1886fd1556b2a0d79e43a3
```

#### Does this PR introduce a user-facing change?


```release-note
None
```
