### PR TITLE
Fix version mismatch between staging and pushing artifacts

### DIFF
--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -221,9 +221,15 @@ func (bi *Instance) findLatestVersion() (latestVersion string, err error) {
 		latestVersion += "-" + bi.opts.VersionSuffix
 	}
 
+	latestVersion = strings.TrimSpace(latestVersion)
+
+	// Update opts.Version so that StageLocalArtifacts and
+	// PushReleaseArtifacts use the same resolved version path.
+	bi.opts.Version = latestVersion
+
 	setupBuildDir(bi)
 
-	return strings.TrimSpace(latestVersion), nil
+	return latestVersion, nil
 }
 
 func setupBuildDir(bi *Instance) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Fix `krel push` failing when the version is auto-discovered (no `--version` flag) and `--version-suffix` is used
- `findLatestVersion()` resolves the version and appends the suffix but never updates `bi.opts.Version`, causing `StageLocalArtifacts()` to stage to a path without the version while `PushReleaseArtifacts()` looks for it with the version

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This was discovered via https://github.com/kubernetes/perf-tests/pull/3845 which broke the `build-and-push-k8s-at-golang-tip` job: https://testgrid.k8s.io/sig-scalability-golang#build-and-push-k8s-at-golang-tip

cc @rf232 @kubernetes/release-managers

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in krel push where auto-discovered versions with a version suffix caused a path mismatch between staging and pushing artifacts.
```