### PR TITLE
Add backoff and timeout to HTTP request retries

### DIFF
--- a/cmd/krel/cmd/announce_send.go
+++ b/cmd/krel/cmd/announce_send.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/release-utils/helpers"
-	"sigs.k8s.io/release-utils/http"
 
+	"k8s.io/release/pkg/consts"
 	"k8s.io/release/pkg/mail"
 	"k8s.io/release/pkg/release"
 )
@@ -104,7 +104,7 @@ func runAnnounce(opts *sendAnnounceOptions, announceRootOpts *announceOptions, r
 	)
 	logrus.Infof("Using announcement remote URL: %s", u)
 
-	content, err := http.NewAgent().Get(u)
+	content, err := consts.NewHTTPAgent().Get(u)
 	if err != nil {
 		return fmt.Errorf(
 			"unable to retrieve release announcement from url: %s: %w", u, err,

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/release-sdk/github"
 	"sigs.k8s.io/release-sdk/object"
 	"sigs.k8s.io/release-utils/helpers"
-	"sigs.k8s.io/release-utils/http"
 
+	"k8s.io/release/pkg/consts"
 	"k8s.io/release/pkg/cve"
 	"k8s.io/release/pkg/notes"
 	"k8s.io/release/pkg/notes/document"
@@ -208,7 +208,7 @@ func (*defaultImpl) Abs(path string) (string, error) {
 }
 
 func (*defaultImpl) GetURLResponse(url string) (string, error) {
-	content, err := http.NewAgent().Get(url)
+	content, err := consts.NewHTTPAgent().Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/consts/main.go
+++ b/pkg/consts/main.go
@@ -18,8 +18,11 @@ package consts
 
 import (
 	"slices"
+	"time"
 
 	"github.com/sirupsen/logrus"
+
+	khttp "sigs.k8s.io/release-utils/http"
 )
 
 const (
@@ -71,6 +74,24 @@ const (
 	DefaultRevision                = "0"
 	DefaultSpecTemplatePath        = "cmd/krel/templates/latest"
 )
+
+const (
+	// httpRetries is the default number of retries for HTTP requests.
+	httpRetries uint = 5
+	// httpTimeout is the default timeout for HTTP requests.
+	httpTimeout = 30 * time.Second
+	// httpRetryWaitTime is the initial backoff wait time between HTTP retries.
+	httpRetryWaitTime = 5 * time.Second
+)
+
+// NewHTTPAgent returns an HTTP agent configured with default retry and timeout
+// settings suitable for CDN-backed URLs.
+func NewHTTPAgent() *khttp.Agent {
+	return khttp.NewAgent().
+		WithTimeout(httpTimeout).
+		WithRetries(httpRetries).
+		WithWaitTime(httpRetryWaitTime)
+}
 
 func IsSupported(field string, input, expected []string) bool {
 	notSupported := []string{}

--- a/pkg/kubecross/impl.go
+++ b/pkg/kubecross/impl.go
@@ -19,7 +19,7 @@ package kubecross
 import (
 	"bytes"
 
-	"sigs.k8s.io/release-utils/http"
+	"k8s.io/release/pkg/consts"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -32,7 +32,7 @@ type impl interface {
 type defaultImpl struct{}
 
 func (*defaultImpl) GetURLResponse(url string) (string, error) {
-	content, err := http.NewAgent().Get(url)
+	content, err := consts.NewHTTPAgent().Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -30,7 +30,8 @@ import (
 	"sigs.k8s.io/release-sdk/gcli"
 	"sigs.k8s.io/release-sdk/object"
 	"sigs.k8s.io/release-utils/helpers"
-	"sigs.k8s.io/release-utils/http"
+
+	"k8s.io/release/pkg/consts"
 )
 
 // Publisher is the structure for publishing anything release related.
@@ -97,7 +98,7 @@ func (*defaultPublisher) GSUtilStatus(args ...string) (bool, error) {
 }
 
 func (*defaultPublisher) GetURLResponse(url string) (string, error) {
-	c, err := http.NewAgent().Get(url)
+	c, err := consts.NewHTTPAgent().Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -24,7 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/git"
-	"sigs.k8s.io/release-utils/http"
+
+	"k8s.io/release/pkg/consts"
 )
 
 // Version is a wrapper around version related functionality.
@@ -42,7 +43,7 @@ type VersionClient interface {
 type versionClient struct{}
 
 func (*versionClient) GetURLResponse(url string) (string, error) {
-	c, err := http.NewAgent().Get(url)
+	c, err := consts.NewHTTPAgent().Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -24,7 +24,7 @@ import (
 	pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/release-utils/http"
+	"k8s.io/release/pkg/consts"
 )
 
 const testgridConfigURL = "https://storage.googleapis.com/k8s-testgrid/config"
@@ -51,7 +51,7 @@ type Client interface {
 type testGridClient struct{}
 
 func (t *testGridClient) GetURLResponse(url string) ([]byte, error) {
-	return http.NewAgent().Get(url)
+	return consts.NewHTTPAgent().Get(url)
 }
 
 // SetClient can be used to set the internal HTTP client.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Increase HTTP timeout from 3s to 30s, retries from 3 to 5, and initial backoff wait from 2s to 5s for all HTTP agent call sites. This prevents transient CDN failures from causing release job failures.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/release/issues/4220

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Increase HTTP retry resilience with 30s timeout, 5 retries, and exponential backoff.
```
