### PR TITLE
add debian trixie and riscv64 support for debian-base

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -24,7 +24,7 @@ CONFIG ?= bookworm
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 
 QEMUVERSION=7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static
@@ -51,6 +51,10 @@ endif
 ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/debian:$(CONFIG)-slim
 	QEMUARCH=s390x
+endif
+ifeq ($(ARCH),riscv64)
+	BASEIMAGE?=riscv64/debian:$(CONFIG)-slim
+	QEMUARCH=riscv64
 endif
 
 sub-build-%:

--- a/images/build/debian-base/trixie/Dockerfile
+++ b/images/build/debian-base/trixie/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/images/build/debian-base/trixie/Dockerfile.build
+++ b/images/build/debian-base/trixie/Dockerfile.build
@@ -1,0 +1,100 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+
+FROM $BASEIMAGE AS certs
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install ca-certificates and dependencies
+RUN apt-get update \
+    && apt-get install -y ca-certificates
+
+FROM $BASEIMAGE
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy only ca-certificates without any dependencies
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Smaller package install size.
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+# Convenience script for building on this base image.
+COPY clean-install /usr/local/bin/clean-install
+
+# An attempt to fix issues like:
+# ```
+# Error while loading /usr/sbin/dpkg-split: No such file or directory
+# Error while loading /usr/sbin/dpkg-deb: No such file or directory
+# ```
+# See: https://github.com/docker/buildx/issues/495
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    ln -s /bin/tar /usr/sbin/tar && \
+    ln -s /bin/rm /usr/sbin/rm
+
+# Update system packages.
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+# Remove unnecessary packages.
+RUN dpkg --purge --force-remove-essential \
+        bash \
+        e2fsprogs \
+        libss2 \
+        libcom-err2 \
+        libext2fs2 \
+        logsave \
+        ncurses-base \
+        ncurses-bin \
+        tzdata \
+    && apt-get autoremove --purge -y
+
+# No-op stubs replace some unnecessary binaries that may be depended on in the install process (in
+# particular we don't run an init process).
+WORKDIR /usr/local/bin
+RUN touch noop && \
+    chmod 555 noop && \
+    ln -s noop runlevel && \
+    ln -s noop invoke-rc.d && \
+    ln -s noop update-rc.d
+WORKDIR /
+
+# Cleanup cached and unnecessary files.
+RUN apt-get autoremove -y && \
+    apt-get clean -y && \
+    tar -czf /usr/share/copyrights.tar.gz /usr/share/common-licenses /usr/share/doc/*/copyright && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /usr/share/common-licenses* \
+        /usr/share/bash-completion \
+        ~/.bashrc \
+        ~/.profile \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    mkdir -p /usr/share/man/man1 /usr/share/man/man2 \
+        /usr/share/man/man3 /usr/share/man/man4 \
+        /usr/share/man/man5 /usr/share/man/man6 \
+        /usr/share/man/man7 /usr/share/man/man8

--- a/images/build/debian-base/trixie/clean-install
+++ b/images/build/debian-base/trixie/clean-install
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/images/build/debian-base/trixie/excludes
+++ b/images/build/debian-base/trixie/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/man/*

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -2,3 +2,8 @@ variants:
   bookworm:
     CONFIG: 'bookworm'
     IMAGE_VERSION: 'bookworm-v1.0.7'
+    ALL_ARCH: amd64 arm arm64 ppc64le s390x
+  trixie:
+    CONFIG: 'trixie'
+    IMAGE_VERSION: 'trixie-v1.0.0'
+    ALL_ARCH: amd64 arm arm64 ppc64le riscv64 s390x


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Debian Trixie is the successor to Bookworm. One of Trixie's advantages is that it now supports riscv64.

Updated debian-base docker image.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add trixie and riscv64 for debian-base image
```
