### PR TITLE
add back cloud-builder/lube-cross for release-1.32 and build if go 1.24.13

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -320,6 +320,13 @@ dependencies:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.32-cross1.24)"
+    version: v1.32.0-go1.24.13-bullseye.0
+    refPaths:
+      - path: images/k8s-cloud-builder/variants.yaml
+        match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
+
   # protobuf
   - name: "registry.k8s.io/build-image/kube-cross: protobuf version"
     version: 23.4
@@ -345,6 +352,13 @@ dependencies:
 
   # Golang (previous release branch: 1.33)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.33)"
+    version: 1.24.13
+    refPaths:
+      - path: images/releng/k8s-ci-builder/variants.yaml
+        match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
+  # Golang (previous release branch: 1.32)
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.32)"
     version: 1.24.13
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -11,3 +11,6 @@ variants:
   v1.33-cross1.24-bullseye:
     CONFIG: 'cross1.24'
     KUBE_CROSS_VERSION: 'v1.33.0-go1.24.13-bullseye.0'
+  v1.32-cross1.24-bullseye:
+    CONFIG: 'cross1.24'
+    KUBE_CROSS_VERSION: 'v1.32.0-go1.24.13-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -29,3 +29,8 @@ variants:
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
     OS_CODENAME: 'bullseye'
+  '1.32':
+    CONFIG: '1.32'
+    GO_VERSION: '1.24.13'
+    GO_VERSION_TOOLING: '1.24.13'
+    OS_CODENAME: 'bullseye'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

add back cloud-builder/lube-cross for release-1.32 and build if go 1.24.13

/assign @xmudrii @saschagrunert  @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/release/issues/4265
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add back cloud-builder/lube-cross for release-1.32 and build if go 1.24.13
```