### PR TITLE
Push and sign arch-specific container images in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/yuin/goldmark v1.7.16
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.35.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.34.0
 	google.golang.org/api v0.252.0
 	k8s.io/apimachinery v0.34.3
@@ -308,7 +309,6 @@ require (
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/time v0.14.0 // indirect


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Restructures `Images.Publish()` into three phases:
1. Collect tarball metadata (sequential)
2. Push and sign arch-specific images (parallel, 3 workers)
3. Create, push, and sign manifest lists (sequential)

Previously, all 24 arch-specific images (6 types x 4 arches) were pushed and signed sequentially. Since push and sign are network-bound, parallelizing them with a small worker pool improves throughput without overwhelming the registry or docker daemon.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Uses the `throttler` library already depended on by the project (used in `cmd/krel/cmd/sign_blobs.go`). Worker count is set conservatively to 3 to respect resource limits on the GCB worker pool.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```