### PR TITLE
Add kube-cross go1.26 variants for release-1.34 and release-1.35

### DIFF
--- a/images/build/cross/variants.yaml
+++ b/images/build/cross/variants.yaml
@@ -17,6 +17,15 @@ variants:
     GO_MAJOR_VERSION: '1.26'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
+  v1.35-go1.26-bullseye:
+    CONFIG: 'go1.26-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.35.0-go1.26.5-bullseye.0'
+    KUBERNETES_VERSION: 'v1.35.0'
+    GO_VERSION: '1.26.5'
+    GO_MAJOR_VERSION: '1.26'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
   v1.35-go1.25-bullseye:
     CONFIG: 'go1.25-bullseye'
     TYPE: 'default'
@@ -24,6 +33,15 @@ variants:
     KUBERNETES_VERSION: 'v1.35.0'
     GO_VERSION: '1.25.12'
     GO_MAJOR_VERSION: '1.25'
+    OS_CODENAME: 'bullseye'
+    REVISION: '0'
+  v1.34-go1.26-bullseye:
+    CONFIG: 'go1.26-bullseye'
+    TYPE: 'default'
+    IMAGE_VERSION: 'v1.34.0-go1.26.5-bullseye.0'
+    KUBERNETES_VERSION: 'v1.34.0'
+    GO_VERSION: '1.26.5'
+    GO_MAJOR_VERSION: '1.26'
     OS_CODENAME: 'bullseye'
     REVISION: '0'
   v1.34-go1.25-bullseye:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Add go1.26 variants to build kube cross images for the release branches

ref: https://github.com/kubernetes/release/issues/4266

/cc @dims @liggitt  @BenTheElder

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
