### PR TITLE
Add krel release-notes rerun subcommand with push support and test coverage

### DIFF
--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -374,8 +374,6 @@ func runReleaseNotes() (err error) {
 // rerunDraftNotes fetches an existing draft branch from a source fork of
 // k/sig-release, regenerates the release notes (applying maps),
 // and optionally pushes the result to a destination fork.
-//
-//nolint:maintidx // complex but acceptable
 func rerunDraftNotes(repoPath, tag string) error {
 	tagVersion, err := helpers.TagStringToSemver(tag)
 	if err != nil {
@@ -474,6 +472,7 @@ func rerunDraftNotes(repoPath, tag string) error {
 	// Add the fetched branch's maps directory to map providers
 	branchMapsDir := filepath.Join(releaseDir, releaseNotesWorkDir, mapsMainDirectory)
 	originalMapProviders := releaseNotesOpts.mapProviders
+
 	if helpers.Exists(branchMapsDir) {
 		logrus.Infof("Loading maps from fetched branch: %s", branchMapsDir)
 		releaseNotesOpts.mapProviders = append([]string{branchMapsDir}, releaseNotesOpts.mapProviders...)

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -110,8 +110,7 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// If none of the operation modes is defined, show the usage help and exit
 		if !releaseNotesOpts.createDraftPR &&
-			!releaseNotesOpts.createWebsitePR &&
-			!releaseNotesOpts.rerun {
+			!releaseNotesOpts.createWebsitePR {
 			if err := cmd.Help(); err != nil {
 				return err
 			}
@@ -125,6 +124,44 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 	},
 }
 
+// rerunCmd represents the `krel release-notes rerun` subcommand.
+var rerunCmd = &cobra.Command{
+	Use:   "rerun",
+	Short: "Rerun release notes generation against an existing draft PR branch",
+	Long: `krel release-notes rerun
+
+Re-generates the release notes draft against an existing PR branch. The process:
+
+1. Clone upstream k/sig-release and fetch the draft branch from --draft-pr-source-fork.
+2. Gather release notes from k/k for the given --tag range.
+3. Apply map files (from the branch and any extra --maps-from paths).
+4. Write the updated markdown and JSON drafts, then commit.
+5. If --draft-pr-push-fork is set, push the branch there (updating any open PR).
+
+The local clone is preserved after the run so you can inspect or push manually.`,
+	Example: `  # Rerun against an existing draft branch and push to a destination fork:
+  krel release-notes rerun \
+    --tag v1.36.0 \
+    --draft-pr-source-fork "myorg/sig-release-repo" \
+    --draft-pr-push-fork "destorg"
+
+  # Rerun with additional maps from a local directory:
+  krel release-notes rerun \
+    --tag v1.36.0 \
+    --draft-pr-source-fork "myorg/sig-release" \
+    --maps-from "/path/to/extra/maps"`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateRerunOpts(releaseNotesOpts)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tag := releaseNotesOpts.tag
+
+		return rerunDraftNotes(releaseNotesOpts.repoPath, tag)
+	},
+}
+
 type releaseNotesOptions struct {
 	createDraftPR       bool
 	createWebsitePR     bool
@@ -132,7 +169,6 @@ type releaseNotesOptions struct {
 	interactiveMode     bool
 	updateRepo          bool
 	useSSH              bool
-	rerun               bool
 	repoPath            string
 	tag                 string
 	userFork            string
@@ -249,43 +285,38 @@ func init() {
 		"only PRs with one of these labels are considered. Set to empty to include all PRs",
 	)
 
-	releaseNotesCmd.PersistentFlags().BoolVar(
-		&releaseNotesOpts.rerun,
-		"rerun",
-		false,
-		"rerun release notes generation against an existing draft branch (mutually exclusive with --create-draft-pr and --create-website-pr)",
-	)
+	_ = releaseNotesCmd.PersistentFlags().MarkDeprecated("create-website-pr", "This flag is deprecated and will be removed in a future release. Use --create-draft-pr instead.")
 
-	releaseNotesCmd.PersistentFlags().StringVar(
+	// Register rerun subcommand flags
+	rerunCmd.Flags().StringVar(
 		&releaseNotesOpts.draftPRSourceFork,
 		"draft-pr-source-fork",
 		"",
-		"k/sig-release fork to fetch the existing draft branch from; 'org' or 'org/repo' (required with --rerun)",
+		"k/sig-release fork to fetch the existing draft branch from; 'org' or 'org/repo' (required)",
 	)
 
-	releaseNotesCmd.PersistentFlags().StringVar(
+	rerunCmd.Flags().StringVar(
 		&releaseNotesOpts.draftPRSourceBranch,
 		"draft-pr-source-branch",
 		"",
 		"branch to fetch from the source k/sig-release fork (default: release-notes-draft-<tag>)",
 	)
 
-	releaseNotesCmd.PersistentFlags().StringVar(
+	rerunCmd.Flags().StringVar(
 		&releaseNotesOpts.draftPRPushFork,
 		"draft-pr-push-fork",
 		"",
 		"k/sig-release fork to push the updated branch to; 'org' or 'org/repo' (omit to skip push)",
 	)
 
-	releaseNotesCmd.PersistentFlags().StringVar(
+	rerunCmd.Flags().StringVar(
 		&releaseNotesOpts.draftPRPushBranch,
 		"draft-pr-push-branch",
 		"",
 		"branch to push to on the destination k/sig-release fork (default: same as source branch)",
 	)
 
-	_ = releaseNotesCmd.PersistentFlags().MarkDeprecated("create-website-pr", "This flag is deprecated and will be removed in a future release. Use --create-draft-pr instead.")
-
+	releaseNotesCmd.AddCommand(rerunCmd)
 	rootCmd.AddCommand(releaseNotesCmd)
 }
 
@@ -320,11 +351,6 @@ func runReleaseNotes() (err error) {
 	// First, validate cmdline options
 	if err := releaseNotesOpts.Validate(); err != nil {
 		return fmt.Errorf("validating command line options: %w", err)
-	}
-
-	// If --rerun is set, enter the rerun codepath and return
-	if releaseNotesOpts.rerun {
-		return rerunDraftNotes(releaseNotesOpts.repoPath, tag)
 	}
 
 	// before running the generators, verify that the repositories are ready
@@ -1303,51 +1329,59 @@ func (o *releaseNotesOptions) Validate() error {
 		return fmt.Errorf("reading tag: %s: %w", releaseNotesOpts.tag, err)
 	}
 
-	// Rerun validation
-	if o.rerun {
-		if o.createDraftPR || o.createWebsitePR {
-			return errors.New("--rerun cannot be used with --create-draft-pr or --create-website-pr")
-		}
-
-		if o.draftPRSourceFork == "" {
-			return errors.New("--draft-pr-source-fork is required when using --rerun")
-		}
-
-		if o.tag == "" {
-			return errors.New("--tag is required when using --rerun")
-		}
-
-		// Parse --draft-pr-source-fork: if no "/" present, append "/sig-release"
-		if !strings.Contains(o.draftPRSourceFork, "/") {
-			o.draftPRSourceFork = o.draftPRSourceFork + "/" + git.DefaultGithubReleaseRepo
-		}
-
-		// Parse --draft-pr-push-fork: if no "/" present, append "/sig-release"
-		if o.draftPRPushFork != "" && !strings.Contains(o.draftPRPushFork, "/") {
-			o.draftPRPushFork = o.draftPRPushFork + "/" + git.DefaultGithubReleaseRepo
-		}
-
-		// Resolve --draft-pr-source-branch default
-		if o.draftPRSourceBranch == "" {
-			o.draftPRSourceBranch = draftBranchPrefix + o.tag
-		}
-
-		// Resolve --draft-pr-push-branch default to source branch
-		if o.draftPRPushBranch == "" {
-			o.draftPRPushBranch = o.draftPRSourceBranch
-		}
-
-		// Warn if --rerun without --maps-from
-		if len(o.mapProviders) == 0 {
-			logrus.Warn("Running --rerun without --maps-from will automatically pick up map files from releases/release-x.yz/release-notes/maps folder")
-		}
-	}
-
 	// Options for PR creation
 	if o.createDraftPR || o.createWebsitePR {
 		if o.userFork == "" {
 			return errors.New("cannot generate the Release Notes PR without --fork")
 		}
+	}
+
+	return nil
+}
+
+// validateRerunOpts validates options specific to the rerun subcommand.
+func validateRerunOpts(o *releaseNotesOptions) error {
+	token, isset := os.LookupEnv(github.TokenEnvKey)
+	if !isset || token == "" {
+		return fmt.Errorf("cannot generate release notes if %s env variable is not set", github.TokenEnvKey)
+	}
+
+	if o.tag == "" {
+		return errors.New("--tag is required")
+	}
+
+	if o.draftPRSourceFork == "" {
+		return errors.New("--draft-pr-source-fork is required")
+	}
+
+	// Parse --draft-pr-source-fork: if no "/" present, append "/sig-release"
+	if !strings.Contains(o.draftPRSourceFork, "/") {
+		o.draftPRSourceFork = o.draftPRSourceFork + "/" + git.DefaultGithubReleaseRepo
+	}
+
+	// Parse --draft-pr-push-fork: if no "/" present, append "/sig-release"
+	if o.draftPRPushFork != "" && !strings.Contains(o.draftPRPushFork, "/") {
+		o.draftPRPushFork = o.draftPRPushFork + "/" + git.DefaultGithubReleaseRepo
+	}
+
+	// Resolve --draft-pr-source-branch default
+	if o.draftPRSourceBranch == "" {
+		o.draftPRSourceBranch = draftBranchPrefix + o.tag
+	}
+
+	// Resolve --draft-pr-push-branch default to source branch
+	if o.draftPRPushBranch == "" {
+		o.draftPRPushBranch = o.draftPRSourceBranch
+	}
+
+	// Warn if rerun without --maps-from
+	if len(o.mapProviders) == 0 {
+		mapsPath := "releases/release-x.yz/release-notes/maps"
+		if tagVersion, err := helpers.TagStringToSemver(o.tag); err == nil {
+			mapsPath = fmt.Sprintf("releases/release-%d.%d/release-notes/maps", tagVersion.Major, tagVersion.Minor)
+		}
+
+		logrus.Warnf("Running rerun without --maps-from will automatically pick up map files from %s folder", mapsPath)
 	}
 
 	return nil

--- a/cmd/krel/cmd/release_notes.go
+++ b/cmd/krel/cmd/release_notes.go
@@ -110,7 +110,8 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// If none of the operation modes is defined, show the usage help and exit
 		if !releaseNotesOpts.createDraftPR &&
-			!releaseNotesOpts.createWebsitePR {
+			!releaseNotesOpts.createWebsitePR &&
+			!releaseNotesOpts.rerun {
 			if err := cmd.Help(); err != nil {
 				return err
 			}
@@ -125,20 +126,25 @@ permissions to your fork of k/sig-release and k-sigs/release-notes.`,
 }
 
 type releaseNotesOptions struct {
-	createDraftPR   bool
-	createWebsitePR bool
-	fixNotes        bool
-	interactiveMode bool
-	updateRepo      bool
-	useSSH          bool
-	repoPath        string
-	tag             string
-	userFork        string
-	websiteRepo     string
-	githubOrg       string
-	draftRepo       string
-	mapProviders    []string
-	includeLabels   []string
+	createDraftPR       bool
+	createWebsitePR     bool
+	fixNotes            bool
+	interactiveMode     bool
+	updateRepo          bool
+	useSSH              bool
+	rerun               bool
+	repoPath            string
+	tag                 string
+	userFork            string
+	websiteRepo         string
+	githubOrg           string
+	draftRepo           string
+	draftPRSourceFork   string
+	draftPRSourceBranch string
+	draftPRPushFork     string
+	draftPRPushBranch   string
+	mapProviders        []string
+	includeLabels       []string
 }
 
 type releaseNotesResult struct {
@@ -243,6 +249,41 @@ func init() {
 		"only PRs with one of these labels are considered. Set to empty to include all PRs",
 	)
 
+	releaseNotesCmd.PersistentFlags().BoolVar(
+		&releaseNotesOpts.rerun,
+		"rerun",
+		false,
+		"rerun release notes generation against an existing draft branch (mutually exclusive with --create-draft-pr and --create-website-pr)",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVar(
+		&releaseNotesOpts.draftPRSourceFork,
+		"draft-pr-source-fork",
+		"",
+		"k/sig-release fork to fetch the existing draft branch from; 'org' or 'org/repo' (required with --rerun)",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVar(
+		&releaseNotesOpts.draftPRSourceBranch,
+		"draft-pr-source-branch",
+		"",
+		"branch to fetch from the source k/sig-release fork (default: release-notes-draft-<tag>)",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVar(
+		&releaseNotesOpts.draftPRPushFork,
+		"draft-pr-push-fork",
+		"",
+		"k/sig-release fork to push the updated branch to; 'org' or 'org/repo' (omit to skip push)",
+	)
+
+	releaseNotesCmd.PersistentFlags().StringVar(
+		&releaseNotesOpts.draftPRPushBranch,
+		"draft-pr-push-branch",
+		"",
+		"branch to push to on the destination k/sig-release fork (default: same as source branch)",
+	)
+
 	_ = releaseNotesCmd.PersistentFlags().MarkDeprecated("create-website-pr", "This flag is deprecated and will be removed in a future release. Use --create-draft-pr instead.")
 
 	rootCmd.AddCommand(releaseNotesCmd)
@@ -279,6 +320,11 @@ func runReleaseNotes() (err error) {
 	// First, validate cmdline options
 	if err := releaseNotesOpts.Validate(); err != nil {
 		return fmt.Errorf("validating command line options: %w", err)
+	}
+
+	// If --rerun is set, enter the rerun codepath and return
+	if releaseNotesOpts.rerun {
+		return rerunDraftNotes(releaseNotesOpts.repoPath, tag)
 	}
 
 	// before running the generators, verify that the repositories are ready
@@ -321,6 +367,232 @@ func runReleaseNotes() (err error) {
 	if releaseNotesOpts.createDraftPR || releaseNotesOpts.createWebsitePR {
 		logrus.Info("Release notes generation complete!")
 	}
+
+	return nil
+}
+
+// rerunDraftNotes fetches an existing draft branch from a source fork of
+// k/sig-release, regenerates the release notes (applying maps),
+// and optionally pushes the result to a destination fork.
+//
+//nolint:maintidx // complex but acceptable
+func rerunDraftNotes(repoPath, tag string) error {
+	tagVersion, err := helpers.TagStringToSemver(tag)
+	if err != nil {
+		return fmt.Errorf("reading tag: %s: %w", tag, err)
+	}
+
+	// Parse source fork org/repo
+	sourceParts := strings.SplitN(releaseNotesOpts.draftPRSourceFork, "/", 2)
+	sourceOrg, sourceRepo := sourceParts[0], sourceParts[1]
+
+	branchname := releaseNotesOpts.draftPRSourceBranch
+
+	gh := github.New()
+
+	// Verify source fork is a fork of k/sig-release
+	logrus.Infof("Verifying %s/%s is a fork of %s/%s",
+		sourceOrg, sourceRepo, git.DefaultGithubOrg, git.DefaultGithubReleaseRepo)
+
+	isFork, err := gh.RepoIsForkOf(
+		sourceOrg, sourceRepo,
+		git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"while checking if %s/%s is a fork of %s/%s: %w",
+			sourceOrg, sourceRepo,
+			git.DefaultGithubOrg, git.DefaultGithubReleaseRepo, err,
+		)
+	}
+
+	if !isFork {
+		return fmt.Errorf(
+			"%s/%s is not a fork of %s/%s",
+			sourceOrg, sourceRepo,
+			git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
+		)
+	}
+
+	// Clone upstream k/sig-release
+	logrus.Info("Cloning upstream kubernetes/sig-release")
+
+	opts := &gogit.CloneOptions{}
+
+	sigReleaseRepo, err := git.CleanCloneGitHubRepo(
+		git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
+		false, true, opts,
+	)
+	if err != nil {
+		return fmt.Errorf("cloning kubernetes/sig-release: %w", err)
+	}
+
+	// Do NOT call Cleanup — preserve the local clone for user inspection
+
+	// Add the source fork as a remote named "source"
+	logrus.Infof("Adding remote 'source' for %s/%s", sourceOrg, sourceRepo)
+
+	// Use HTTPS for the source remote — it's a read-only fetch from a public fork
+	if err := sigReleaseRepo.AddRemote("source", sourceOrg, sourceRepo, false); err != nil {
+		return fmt.Errorf("adding source remote %s/%s: %w", sourceOrg, sourceRepo, err)
+	}
+
+	// Fetch the source branch
+	logrus.Infof("Fetching branch %s from source remote", branchname)
+
+	if err := command.NewWithWorkDir(
+		sigReleaseRepo.Dir(), "git", "fetch", "source", branchname,
+	).RunSuccess(); err != nil {
+		// Handle error when the source branch does not exist
+		return fmt.Errorf(
+			"fetching branch %s from %s/%s: branch may not exist on the source fork: %w",
+			branchname, sourceOrg, sourceRepo, err,
+		)
+	}
+
+	// Checkout the fetched branch locally
+	logrus.Infof("Checking out branch %s", branchname)
+
+	if err := command.NewWithWorkDir(
+		sigReleaseRepo.Dir(), "git", "checkout", "-B", branchname, "source/"+branchname,
+	).RunSuccess(); err != nil {
+		return fmt.Errorf("checking out branch %s: %w", branchname, err)
+	}
+
+	// Compute startTag (previous minor version, same as createDraftPR)
+	start := helpers.SemverToTagString(semver.Version{
+		Major: tagVersion.Major,
+		Minor: tagVersion.Minor - 1,
+		Patch: 0,
+	})
+
+	// Gather release notes from k/k.
+	// The release path inside the sig-release repository
+	releasePath := filepath.Join("releases", fmt.Sprintf("release-%d.%d", tagVersion.Major, tagVersion.Minor))
+	releaseDir := filepath.Join(sigReleaseRepo.Dir(), releasePath)
+
+	// Add the fetched branch's maps directory to map providers
+	branchMapsDir := filepath.Join(releaseDir, releaseNotesWorkDir, mapsMainDirectory)
+	originalMapProviders := releaseNotesOpts.mapProviders
+	if helpers.Exists(branchMapsDir) {
+		logrus.Infof("Loading maps from fetched branch: %s", branchMapsDir)
+		releaseNotesOpts.mapProviders = append([]string{branchMapsDir}, releaseNotesOpts.mapProviders...)
+	}
+
+	releaseNotes, err := gatherNotesFrom(repoPath, start)
+	if err != nil {
+		return fmt.Errorf("gathering release notes for tag %s: %w", start, err)
+	}
+
+	// Restore original map providers
+	releaseNotesOpts.mapProviders = originalMapProviders
+
+	// Build the notes result (markdown + JSON)
+	result, err := buildNotesResult(start, releaseNotes)
+	if err != nil {
+		return fmt.Errorf("building release notes results: %w", err)
+	}
+
+	// Write the regenerated files to the working tree
+	logrus.Debugf("Release notes draft files will be written to %s", releaseDir)
+
+	if err := createNotesWorkDir(releaseDir); err != nil {
+		return fmt.Errorf("creating working directory: %w", err)
+	}
+
+	//nolint:gosec // TODO(gosec): G306
+	if err := os.WriteFile(
+		filepath.Join(releaseDir, releaseNotesWorkDir, draftMarkdownFile),
+		[]byte(result.markdown), 0o644,
+	); err != nil {
+		return fmt.Errorf("writing release notes draft: %w", err)
+	}
+
+	logrus.Infof("Release Notes Markdown Draft written to %s",
+		filepath.Join(releaseDir, releaseNotesWorkDir, draftMarkdownFile))
+
+	//nolint:gosec // TODO(gosec): G306
+	if err := os.WriteFile(
+		filepath.Join(releaseDir, releaseNotesWorkDir, draftJSONFile),
+		[]byte(result.json), 0o644,
+	); err != nil {
+		return fmt.Errorf("writing release notes json file: %w", err)
+	}
+
+	logrus.Infof("Release Notes JSON version written to %s",
+		filepath.Join(releaseDir, releaseNotesWorkDir, draftJSONFile))
+
+	// Create a commit with the updated files
+	if err := createDraftCommit(
+		sigReleaseRepo, releasePath, "Release Notes draft for k/k "+tag,
+	); err != nil {
+		return fmt.Errorf("creating release notes commit: %w", err)
+	}
+
+	// Optional push to destination fork
+	if releaseNotesOpts.draftPRPushFork != "" {
+		pushParts := strings.SplitN(releaseNotesOpts.draftPRPushFork, "/", 2)
+		pushOrg, pushRepo := pushParts[0], pushParts[1]
+		pushBranch := releaseNotesOpts.draftPRPushBranch
+
+		// Verify push fork is a fork of k/sig-release
+		logrus.Infof("Verifying %s/%s is a fork of %s/%s",
+			pushOrg, pushRepo, git.DefaultGithubOrg, git.DefaultGithubReleaseRepo)
+
+		isPushFork, err := gh.RepoIsForkOf(
+			pushOrg, pushRepo,
+			git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"while checking if %s/%s is a fork of %s/%s: %w",
+				pushOrg, pushRepo,
+				git.DefaultGithubOrg, git.DefaultGithubReleaseRepo, err,
+			)
+		}
+
+		if !isPushFork {
+			return fmt.Errorf(
+				"%s/%s is not a fork of %s/%s",
+				pushOrg, pushRepo,
+				git.DefaultGithubOrg, git.DefaultGithubReleaseRepo,
+			)
+		}
+
+		// Add the push fork as a remote named "userfork"
+		if err := sigReleaseRepo.AddRemote(userForkName, pushOrg, pushRepo, false); err != nil {
+			return fmt.Errorf("adding push remote %s/%s: %w", pushOrg, pushRepo, err)
+		}
+
+		// Push with --force-with-lease
+		logrus.Infof("Pushing to %s/%s branch %s with --force-with-lease", pushOrg, pushRepo, pushBranch)
+
+		if err := command.NewWithWorkDir(
+			sigReleaseRepo.Dir(),
+			"git", "push", "--force-with-lease", userForkName, branchname+":"+pushBranch,
+		).RunSuccess(); err != nil {
+			return fmt.Errorf("pushing to %s/%s branch %s: %w", pushOrg, pushRepo, pushBranch, err)
+		}
+
+		// Log that existing PR will be updated
+		logrus.Infof("Pushed to %s/%s branch %s — any existing PR will be updated by this push", pushOrg, pushRepo, pushBranch)
+	}
+
+	// Print the local clone path
+	fmt.Println()
+	fmt.Println("Local sig-release clone preserved at:")
+	fmt.Println(sigReleaseRepo.Dir())
+
+	if releaseNotesOpts.draftPRPushFork == "" {
+		fmt.Println()
+		fmt.Println("No --draft-pr-push-fork was specified, so no push was performed.")
+		fmt.Println("To push manually, run:")
+		fmt.Printf("  cd %s\n", sigReleaseRepo.Dir())
+		fmt.Printf("  git remote add userfork <your-fork-url>\n")
+		fmt.Printf("  git push --force-with-lease userfork %s\n", branchname)
+	}
+
+	logrus.Info("Rerun complete!")
 
 	return nil
 }
@@ -1030,6 +1302,46 @@ func (o *releaseNotesOptions) Validate() error {
 	_, err := helpers.TagStringToSemver(releaseNotesOpts.tag)
 	if err != nil {
 		return fmt.Errorf("reading tag: %s: %w", releaseNotesOpts.tag, err)
+	}
+
+	// Rerun validation
+	if o.rerun {
+		if o.createDraftPR || o.createWebsitePR {
+			return errors.New("--rerun cannot be used with --create-draft-pr or --create-website-pr")
+		}
+
+		if o.draftPRSourceFork == "" {
+			return errors.New("--draft-pr-source-fork is required when using --rerun")
+		}
+
+		if o.tag == "" {
+			return errors.New("--tag is required when using --rerun")
+		}
+
+		// Parse --draft-pr-source-fork: if no "/" present, append "/sig-release"
+		if !strings.Contains(o.draftPRSourceFork, "/") {
+			o.draftPRSourceFork = o.draftPRSourceFork + "/" + git.DefaultGithubReleaseRepo
+		}
+
+		// Parse --draft-pr-push-fork: if no "/" present, append "/sig-release"
+		if o.draftPRPushFork != "" && !strings.Contains(o.draftPRPushFork, "/") {
+			o.draftPRPushFork = o.draftPRPushFork + "/" + git.DefaultGithubReleaseRepo
+		}
+
+		// Resolve --draft-pr-source-branch default
+		if o.draftPRSourceBranch == "" {
+			o.draftPRSourceBranch = draftBranchPrefix + o.tag
+		}
+
+		// Resolve --draft-pr-push-branch default to source branch
+		if o.draftPRPushBranch == "" {
+			o.draftPRPushBranch = o.draftPRSourceBranch
+		}
+
+		// Warn if --rerun without --maps-from
+		if len(o.mapProviders) == 0 {
+			logrus.Warn("Running --rerun without --maps-from will automatically pick up map files from releases/release-x.yz/release-notes/maps folder")
+		}
 	}
 
 	// Options for PR creation

--- a/cmd/krel/cmd/release_notes_test.go
+++ b/cmd/krel/cmd/release_notes_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setGitHubToken sets a dummy GITHUB_TOKEN for Validate() which checks it early.
+func setGitHubToken(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "fake-token-for-testing")
+}
+
+func TestValidateRerun_MutualExclusion(t *testing.T) {
+	setGitHubToken(t)
+
+	tests := []struct {
+		name            string
+		createDraftPR   bool
+		createWebsitePR bool
+	}{
+		{
+			name:          "rerun with createDraftPR",
+			createDraftPR: true,
+		},
+		{
+			name:            "rerun with createWebsitePR",
+			createWebsitePR: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &releaseNotesOptions{
+				rerun:             true,
+				tag:               "v1.32.0",
+				draftPRSourceFork: "myorg/sig-release",
+				createDraftPR:     tc.createDraftPR,
+				createWebsitePR:   tc.createWebsitePR,
+			}
+			releaseNotesOpts = opts
+			err := opts.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "cannot be used with")
+		})
+	}
+}
+
+func TestValidateRerun_RequiredFlags(t *testing.T) {
+	setGitHubToken(t)
+
+	t.Run("missing draftPRSourceFork", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:             true,
+			tag:               "v1.32.0",
+			draftPRSourceFork: "",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--draft-pr-source-fork is required")
+	})
+
+	t.Run("missing tag", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:             true,
+			tag:               "",
+			draftPRSourceFork: "myorg/sig-release",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.Error(t, err)
+		// tag validation happens before rerun validation via TagStringToSemver
+		require.Error(t, err)
+	})
+}
+
+func TestValidateRerun_ForkNormalization(t *testing.T) {
+	setGitHubToken(t)
+
+	t.Run("org-only source fork gets /sig-release appended", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:             true,
+			tag:               "v1.32.0",
+			draftPRSourceFork: "myorg",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "myorg/sig-release", opts.draftPRSourceFork)
+	})
+
+	t.Run("full org/repo source fork unchanged", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:             true,
+			tag:               "v1.32.0",
+			draftPRSourceFork: "myorg/myrepo",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "myorg/myrepo", opts.draftPRSourceFork)
+	})
+
+	t.Run("org-only push fork gets /sig-release appended", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:             true,
+			tag:               "v1.32.0",
+			draftPRSourceFork: "myorg/sig-release",
+			draftPRPushFork:   "pushorg",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "pushorg/sig-release", opts.draftPRPushFork)
+	})
+}
+
+func TestValidateRerun_BranchDefaults(t *testing.T) {
+	setGitHubToken(t)
+
+	t.Run("empty source branch defaults to release-notes-draft-<tag>", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:               true,
+			tag:                 "v1.32.0",
+			draftPRSourceFork:   "myorg/sig-release",
+			draftPRSourceBranch: "",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "release-notes-draft-v1.32.0", opts.draftPRSourceBranch)
+	})
+
+	t.Run("empty push branch defaults to source branch", func(t *testing.T) {
+		opts := &releaseNotesOptions{
+			rerun:               true,
+			tag:                 "v1.32.0",
+			draftPRSourceFork:   "myorg/sig-release",
+			draftPRSourceBranch: "my-branch",
+			draftPRPushBranch:   "",
+		}
+		releaseNotesOpts = opts
+		err := opts.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "my-branch", opts.draftPRPushBranch)
+	})
+}
+
+func TestValidateRerun_ValidOptions(t *testing.T) {
+	setGitHubToken(t)
+
+	opts := &releaseNotesOptions{
+		rerun:             true,
+		tag:               "v1.32.0",
+		draftPRSourceFork: "myorg/sig-release",
+	}
+	releaseNotesOpts = opts
+	err := opts.Validate()
+	require.NoError(t, err)
+}

--- a/cmd/krel/cmd/release_notes_test.go
+++ b/cmd/krel/cmd/release_notes_test.go
@@ -17,162 +17,142 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
-// setGitHubToken sets a dummy GITHUB_TOKEN for Validate() which checks it early.
 func setGitHubToken(t *testing.T) {
 	t.Helper()
 	t.Setenv("GITHUB_TOKEN", "fake-token-for-testing")
 }
 
-func TestValidateRerun_MutualExclusion(t *testing.T) {
+func TestValidateRerunOpts_RequiredFlags(t *testing.T) {
 	setGitHubToken(t)
-
-	tests := []struct {
-		name            string
-		createDraftPR   bool
-		createWebsitePR bool
-	}{
-		{
-			name:          "rerun with createDraftPR",
-			createDraftPR: true,
-		},
-		{
-			name:            "rerun with createWebsitePR",
-			createWebsitePR: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			opts := &releaseNotesOptions{
-				rerun:             true,
-				tag:               "v1.32.0",
-				draftPRSourceFork: "myorg/sig-release",
-				createDraftPR:     tc.createDraftPR,
-				createWebsitePR:   tc.createWebsitePR,
-			}
-			releaseNotesOpts = opts
-			err := opts.Validate()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "cannot be used with")
-		})
-	}
-}
-
-func TestValidateRerun_RequiredFlags(t *testing.T) {
-	setGitHubToken(t)
-
 	t.Run("missing draftPRSourceFork", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:             true,
 			tag:               "v1.32.0",
 			draftPRSourceFork: "",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "--draft-pr-source-fork is required")
 	})
 
 	t.Run("missing tag", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:             true,
 			tag:               "",
 			draftPRSourceFork: "myorg/sig-release",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.Error(t, err)
-		// tag validation happens before rerun validation via TagStringToSemver
-		require.Error(t, err)
+		require.Contains(t, err.Error(), "--tag is required")
 	})
 }
 
-func TestValidateRerun_ForkNormalization(t *testing.T) {
+func TestValidateRerunOpts_ForkNormalization(t *testing.T) {
 	setGitHubToken(t)
-
 	t.Run("org-only source fork gets /sig-release appended", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:             true,
 			tag:               "v1.32.0",
 			draftPRSourceFork: "myorg",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.NoError(t, err)
 		require.Equal(t, "myorg/sig-release", opts.draftPRSourceFork)
 	})
 
 	t.Run("full org/repo source fork unchanged", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:             true,
 			tag:               "v1.32.0",
 			draftPRSourceFork: "myorg/myrepo",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.NoError(t, err)
 		require.Equal(t, "myorg/myrepo", opts.draftPRSourceFork)
 	})
 
 	t.Run("org-only push fork gets /sig-release appended", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:             true,
 			tag:               "v1.32.0",
 			draftPRSourceFork: "myorg/sig-release",
 			draftPRPushFork:   "pushorg",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.NoError(t, err)
 		require.Equal(t, "pushorg/sig-release", opts.draftPRPushFork)
 	})
 }
 
-func TestValidateRerun_BranchDefaults(t *testing.T) {
+func TestValidateRerunOpts_BranchDefaults(t *testing.T) {
 	setGitHubToken(t)
-
 	t.Run("empty source branch defaults to release-notes-draft-<tag>", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:               true,
 			tag:                 "v1.32.0",
 			draftPRSourceFork:   "myorg/sig-release",
 			draftPRSourceBranch: "",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.NoError(t, err)
 		require.Equal(t, "release-notes-draft-v1.32.0", opts.draftPRSourceBranch)
 	})
 
 	t.Run("empty push branch defaults to source branch", func(t *testing.T) {
 		opts := &releaseNotesOptions{
-			rerun:               true,
 			tag:                 "v1.32.0",
 			draftPRSourceFork:   "myorg/sig-release",
 			draftPRSourceBranch: "my-branch",
 			draftPRPushBranch:   "",
 		}
-		releaseNotesOpts = opts
-		err := opts.Validate()
+		err := validateRerunOpts(opts)
 		require.NoError(t, err)
 		require.Equal(t, "my-branch", opts.draftPRPushBranch)
 	})
 }
 
-func TestValidateRerun_ValidOptions(t *testing.T) {
+func TestValidateRerunOpts_ValidOptions(t *testing.T) {
 	setGitHubToken(t)
 
 	opts := &releaseNotesOptions{
-		rerun:             true,
 		tag:               "v1.32.0",
 		draftPRSourceFork: "myorg/sig-release",
 	}
-	releaseNotesOpts = opts
-	err := opts.Validate()
+	err := validateRerunOpts(opts)
 	require.NoError(t, err)
+}
+
+func TestValidateRerunOpts_DynamicMapsWarning(t *testing.T) {
+	setGitHubToken(t)
+
+	tests := []struct {
+		name     string
+		tag      string
+		expected string
+	}{
+		{"alpha tag", "v1.32.0-alpha.1", "releases/release-1.32/release-notes/maps"},
+		{"beta tag", "v1.33.0-beta.0", "releases/release-1.33/release-notes/maps"},
+		{"rc tag", "v1.36.0-rc.2", "releases/release-1.36/release-notes/maps"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := logrus.StandardLogger().Out
+
+			var buf bytes.Buffer
+
+			logrus.SetOutput(&buf)
+			defer logrus.SetOutput(orig)
+
+			opts := &releaseNotesOptions{
+				tag:               tc.tag,
+				draftPRSourceFork: "myorg/sig-release",
+				mapProviders:      []string{},
+			}
+			err := validateRerunOpts(opts)
+			require.NoError(t, err)
+			require.Contains(t, buf.String(), tc.expected)
+		})
+	}
 }

--- a/docs/krel/release-notes.md
+++ b/docs/krel/release-notes.md
@@ -64,7 +64,7 @@ Global Flags:
 
 ### Examples
 
-`krel release-notes` has two main modes of operation:
+`krel release-notes` has three main modes of operation:
 
 #### Update the Release Notes markdown draft
 
@@ -105,6 +105,54 @@ krel release-notes --create-website-pr --fork=kubefriend --tag v1.19.0-beta.1
 As with `--create-draft-pr`, `--tag` is optional and will default to the latest release.
 You can override the name of your fork of kubernetes-sigs/release-notes by specifying
 the full repository slug: `--fork=myorg/myreponame`.
+
+#### Rerun against an existing draft branch
+
+After the initial `--create-draft-pr` run creates a PR against k/sig-release, reviewers may suggest changes. To incorporate those changes (via [map files](../release-notes-maps.md)), you need to regenerate the draft against the existing branch.
+
+The `rerun` subcommand handles this workflow — it fetches an existing draft branch from any fork, regenerates the notes with maps applied, and optionally pushes the result to a destination fork.
+
+This solves the problem where re-running `--create-draft-pr` fails because the branch already exists on the fork, and also supports handoffs where a different team member needs to pick up the rerun work from a colleague's fork.
+
+The process:
+
+1. Clone upstream k/sig-release and fetch the draft branch from `--draft-pr-source-fork`
+2. Gather release notes from k/k for the given `--tag` range
+3. Apply map files (from the branch and any extra `--maps-from` paths)
+4. Write the updated markdown and JSON drafts, then commit
+5. If `--draft-pr-push-fork` is set, push the branch there (updating any open PR)
+
+The local clone is preserved after the run so you can inspect or push manually.
+
+```bash
+# Rerun and push to your own fork (updates the open PR):
+krel release-notes rerun \
+  --tag v1.36.0-beta.0 \
+  --draft-pr-source-fork colleague \
+  --draft-pr-push-fork myfork
+
+# Rerun with additional local maps, no push (inspect locally):
+krel release-notes rerun \
+  --tag v1.36.0-beta.0 \
+  --draft-pr-source-fork myfork \
+  --maps-from /path/to/extra/maps
+```
+
+The `--draft-pr-source-fork` flag accepts either an org name (`myorg`, which expands to `myorg/sig-release`) or a full slug (`myorg/myrepo`).  
+The same applies to `--draft-pr-push-fork`.
+
+If `--draft-pr-source-branch` is not specified, it defaults to `release-notes-draft-<tag>`.
+
+Flags specific to `rerun`:
+
+```
+      --draft-pr-source-fork string     k/sig-release fork to fetch the existing draft branch from (required)
+      --draft-pr-source-branch string   branch to fetch (default: release-notes-draft-<tag>)
+      --draft-pr-push-fork string       k/sig-release fork to push the updated branch to (omit to skip push)
+      --draft-pr-push-branch string     branch to push to on the destination fork (default: same as source branch)
+```
+
+Inherited flags from the parent command (`--tag`, `--maps-from`, `--repo`, `--use-ssh`, `--update-repo`, `--include-labels`) are also available.
 
 ### Usage notes
 

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1130,6 +1130,7 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 
 	if noteMap.ReleaseNote.SIGs != nil {
 		rn.SIGs = *noteMap.ReleaseNote.SIGs
+		reRenderMarkdown = true
 	}
 
 	if noteMap.ReleaseNote.Feature != nil {
@@ -1163,7 +1164,7 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 				indented, rn.PrNumber, rn.PrURL, rn.Author, rn.AuthorURL)
 		}
 		// Add sig labels to markdown
-		if len(rn.SIGs) > 1 {
+		if len(rn.SIGs) >= 1 {
 			markdown = fmt.Sprintf("%s [%s]", markdown, prettifySIGList(rn.SIGs))
 		}
 		// Uppercase the first character of the markdown to make it look uniform

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -1095,12 +1095,16 @@ func (rn *ReleaseNote) ApplyMap(noteMap *ReleaseNotesMap, markdownLinks bool) er
 
 	rn.IsMapped = true
 
-	if noteMap.PRBody != nil && rn.PRBody != "" && rn.PRBody != *noteMap.PRBody {
-		logrus.Warnf("Original PR body of release note mapping changed for PR: #%d", rn.PrNumber)
+	if noteMap.PRBody != nil {
+		if rn.PRBody != "" && rn.PRBody != *noteMap.PRBody {
+			logrus.Warnf("Original PR body of release note mapping changed for PR: #%d", rn.PrNumber)
 
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(rn.PRBody, *noteMap.PRBody, false)
-		logrus.Warnf("The diff between actual release note body and mapped one is:\n%s", dmp.DiffPrettyText(diffs))
+			dmp := diffmatchpatch.New()
+			diffs := dmp.DiffMain(rn.PRBody, *noteMap.PRBody, false)
+			logrus.Warnf("The diff between actual release note body and mapped one is:\n%s", dmp.DiffPrettyText(diffs))
+		}
+
+		rn.PRBody = *noteMap.PRBody
 	}
 
 	reRenderMarkdown := false

--- a/pkg/notes/notes_map.go
+++ b/pkg/notes/notes_map.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v4"
@@ -131,17 +132,20 @@ type ReleaseNotesDataField any
 
 // DirectoryMapProvider is a provider that gets maps from a directory.
 type DirectoryMapProvider struct {
-	Path string
-	Maps map[int][]*ReleaseNotesMap
+	Path    string
+	Maps    map[int][]*ReleaseNotesMap
+	once    sync.Once
+	loadErr error
 }
 
 // GetMapsForPR get the release notes maps for a specific PR number.
 func (mp *DirectoryMapProvider) GetMapsForPR(pr int) (notesMap []*ReleaseNotesMap, err error) {
-	if mp.Maps == nil {
-		err := mp.readMaps()
-		if err != nil {
-			return nil, fmt.Errorf("while reading release notes maps: %w", err)
-		}
+	mp.once.Do(func() {
+		mp.loadErr = mp.readMaps()
+	})
+
+	if mp.loadErr != nil {
+		return nil, fmt.Errorf("while reading release notes maps: %w", mp.loadErr)
 	}
 
 	if notesMap, ok := mp.Maps[pr]; ok {

--- a/pkg/notes/notes_map_test.go
+++ b/pkg/notes/notes_map_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notes
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,6 +65,43 @@ func TestGetMapsForPR(t *testing.T) {
 	maps, err = provider.GetMapsForPR(123)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, 4, len(maps))
+}
+
+func TestGetMapsForPR_Concurrent(t *testing.T) {
+	provider := &DirectoryMapProvider{Path: "maps/testdata"}
+
+	const numGoroutines = 100
+
+	var wg sync.WaitGroup
+
+	wg.Add(numGoroutines)
+
+	results := make([][]*ReleaseNotesMap, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+
+			results[idx], errs[idx] = provider.GetMapsForPR(95000)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All calls should succeed
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d returned error", i)
+	}
+
+	// All calls should return consistent results
+	for i := 1; i < numGoroutines; i++ {
+		require.Len(t, results[i], len(results[0]),
+			"goroutine %d returned different number of maps", i)
+	}
+
+	// Maps should be populated (non-empty result for known PR)
+	require.NotEmpty(t, results[0], "expected non-empty maps for PR 95000")
 }
 
 func TestReleaseNotesMapIntegrity(t *testing.T) {


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Adds a `krel release-notes rerun` subcommand that fetches an existing draft branch from a source fork of k/sig-release, regenerates the release notes (applying maps), commits the result, and optionally pushes to a destination fork. This supports iterative release notes workflows where the draft needs to be regenerated multiple times during a release cycle.

Also fixes a bug where SIG labels were dropped from the markdown during `ApplyMap` re-rendering, and makes `DirectoryMapProvider.GetMapsForPR` thread-safe.

#### Changes:

**`cmd/krel/cmd/release_notes.go`**
- Add `rerunCmd` as a proper cobra subcommand of `release-notes` (not a flag) with its own flags, validation, help text, and examples
- Add `--draft-pr-source-fork` (required): specifies the k/sig-release fork to fetch the existing draft branch from (`org` or `org/repo`)
- Add `--draft-pr-source-branch`: branch to fetch (defaults to `release-notes-draft-<tag>`)
- Add `--draft-pr-push-fork`: optional destination fork to push regenerated notes to (`org` or `org/repo`, omit to skip push)
- Add `--draft-pr-push-branch`: branch to push to on the destination fork (defaults to source branch)
- Add `rerunDraftNotes()` function: clones upstream k/sig-release, fetches the draft branch from source fork, auto-discovers maps from the branch, regenerates release notes, commits, and optionally pushes with `--force-with-lease`
- Add `validateRerunOpts()`: validates `GITHUB_TOKEN`, required flags, fork normalization (`"myorg"` → `"myorg/sig-release"`), branch default resolution, and dynamic `--maps-from` warning (e.g. `releases/release-1.32/release-notes/maps` instead of `release-x.yz`)
- Add detailed `Long` description with numbered process steps and `Example` field with realistic invocations

**`pkg/notes/notes.go`**
- Fix SIG labels dropped from markdown during `ApplyMap` re-render: change `len(rn.SIGs) > 1` to `len(rn.SIGs) >= 1` so single-SIG notes retain their `[SIG Foo]` suffix
- Set `reRenderMarkdown = true` when `noteMap.ReleaseNote.SIGs` is applied, ensuring the markdown is rebuilt with the updated SIG list
- Set `rn.PRBody = *noteMap.PRBody` so that `pr_body` is applied from maps to `.json` file (similar to all other fields)

**`pkg/notes/notes_map.go`**
- Replace nil-check on `Maps` with `sync.Once` in `DirectoryMapProvider.GetMapsForPR` to make concurrent calls thread-safe

**`cmd/krel/cmd/release_notes_test.go`** (new file)
- `TestValidateRerunOpts_RequiredFlags`: missing `--draft-pr-source-fork` and missing `--tag` both error
- `TestValidateRerunOpts_ForkNormalization`: org-only source/push fork gets `/sig-release` appended; full `org/repo` stays unchanged
- `TestValidateRerunOpts_BranchDefaults`: empty source branch defaults to `release-notes-draft-<tag>`; empty push branch defaults to source branch
- `TestValidateRerunOpts_ValidOptions`: all required flags set, validation returns nil
- `TestValidateRerunOpts_DynamicMapsWarning`: verifies the warning contains the dynamic path for alpha, beta, and rc tags

**`pkg/notes/notes_map_test.go`**
- `TestGetMapsForPR_Concurrent`: 100 goroutines calling `GetMapsForPR` on the same `DirectoryMapProvider` instance, asserting consistent results and no panics

#### Help output:

```
$ krel release-notes rerun -h
krel release-notes rerun

Re-generates the release notes draft against an existing PR branch. The process:

1. Clone upstream k/sig-release and fetch the draft branch from --draft-pr-source-fork.
2. Gather release notes from k/k for the given --tag range.
3. Apply map files (from the branch and any extra --maps-from paths).
4. Write the updated markdown and JSON drafts, then commit.
5. If --draft-pr-push-fork is set, push the branch there (updating any open PR).

The local clone is preserved after the run so you can inspect or push manually.

Examples:
  # Rerun against an existing draft branch and push to a destination fork:
  krel release-notes rerun \
    --tag v1.36.0 \
    --draft-pr-source-fork myorg \
    --draft-pr-push-fork destorg

  # Rerun with additional maps from a local directory:
  krel release-notes rerun \
    --tag v1.36.0 \
    --draft-pr-source-fork myorg/sig-release \
    --maps-from /path/to/extra/maps
```

#### Which issue(s) this PR fixes:

#4348 #4121

#### Special notes for your reviewer:

- The 9 pre-existing test failures in `sut_test.go` / `ff_test.go` are unrelated to this PR — they fail on `master` as well (git push errors in the test harness).
- All new tests pass with `go test -race`.
- `golangci-lint run` passes clean.
- The `rerun` functionality was initially implemented as a `--rerun` flag, then extracted into a proper cobra subcommand for better UX (dedicated help, examples, flag scoping).

#### Does this PR introduce a user-facing change?

```release-note
Add `krel release-notes rerun` subcommand for iterative release notes regeneration against an existing draft branch.
```