### PR TITLE
Update k8s-cloud-builder and k8s-ci-builder to Go 1.26.4/1.25.11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -257,26 +257,32 @@ dependencies:
 
   # kube-cross dependents (i.e. k8s-cloud-builder)
   # To be updated after kubernetes/kubernetes update)
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.37-cross1.26)"
+    version: v1.37.0-go1.26.4-bullseye.0
+    refPaths:
+      - path: images/k8s-cloud-builder/variants.yaml
+        match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.36-cross1.26)"
-    version: v1.36.0-go1.26.2-bullseye.0
+    version: v1.36.0-go1.26.4-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.35-cross1.25)"
-    version: v1.35.0-go1.25.9-bullseye.0
+    version: v1.35.0-go1.25.11-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.25)"
-    version: v1.34.0-go1.25.9-bullseye.0
+    version: v1.34.0-go1.25.11-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.33-cross1.25)"
-    version: v1.33.0-go1.25.9-bullseye.0
+    version: v1.33.0-go1.25.11-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -290,57 +296,70 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.26.2
+    version: 1.26.4
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
+  # Golang (previous release branch: 1.36)
+  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.36)"
+    version: 1.26.4
+    refPaths:
+      - path: images/releng/k8s-ci-builder/variants.yaml
+        match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
+
   # Golang (previous release branch: 1.35)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.35)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.34)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.34)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.33)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.33)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.26.2
+    version: 1.26.4
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
+  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.36)"
+    version: 1.26.4
+    refPaths:
+      - path: images/releng/k8s-ci-builder/variants.yaml
+        match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
+
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.35)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.34)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.33)"
-    version: 1.25.9
+    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/Dockerfile
+++ b/images/k8s-cloud-builder/Dockerfile
@@ -71,11 +71,24 @@ RUN pip3 install --no-cache-dir \
 ARG GOOGLE_DIR='/opt/google'
 
 # Install gcloud
-RUN bash -c \
-      'bash <(curl -sSL https://sdk.cloud.google.com) \
-        --install-dir="${GOOGLE_DIR}" \
-        --disable-prompts \
-        >/dev/null'
+#
+# Pin to the last release that still supports Python 3.9. The kube-cross base
+# image is Debian bullseye (Python 3.9), but gcloud CLI >= 554.0.0 requires
+# Python 3.10+ and fails to install on 3.9 with:
+#   TypeError: unsupported operand type(s) for |: 'type' and 'type'
+# TODO: migrate the kube-cross base image to bookworm (Python 3.11) or trixie,
+# then drop this pin and install the latest gcloud SDK again.
+ARG CLOUD_SDK_VERSION=553.0.0
+RUN mkdir -p "${GOOGLE_DIR}" \
+    && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
+      | tar -xz -C "${GOOGLE_DIR}" \
+    && "${GOOGLE_DIR}/google-cloud-sdk/install.sh" \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false \
+        --quiet \
+        >/dev/null
 
 ENV PATH="${GOOGLE_DIR}/google-cloud-sdk/bin:${PATH}"
 

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,13 +1,16 @@
 variants:
+  v1.37-cross1.26-bullseye:
+    CONFIG: 'cross1.26'
+    KUBE_CROSS_VERSION: 'v1.37.0-go1.26.4-bullseye.0'
   v1.36-cross1.26-bullseye:
     CONFIG: 'cross1.26'
-    KUBE_CROSS_VERSION: 'v1.36.0-go1.26.2-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.36.0-go1.26.4-bullseye.0'
   v1.35-cross1.25-bullseye:
     CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.35.0-go1.25.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.35.0-go1.25.11-bullseye.0'
   v1.34-cross1.25-bullseye:
     CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.34.0-go1.25.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.34.0-go1.25.11-bullseye.0'
   v1.33-cross1.25-bullseye:
     CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.33.0-go1.25.9-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.33.0-go1.25.11-bullseye.0'

--- a/images/releng/k8s-ci-builder/Dockerfile
+++ b/images/releng/k8s-ci-builder/Dockerfile
@@ -108,7 +108,12 @@ RUN echo "Installing Packages ..." \
         && rm "${GO_TARBALL}"\
         && mkdir -p "${GOPATH}/bin" \
     && echo "Installing gcloud SDK, kubectl ..." \
-        && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz --output google-cloud-sdk.tar.gz \
+        `# Pin to the last gcloud release supporting Python 3.9: the bullseye` \
+        `# base ships Python 3.9, but gcloud CLI >= 554.0.0 requires 3.10+ and` \
+        `# fails with "TypeError: unsupported operand type(s) for |".` \
+        `# TODO: migrate the base image to bookworm/trixie, then drop this pin.` \
+        && CLOUD_SDK_VERSION=553.0.0 \
+        && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" --output google-cloud-sdk.tar.gz \
         && tar xzf google-cloud-sdk.tar.gz -C / \
         && rm google-cloud-sdk.tar.gz \
         && /google-cloud-sdk/install.sh \

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.26.2
-GO_VERSION_TOOLING ?= 1.26.2
+GO_VERSION ?= 1.26.4
+GO_VERSION_TOOLING ?= 1.26.4
 OS_CODENAME ?= bookworm
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,31 +1,36 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.26.2'
-    GO_VERSION_TOOLING: '1.26.2'
+    GO_VERSION: '1.26.4'
+    GO_VERSION_TOOLING: '1.26.4'
     OS_CODENAME: 'bookworm'
   next:
     CONFIG: next
-    GO_VERSION: '1.26.2'
-    GO_VERSION_TOOLING: '1.26.2'
+    GO_VERSION: '1.26.4'
+    GO_VERSION_TOOLING: '1.26.4'
+    OS_CODENAME: 'bookworm'
+  '1.37':
+    CONFIG: '1.36'
+    GO_VERSION: '1.26.4'
+    GO_VERSION_TOOLING: '1.26.4'
     OS_CODENAME: 'bookworm'
   '1.36':
     CONFIG: '1.36'
-    GO_VERSION: '1.26.2'
-    GO_VERSION_TOOLING: '1.26.2'
+    GO_VERSION: '1.26.4'
+    GO_VERSION_TOOLING: '1.26.4'
     OS_CODENAME: 'bookworm'
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: '1.25.9'
-    GO_VERSION_TOOLING: '1.25.9'
+    GO_VERSION: '1.25.11'
+    GO_VERSION_TOOLING: '1.25.11'
     OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: '1.25.9'
-    GO_VERSION_TOOLING: '1.25.9'
+    GO_VERSION: '1.25.11'
+    GO_VERSION_TOOLING: '1.25.11'
     OS_CODENAME: 'bookworm'
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: '1.25.9'
-    GO_VERSION_TOOLING: '1.25.9'
+    GO_VERSION: '1.25.11'
+    GO_VERSION_TOOLING: '1.25.11'
     OS_CODENAME: 'bookworm'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update k8s-cloud-builder and k8s-ci-builder to Go 1.26.4/1.25.11

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/4421

#### Does this PR introduce a user-facing change?
```release-note
- Update k8s-cloud-builder and k8s-ci-builder to Go 1.26.4/1.25.11
```

/assign @Verolop @palnabarun @saschagrunert  
cc @kubernetes/release-engineering 