### PR TITLE
Bump distroless-iptables to use Go 1.26.3/1.25.10

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -390,19 +390,19 @@ dependencies:
         match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.26)"
-    version: v0.9.1
+    version: v0.9.2
     refPaths:
       - path: images/build/distroless-iptables/variants.yaml
         match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.26)"
-    version: v2.4.0-go1.26.2-bookworm.0
+    version: v2.4.0-go1.26.3-bookworm.0
     refPaths:
       - path: images/build/distroless-iptables/variants.yaml
         match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.25)"
-    version: v0.8.9
+    version: v0.8.10
     refPaths:
       - path: images/build/distroless-iptables/Makefile
         match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -410,7 +410,7 @@ dependencies:
         match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/go-runner: dependents (distroless-bookworm-go1.25)"
-    version: v2.4.0-go1.25.9-bookworm.0
+    version: v2.4.0-go1.25.10-bookworm.0
     refPaths:
       - path: images/build/distroless-iptables/variants.yaml
         match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,10 +18,10 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.8.9
+IMAGE_VERSION ?= v0.8.10
 CONFIG ?= distroless-bookworm
 BASEIMAGE ?= debian:bookworm-slim
-GORUNNER_VERSION ?= v2.4.0-go1.25.9-bookworm.0
+GORUNNER_VERSION ?= v2.4.0-go1.25.10-bookworm.0
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   distroless-bookworm-go1.26:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.9.1'
+    IMAGE_VERSION: 'v0.9.2'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.4.0-go1.26.2-bookworm.0'
+    GORUNNER_VERSION: 'v2.4.0-go1.26.3-bookworm.0'
   distroless-bookworm-go1.25:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.8.9'
+    IMAGE_VERSION: 'v0.8.10'
     BASEIMAGE: 'debian:bookworm-slim'
-    GORUNNER_VERSION: 'v2.4.0-go1.25.9-bookworm.0'
+    GORUNNER_VERSION: 'v2.4.0-go1.25.10-bookworm.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Bump distroless-iptables to use Go 1.26.3/1.25.10

#### Which issue(s) this PR fixes:

xref #4397 

#### Does this PR introduce a user-facing change?
```release-note
Bump distroless-iptables to use Go 1.26.3/1.25.10
```

cc @kubernetes/release-engineering 