### PR TITLE
Bump distroless-iptables to v0.9.4/v0.8.12

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -422,7 +422,7 @@ dependencies:
         match: "DEBIAN_BASE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.26)"
-    version: v0.9.3
+    version: v0.9.4
     refPaths:
       - path: images/build/distroless-iptables/Makefile
         match: IMAGE_VERSION\ \?=\ v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -436,7 +436,7 @@ dependencies:
         match: GORUNNER_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'
 
   - name: "registry.k8s.io/build-image/distroless-iptables (distroless-bookworm-go1.25)"
-    version: v0.8.11
+    version: v0.8.12
     refPaths:
       - path: images/build/distroless-iptables/variants.yaml
         match: IMAGE_VERSION:\ \'v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\'

--- a/images/build/distroless-iptables/Makefile
+++ b/images/build/distroless-iptables/Makefile
@@ -18,7 +18,7 @@ REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/distroless-iptables
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= v0.9.3
+IMAGE_VERSION ?= v0.9.4
 CONFIG ?= distroless-bookworm
 BASEIMAGE ?= debian:bookworm-slim
 GORUNNER_VERSION ?= v2.4.0-go1.26.4-bookworm.0

--- a/images/build/distroless-iptables/variants.yaml
+++ b/images/build/distroless-iptables/variants.yaml
@@ -1,11 +1,11 @@
 variants:
   distroless-bookworm-go1.26:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.9.3'
+    IMAGE_VERSION: 'v0.9.4'
     BASEIMAGE: 'debian:bookworm-slim'
     GORUNNER_VERSION: 'v2.4.0-go1.26.4-bookworm.0'
   distroless-bookworm-go1.25:
     CONFIG: 'distroless-bookworm'
-    IMAGE_VERSION: 'v0.8.11'
+    IMAGE_VERSION: 'v0.8.12'
     BASEIMAGE: 'debian:bookworm-slim'
     GORUNNER_VERSION: 'v2.4.0-go1.25.11-bookworm.0'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bumps the distroless-iptables image versions (go1.26: v0.9.3 -> v0.9.4, go1.25: v0.8.11 -> v0.8.12) after the patched nftables binaries change in #4419.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```