### PR TITLE
Make TagRepository step idempotent for safe krel stage re-runs

### DIFF
--- a/pkg/anago/stage.go
+++ b/pkg/anago/stage.go
@@ -432,17 +432,45 @@ func (d *DefaultStage) TagRepository() error {
 	for _, version := range d.state.versions.Ordered() {
 		logrus.Infof("Preparing version %s", version)
 
-		// Ensure that the tag not already exists
-		if _, err := d.impl.RevParseTag(repo, version); err == nil {
-			return fmt.Errorf("tag %s already exists", version)
-		}
-
 		// Usually the build version contains a commit we can reference. If
 		// not, because the build version is exactly a tag, then we fallback to
 		// that tag.
 		commit := d.options.BuildVersion
 		if len(d.state.semverBuildVersion.Build) > 0 {
 			commit = d.state.semverBuildVersion.Build[0]
+		}
+
+		// If the tag already exists from a previous (partial) run, verify it
+		// points to the expected commit and skip re-tagging. On release
+		// branches the tag sits on an empty release commit whose parent is the
+		// build version commit, so accept that case as well.
+		if existingTagCommit, err := d.impl.RevParseTag(repo, version); err == nil {
+			expectedCommitSHA, err := d.impl.RevParse(repo, commit)
+			if err != nil {
+				return fmt.Errorf("resolve expected commit %s: %w", commit, err)
+			}
+
+			if existingTagCommit == expectedCommitSHA {
+				logrus.Infof("Tag %s already points to correct commit %s, skipping tag creation", version, expectedCommitSHA)
+
+				continue
+			}
+
+			// On release branches the tag is created on an empty release
+			// commit whose first parent is the build commit, so accept that
+			// too. On the default branch the tag must point exactly at the
+			// build commit, so this exception is gated to release branches.
+			taggedOnReleaseBranch := strings.HasPrefix(d.options.ReleaseBranch, "release-") &&
+				(!d.state.createReleaseBranch || version == d.state.versions.Prime())
+			if taggedOnReleaseBranch {
+				if parentCommit, perr := d.impl.RevParse(repo, version+"^"); perr == nil && parentCommit == expectedCommitSHA {
+					logrus.Infof("Tag %s already points to a release commit on top of %s, skipping tag creation", version, expectedCommitSHA)
+
+					continue
+				}
+			}
+
+			return fmt.Errorf("tag %s already exists but points to commit %s, expected %s", version, existingTagCommit, expectedCommitSHA)
 		}
 
 		if d.state.createReleaseBranch {
@@ -455,10 +483,15 @@ func (d *DefaultStage) TagRepository() error {
 					d.options.ReleaseBranch, commit,
 				)
 
+				// Use -B so a re-run resets the branch to the build commit
+				// instead of failing if it already exists from a previous
+				// partial run. This also guarantees HEAD is at the build
+				// commit, so the empty release commit below is not stacked on
+				// top of a stale one.
 				if err := d.impl.Checkout(
-					repo, "-b", d.options.ReleaseBranch, commit,
+					repo, "-B", d.options.ReleaseBranch, commit,
 				); err != nil {
-					return fmt.Errorf("create new release branch: %w", err)
+					return fmt.Errorf("create release branch: %w", err)
 				}
 			} else {
 				logrus.Infof(

--- a/pkg/anago/stage_test.go
+++ b/pkg/anago/stage_test.go
@@ -289,9 +289,10 @@ func TestTagRepository(t *testing.T) {
 			createReleaseBranch: true,
 			shouldError:         true,
 		},
-		{ // failure on RevParse new rc creating release branch
+		{ // tag exists but resolving the expected commit fails, new rc creating release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseTagReturns("", nil)
+				mock.RevParseTagReturns("existingcommit123", nil) // Tag exists
+				mock.RevParseReturns("", err)                     // But RevParse fails to resolve expected commit
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -326,9 +327,10 @@ func TestTagRepository(t *testing.T) {
 			createReleaseBranch: true,
 			shouldError:         true,
 		},
-		{ // failure on RevParse new rc checking out release branch
+		{ // tag exists but resolving the expected commit fails, new rc checking out release branch
 			prepare: func(mock *anagofakes.FakeStageImpl) {
-				mock.RevParseTagReturns("", nil)
+				mock.RevParseTagReturns("existingcommit456", nil) // Tag exists
+				mock.RevParseReturns("", err)                     // But RevParse fails to resolve expected commit
 			},
 			versions:            newRCVersions,
 			releaseBranch:       "release-1.20",
@@ -369,6 +371,17 @@ func TestTagRepository(t *testing.T) {
 			versions:      newBetaVersions,
 			releaseBranch: git.DefaultBranch,
 			shouldError:   true,
+		},
+		{ // idempotent: single tag exists and points to correct commit, should skip
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				// Tag exists and returns a commit SHA
+				mock.RevParseTagReturns("1234567890abcdef", nil)
+				// RevParse resolves the expected commit to the same SHA
+				mock.RevParseReturns("1234567890abcdef", nil)
+			},
+			versions:      newBetaVersions, // Only has one version: v1.20.0-beta.1
+			releaseBranch: git.DefaultBranch,
+			shouldError:   false,
 		},
 	} {
 		opts := anago.DefaultStageOptions()
@@ -709,6 +722,103 @@ func TestGenerateBillOfMaterials(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+	}
+}
+
+func TestTagRepositoryIdempotent(t *testing.T) {
+	// Test with single version to isolate the issue
+	singleVersions := release.NewReleaseVersions(
+		"v1.20.0-beta.1", "", "", "v1.20.0-beta.1", "",
+	)
+	rcReleaseBranchVersions := release.NewReleaseVersions(
+		"v1.20.0-rc.0", "", "v1.20.0-rc.0", "", "",
+	)
+
+	for _, tc := range []struct {
+		name                string
+		prepare             func(*anagofakes.FakeStageImpl)
+		versions            *release.Versions
+		releaseBranch       string
+		createReleaseBranch bool
+		shouldError         bool
+	}{
+		{
+			name: "tag exists and points to correct commit - should skip",
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.RevParseTagReturns("1234567890abcdef", nil)
+				mock.RevParseReturns("1234567890abcdef", nil)
+			},
+			versions:      singleVersions,
+			releaseBranch: git.DefaultBranch,
+			shouldError:   false,
+		},
+		{
+			name: "tag exists but points to wrong commit - should error",
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.RevParseTagReturns("wrongcommit1234567890abcdef", nil)
+				mock.RevParseReturns("1234567890abcdef", nil)
+			},
+			versions:      singleVersions,
+			releaseBranch: git.DefaultBranch,
+			shouldError:   true,
+		},
+		{
+			name: "tag exists but RevParse fails - should error",
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.RevParseTagReturns("1234567890abcdef", nil)
+				mock.RevParseReturns("", err)
+			},
+			versions:      singleVersions,
+			releaseBranch: git.DefaultBranch,
+			shouldError:   true,
+		},
+		{
+			name: "release branch tag on empty commit above build commit - should skip",
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.RevParseTagReturns("emptyReleaseCommit", nil) // tag on empty release commit
+				mock.RevParseReturns("buildVersionCommit", nil)    // expected and tag parent both = build commit
+			},
+			versions:            rcReleaseBranchVersions,
+			releaseBranch:       "release-1.20",
+			createReleaseBranch: true,
+			shouldError:         false,
+		},
+		{
+			name: "default branch tag points to child of build commit - should error",
+			prepare: func(mock *anagofakes.FakeStageImpl) {
+				mock.RevParseTagReturns("childOfBuildCommit", nil)
+				mock.RevParseReturns("buildVersionCommit", nil) // parent would match, but not a release branch
+			},
+			versions:      singleVersions,
+			releaseBranch: git.DefaultBranch,
+			shouldError:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := anago.DefaultStageOptions()
+			opts.BuildVersion = "v1.20.0-beta.1.358+4628c605aadb9b"
+			opts.ReleaseBranch = tc.releaseBranch
+			state := anago.DefaultState()
+			err := opts.Validate(state)
+			require.NoError(t, err)
+
+			sut := anago.NewDefaultStage(opts)
+
+			state.SetVersions(tc.versions)
+			state.SetCreateReleaseBranch(tc.createReleaseBranch)
+			sut.SetState(&anago.StageState{state})
+
+			mock := &anagofakes.FakeStageImpl{}
+			tc.prepare(mock)
+			sut.SetImpl(mock)
+
+			err = sut.TagRepository()
+			if tc.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The TagRepository step in `krel stage` previously
failed with "tag already exists" errors when re-run after failures, making it impossible to recover from partial staging runs. This change makes the step
idempotent while preserving safety checks.

Changes:
- Check if existing tags point to correct commits (skip if correct, error if wrong)
- Make branch creation idempotent (use existing branch if available)
- Add test coverage for idempotent behavior
- Fix existing test mocks affected by the new logic

This allows `krel stage` to be safely re-run after failures without manual cleanup, improving the developer experience and reducing manual intervention in CI/staging workflows.

#### Which issue(s) this PR fixes:

krel stage cannot be safely re-run after failures, causing operational friction in release workflows.

When krel stage fails partway through (e.g., during Build, Changelog, or StageArtifacts steps), attempting to re-run it will result in an error.

This forces manual cleanup of git tags before retry attempts, slowing down release processes and requiring manual intervention in CI/staging pipelines.

#### Special notes for your reviewer:

Reason is that the TagRepository step fails immediately when trying to create tags that already exist, even if they point to the correct commits from the previous run.

#### Does this PR introduce a user-facing change?

```release-note
Make TagRepository step idempotent for safe krel stage re-runs
```
