### PR TITLE
Make QEMU version, arch and flags overridable via environment variables

### DIFF
--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -24,7 +24,7 @@ CONFIG ?= bookworm
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 
 QEMUVERSION ?= 7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -26,8 +26,9 @@ TAR_FILE ?= rootfs.tar
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
-QEMUVERSION=7.2.0-1
+QEMUVERSION ?= 7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static
+QEMUFLAGS ?= --reset -p yes
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
@@ -75,7 +76,7 @@ build: clean
 	umask 0022
 
 	# Enable execution of multi-architecture containers
-	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) --reset -p yes
+	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) $(QEMUFLAGS)
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
 

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -24,7 +24,7 @@ BASEIMAGE ?= debian:bookworm-slim
 GORUNNER_VERSION ?= v2.4.0-go1.25.10-bookworm.0
 
 ARCH?=amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 
 BASE_REGISTRY?=registry.k8s.io/build-image
 

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -30,8 +30,9 @@ BASE_REGISTRY?=registry.k8s.io/build-image
 
 GORUNNERIMAGE?=$(BASE_REGISTRY)/go-runner:$(GORUNNER_VERSION)
 
-QEMUVERSION=7.2.0-1
+QEMUVERSION ?= 7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static
+QEMUFLAGS ?= --reset -p yes
 
 ifneq ($(ARCH), amd64)
 	SKIP_WRAPPER_CHECK=--no-sanity-check
@@ -47,7 +48,7 @@ build:
 	umask 0022
 
 	# Enable execution of multi-architecture containers
-	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) --reset -p yes
+	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) $(QEMUFLAGS)
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
 	docker buildx build \

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -29,8 +29,9 @@ BASE_REGISTRY?=registry.k8s.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)
 
 # Build args
-QEMUVERSION=7.2.0-1
+QEMUVERSION ?= 7.2.0-1
 QEMUIMAGE ?= multiarch/qemu-user-static
+QEMUFLAGS ?= --reset -p yes
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
@@ -40,7 +41,7 @@ build:
 	umask 0022
 
 	# Enable execution of multi-architecture containers
-	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) --reset -p yes
+	docker run --rm --privileged $(QEMUIMAGE):$(QEMUVERSION) $(QEMUFLAGS)
 	docker buildx version
 	BUILDER=$(shell docker buildx create --use)
 	docker buildx build \

--- a/images/build/setcap/Makefile
+++ b/images/build/setcap/Makefile
@@ -23,7 +23,7 @@ CONFIG ?= bookworm
 DEBIAN_BASE_VERSION ?= bookworm-v1.0.7
 
 ARCH?=amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 
 BASE_REGISTRY?=registry.k8s.io/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):$(DEBIAN_BASE_VERSION)


### PR DESCRIPTION
Allow customizing QEMUVERSION and QEMUFLAGS without modifying Makefiles, so that users can use different QEMU configurations for cross-arch builds.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

https://github.com/kubernetes/release/issues/4417

#### What this PR does / why we need it:

Makes QEMU version, flags, and ALL_ARCH configurable via environment variables in three image build Makefiles:

- Changes `QEMUVERSION` from `=` to `?=` so it can be overridden
- Extracts hardcoded `--reset -p yes` flags into a new `QEMUFLAGS` variable with `?=` assignment
- Replaces the inline flags in `docker run` with `$(QEMUFLAGS)`
- Changes `ALL_ARCH` from `=` to `?=` so target architectures can be overridden

This allows downstream users and CI pipelines to customize QEMU behavior and target architectures without patching the Makefiles.

**Files changed:**
- `images/build/debian-base/Makefile`
- `images/build/distroless-iptables/Makefile`
- `images/build/setcap/Makefile`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The changes are identical across all three files — extracting hardcoded values into conditionally-assignable variables (`?=`). The default behavior is unchanged.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

