### PR TITLE
bump gcr.io/k8s-staging-test-infra/gcb-docker-gcloud to v20260205-38cfa9523f

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -460,7 +460,7 @@ dependencies:
 
   # Build environments
   - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud"
-    version: v20210917-12df099d55
+    version: v20260205-38cfa9523f
     refPaths:
       - path: images/build/cross/cloudbuild.yaml
         match: "name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v[0-9]{8}-[a-z0-9]{10}'"

--- a/images/build/cross/cloudbuild.yaml
+++ b/images/build/cross/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   substitutionOption: ALLOW_LOOSE
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: 'bash'
     dir: ./images/build/cross
     env:

--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: bash
     dir: ./images/build/debian-base
     env:

--- a/images/build/distroless-iptables/cloudbuild.yaml
+++ b/images/build/distroless-iptables/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: bash
     dir: ./images/build/distroless-iptables
     env:

--- a/images/build/go-runner/cloudbuild.yaml
+++ b/images/build/go-runner/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
       - '--certificate-identity=keyless@distroless.iam.gserviceaccount.com'
       - 'gcr.io/distroless/$_DISTROLESS_IMAGE'
 
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: 'bash'
     dir: ./images/build/go-runner
     env:

--- a/images/build/setcap/cloudbuild.yaml
+++ b/images/build/setcap/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: bash
     dir: ./images/build/setcap
     env:

--- a/images/releng/k8s-ci-builder/cloudbuild.yaml
+++ b/images/releng/k8s-ci-builder/cloudbuild.yaml
@@ -11,7 +11,7 @@ options:
 
 steps:
   # TODO: Update image version
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: 'bash'
     dir: ./images/releng/k8s-ci-builder
     env:


### PR DESCRIPTION
running a very old image, bringing to the latest 


