### PR TITLE
Update go for k8s-cloud-builder and k8s-ci-builder to Go 1.26.5/1.25.12 and drop k8s 1.33 variants

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -281,12 +281,6 @@ dependencies:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.33-cross1.25)"
-    version: v1.33.0-go1.25.11-bullseye.0
-    refPaths:
-      - path: images/k8s-cloud-builder/variants.yaml
-        match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
-
   # protobuf
   - name: "registry.k8s.io/build-image/kube-cross: protobuf version"
     version: 23.4
@@ -324,13 +318,6 @@ dependencies:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
-  # Golang (previous release branch: 1.33)
-  - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.33)"
-    version: 1.25.11
-    refPaths:
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
-
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
     version: 1.26.5
@@ -354,12 +341,6 @@ dependencies:
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.34)"
     version: 1.25.12
-    refPaths:
-      - path: images/releng/k8s-ci-builder/variants.yaml
-        match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
-
-  - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.33)"
-    version: 1.25.11
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -258,25 +258,25 @@ dependencies:
   # kube-cross dependents (i.e. k8s-cloud-builder)
   # To be updated after kubernetes/kubernetes update)
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.37-cross1.26)"
-    version: v1.37.0-go1.26.4-bullseye.0
+    version: v1.37.0-go1.26.5-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.36-cross1.26)"
-    version: v1.36.0-go1.26.4-bullseye.0
+    version: v1.36.0-go1.26.5-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.35-cross1.25)"
-    version: v1.35.0-go1.25.11-bullseye.0
+    version: v1.35.0-go1.25.12-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.25)"
-    version: v1.34.0-go1.25.11-bullseye.0
+    version: v1.34.0-go1.25.12-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -296,7 +296,7 @@ dependencies:
 
   # Golang (current release branch: master)
   - name: "golang: after kubernetes/kubernetes update (master)"
-    version: 1.26.4
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -305,21 +305,21 @@ dependencies:
 
   # Golang (previous release branch: 1.36)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.36)"
-    version: 1.26.4
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.35)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.35)"
-    version: 1.25.11
+    version: 1.25.12
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.34)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.34)"
-    version: 1.25.11
+    version: 1.25.12
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -333,7 +333,7 @@ dependencies:
 
   # k8s-ci-builder
   - name: "golang: releng tooling for k8s-ci-builder (master)"
-    version: 1.26.4
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/Makefile
         match: GO_VERSION_TOOLING\ \?=\ \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -341,19 +341,19 @@ dependencies:
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.36)"
-    version: 1.26.4
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.35)"
-    version: 1.25.11
+    version: 1.25.12
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.34)"
-    version: 1.25.11
+    version: 1.25.12
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -11,6 +11,3 @@ variants:
   v1.34-cross1.25-bullseye:
     CONFIG: 'cross1.25'
     KUBE_CROSS_VERSION: 'v1.34.0-go1.25.12-bullseye.0'
-  v1.33-cross1.25-bullseye:
-    CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.33.0-go1.25.11-bullseye.0'

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -1,16 +1,16 @@
 variants:
   v1.37-cross1.26-bullseye:
     CONFIG: 'cross1.26'
-    KUBE_CROSS_VERSION: 'v1.37.0-go1.26.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.37.0-go1.26.5-bullseye.0'
   v1.36-cross1.26-bullseye:
     CONFIG: 'cross1.26'
-    KUBE_CROSS_VERSION: 'v1.36.0-go1.26.4-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.36.0-go1.26.5-bullseye.0'
   v1.35-cross1.25-bullseye:
     CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.35.0-go1.25.11-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.35.0-go1.25.12-bullseye.0'
   v1.34-cross1.25-bullseye:
     CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.34.0-go1.25.11-bullseye.0'
+    KUBE_CROSS_VERSION: 'v1.34.0-go1.25.12-bullseye.0'
   v1.33-cross1.25-bullseye:
     CONFIG: 'cross1.25'
     KUBE_CROSS_VERSION: 'v1.33.0-go1.25.11-bullseye.0'

--- a/images/releng/k8s-ci-builder/Makefile
+++ b/images/releng/k8s-ci-builder/Makefile
@@ -24,8 +24,8 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 TAG ?= $(shell git describe --tags --always --dirty)
 
 # Build args
-GO_VERSION ?= 1.26.4
-GO_VERSION_TOOLING ?= 1.26.4
+GO_VERSION ?= 1.26.5
+GO_VERSION_TOOLING ?= 1.26.5
 OS_CODENAME ?= bookworm
 IMAGE_ARG ?= $(IMAGE):$(TAG)-$(CONFIG)
 

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -29,8 +29,3 @@ variants:
     GO_VERSION: '1.25.12'
     GO_VERSION_TOOLING: '1.25.12'
     OS_CODENAME: 'bookworm'
-  '1.33':
-    CONFIG: '1.33'
-    GO_VERSION: '1.25.11'
-    GO_VERSION_TOOLING: '1.25.11'
-    OS_CODENAME: 'bookworm'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -1,33 +1,33 @@
 variants:
   default:
     CONFIG: default
-    GO_VERSION: '1.26.4'
-    GO_VERSION_TOOLING: '1.26.4'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'
   next:
     CONFIG: next
-    GO_VERSION: '1.26.4'
-    GO_VERSION_TOOLING: '1.26.4'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'
   '1.37':
     CONFIG: '1.36'
-    GO_VERSION: '1.26.4'
-    GO_VERSION_TOOLING: '1.26.4'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'
   '1.36':
     CONFIG: '1.36'
-    GO_VERSION: '1.26.4'
-    GO_VERSION_TOOLING: '1.26.4'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: '1.25.11'
-    GO_VERSION_TOOLING: '1.25.11'
+    GO_VERSION: '1.25.12'
+    GO_VERSION_TOOLING: '1.25.12'
     OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: '1.25.11'
-    GO_VERSION_TOOLING: '1.25.11'
+    GO_VERSION: '1.25.12'
+    GO_VERSION_TOOLING: '1.25.12'
     OS_CODENAME: 'bookworm'
   '1.33':
     CONFIG: '1.33'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- Update k8s-cloud-builder and k8s-ci-builder to Go 1.25.5/1.24.12
- Drop k8s-cloud-builder and k8s-ci-builder variant for k8s 1.33

#### Which issue(s) this PR fixes:

Part of #4449

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
- Update k8s-cloud-builder and k8s-ci-builder to Go 1.25.5/1.24.12
- Drop k8s-cloud-builder and k8s-ci-builder variant for k8s 1.33
```
