### PR TITLE
k8s-ci-builder: Switch from Debian bullseye to bookworm

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -399,10 +399,6 @@ dependencies:
         match: OS_CODENAME\ \?=\ bullseye
       - path: images/build/cross/variants.yaml
         match: "OS_CODENAME: 'bullseye'"
-      - path: images/releng/k8s-ci-builder/Makefile
-        match: OS_CODENAME\ \?=\ bullseye
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: "OS_CODENAME: 'bullseye'"
 
   - name: "Debian: codename (default)"
     version: bookworm
@@ -419,6 +415,8 @@ dependencies:
         match: "CONFIG: 'bookworm'"
       - path: images/releng/ci/variants.yaml
         match: "OS_CODENAME: 'bookworm'"
+      - path: images/releng/k8s-ci-builder/Makefile
+        match: OS_CODENAME\ \?=\ bookworm
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "OS_CODENAME: 'bookworm'"
 

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -26,7 +26,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 # Build args
 GO_VERSION ?= 1.25.7
 GO_VERSION_TOOLING ?= 1.25.7
-OS_CODENAME ?= bullseye
+OS_CODENAME ?= bookworm
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 
 BUILD_ARGS = --build-arg=GO_VERSION=$(GO_VERSION) \

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -3,7 +3,7 @@ variants:
     CONFIG: default
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   next:
     CONFIG: next
     GO_VERSION: '1.26.0'
@@ -13,24 +13,24 @@ variants:
     CONFIG: '1.36'
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.35':
     CONFIG: '1.35'
     GO_VERSION: '1.25.7'
     GO_VERSION_TOOLING: '1.25.7'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.33':
     CONFIG: '1.33'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: '1.24.13'
     GO_VERSION_TOOLING: '1.24.13'
-    OS_CODENAME: 'bullseye'
+    OS_CODENAME: 'bookworm'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Switches the k8s-ci-builder image from Debian bullseye to bookworm. The latest Google Cloud SDK requires Python 3.10+ (`str | None` union type syntax), but bullseye only ships Python 3.9. This has caused all k8s-ci-builder variants except `next` (already on bookworm) to fail since ~Feb 24.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The `next` variant has been on bookworm since mid-2023 without issues. The glibc compatibility concern only applies to kube-cross (which builds the Kubernetes binaries shipped to users), not k8s-ci-builder (which only runs release tools inside CI).

https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-release-push-image-k8s-ci-builder

#### Does this PR introduce a user-facing change?

```release-note
NONE
```