### PR TITLE
krel: add validation for mutliple matching constraints

### DIFF
--- a/pkg/obs/specs/pkgdef.go
+++ b/pkg/obs/specs/pkgdef.go
@@ -155,24 +155,37 @@ func (s *Specs) GetPackageMetadata(templateDir, packageName, packageVersion stri
 
 // GetMetadataWithVersionConstraint parses metadata and takes metadata that
 // matches the given version constraint.
-func (s *Specs) GetMetadataWithVersionConstraint(packageName, packageVersion string, constraintedMetadata []metadata.PackageMetadata) (*metadata.PackageMetadata, error) {
-	for _, m := range constraintedMetadata {
+func (s *Specs) GetMetadataWithVersionConstraint(packageName, packageVersion string, constrainedMetadata []metadata.PackageMetadata) (*metadata.PackageMetadata, error) {
+	kubeSemVer, err := s.TagStringToSemver(packageVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parsing package version %s: %w", packageVersion, err)
+	}
+
+	lastMatchedIdx := -1
+	matchedConstraints := []string{}
+
+	for i, m := range constrainedMetadata {
 		r, err := semver.ParseRange(m.VersionConstraint)
 		if err != nil {
 			return nil, fmt.Errorf("parsing semver range for package %s: %w", packageName, err)
 		}
 
-		kubeSemVer, err := s.TagStringToSemver(packageVersion)
-		if err != nil {
-			return nil, fmt.Errorf("parsing package version %s: %w", packageVersion, err)
-		}
-
 		if r(kubeSemVer) {
-			return &m, nil
+			matchedConstraints = append(matchedConstraints, m.VersionConstraint)
+			lastMatchedIdx = i
 		}
 	}
 
-	return nil, fmt.Errorf("package %s is not defined in metadata.yaml file", packageName)
+	if len(matchedConstraints) > 1 {
+		return nil, fmt.Errorf("multiple constraints match for package %q with version %q: %#v",
+			packageName, packageVersion, matchedConstraints)
+	}
+
+	if lastMatchedIdx != -1 {
+		return &constrainedMetadata[lastMatchedIdx], nil
+	}
+
+	return nil, fmt.Errorf("package %q is not defined in metadata.yaml file", packageName)
 }
 
 // GetPackageSource gets the download link for artifacts for the given package.

--- a/pkg/obs/specs/pkgdef_test.go
+++ b/pkg/obs/specs/pkgdef_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package specs_test
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -192,6 +193,96 @@ func TestConstructPackageDefinition(t *testing.T) {
 			require.Equal(t, tc.channel, pkgDef.Channel)
 			require.Equal(t, tc.version, pkgDef.Version)
 		}
+	}
+}
+
+func TestGetMetadataWithVersionConstraint(t *testing.T) {
+	testcases := []struct {
+		name            string
+		packageVersion  string
+		constrainedMeta []metadata.PackageMetadata
+		prepare         func(mock *specsfakes.FakeImpl, ver semver.Version)
+		shouldErr       bool
+		expectedResult  *metadata.PackageMetadata
+	}{
+		{
+			name:           "single matching constraint returns metadata",
+			packageVersion: "1.30.0",
+			constrainedMeta: []metadata.PackageMetadata{
+				{VersionConstraint: ">=1.28.0 <1.31.0"},
+				{VersionConstraint: ">=1.31.0"},
+			},
+			prepare: func(mock *specsfakes.FakeImpl, ver semver.Version) {
+				mock.TagStringToSemverReturns(ver, nil)
+			},
+			shouldErr:      false,
+			expectedResult: &metadata.PackageMetadata{VersionConstraint: ">=1.28.0 <1.31.0"},
+		},
+		{
+			name:           "multiple overlapping constraints return error",
+			packageVersion: "1.30.0",
+			constrainedMeta: []metadata.PackageMetadata{
+				{VersionConstraint: ">=1.28.0"},
+				{VersionConstraint: ">=1.29.0"},
+			},
+			prepare: func(mock *specsfakes.FakeImpl, ver semver.Version) {
+				mock.TagStringToSemverReturns(ver, nil)
+			},
+			shouldErr: true,
+		},
+		{
+			name:           "no matching constraint returns error",
+			packageVersion: "1.27.0",
+			constrainedMeta: []metadata.PackageMetadata{
+				{VersionConstraint: ">=1.28.0"},
+			},
+			prepare: func(mock *specsfakes.FakeImpl, ver semver.Version) {
+				v, _ := semver.New("1.27.0")
+				mock.TagStringToSemverReturns(*v, nil)
+			},
+			shouldErr: true,
+		},
+		{
+			name:           "invalid version returns error",
+			packageVersion: "not-a-version",
+			constrainedMeta: []metadata.PackageMetadata{
+				{VersionConstraint: ">=1.28.0"},
+			},
+			prepare: func(mock *specsfakes.FakeImpl, ver semver.Version) {
+				mock.TagStringToSemverReturns(ver, errors.New("invalid version"))
+			},
+			shouldErr: true,
+		},
+		{
+			name:           "invalid constraint expression returns error",
+			packageVersion: "1.30.0",
+			constrainedMeta: []metadata.PackageMetadata{
+				{VersionConstraint: "not-a-constraint"},
+			},
+			prepare: func(mock *specsfakes.FakeImpl, ver semver.Version) {
+				mock.TagStringToSemverReturns(ver, nil)
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ver, _ := semver.New("1.30.0")
+
+			sut := specs.New(&specs.Options{})
+			mock := &specsfakes.FakeImpl{}
+			tc.prepare(mock, *ver)
+			sut.SetImpl(mock)
+
+			result, err := sut.GetMetadataWithVersionConstraint("testpkg", tc.packageVersion, tc.constrainedMeta)
+			if tc.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedResult, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
If the parsed version constraints end up with multiple matches throw an error instead of using the first match.

This would avoid the potential for mistakes where the last added constraint is not respected because an earlier match was found.

An alternative approach would be to always use the last match.
In any case, there would be a change in behavior, which might be undesired.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

follow-up on: https://github.com/kubernetes/release/pull/4387
related to:  https://github.com/kubernetes/kubernetes/issues/138534#issuecomment-4313719585

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
krel: when parsing metadata, error if a package version matches multiple constraints.
```
