### PR TITLE
Pre-populate Go module cache before SBOM generation

### DIFF
--- a/pkg/anago/anagofakes/fake_stage_impl.go
+++ b/pkg/anago/anagofakes/fake_stage_impl.go
@@ -270,6 +270,17 @@ type FakeStageImpl struct {
 		result1 []in_toto.Subject
 		result2 error
 	}
+	GoModDownloadStub        func(string) error
+	goModDownloadMutex       sync.RWMutex
+	goModDownloadArgsForCall []struct {
+		arg1 string
+	}
+	goModDownloadReturns struct {
+		result1 error
+	}
+	goModDownloadReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ListBinariesStub func(string) ([]struct {
 		Path     string
 		Platform string
@@ -1690,6 +1701,67 @@ func (fake *FakeStageImpl) GetProvenanceSubjectsReturnsOnCall(i int, result1 []i
 		result1 []in_toto.Subject
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeStageImpl) GoModDownload(arg1 string) error {
+	fake.goModDownloadMutex.Lock()
+	ret, specificReturn := fake.goModDownloadReturnsOnCall[len(fake.goModDownloadArgsForCall)]
+	fake.goModDownloadArgsForCall = append(fake.goModDownloadArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GoModDownloadStub
+	fakeReturns := fake.goModDownloadReturns
+	fake.recordInvocation("GoModDownload", []interface{}{arg1})
+	fake.goModDownloadMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStageImpl) GoModDownloadCallCount() int {
+	fake.goModDownloadMutex.RLock()
+	defer fake.goModDownloadMutex.RUnlock()
+	return len(fake.goModDownloadArgsForCall)
+}
+
+func (fake *FakeStageImpl) GoModDownloadCalls(stub func(string) error) {
+	fake.goModDownloadMutex.Lock()
+	defer fake.goModDownloadMutex.Unlock()
+	fake.GoModDownloadStub = stub
+}
+
+func (fake *FakeStageImpl) GoModDownloadArgsForCall(i int) string {
+	fake.goModDownloadMutex.RLock()
+	defer fake.goModDownloadMutex.RUnlock()
+	argsForCall := fake.goModDownloadArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStageImpl) GoModDownloadReturns(result1 error) {
+	fake.goModDownloadMutex.Lock()
+	defer fake.goModDownloadMutex.Unlock()
+	fake.GoModDownloadStub = nil
+	fake.goModDownloadReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStageImpl) GoModDownloadReturnsOnCall(i int, result1 error) {
+	fake.goModDownloadMutex.Lock()
+	defer fake.goModDownloadMutex.Unlock()
+	fake.GoModDownloadStub = nil
+	if fake.goModDownloadReturnsOnCall == nil {
+		fake.goModDownloadReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.goModDownloadReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeStageImpl) ListBinaries(arg1 string) ([]struct {

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -613,6 +613,13 @@ func TestGenerateBillOfMaterials(t *testing.T) {
 		shouldError bool
 	}{
 		{
+			// GoModDownload fails
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.GoModDownloadReturns(err)
+			},
+			shouldError: true,
+		},
+		{
 			// GenerateSourceTreeBOM fails
 			prepare: func(mock *anagofakes.FakeStageImpl) {
 				mock.GenerateSourceTreeBOMReturns(nil, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Runs `go mod download` in the k/k directory before SBOM generation. This populates GOMODCACHE so the bom tool's license scanner resolves packages locally instead of git-cloning ~160 dependency repositories one by one.

During mock stage (cold cache), SBOM generation takes ~15 minutes with the majority spent on sequential git clones. This optimization should reduce that significantly by ensuring Go module sources are already available locally.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The bom library checks `curPkg.LocalInstall` (populated from `go list -deps -e -json`) before deciding to download. When GOMODCACHE is populated, `go list` sets `LocalInstall` and the bom tool skips its own git clone.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```