### PR TITLE
schedule-builder: don't skip adding to EOL if next release is not set

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -243,12 +243,6 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 
 	for i, sched := range schedule.Schedules {
 		for {
-			if sched.Next == nil {
-				logrus.Warnf("Next release not set for %s, skipping", sched.Release)
-
-				break
-			}
-
 			eolDate, err := time.Parse(refDate, sched.EndOfLifeDate)
 			if err != nil {
 				return fmt.Errorf("parse end of life date: %w", err)
@@ -261,14 +255,31 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 					break
 				}
 
+				// Get latest previous release to use as final patch release if next release is not available
+				if sched.Next == nil {
+					if len(sched.PreviousPatches) == 0 {
+						logrus.Warnf("No next and previous patches found for %s, skipping adding to EOL", sched.Release)
+
+						break
+					}
+
+					sched.Next = sched.PreviousPatches[0]
+				}
+
 				logrus.Infof("Moving %s to end of life", sched.Release)
 				eolBranches.Branches = append([]*EolBranch{{
 					Release:           sched.Release,
 					FinalPatchRelease: sched.Next.Release,
-					EndOfLifeDate:     sched.Next.TargetDate,
+					EndOfLifeDate:     sched.EndOfLifeDate,
 				}}, eolBranches.Branches...)
 
 				removeSchedules = append(removeSchedules, i)
+
+				break
+			}
+
+			if sched.Next == nil {
+				logrus.Warnf("Next release not set for %s, skipping", sched.Release)
 
 				break
 			}

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -368,7 +368,33 @@ func TestUpdatePatchSchedule(t *testing.T) {
 						MaintenanceModeStartDate: "2024-12-01",
 					},
 					{ // next not set
-						Release: "1.29",
+						Release:       "1.29",
+						EndOfLifeDate: "2025-02-28",
+					},
+					{ // next and previous not set & EOL
+						Release:       "1.17",
+						EndOfLifeDate: "2021-01-13",
+					},
+					{ // next not set & EOL
+						Release:       "1.23",
+						EndOfLifeDate: "2023-02-28",
+						PreviousPatches: []*PatchRelease{
+							{
+								Release:            "1.23.17",
+								CherryPickDeadline: "2023-02-10",
+								TargetDate:         "2023-02-15",
+							},
+							{
+								Release:            "1.23.16",
+								CherryPickDeadline: "2023-01-13",
+								TargetDate:         "2023-01-18",
+							},
+							{
+								Release:            "1.23.15",
+								CherryPickDeadline: "2022-12-02",
+								TargetDate:         "2022-12-08",
+							},
+						},
 					},
 					{ // EOL
 						Release:       "1.20",
@@ -425,7 +451,12 @@ func TestUpdatePatchSchedule(t *testing.T) {
 						},
 					},
 					{
-						Release: "1.29",
+						Release:       "1.29",
+						EndOfLifeDate: "2025-02-28",
+					},
+					{
+						Release:       "1.17",
+						EndOfLifeDate: "2021-01-13",
 					},
 				},
 				UpcomingReleases: []*PatchRelease{
@@ -448,7 +479,12 @@ func TestUpdatePatchSchedule(t *testing.T) {
 					{
 						Release:           "1.20",
 						FinalPatchRelease: "1.20.10",
-						EndOfLifeDate:     "2023-12-12",
+						EndOfLifeDate:     "2023-01-01",
+					},
+					{
+						Release:           "1.23",
+						FinalPatchRelease: "1.23.17",
+						EndOfLifeDate:     "2023-02-28",
 					},
 				},
 			},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the next release is not available, look for the latest previous patch available. Only skip if both are not available. The previous skip that was added to prevent a panic when the next release is not set still occurs after the EOL check. Also change EOL date value to use EndOfLifeDate instead of TargetDate.

#### Which issue(s) this PR fixes:

Fixes #4450

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `schedule-builder` skipping the addition of releases to `eol.yaml` when the `next` field is not set in `schedule.yaml`.
```
