### PR TITLE
set the surrogate key as an object metadata

### DIFF
--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -389,7 +389,7 @@ func (p *Publisher) PublishToGcs(
 		"-m",
 		"-h", "Content-Type:text/plain",
 		"-h", "Cache-Control:private, max-age=0, no-transform",
-		"-h", "Surrogate-Key: "+surrogateKey,
+		"-h", "x-goog-meta-surrogate-key: "+surrogateKey,
 		"cp",
 		latestFile,
 		publishFileDst,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

#4280 had a small error, instead of setting the header directly, we set a custom metadata key and then parse it Fastly like this:

https://github.com/kubernetes/k8s.io/blob/8183260852498f433a800e3822a80d0fe3e99f03/infra/fastly/terraform/cdn/vcl/binaries.vcl#L98


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use proper surrogate key for version markers
```
