### PR TITLE
krel/templates: adjust kubeadm constraint for >= 1.30

### DIFF
--- a/cmd/krel/templates/latest/metadata.yaml
+++ b/cmd/krel/templates/latest/metadata.yaml
@@ -69,7 +69,7 @@ kubeadm:
         versionConstraint: ">= 1.2.0"
       - name: cri-tools
         versionConstraint: ">= 1.28.0"
-  - versionConstraint: ">= 1.30.0"
+  - versionConstraint: ">= 1.30.0 < 1.32.0"
     sourceURLTemplate: "{{ KubernetesURL }}"
     dependencies:
       - name: cri-tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug cleanup

#### What this PR does / why we need it:

There are two ">=" constraints in the krel depedency metadata
for kubeadm. One for >= 1.30.0 with cri-tools as a dependecy,
and one for >= 1.32.0 with no depedencies. krel ends up using the
first one when making a decision.

Adjust the first constraint to be a range: ">= 1.30.0 < 1.32.0".
This would allow kubeadm >= 1.32.0 to have no dependencies.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

xref https://github.com/kubernetes/kubernetes/issues/138534#issuecomment-4313719585

#### Special notes for your reviewer:

This is also an optional follow-up to add validation:
- https://github.com/kubernetes/release/pull/4388

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel: make versions of kubeadm >= 1.32.0 to not depend on cri-tools
```
