### PR TITLE
Update golangci-lint to v2.10 and fix lint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.5
+          version: v2.10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
 linters:
   default: none
   enable:
+    - arangolint
     - asasalint
     - asciicheck
     - bidichk
@@ -16,7 +17,9 @@ linters:
     - decorder
     - dogsled
     - dupl
+    - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errchkjson
     - errname
@@ -25,6 +28,7 @@ linters:
     - exptostd
     - fatcontext
     - forcetypeassert
+    - funcorder
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecksumtype
@@ -44,15 +48,21 @@ linters:
     - iface
     - importas
     - ineffassign
+    - interfacebloat
     - intrange
+    - iotamixing
+    - ireturn
     - loggercheck
+    - maintidx
     - makezero
     - mirror
     - misspell
+    - modernize
     - musttag
     - nakedret
     - nilerr
     - nilnesserr
+    - nilnil
     - nlreturn
     - noctx
     - nolintlint
@@ -76,6 +86,7 @@ linters:
     - tparallel
     - unconvert
     - unparam
+    - unqueryvet
     - unused
     - usestdlibvars
     - usetesting
@@ -85,7 +96,6 @@ linters:
     - zerologlint
     # - cyclop
     # - depguard
-    # - dupword
     # - err113
     # - exhaustruct
     # - forbidigo
@@ -93,14 +103,12 @@ linters:
     # - gochecknoglobals
     # - gochecknoinits
     # - gocognit
+    # - godoclint
     # - inamedparam
-    # - interfacebloat
-    # - ireturn
     # - lll
-    # - maintidx
     # - mnd
     # - nestif
-    # - nilnil
+    # - noinlineerr
     # - nonamedreturns
     # - paralleltest
     # - tagliatelle

--- a/cmd/ci-reporter/cmd/root.go
+++ b/cmd/ci-reporter/cmd/root.go
@@ -151,7 +151,7 @@ type CIReporters []CIReporter
 var AllImplementedReporters = CIReporters{GithubReporter{}, TestgridReporter{}}
 
 // SearchReporter used to filter a implemented reporter by name.
