### PR TITLE
Revert "Use blobless clone for fresh k/k checkouts during stage"

### DIFF
--- a/pkg/release/workspace.go
+++ b/pkg/release/workspace.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/release-sdk/git"
 	"sigs.k8s.io/release-sdk/github"
 	"sigs.k8s.io/release-sdk/object"
-	"sigs.k8s.io/release-utils/command"
 	"sigs.k8s.io/release-utils/helpers"
 	"sigs.k8s.io/release-utils/tar"
 )
@@ -59,34 +58,9 @@ func PrepareWorkspaceStage(directory string, noMock bool) error {
 
 	logrus.Infof("Cloning repository %s/%s to %s", k8sOrg, k8sRepo, directory)
 
-	var repo *git.Repo
-
-	if !helpers.Exists(directory) {
-		// Use blobless clone for fresh checkouts. This downloads the full
-		// commit graph (needed for changelog generation) but defers blob
-		// downloads until checkout, significantly reducing clone time.
-		repoURL := git.GetRepoURL(k8sOrg, k8sRepo, false)
-		logrus.Infof("Performing blobless clone from %s", repoURL)
-
-		if err := command.New(
-			"git", "clone", "--filter=blob:none", repoURL, directory,
-		).RunSuccess(); err != nil {
-			return fmt.Errorf("blobless clone k/k repository: %w", err)
-		}
-
-		var err error
-
-		repo, err = git.OpenRepo(directory)
-		if err != nil {
-			return fmt.Errorf("open blobless-cloned k/k repository: %w", err)
-		}
-	} else {
-		var err error
-
-		repo, err = git.CloneOrOpenGitHubRepo(directory, k8sOrg, k8sRepo, false)
-		if err != nil {
-			return fmt.Errorf("clone k/k repository: %w", err)
-		}
+	repo, err := git.CloneOrOpenGitHubRepo(directory, k8sOrg, k8sRepo, false)
+	if err != nil {
+		return fmt.Errorf("clone k/k repository: %w", err)
 	}
 
 	// Prewarm the SPDX licenses cache. As it is one of the main


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This was originally attempted in #4339:

> Reverts commit 3d02b4af ("Use blobless clone for fresh k/k checkouts during stage"). The blobless clone (`--filter=blob:none`) causes `git commit --allow-empty` to fail during the tagging step with "invalid object" errors. The GCB cloud builder image uses git 2.30.2, which has incomplete support for partial clone tree validation. This broke mock stage runs for both release-1.35 and release-1.34.

I can't find any context on why was this revert closed, but we're still running into the same issue. Let's proceed with the revert, and then we can figure out if we can get a newer Git version. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

From the original revert PR:

> Confirmed that reverting to a full clone fixes the issue. The blobless clone optimization can be revisited once the cloud builder image ships a newer git version.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @Verolop @jimangel @saschagrunert 
cc @kubernetes/release-engineering