### PR TITLE
Use regional Cloud Build API with pagination in GetJobsByTag

### DIFF
--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -408,10 +408,31 @@ func GetJobsByTag(project, tagsFilter string) ([]*cloudbuild.Build, error) {
 		return nil, fmt.Errorf("failed to fetching gcloud credentials... try running \"gcloud auth application-default login\": %w", err)
 	}
 
-	req, err := service.Projects.Builds.List(project).Filter(tagsFilter).PageSize(50).Do()
-	if err != nil {
-		return nil, fmt.Errorf("failed to listing the builds: %w", err)
+	parent := fmt.Sprintf("projects/%s/locations/us-central1", project)
+
+	var allBuilds []*cloudbuild.Build
+
+	pageToken := ""
+
+	for {
+		call := service.Projects.Locations.Builds.List(parent).Filter(tagsFilter).PageSize(50)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list the builds: %w", err)
+		}
+
+		allBuilds = append(allBuilds, resp.Builds...)
+
+		if resp.NextPageToken == "" {
+			break
+		}
+
+		pageToken = resp.NextPageToken
 	}
 
-	return req.Builds, nil
+	return allBuilds, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates `GetJobsByTag` to:

1. Use the regional Cloud Build API (`Projects.Locations.Builds.List`) targeting `us-central1`, consistent with how builds are submitted in `RunSingleJob`.
2. Paginate through all result pages using `NextPageToken` instead of returning only the first 50 results.

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/sig-release/issues/2954

#### Does this PR introduce a user-facing change?
```release-note
Use regional Cloud Build API with pagination in GetJobsByTag
```