### PR TITLE
fix: default to git graph traversal for release notes gathering

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,9 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019: intoto.Subject is deprecated"
+      - linters:
+          - nolintlint
+        text: "directive .* is unused for linter \"ireturn\""
     paths:
       - third_party$
       - builtin$

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -215,8 +215,8 @@ func init() {
 	releaseNotesCmd.PersistentFlags().BoolVar(
 		&releaseNotesOpts.listReleaseNotesV2,
 		"list-v2",
-		false,
-		"enable experimental implementation to list commits (ListReleaseNotesV2)",
+		true,
+		"use git graph traversal to list commits instead of GitHub API date-based filtering",
 	)
 
 	releaseNotesCmd.PersistentFlags().BoolVar(

--- a/docs/krel/release-notes.md
+++ b/docs/krel/release-notes.md
@@ -52,7 +52,7 @@ Flags:
       --fix                 fix release notes
       --fork string         the user's fork in the form org/repo. Used to submit Pull Requests for the website and draft
   -h, --help                help for release-notes
-      --list-v2             enable experimental implementation to list commits (ListReleaseNotesV2)
+      --list-v2             use git graph traversal to list commits instead of GitHub API date-based filtering (default true)
   -m, --maps-from strings   specify a location to recursively look for release notes *.y[a]ml file mappings
       --repo string         the local path to the repository to be used (default "/tmp/k8s")
   -t, --tag string          version tag for the notes

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/release/pkg/release"
 )
 
-func mockRepo() gcb.Repository { //nolint:ireturn // interface return is by design
+func mockRepo() *gcbfakes.FakeRepository {
 	mock := &gcbfakes.FakeRepository{}
 	mock.OpenReturns(nil)
 	mock.CheckStateReturns(nil)
@@ -40,14 +40,14 @@ func mockRepo() gcb.Repository { //nolint:ireturn // interface return is by desi
 	return mock
 }
 
-func mockVersion(version string) gcb.Version { //nolint:ireturn // interface return is by design
+func mockVersion(version string) *gcbfakes.FakeVersion {
 	mock := &gcbfakes.FakeVersion{}
 	mock.GetKubeVersionForBranchReturns(version, nil)
 
 	return mock
 }
 
-func mockRelease(version string) gcb.Release { //nolint:ireturn // interface return is by design
+func mockRelease(version string) *gcbfakes.FakeRelease {
 	mock := &gcbfakes.FakeRelease{}
 	mock.GenerateReleaseVersionReturns(
 		release.NewReleaseVersions(version, "", "", "", ""), nil,

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -265,8 +265,6 @@ func GatherReleaseNotes(opts *options.Options) (*ReleaseNotes, error) {
 	startTime := time.Now()
 
 	if gatherer.options.ListReleaseNotesV2 {
-		logrus.Warn("EXPERIMENTAL IMPLEMENTATION ListReleaseNotesV2 ENABLED")
-
 		releaseNotes, err = gatherer.ListReleaseNotesV2()
 	} else {
 		releaseNotes, err = gatherer.ListReleaseNotes()

--- a/pkg/notes/notes_v2.go
+++ b/pkg/notes/notes_v2.go
@@ -73,6 +73,12 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 		releaseNotes: NewReleaseNotes(),
 	}
 
+	dedupeCache := struct {
+		sync.Mutex
+
+		seen map[string]struct{}
+	}{seen: map[string]struct{}{}}
+
 	pairsCount := len(pairs)
 	logrus.Infof("processing release notes for %d commits", pairsCount)
 
@@ -89,16 +95,16 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 			var noteMaps []*ReleaseNotesMap
 
 			for _, provider := range mapProviders {
-				var err error
-
-				noteMaps, err = provider.GetMapsForPR(pair.PrNum)
+				providerMaps, err := provider.GetMapsForPR(pair.PrNum)
 				if err != nil {
 					logrus.WithFields(logrus.Fields{
 						"pr": pair.PrNum,
 					}).Errorf("ignore err: %v", err)
 
-					noteMaps = []*ReleaseNotesMap{}
+					continue
 				}
+
+				noteMaps = append(noteMaps, providerMaps...)
 			}
 
 			releaseNote, err := g.buildReleaseNote(pair)
@@ -112,13 +118,27 @@ func (g *Gatherer) ListReleaseNotesV2() (*ReleaseNotes, error) {
 						}
 					}
 
-					logrus.WithFields(logrus.Fields{
-						"pr":   pair.PrNum,
-						"note": releaseNote.Text,
-					}).Debugf("finalized release note")
-					aggregator.Lock()
-					aggregator.releaseNotes.Set(pair.PrNum, releaseNote)
-					aggregator.Unlock()
+					dedupeCache.Lock()
+
+					_, duplicate := dedupeCache.seen[releaseNote.Markdown]
+					if !duplicate {
+						dedupeCache.seen[releaseNote.Markdown] = struct{}{}
+					}
+					dedupeCache.Unlock()
+
+					if duplicate {
+						logrus.WithFields(logrus.Fields{
+							"pr": pair.PrNum,
+						}).Debugf("skip: duplicate release note")
+					} else {
+						logrus.WithFields(logrus.Fields{
+							"pr":   pair.PrNum,
+							"note": releaseNote.Text,
+						}).Debugf("finalized release note")
+						aggregator.Lock()
+						aggregator.releaseNotes.Set(pair.PrNum, releaseNote)
+						aggregator.Unlock()
+					}
 				} else {
 					logrus.WithFields(logrus.Fields{
 						"pr": pair.PrNum,
@@ -170,6 +190,22 @@ func (g *Gatherer) buildReleaseNote(pair *commitPrPair) (*ReleaseNote, error) {
 		}).Debugf("ignore err: %v", err)
 
 		return nil, nil //nolint:nilnil // intentional nil,nil return
+	}
+
+	if isAutomatedCherryPickPR(pr) {
+		logrus.Infof("PR #%d seems to be an automated cherry-pick, retrieving origin info", pr.GetNumber())
+
+		originPRNum, err := originPrNumFromPr(pr)
+		if err != nil {
+			return nil, err
+		}
+
+		originPR, err := g.getPr(originPRNum)
+		if err != nil {
+			return nil, err
+		}
+
+		pr.User = originPR.GetUser()
 	}
 
 	documentation := DocumentationFromString(prBody)
@@ -290,6 +326,10 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 			return nil, fmt.Errorf("finding CommitObject: %w", err)
 		}
 
+		if len(commitPointer.ParentHashes) == 0 {
+			return nil, fmt.Errorf("commit %s has no parents, cannot traverse further", hashString)
+		}
+
 		// Find and collect PR number from commit message
 		prNums, err := prsNumForCommitFromMessage(commitPointer.Message)
 		if errors.Is(err, errNoPRIDFoundInCommitMessage) {
@@ -297,7 +337,6 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 				"sha": hashString,
 			}).Debug("no associated PR found")
 
-			// Advance pointer based on left parent
 			hashPointer = commitPointer.ParentHashes[0]
 
 			continue
@@ -308,7 +347,6 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 				"sha": hashString,
 			}).Warnf("ignore err: %v", err)
 
-			// Advance pointer based on left parent
 			hashPointer = commitPointer.ParentHashes[0]
 
 			continue
@@ -322,7 +360,6 @@ func (g *Gatherer) listLeftParentCommits(opts *options.Options) ([]*commitPrPair
 		// Only taking the first one, assuming they are merged by Prow
 		pairs = append(pairs, &commitPrPair{Commit: commitPointer, PrNum: prNums[0]})
 
-		// Advance pointer based on left parent
 		hashPointer = commitPointer.ParentHashes[0]
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The V1 `listCommits()` uses the GitHub API's `Since`/`Until` parameters, which filter commits by committer date. This silently skips PRs whose commits have committer dates outside the expected range (due to rebasing, cherry-picks, or clock skew).

The V2 implementation walks the git commit graph directly via left parents, which is deterministic and date-independent. This PR makes it the default by flipping `--list-v2` to `true`.

Also fixes several pre-existing issues in the V2 code path:
- Guard against panic on commits with no parents
- Resolve cherry-pick PR authors from the origin PR (instead of showing `k8s-infra-cherrypick-robot`)
- Deduplicate release notes by markdown content
- Accumulate maps from all providers instead of only the last one

#### Which issue(s) this PR fixes:

Fixes #4125

#### Special notes for your reviewer:

The `--list-v2=false` flag still works for opting out.

#### Does this PR introduce a user-facing change?

```release-note
krel release-notes now defaults to git graph traversal (--list-v2) instead of GitHub API date-based filtering, fixing cases where PRs were silently skipped due to unexpected committer dates.
```