### PR TITLE
Exclude .git directories from staged source tarball

### DIFF
--- a/pkg/build/push.go
+++ b/pkg/build/push.go
@@ -525,13 +525,15 @@ func (bi *Instance) StageLocalSourceTree(workDir, buildVersion string) error {
 	tarballPath := filepath.Join(workDir, release.SourcesTar)
 	logrus.Infof("Creating source tree tarball %s", tarballPath)
 
-	exclude, err := regexp.Compile(fmt.Sprintf(`.*/%s-.*`, release.BuildDir))
+	excludeBuildDir, err := regexp.Compile(fmt.Sprintf(`.*/%s-.*`, release.BuildDir))
 	if err != nil {
 		return fmt.Errorf("compile tarball exclude regex: %w", err)
 	}
 
+	excludeGit := regexp.MustCompile(`(^|/)\.git(/|$)`)
+
 	if err := tar.Compress(
-		tarballPath, filepath.Join(workDir, "src"), exclude,
+		tarballPath, filepath.Join(workDir, "src"), excludeBuildDir, excludeGit,
 	); err != nil {
 		return fmt.Errorf("create tarball: %w", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`StageLocalSourceTree` archives `/workspace/src` into `src.tar.gz` but only excludes build output directories. The `.git` directory and its contents should not be included in the source archive. Adds a second exclusion regex to filter out `.git` directories from the source tarball.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```