### PR TITLE
bump k8s-ci-builder's image base os to bookworm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -399,10 +399,6 @@ dependencies:
         match: OS_CODENAME\ \?=\ bullseye
       - path: images/build/cross/variants.yaml
         match: "OS_CODENAME: 'bullseye'"
-      - path: images/releng/k8s-ci-builder/Makefile
-        match: OS_CODENAME\ \?=\ bullseye
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: "OS_CODENAME: 'bullseye'"
 
   - name: "Debian: codename (default)"
     version: bookworm
@@ -421,6 +417,8 @@ dependencies:
         match: "OS_CODENAME: 'bookworm'"
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "OS_CODENAME: 'bookworm'"
+      - path: images/releng/k8s-ci-builder/Makefile
+        match: OS_CODENAME\ \?=\ bookworm
 
   - name: "registry.k8s.io/build-image/debian-base"
     version: bookworm-v1.0.7

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -26,7 +26,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 # Build args
 GO_VERSION ?= 1.25.7
 GO_VERSION_TOOLING ?= 1.25.7
-OS_CODENAME ?= bullseye
+OS_CODENAME ?= bookworm
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -3,7 +3,7 @@ variants:
     CONFIG: default
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   next:
     CONFIG: next
     GO_VERSION: '1.26.0'
@@ -13,24 +13,24 @@ variants:
     CONFIG: '1.36'
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.35':
     CONFIG: '1.35'
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.33':
     CONFIG: '1.33'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

k8s-ci-builder has been broken since 0.19.0 because bookworm's python version is too old for gcloud and I need the fastly changes for build-fast and build-master jobs

/cc @xmudrii @saschagrunert 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bumped k8s-ci-builder base os to bookworm
```
