### PR TITLE
add distroless for go 1.26

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -426,6 +426,18 @@ dependencies:
       - path: images/build/setcap/variants.yaml
         match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.26)"
+    version: v0.9.0
+    refPaths:
+      - path: images/build/distroless-iptables/variants.yaml
+        match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
+  - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.26)"
+    version: v2.4.0-go1.26.0-bookworm.0
+    refPaths:
+      - path: images/build/distroless-iptables/variants.yaml
+        match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
+
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.25)"
     version: v0.8.8
     refPaths:

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,4 +1,9 @@
 variants:
+  distroless-bookworm-go1.26:
+    CONFIG: 'distroless-bookworm'
+    IMAGE_VERSION: 'v0.9.0'
+    BASEIMAGE: 'debian:bookworm-slim'
+    GORUNNER_VERSION: 'v2.4.0-go1.26.0-bookworm.0'
   distroless-bookworm-go1.25:
     CONFIG: 'distroless-bookworm'
     IMAGE_VERSION: 'v0.8.8'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Add distroless-iptables to use Go 1.26.0

/assign @saschagrunert  @xmudrii  @Verolop  
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/release/issues/4266

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add distroless-iptables to use Go 1.26.0
```