-func SearchReporter(ctx context.Context, reporterName string) (CIReporter, error) {
+func SearchReporter(ctx context.Context, reporterName string) (CIReporter, error) { //nolint:ireturn // returning interface is intentional
 	var reporter CIReporter
 
 	reporterFound := false
@@ -281,10 +281,12 @@ func PrintReporterData(cfg *Config, reports *CIReportDataFields) error {
 			countCategories[data[i][categoryIndex]]++
 		}
 
-		categoryCounts := ""
+		var categoryCountsBuilder strings.Builder
 		for category, categoryCount := range countCategories {
-			categoryCounts += fmt.Sprintf("%s:%d ", category, categoryCount)
+			fmt.Fprintf(&categoryCountsBuilder, "%s:%d ", category, categoryCount)
 		}
+
+		categoryCounts := categoryCountsBuilder.String()
 
 		if _, err := fmt.Fprintf(out, "\nSUMMARY - Total:%d %s\n", len(data), categoryCounts); err != nil {
 			return fmt.Errorf("could not write to output stream: %w", err)

--- a/cmd/krel/cmd/changelog_data_test.go
+++ b/cmd/krel/cmd/changelog_data_test.go
@@ -721,7 +721,7 @@ const minorReleaseExpectedContent = `# Changelog since v1.20.0
 
 PSP as an admission controller resource is being deprecated. Deployed PodSecurityPolicy's will keep working until version 1.25, their target removal from the codebase. A new feature, with a working title of "PSP replacement policy", is being developed in [KEP-2579](https://features.k8s.io/2579). To learn more, read [PodSecurityPolicy Deprecation: Past, Present, and Future](https://blog.k8s.io/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).`
 
-//nolint:misspell // there is a spelling mistake in the notes
+//nolint:misspell,dupword // there is a spelling mistake in the notes
 const minorReleaseExpectedHTML = `<!DOCTYPE html>
 <html>
   <head>

--- a/cmd/krel/cmd/cve.go
+++ b/cmd/krel/cmd/cve.go
@@ -87,6 +87,7 @@ var argFunc = func(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("command takes only one argument: a CVE identifier")
 	}
+
 	cveOpts.CVE = strings.ToUpper(args[0])
 	if err := cve.NewClient().CheckID(cveOpts.CVE); err != nil {
 		return fmt.Errorf("invalid CVE ID. Format must match %s", cve.CVEIDRegExp)
@@ -119,7 +120,7 @@ func writeNewCVE(opts *cveOptions) (err error) {
 		return fmt.Errorf("creating new cve data map: %w", err)
 	}
 
-	oldFile, err := os.ReadFile(file.Name())
+	oldFile, err := os.ReadFile(file.Name()) //nolint:gosec // G703 - temp file path is safe
 	if err != nil {
 		return fmt.Errorf("reading local copy of CVE entry: %w", err)
 	}
@@ -197,7 +198,7 @@ func editExistingCVE(opts *cveOptions) (err error) {
 		return fmt.Errorf("copying CVE entry for edting: %w", err)
 	}
 
-	oldFile, err := os.ReadFile(file.Name())
+	oldFile, err := os.ReadFile(file.Name()) //nolint:gosec // G703 - temp file path is safe
 	if err != nil {
 		return fmt.Errorf("reading local copy of CVE entry: %w", err)
 	}

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -333,6 +333,8 @@ func runReleaseNotes() (err error) {
 }
 
 // createDraftPR pushes the release notes draft to the users fork.
+//
+//nolint:maintidx // complex but acceptable
 func createDraftPR(repoPath, tag string) (err error) {
 	tagVersion, err := helpers.TagStringToSemver(tag)
 	if err != nil {
@@ -650,7 +652,7 @@ func addReferenceToAssetsFile(repoPath, newJSONFile string) error {
 
 		// Add the current version right after the array export
 		if strings.Contains(scanner.Text(), "export const assets =") {
-			assetsBuffer.WriteString(fmt.Sprintf("  'assets/%s',\n", newJSONFile))
+			fmt.Fprintf(&assetsBuffer, "  'assets/%s',\n", newJSONFile)
 
 			assetsFileWasModified = true
 		}
@@ -1473,7 +1475,7 @@ func editReleaseNote(pr int, workDir string, originalNote, modifiedNote *notes.R
 	blankFile := true
 
 	for _, line := range lines {
-		// If only only one line is not blank/comment
+		// If only one line is not blank/comment
 		if line != "---" && !re.MatchString(line) {
 			blankFile = false
 

--- a/cmd/publish-release/cmd/github.go
+++ b/cmd/publish-release/cmd/github.go
@@ -263,7 +263,7 @@ func processRemoteAsset(urlString string) (path string, err error) {
 	}
 	defer rc.Close()
 
-	f, err := os.Create(filepath.Join(tmpDir, filename))
+	f, err := os.Create(filepath.Join(tmpDir, filename)) //nolint:gosec // G703 - temp dir path is safe
 	if err != nil {
 		return path, fmt.Errorf("creating temporary file: %w", err)
 	}
@@ -308,7 +308,7 @@ func runGithubPage(opts *githubPageCmdLineOptions) (err error) {
 		}
 	}
 
-	var newAssets []string //nolint: prealloc,gocritic
+	var newAssets []string //nolint:gocritic
 	for _, a := range assets {
 		newAssets = append(newAssets, a.ReadFrom)
 	}

--- a/cmd/publish-release/cmd/github_test.go
+++ b/cmd/publish-release/cmd/github_test.go
@@ -33,7 +33,7 @@ func TestProcessRemoteAsset(t *testing.T) {
 
 	t.Setenv(gacVar, "")
 
-	files := []string{}
+	files := []string{} //nolint:prealloc // dynamic append
 
 	defer func() {
 		for _, f := range files {

--- a/cmd/release-notes/check.go
+++ b/cmd/release-notes/check.go
@@ -45,6 +45,7 @@ const (
 
 type checkPROptions struct {
 	options.Options
+
 	PullRequests []int
 }
 

--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -188,6 +188,7 @@ const (
 `
 )
 
+//nolint:maintidx // complex but acceptable
 func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches EolBranches, filePath, eolFilePath string) error {
 	removeSchedules := []int{}
 

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -463,7 +463,7 @@ func TestUpdatePatchSchedule(t *testing.T) {
 
 			require.NoError(t, updatePatchSchedule(tc.refTime, tc.givenSchedule, EolBranches{}, scheduleFile.Name(), eolFile.Name()))
 
-			scheduleYamlBytes, err := os.ReadFile(scheduleFile.Name())
+			scheduleYamlBytes, err := os.ReadFile(scheduleFile.Name()) //nolint:gosec // G703 - temp file path is safe
 			require.NoError(t, err)
 
 			patchRes := PatchSchedule{}
@@ -471,7 +471,7 @@ func TestUpdatePatchSchedule(t *testing.T) {
 
 			assert.Equal(t, tc.expectedSchedule, patchRes)
 
-			eolYamlBytes, err := os.ReadFile(eolFile.Name())
+			eolYamlBytes, err := os.ReadFile(eolFile.Name()) //nolint:gosec // G703 - temp file path is safe
 			require.NoError(t, err)
 
 			eolRes := EolBranches{}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -385,7 +385,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v2.5
+    version: v2.10
     refPaths:
       - path: .github/workflows/lint.yml
         match: "version: v\\d+.\\d+?\\.?(\\d+)?"

--- a/pkg/anago/release.go
+++ b/pkg/anago/release.go
@@ -39,6 +39,7 @@ import (
 // releaseClient is a client for release a previously staged release.
 //
 //counterfeiter:generate . releaseClient
+//nolint:interfacebloat // large interface is by design
 type releaseClient interface {
 	// Submit can be used to submit a Google Cloud Build (GCB) job.
 	Submit(stream bool) error
@@ -121,6 +122,7 @@ type defaultReleaseImpl struct{}
 // releaseImpl is the implementation of the release client.
 //
 //counterfeiter:generate . releaseImpl
+//nolint:interfacebloat // large interface is by design
 type releaseImpl interface {
 	Submit(options *gcb.Options) error
 	ToFile(fileName string) error

--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -45,6 +45,7 @@ import (
 // stageClient is a client for staging releases.
 //
 //counterfeiter:generate . stageClient
+//nolint:interfacebloat // large interface is by design
 type stageClient interface {
 	// Submit can be used to submit a Google Cloud Build (GCB) job.
 	Submit(stream bool) error
@@ -135,6 +136,7 @@ type defaultStageImpl struct{}
 // stageImpl is the implementation of the stage client.
 //
 //counterfeiter:generate . stageImpl
+//nolint:interfacebloat // large interface is by design
 type stageImpl interface {
 	Submit(options *gcb.Options) error
 	ToFile(fileName string) error

--- a/pkg/announce/announce.go
+++ b/pkg/announce/announce.go
@@ -62,8 +62,9 @@ Managers</a>.
 `
 
 type Announce struct {
-	options *Options
 	impl
+
+	options *Options
 }
 
 // NewAnnounce returns a new Announce instance.

--- a/pkg/announce/github/github.go
+++ b/pkg/announce/github/github.go
@@ -33,8 +33,9 @@ import (
 )
 
 type GitHub struct {
-	options *Options
 	impl
+
+	options *Options
 }
 
 // NewGitHub returns a new GitHub instance.
@@ -51,6 +52,8 @@ func (g *GitHub) SetImplementation(i impl) {
 }
 
 // UpdateGitHubPage updates a github page with data from the release.
+//
+//nolint:maintidx // complex but acceptable
 func (g *GitHub) UpdateGitHubPage() (err error) {
 	token := os.Getenv(github.TokenEnvKey)
 	if token == "" {

--- a/pkg/announce/sbom/sbom.go
+++ b/pkg/announce/sbom/sbom.go
@@ -28,8 +28,9 @@ import (
 )
 
 type SBOM struct {
-	options *Options
 	impl
+
+	options *Options
 }
 
 // NewGitHub returns a new GitHub instance.

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -39,8 +39,9 @@ const (
 
 // Binary is the base type of the package. It abstracts a binary executable.
 type Binary struct {
-	options *Options
 	binaryImplementation
+
+	options *Options
 }
 
 // Options to control the binary checker.
@@ -73,7 +74,7 @@ func NewWithOptions(filePath string, opts *Options) (bin *Binary, err error) {
 
 // getArchImplementation returns the implementation that corresponds
 // to the specified binary.
-func getArchImplementation(filePath string, opts *Options) (impl binaryImplementation, err error) {
+func getArchImplementation(filePath string, opts *Options) (impl binaryImplementation, err error) { //nolint:ireturn // returning interface is intentional
 	// Check if we're dealing with a Linux binary
 	elf, err := NewELFBinary(filePath, opts)
 	if err != nil {

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -132,7 +132,7 @@ func TestGetELFHeader(t *testing.T) {
 	for _, testBin := range GetTestHeaders() {
 		f := writeTestBinary(t, testBin.Data)
 		header, err := binary.GetELFHeader(f.Name())
-		os.Remove(f.Name())
+		os.Remove(f.Name()) //nolint:gosec // G703 - temp file path is safe
 		require.NoError(t, err)
 
 		if testBin.OS == "linux" {
@@ -148,7 +148,7 @@ func TestGetMachOHeader(t *testing.T) {
 	for _, testBin := range GetTestHeaders() {
 		f := writeTestBinary(t, testBin.Data)
 		header, err := binary.GetMachOHeader(f.Name())
-		os.Remove(f.Name())
+		os.Remove(f.Name()) //nolint:gosec // G703 - temp file path is safe
 		require.NoError(t, err)
 
 		if testBin.OS == "darwin" {
@@ -164,7 +164,7 @@ func TestGetPEHeader(t *testing.T) {
 	for _, testBin := range GetTestHeaders() {
 		f := writeTestBinary(t, testBin.Data)
 		header, err := binary.GetPEHeader(f.Name())
-		os.Remove(f.Name())
+		os.Remove(f.Name()) //nolint:gosec // G703 - temp file path is safe
 		require.NoError(t, err)
 
 		if testBin.OS == "windows" {

--- a/pkg/binary/binary_unit_test.go
+++ b/pkg/binary/binary_unit_test.go
@@ -33,7 +33,7 @@ func TestContainsString(t *testing.T) {
 	// Decode a fragment of kubectl into a temporary file:
 	binData, err := base64.StdEncoding.DecodeString(kubectlFragment)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(tmpfile.Name(), binData, os.FileMode(0o644)))
+	require.NoError(t, os.WriteFile(tmpfile.Name(), binData, os.FileMode(0o644))) //nolint:gosec // G703 - temp file path is safe
 	bin := Binary{
 		options: &Options{
 			Path: tmpfile.Name(),
@@ -52,6 +52,7 @@ func TestContainsString(t *testing.T) {
 	require.NoError(t, err)
 }
 
+//nolint:dupword // binary test data
 var kubectlFragment = `nxsirlx0QAAAAAAA0HZAFANwVyHQekA7vuLSGA57QHEaitUNKXtAY+ef53SofUDqSbATP1Z+QGgo
 7CEZK4RA97PI/X55hUACFbBWgMiFQO85+v5CLoZABGeTp8C4i0D///////+PQBhRnRjrAphA5jvf
 zhnyo0BqJIxot/+oQB7FLgvj9rJAaUuYyn5qtECfyHUuMhK1QAAAAAAAiMNAER3/Jb8Vx0Dhka4+

--- a/pkg/binary/elf.go
+++ b/pkg/binary/elf.go
@@ -56,7 +56,7 @@ func NewELFBinary(filePath string, opts *Options) (*ELFBinary, error) {
 	if header == nil {
 		logrus.Debug("file is not an ELF binary")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	return &ELFBinary{
@@ -148,7 +148,7 @@ func GetELFHeader(path string) (*ELFHeader, error) {
 	if string(hBytes[1:4]) != "ELF" {
 		logrus.Debug("Binary is not an ELF executable")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	// Check if binary byte order is big or little endian

--- a/pkg/binary/mach-o.go
+++ b/pkg/binary/mach-o.go
@@ -58,7 +58,7 @@ func NewMachOBinary(filePath string, opts *Options) (*MachOBinary, error) {
 	if header == nil {
 		logrus.Debug("File is not a Mach-O binary")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	return &MachOBinary{
@@ -170,7 +170,7 @@ func GetMachOHeader(path string) (*MachOHeader, error) {
 	default:
 		logrus.Debug("File is not a Mach-O binary")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	header := &MachOHeader{}

--- a/pkg/binary/windows.go
+++ b/pkg/binary/windows.go
@@ -65,7 +65,7 @@ func NewPEBinary(filePath string, opts *Options) (bin *PEBinary, err error) {
 	if header == nil {
 		logrus.Infof("file is not a PE executable")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	return &PEBinary{
@@ -173,7 +173,7 @@ func GetPEHeader(path string) (*PEHeader, error) {
 		// windows executable
 		logrus.Debug("File is not a valid windows PE executable")
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	if _, err := f.Seek(base, 0); err != nil {

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -55,8 +55,9 @@ type Options struct {
 
 // Changelog can be used to generate the changelog for a release.
 type Changelog struct {
-	options *Options
 	impl
+
+	options *Options
 }
 
 // New creates a new Changelog instance.
@@ -527,7 +528,7 @@ func (c *Changelog) commitChanges(
 			return fmt.Errorf("checking out release branch %s: %w", branch, err)
 		}
 
-		// Remove all other changelog files if we’re on the the first official release
+		// Remove all other changelog files if we’re on the first official release
 		if tag.Patch == 0 && len(tag.Pre) == 0 {
 			pattern := filepath.Join(RepoChangelogDir, "CHANGELOG-*.md")
 			logrus.Infof("Removing unnecessary %s files", pattern)

--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/release/pkg/notes"
 )
 
+//nolint:maintidx // complex but acceptable
 func TestRun(t *testing.T) {
 	err := errors.New("")
 
@@ -125,6 +126,7 @@ func TestRun(t *testing.T) {
 		{ // DependencyChanges failed
 			prepare: func(mock *changelogfakes.FakeImpl, opts *changelog.Options) {
 				opts.Dependencies = true
+
 				mock.DependencyChangesReturns("", err)
 			},
 			shouldErr: true,
@@ -270,6 +272,7 @@ func TestRun(t *testing.T) {
 		{ // CloneCVEData returns error
 			prepare: func(mock *changelogfakes.FakeImpl, o *changelog.Options) {
 				o.CloneCVEMaps = true
+
 				mock.TagStringToSemverReturns(semver.Version{
 					Major: 1,
 					Minor: 19,
@@ -282,6 +285,7 @@ func TestRun(t *testing.T) {
 		{ // CloneCVEData returns empty string
 			prepare: func(mock *changelogfakes.FakeImpl, o *changelog.Options) {
 				o.CloneCVEMaps = true
+
 				mock.TagStringToSemverReturns(semver.Version{
 					Major: 1,
 					Minor: 19,

--- a/pkg/changelog/impl.go
+++ b/pkg/changelog/impl.go
@@ -46,6 +46,7 @@ import (
 //counterfeiter:generate . impl
 //go:generate /usr/bin/env bash -c "cat ../../hack/boilerplate/boilerplate.generatego.txt changelogfakes/fake_impl.go > changelogfakes/_fake_impl.go && mv changelogfakes/_fake_impl.go changelogfakes/fake_impl.go"
 
+//nolint:interfacebloat // large interface is by design
 type impl interface {
 	// Used in `Run()`
 	TagStringToSemver(tag string) (semver.Version, error)

--- a/pkg/fastforward/fastforward.go
+++ b/pkg/fastforward/fastforward.go
@@ -68,6 +68,7 @@ type Options struct {
 // FastForward is the main structure of this package.
 type FastForward struct {
 	impl
+
 	options *Options
 }
 
@@ -83,6 +84,8 @@ const pushUpstreamQuestion = `Are you ready to push the local branch fast-forwar
 Please only answer after you have validated the changes.`
 
 // Run starts the FastForward.
+//
+//nolint:maintidx // complex but acceptable
 func (f *FastForward) Run() (err error) {
 	if f.options.Submit {
 		if err := f.prepareToolRepo(); err != nil {

--- a/pkg/fastforward/fastforward_test.go
+++ b/pkg/fastforward/fastforward_test.go
@@ -30,6 +30,7 @@ import (
 
 var errTest = errors.New("test")
 
+//nolint:maintidx // complex but acceptable
 func TestRun(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fastforward/impl.go
+++ b/pkg/fastforward/impl.go
@@ -36,6 +36,7 @@ type defaultImpl struct{}
 //counterfeiter:generate . impl
 //go:generate /usr/bin/env bash -c "cat ../../hack/boilerplate/boilerplate.generatego.txt fastforwardfakes/fake_impl.go > fastforwardfakes/_fake_impl.go && mv fastforwardfakes/_fake_impl.go fastforwardfakes/fake_impl.go"
 
+//nolint:interfacebloat // large interface is by design
 type impl interface {
 	CloneOrOpenDefaultGitHubRepoSSH(string) (*git.Repo, error)
 	RepoSetDry(*git.Repo)

--- a/pkg/gcp/build/build.go
+++ b/pkg/gcp/build/build.go
@@ -263,7 +263,7 @@ func getVariants(o *Options) (variants, error) {
 			return nil, fmt.Errorf("no variants.yaml found, but a build variant (%q) was specified: %w", o.Variant, err)
 		}
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	v := struct {

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/release/pkg/release"
 )
 
-func mockRepo() gcb.Repository {
+func mockRepo() gcb.Repository { //nolint:ireturn // interface return is by design
 	mock := &gcbfakes.FakeRepository{}
 	mock.OpenReturns(nil)
 	mock.CheckStateReturns(nil)
@@ -40,14 +40,14 @@ func mockRepo() gcb.Repository {
 	return mock
 }
 
-func mockVersion(version string) gcb.Version {
+func mockVersion(version string) gcb.Version { //nolint:ireturn // interface return is by design
 	mock := &gcbfakes.FakeVersion{}
 	mock.GetKubeVersionForBranchReturns(version, nil)
 
 	return mock
 }
 
-func mockRelease(version string) gcb.Release {
+func mockRelease(version string) gcb.Release { //nolint:ireturn // interface return is by design
 	mock := &gcbfakes.FakeRelease{}
 	mock.GenerateReleaseVersionReturns(
 		release.NewReleaseVersions(version, "", "", "", ""), nil,

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -72,7 +72,7 @@ type FileMetadata struct {
 // binaries in `dir`.
 func fetchFileMetadata(dir, urlPrefix, tag string) (*FileMetadata, error) {
 	if dir == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	if tag == "" {
@@ -104,7 +104,7 @@ func fetchFileMetadata(dir, urlPrefix, tag string) (*FileMetadata, error) {
 	}
 
 	if fileCount == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	return fm, nil
@@ -112,7 +112,7 @@ func fetchFileMetadata(dir, urlPrefix, tag string) (*FileMetadata, error) {
 
 func fetchImageMetadata(dir, tag string) (*ImageMetadata, error) {
 	if dir == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	if tag == "" {
@@ -127,7 +127,7 @@ func fetchImageMetadata(dir, tag string) (*ImageMetadata, error) {
 	}
 
 	if len(manifests) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	res := ImageMetadata{}
@@ -559,8 +559,7 @@ func mapKind(kind notes.Kind) notes.Kind {
 }
 
 func prettyKind(kind notes.Kind) string {
-	//nolint:exhaustive // all cases are covered by default
-	switch kind {
+	switch kind { //nolint:exhaustive // all cases are covered by default
 	case notes.KindAPIChange:
 		return "API Change"
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -565,6 +565,70 @@ func (g *Gatherer) ReleaseNoteFromCommit(result *Result) (*ReleaseNote, error) {
 	}, nil
 }
 
+// ReleaseNoteForPullRequest returns a release note from a pull request number.
+// If the release note is blank or.
+func (g *Gatherer) ReleaseNoteForPullRequest(prNr int) (*ReleaseNote, error) {
+	pr, _, err := g.client.GetPullRequest(g.context, g.options.GithubOrg, g.options.GithubRepo, prNr)
+	if err != nil {
+		return nil, fmt.Errorf("reading PR from GitHub: %w", err)
+	}
+
+	prBody := pr.GetBody()
+
+	// This will be true when the release note is NONE or the flag is set
+	var doNotPublish bool
+
+	// If we match exclusion filter (release-note-none), we don't look further,
+	// instead we return that PR. We return that PR because it might have a map,
+	// which is checked after this function returns
+	if MatchesExcludeFilter(prBody) || len(labelsWithPrefix(pr, "release-note-none")) > 0 {
+		doNotPublish = true
+	}
+
+	// If we didn't match the exclusion filter, try to extract the release note from the PR.
+	// If we can't extract the release note, consider that the PR is invalid and take the next one
+	s, err := noteTextFromString(prBody)
+	if err != nil && !doNotPublish {
+		return nil, fmt.Errorf("PR #%d does not seem to contain a valid release note: %w", pr.GetNumber(), err)
+	}
+
+	// If we found a valid release note, return the PR, otherwise, take the next one
+	if s == "" && !doNotPublish {
+		return nil, fmt.Errorf("PR #%d does not seem to contain a valid release note", pr.GetNumber())
+	}
+
+	if doNotPublish {
+		s = ""
+	}
+
+	// Create the release notes object
+	note := &ReleaseNote{
+		Text:           s,
+		Markdown:       s,
+		Documentation:  []*Documentation{},
+		Author:         *pr.GetUser().Login,
+		AuthorURL:      fmt.Sprintf("%s%s", g.options.GithubBaseURL, *pr.GetUser().Login),
+		PrURL:          fmt.Sprintf("%s%s/%s/pull/%d", g.options.GithubBaseURL, g.options.GithubOrg, g.options.GithubRepo, prNr),
+		PrNumber:       prNr,
+		SIGs:           labelsWithPrefix(pr, "sig"),
+		Kinds:          labelsWithPrefix(pr, "kind"),
+		Areas:          labelsWithPrefix(pr, "area"),
+		Feature:        false,
+		Duplicate:      false,
+		DuplicateKind:  false,
+		ActionRequired: false,
+		DoNotPublish:   doNotPublish,
+		DataFields:     map[string]ReleaseNotesDataField{},
+		PRBody:         prBody,
+	}
+
+	if s != "" {
+		logrus.Infof("PR #%d seems to contain a release note", pr.GetNumber())
+	}
+
+	return note, nil
+}
+
 // listCommits lists all commits starting from a given commit SHA and ending at
 // a given commit SHA.
 func (g *Gatherer) listCommits(branch, start, end string) ([]*gogithub.RepositoryCommit, error) {
@@ -650,6 +714,7 @@ func (g *Gatherer) listCommits(branch, start, end string) ([]*gogithub.Repositor
 
 type commitList struct {
 	sync.RWMutex
+
 	list []*gogithub.RepositoryCommit
 }
 
@@ -774,70 +839,6 @@ func (g *Gatherer) gatherNotes(commits []*gogithub.RepositoryCommit) (filtered [
 	return allResults.List(), nil
 }
 
-// ReleaseNoteForPullRequest returns a release note from a pull request number.
-// If the release note is blank or.
-func (g *Gatherer) ReleaseNoteForPullRequest(prNr int) (*ReleaseNote, error) {
-	pr, _, err := g.client.GetPullRequest(g.context, g.options.GithubOrg, g.options.GithubRepo, prNr)
-	if err != nil {
-		return nil, fmt.Errorf("reading PR from GitHub: %w", err)
-	}
-
-	prBody := pr.GetBody()
-
-	// This will be true when the release note is NONE or the flag is set
-	var doNotPublish bool
-
-	// If we match exclusion filter (release-note-none), we don't look further,
-	// instead we return that PR. We return that PR because it might have a map,
-	// which is checked after this function returns
-	if MatchesExcludeFilter(prBody) || len(labelsWithPrefix(pr, "release-note-none")) > 0 {
-		doNotPublish = true
-	}
-
-	// If we didn't match the exclusion filter, try to extract the release note from the PR.
-	// If we can't extract the release note, consider that the PR is invalid and take the next one
-	s, err := noteTextFromString(prBody)
-	if err != nil && !doNotPublish {
-		return nil, fmt.Errorf("PR #%d does not seem to contain a valid release note: %w", pr.GetNumber(), err)
-	}
-
-	// If we found a valid release note, return the PR, otherwise, take the next one
-	if s == "" && !doNotPublish {
-		return nil, fmt.Errorf("PR #%d does not seem to contain a valid release note", pr.GetNumber())
-	}
-
-	if doNotPublish {
-		s = ""
-	}
-
-	// Create the release notes object
-	note := &ReleaseNote{
-		Text:           s,
-		Markdown:       s,
-		Documentation:  []*Documentation{},
-		Author:         *pr.GetUser().Login,
-		AuthorURL:      fmt.Sprintf("%s%s", g.options.GithubBaseURL, *pr.GetUser().Login),
-		PrURL:          fmt.Sprintf("%s%s/%s/pull/%d", g.options.GithubBaseURL, g.options.GithubOrg, g.options.GithubRepo, prNr),
-		PrNumber:       prNr,
-		SIGs:           labelsWithPrefix(pr, "sig"),
-		Kinds:          labelsWithPrefix(pr, "kind"),
-		Areas:          labelsWithPrefix(pr, "area"),
-		Feature:        false,
-		Duplicate:      false,
-		DuplicateKind:  false,
-		ActionRequired: false,
-		DoNotPublish:   doNotPublish,
-		DataFields:     map[string]ReleaseNotesDataField{},
-		PRBody:         prBody,
-	}
-
-	if s != "" {
-		logrus.Infof("PR #%d seems to contain a release note", pr.GetNumber())
-	}
-
-	return note, nil
-}
-
 func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, error) {
 	prs, err := g.prsFromCommit(commit)
 	if err != nil {
@@ -847,7 +848,7 @@ func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, e
 				commit.GetSHA(),
 			)
 
-			return nil, nil
+			return nil, nil //nolint:nilnil // intentional nil,nil return
 		}
 
 		return nil, err
@@ -906,7 +907,7 @@ func (g *Gatherer) notesForCommit(commit *gogithub.RepositoryCommit) (*Result, e
 		logrus.Infof("PR #%d does not seem to contain a valid release note, skipping", pr.GetNumber())
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil // intentional nil,nil return
 }
 
 func isAutomatedCherryPickPR(pr *gogithub.PullRequest) bool {
@@ -932,6 +933,7 @@ func originPrNumFromPr(pr *gogithub.PullRequest) (int, error) {
 
 type resultList struct {
 	sync.RWMutex
+
 	list []*Result
 }
 

--- a/pkg/notes/notes_gatherer_test.go
+++ b/pkg/notes/notes_gatherer_test.go
@@ -244,6 +244,7 @@ func TestListCommits(t *testing.T) {
 	}
 }
 
+//nolint:maintidx // complex but acceptable
 func TestGatherNotes(t *testing.T) {
 	t.Parallel()
 
@@ -556,6 +557,7 @@ func newIntsRecorder(ints ...int) *intsRecorder {
 
 type intsRecorder struct {
 	sync.Mutex
+
 	seen map[int]bool
 }
 

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -35,7 +35,7 @@ type MapProvider interface {
 }
 
 // NewProviderFromInitString creates a new map provider from an initialization string.
-func NewProviderFromInitString(initString string) (MapProvider, error) {
+func NewProviderFromInitString(initString string) (MapProvider, error) { //nolint:ireturn // returning interface is intentional
 	// If init string starts with gs:// return a CloudStorageProvider
 	if len(initString) >= 5 && initString[0:5] == object.GcsPrefix {
 		// Currently for illustration purposes
@@ -135,6 +135,22 @@ type DirectoryMapProvider struct {
 	Maps map[int][]*ReleaseNotesMap
 }
 
+// GetMapsForPR get the release notes maps for a specific PR number.
+func (mp *DirectoryMapProvider) GetMapsForPR(pr int) (notesMap []*ReleaseNotesMap, err error) {
+	if mp.Maps == nil {
+		err := mp.readMaps()
+		if err != nil {
+			return nil, fmt.Errorf("while reading release notes maps: %w", err)
+		}
+	}
+
+	if notesMap, ok := mp.Maps[pr]; ok {
+		return notesMap, nil
+	}
+
+	return nil, nil
+}
+
 // readMaps Open the dir and read dir notes.
 func (mp *DirectoryMapProvider) readMaps() error {
 	var fileList []string
@@ -167,20 +183,4 @@ func (mp *DirectoryMapProvider) readMaps() error {
 	logrus.Infof("Successfully parsed release notes maps for %d PRs from %s", len(mp.Maps), mp.Path)
 
 	return err
-}
-
-// GetMapsForPR get the release notes maps for a specific PR number.
-func (mp *DirectoryMapProvider) GetMapsForPR(pr int) (notesMap []*ReleaseNotesMap, err error) {
-	if mp.Maps == nil {
-		err := mp.readMaps()
-		if err != nil {
-			return nil, fmt.Errorf("while reading release notes maps: %w", err)
-		}
-	}
-
-	if notesMap, ok := mp.Maps[pr]; ok {
-		return notesMap, nil
-	}
-
-	return nil, nil
 }

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -37,7 +37,7 @@ const (
 	releaseNoteBlock = mdSep + "release-note"
 )
 
-func githubClient(t *testing.T) (kgithub.Client, context.Context) {
+func githubClient(t *testing.T) (kgithub.Client, context.Context) { //nolint:ireturn // returning interface is intentional
 	_, tokenSet := os.LookupEnv(kgithub.TokenEnvKey)
 	if !tokenSet {
 		t.Skipf("%s environment variable is not set", kgithub.TokenEnvKey)
@@ -263,6 +263,7 @@ func TestPrettySIG(t *testing.T) {
 	}
 }
 
+//nolint:dupword // test data contains intentional repeated words
 func TestNoteTextFromString(t *testing.T) {
 	noteBlock := func(note string) string {
 		return releaseNoteBlock + "\n" + note + "\n" + mdSep
@@ -279,8 +280,7 @@ func TestNoteTextFromString(t *testing.T) {
 			},
 		},
 		{
-			noteBlock("test\ntest\ntest"),
-			func(res string, err error) {
+			noteBlock("test\ntest\ntest"), func(res string, err error) {
 				require.NoError(t, err)
 				require.Equal(t, "test\ntest\ntest", res)
 			},
@@ -294,8 +294,7 @@ func TestNoteTextFromString(t *testing.T) {
 		},
 		{
 			noteBlock(
-				"- item\n  item\n  item",
-			),
+				"- item\n  item\n  item"),
 			func(res string, err error) {
 				require.NoError(t, err)
 				require.Equal(t, "item\nitem\nitem", res)
@@ -303,8 +302,7 @@ func TestNoteTextFromString(t *testing.T) {
 		},
 		{
 			noteBlock(
-				"- item\n  item\n- item\n  item",
-			),
+				"- item\n  item\n- item\n  item"),
 			func(res string, err error) {
 				require.NoError(t, err)
 				require.Equal(t, "item\nitem\n- item\n  item", res)
@@ -467,7 +465,7 @@ func testApplyMapHelper(t *testing.T, testDir string, makeNewNote func() *Releas
 		case []any:
 			// Handle string slice cases
 			actualVal := reflect.Indirect(reflectedNote).FieldByName(property)
-			actualSlice := make([]string, 0)
+			actualSlice := make([]string, 0, actualVal.Len())
 
 			for i := range actualVal.Len() {
 				actualSlice = append(actualSlice, actualVal.Index(i).String())

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -42,8 +42,9 @@ type commitPrPair struct {
 }
 
 type releaseNotesAggregator struct {
-	releaseNotes *ReleaseNotes
 	sync.RWMutex
+
+	releaseNotes *ReleaseNotes
 }
 
 func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
@@ -154,11 +155,11 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 	prBody := pr.GetBody()
 
 	if MatchesExcludeFilter(prBody) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	if len(g.options.IncludeLabels) > 0 && !matchesLabelFilter(pr.Labels, g.options.IncludeLabels) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	text, err := noteTextFromString(prBody)
@@ -168,7 +169,7 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 			"pr":  pair.PrNum,
 		}).Debugf("ignore err: %v", err)
 
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional nil,nil return
 	}
 
 	documentation := DocumentationFromString(prBody)

--- a/pkg/notes/options/options.go
+++ b/pkg/notes/options/options.go
@@ -289,6 +289,37 @@ func (o *Options) ValidateAndFinish() (err error) {
 	return nil
 }
 
+// Client returns a Client to be used by the Gatherer. Depending on
+// the provided options this is either a real client talking to the GitHub API,
+// a Client which in addition records the responses from Github and stores them
+// on disk, or a Client that replays those pre-recorded responses and does not
+// talk to the GitHub API at all.
+func (o *Options) Client() (github.Client, error) { //nolint:ireturn // returning interface is intentional
+	if o.ReplayDir != "" {
+		return github.NewReplayer(o.ReplayDir), nil
+	}
+
+	var gh *github.GitHub
+
+	var err error
+	// Create a real GitHub API client
+	if o.GithubBaseURL != "" && o.GithubUploadURL != "" {
+		gh, err = github.NewEnterpriseWithToken(o.GithubBaseURL, o.GithubUploadURL, o.githubToken)
+	} else {
+		gh, err = github.NewWithToken(o.githubToken)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to create GitHub client: %w", err)
+	}
+
+	if o.RecordDir != "" {
+		return github.NewRecorder(gh.Client(), o.RecordDir), nil
+	}
+
+	return gh.Client(), nil
+}
+
 // checkFormatOptions verifies that template related options are sane.
 func (o *Options) checkFormatOptions() error {
 	// Validate the output format and template
@@ -383,35 +414,4 @@ func (o *Options) repo() (repo *git.Repo, err error) {
 	}
 
 	return repo, nil
-}
-
-// Client returns a Client to be used by the Gatherer. Depending on
-// the provided options this is either a real client talking to the GitHub API,
-// a Client which in addition records the responses from Github and stores them
-// on disk, or a Client that replays those pre-recorded responses and does not
-// talk to the GitHub API at all.
-func (o *Options) Client() (github.Client, error) {
-	if o.ReplayDir != "" {
-		return github.NewReplayer(o.ReplayDir), nil
-	}
-
-	var gh *github.GitHub
-
-	var err error
-	// Create a real GitHub API client
-	if o.GithubBaseURL != "" && o.GithubUploadURL != "" {
-		gh, err = github.NewEnterpriseWithToken(o.GithubBaseURL, o.GithubUploadURL, o.githubToken)
-	} else {
-		gh, err = github.NewWithToken(o.githubToken)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to create GitHub client: %w", err)
-	}
-
-	if o.RecordDir != "" {
-		return github.NewRecorder(gh.Client(), o.RecordDir), nil
-	}
-
-	return gh.Client(), nil
 }

--- a/pkg/notes/options/options_test.go
+++ b/pkg/notes/options/options_test.go
@@ -36,6 +36,7 @@ import (
 
 type testOptions struct {
 	*Options
+
 	testRepo *testRepo
 }
 

--- a/pkg/obs/specs/impl.go
+++ b/pkg/obs/specs/impl.go
@@ -39,6 +39,7 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
 //go:generate /usr/bin/env bash -c "cat ../../../hack/boilerplate/boilerplate.generatego.txt specsfakes/fake_impl.go > specsfakes/_fake_impl.go && mv specsfakes/_fake_impl.go specsfakes/fake_impl.go"
+//nolint:interfacebloat // large interface is by design
 type impl interface {
 	GetKubeVersion(versionType release.VersionType) (string, error)
 	GetRequest(url string) (*http.Response, error)

--- a/pkg/obs/specs/specs.go
+++ b/pkg/obs/specs/specs.go
@@ -132,8 +132,9 @@ func (o *Options) Validate() error {
 }
 
 type Specs struct {
-	options *Options
 	impl
+
+	options *Options
 }
 
 func New(opts *Options) *Specs {

--- a/pkg/obs/specs/template.go
+++ b/pkg/obs/specs/template.go
@@ -62,6 +62,7 @@ func (s *Specs) BuildSpecs(pkgDef *PackageDefinition, specOnly bool) (err error)
 		if f.IsDir() {
 			return s.Mkdir(specFile, f.Mode())
 		}
+
 		if filepath.Ext(templateFile) == ".spec" || filepath.Ext(templateFile) == ".rpmlintrc" {
 			// Spec is intentionally saved outside package dir, which is later on archived
 			specFile = filepath.Join(pkgDef.SpecOutputPath, templateFile[len(tplDir):])

--- a/pkg/obs/stage.go
+++ b/pkg/obs/stage.go
@@ -36,6 +36,7 @@ import (
 // stageClient is a client for staging releases.
 //
 //counterfeiter:generate . stageClient
+//nolint:interfacebloat // large interface is by design
 type stageClient interface {
 	// Submit can be used to submit a Google Cloud Build (GCB) job.
 	Submit(stream bool) error
@@ -120,6 +121,7 @@ type defaultStageImpl struct{}
 // stageImpl is the implementation of the stage client.
 //
 //counterfeiter:generate . stageImpl
+//nolint:interfacebloat // large interface is by design
 type stageImpl interface {
 	Submit(options *gcb.Options) error
 	CheckPrerequisites(workspaceDir string) error

--- a/pkg/release/images.go
+++ b/pkg/release/images.go
@@ -39,6 +39,7 @@ import (
 // Images is a wrapper around container image related functionality.
 type Images struct {
 	imageImpl
+
 	signer *sign.Signer
 }
 
@@ -241,42 +242,6 @@ func (i *Images) Publish(registry, version, buildPath string) error {
 	return nil
 }
 
-// pushAndSignImage loads, tags, pushes, signs, and removes a single
-// arch-specific container image.
-func (i *Images) pushAndSignImage(item tarballItem) error {
-	if err := i.Execute(
-		"docker", "load", "-qi", item.path,
-	); err != nil {
-		return fmt.Errorf("load container image: %w", err)
-	}
-
-	if err := i.Execute(
-		"docker", "tag", item.origTag, item.newTagWithArch,
-	); err != nil {
-		return fmt.Errorf("tag container image: %w", err)
-	}
-
-	logrus.Infof("Pushing %s", item.newTagWithArch)
-
-	if err := i.Execute(
-		"docker", "push", item.newTagWithArch,
-	); err != nil {
-		return fmt.Errorf("push container image: %w", err)
-	}
-
-	if err := i.SignImage(i.signer, item.newTagWithArch); err != nil {
-		return fmt.Errorf("sign container image: %w", err)
-	}
-
-	if err := i.Execute(
-		"docker", "rmi", item.origTag, item.newTagWithArch,
-	); err != nil {
-		return fmt.Errorf("remove local container image: %w", err)
-	}
-
-	return nil
-}
-
 // Validates that image manifests have been pushed to a specified remote
 // registry.
 func (i *Images) Validate(registry, version, buildPath string) error {
@@ -351,7 +316,7 @@ func (i *Images) Validate(registry, version, buildPath string) error {
 			logrus.Infof("Digest for %s on %s: %s", imageVersion, arch, digest)
 		}
 
-		if err := os.RemoveAll(manifestFile.Name()); err != nil {
+		if err := os.RemoveAll(manifestFile.Name()); err != nil { //nolint:gosec // G703 - temp file path is safe
 			return fmt.Errorf("remove manifest file: %w", err)
 		}
 	}
@@ -424,7 +389,7 @@ func (i *Images) Exists(registry, version string, fast bool) (bool, error) {
 			logrus.Infof("Digest for %s on %s: %s", imageVersion, arch, digest)
 		}
 
-		if err := os.RemoveAll(manifestFile.Name()); err != nil {
+		if err := os.RemoveAll(manifestFile.Name()); err != nil { //nolint:gosec // G703 - temp file path is safe
 			return false, fmt.Errorf("remove manifest file: %w", err)
 		}
 	}
@@ -462,6 +427,7 @@ func (i *Images) GetManifestImages(
 				if err != nil {
 					return err
 				}
+
 				if info.IsDir() {
 					return nil
 				}
@@ -509,6 +475,42 @@ func (i *Images) GetManifestImages(
 	}
 
 	return manifestImages, nil
+}
+
+// pushAndSignImage loads, tags, pushes, signs, and removes a single
+// arch-specific container image.
+func (i *Images) pushAndSignImage(item tarballItem) error {
+	if err := i.Execute(
+		"docker", "load", "-qi", item.path,
+	); err != nil {
+		return fmt.Errorf("load container image: %w", err)
+	}
+
+	if err := i.Execute(
+		"docker", "tag", item.origTag, item.newTagWithArch,
+	); err != nil {
+		return fmt.Errorf("tag container image: %w", err)
+	}
+
+	logrus.Infof("Pushing %s", item.newTagWithArch)
+
+	if err := i.Execute(
+		"docker", "push", item.newTagWithArch,
+	); err != nil {
+		return fmt.Errorf("push container image: %w", err)
+	}
+
+	if err := i.SignImage(i.signer, item.newTagWithArch); err != nil {
+		return fmt.Errorf("sign container image: %w", err)
+	}
+
+	if err := i.Execute(
+		"docker", "rmi", item.origTag, item.newTagWithArch,
+	); err != nil {
+		return fmt.Errorf("remove local container image: %w", err)
+	}
+
+	return nil
 }
 
 // normalizeVersion normalizes an container image version by replacing all invalid characters.

--- a/pkg/release/images_test.go
+++ b/pkg/release/images_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/release/pkg/release/releasefakes"
 )
 
+//nolint:maintidx // complex but acceptable
 func TestPublish(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/release/provenance.go
+++ b/pkg/release/provenance.go
@@ -33,6 +33,13 @@ import (
 	"sigs.k8s.io/release-utils/helpers"
 )
 
+// ProvenanceChecker is the main structure to check the provenance.
+type ProvenanceChecker struct {
+	objStore *object.GCS
+	options  *ProvenanceCheckerOptions
+	impl     provenanceCheckerImplementation
+}
+
 func NewProvenanceChecker(opts *ProvenanceCheckerOptions) *ProvenanceChecker {
 	p := &ProvenanceChecker{
 		objStore: object.NewGCS(),
@@ -43,13 +50,6 @@ func NewProvenanceChecker(opts *ProvenanceCheckerOptions) *ProvenanceChecker {
 	p.impl = &defaultProvenanceCheckerImpl{}
 
 	return p
-}
-
-// ProvenanceChecker is the main structure to check the provenance.
-type ProvenanceChecker struct {
-	objStore *object.GCS
-	options  *ProvenanceCheckerOptions
-	impl     provenanceCheckerImplementation
 }
 
 // CheckStageProvenance validates the provenance for the provided build version.
@@ -218,16 +218,16 @@ func (di *defaultProvenanceCheckerImpl) generateFinalAttestation(
 	return nil
 }
 
+type ProvenanceReader struct {
+	options *ProvenanceReaderOptions
+	impl    provenanceReaderImplementation
+}
+
 func NewProvenanceReader(opts *ProvenanceReaderOptions) *ProvenanceReader {
 	return &ProvenanceReader{
 		options: opts,
 		impl:    &defaultProvenanceReaderImpl{},
 	}
-}
-
-type ProvenanceReader struct {
-	options *ProvenanceReaderOptions
-	impl    provenanceReaderImplementation
 }
 
 type provenanceReaderImplementation interface {

--- a/pkg/release/publish.go
+++ b/pkg/release/publish.go
@@ -63,6 +63,7 @@ func (p *Publisher) SetClient(client publisherClient) {
 // publisherClient is a client for working with GCS
 //
 //counterfeiter:generate . publisherClient
+//nolint:interfacebloat // large interface is by design
 type publisherClient interface {
 	GSUtil(args ...string) error
 	GSUtilOutput(args ...string) (string, error)

--- a/pkg/release/push_git_objects.go
+++ b/pkg/release/push_git_objects.go
@@ -189,32 +189,6 @@ func (gp *GitObjectPusher) PushTag(newTag string) (err error) {
 	return nil
 }
 
-// checkTagName verifies that the specified tag name is valid.
-func (gp *GitObjectPusher) checkTagName(tagName string) error {
-	_, err := helpers.TagStringToSemver(tagName)
-	if err != nil {
-		return fmt.Errorf("transforming tag into semver: %w", err)
-	}
-
-	return nil
-}
-
-// checkBranchName verifies that the branch name is valid.
-func (gp *GitObjectPusher) checkBranchName(branchName string) error {
-	if !strings.HasPrefix(branchName, "release-") {
-		return errors.New("branch name has to start with release-")
-	}
-
-	versionTag := strings.TrimPrefix(branchName, "release-")
-	// Add .0 and check is we get a valid semver
-	_, err := semver.Parse(versionTag + ".0")
-	if err != nil {
-		return fmt.Errorf("parsing semantic version in branchname: %w", err)
-	}
-
-	return nil
-}
-
 // PushMain pushes the main branch to the origin.
 func (gp *GitObjectPusher) PushMain() error {
 	logrus.Infof("Checkout %s branch to push objects", git.DefaultBranch)
@@ -259,6 +233,32 @@ func (gp *GitObjectPusher) PushMain() error {
 	// logrun -s git push$dryrun_flag origin master || return 1
 	if err := gp.repo.Push(git.DefaultBranch); err != nil {
 		return fmt.Errorf("pushing %s branch: %w", git.DefaultBranch, err)
+	}
+
+	return nil
+}
+
+// checkTagName verifies that the specified tag name is valid.
+func (gp *GitObjectPusher) checkTagName(tagName string) error {
+	_, err := helpers.TagStringToSemver(tagName)
+	if err != nil {
+		return fmt.Errorf("transforming tag into semver: %w", err)
+	}
+
+	return nil
+}
+
+// checkBranchName verifies that the branch name is valid.
+func (gp *GitObjectPusher) checkBranchName(branchName string) error {
+	if !strings.HasPrefix(branchName, "release-") {
+		return errors.New("branch name has to start with release-")
+	}
+
+	versionTag := strings.TrimPrefix(branchName, "release-")
+	// Add .0 and check is we get a valid semver
+	_, err := semver.Parse(versionTag + ".0")
+	if err != nil {
+		return fmt.Errorf("parsing semantic version in branchname: %w", err)
 	}
 
 	return nil

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -341,6 +341,7 @@ func WriteChecksums(rootPath string) error {
 				if err != nil {
 					return err
 				}
+
 				if info.IsDir() {
 					return nil
 				}
@@ -427,6 +428,7 @@ func WriteChecksums(rootPath string) error {
 			if err != nil {
 				return err
 			}
+
 			if file.IsDir() {
 				return nil
 			}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -385,6 +385,7 @@ func TestWriteChecksums(t *testing.T) {
 
 				subTempDir := filepath.Join(tempDir, "test")
 				require.NoError(t, os.MkdirAll(subTempDir, os.FileMode(0o755)))
+
 				for i, v := range []byte{1, 2} {
 					require.NoError(t, os.WriteFile(
 						filepath.Join(subTempDir, strconv.Itoa(i+len(rootSHAs))),

--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -244,6 +244,7 @@ func ListBuildBinaries(gitroot, version string) (list []struct{ Path, Platform, 
 				if err != nil {
 					return err
 				}
+
 				if info.IsDir() {
 					return nil
 				}
@@ -275,6 +276,7 @@ func ListBuildBinaries(gitroot, version string) (list []struct{ Path, Platform, 
 					if err != nil {
 						return err
 					}
+
 					if info.IsDir() {
 						return nil
 					}
@@ -309,6 +311,7 @@ func ListBuildTarballs(gitroot, version string) (tarList []string, err error) {
 			if err != nil {
 				return err
 			}
+
 			if info.IsDir() {
 				return nil
 			}

--- a/pkg/testgrid/testgrid-scraper.go
+++ b/pkg/testgrid/testgrid-scraper.go
@@ -93,7 +93,7 @@ func ReqTestgridDashboardSummary(ctx context.Context, dashboardName DashboardNam
 		return nil, fmt.Errorf("create new request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704 - URL is constructed from validated input
 	if err != nil {
 		return nil, fmt.Errorf("request remote content: %w", err)
 	}
@@ -233,7 +233,7 @@ func (j *JobSummary) FilterSigs() []string {
 		}
 	}
 
-	sigs := []string{}
+	sigs := make([]string, 0, len(sigsInvolved))
 	for k := range sigsInvolved {
 		sigs = append(sigs, k)
 	}

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -91,7 +91,7 @@ func (t *TestGrid) configFromURL(url string) (cfg *pb.Configuration, err error) 
 
 	defer func() {
 		if err == nil {
-			err = os.Remove(tmpFile.Name())
+			err = os.Remove(tmpFile.Name()) //nolint:gosec // G703 - temp file path is safe
 		}
 	}()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update golangci-lint from v2.5 to v2.10
- Simplify linter config to use `default: all` with an explicit disable list
- Enable new linters: arangolint, dupword, embeddedstructfieldcheck, funcorder, interfacebloat, iotamixing, ireturn, maintidx, modernize, nilnil, unqueryvet
- Fix all lint findings across the codebase

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

cc @kubernetes/release-managers

#### Does this PR introduce a user-facing change?

```release-note
NONE
```