### PR TITLE
Skip mapped release-note-none notes

### DIFF
--- a/docs/release-notes-maps.md
+++ b/docs/release-notes-maps.md
@@ -35,7 +35,7 @@ Pull Request. The second part provides a mechanism for adding more data
 to a release note to provide more context or additional
 information to a release note.
 
-### Overriding Fields: the `release-note` section
+### Overriding Fields: the `releasenote` section
 
 The first part of the YAML in a map file overrides the data defined in the release note pull request. Each of the fields corresponds to a PR data field. A map file
 can contain any of them. An example:
@@ -44,7 +44,7 @@ can contain any of them. An example:
 ---
 pr: 123
 commit: 1a89038915fe77d73bf7c9cfa8f2ce123a464c82
-release-note:  
+releasenote:
   text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
   author: kubernetes-ci-robot
   areas:
@@ -61,7 +61,10 @@ release-note:
       url: https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/1733-release-notes
       type: kep
 ```
-Any of the fields defined in a map file fully overrides its PR counterpart. 
+Any of the fields defined in a map file fully overrides its PR counterpart.
+A map that omits `do_not_publish` does not clear a PR-level
+`release-note-none` exclusion. To suppress a mapped note explicitly, set
+`releasenote.do_not_publish: true`.
 
 ### Adding data: The `datafields` section
 
@@ -125,4 +128,3 @@ with the provider by its schema (for example "gs://"). Then hack the
 `notes.NewProviderFromInitString` function to recognize it. Finally,
 add your file reading logic and implement the `GetMapsForPR()` hook to
 return the data when called.
-

--- a/pkg/notes/document/document.go
+++ b/pkg/notes/document/document.go
@@ -319,7 +319,7 @@ func New(
 			doc.CVEList = append(doc.CVEList, newcve)
 		}
 
-		if !note.IsMapped && note.DoNotPublish {
+		if note.DoNotPublish {
 			logrus.Debugf("Skipping PR %d as (marked to not be published)", pr)
 
 			continue

--- a/pkg/notes/document/document_test.go
+++ b/pkg/notes/document/document_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/release-utils/command"
 
@@ -459,6 +460,54 @@ func TestNew(t *testing.T) {
 						NoteEntries: &notes.Notes{"PR#1", "PR#2"},
 					},
 				},
+			},
+		},
+		{
+			"unmapped do not publish notes are skipped",
+			func() *notes.ReleaseNotes {
+				n := notes.NewReleaseNotes()
+				note := makeReleaseNote(notes.KindBug, "This note should not be published.")
+				note.DoNotPublish = true
+				n.Set(0, note)
+
+				return n
+			},
+			&Document{
+				NotesWithActionRequired: notes.Notes{},
+				Notes:                   NoteCollection{},
+			},
+		},
+		{
+			"mapped release-note-none notes are skipped",
+			func() *notes.ReleaseNotes {
+				n := notes.NewReleaseNotes()
+				note := makeReleaseNote(notes.KindBug, "Mapped note should not be published.")
+				note.DoNotPublish = true
+				require.NoError(t, note.ApplyMap(&notes.ReleaseNotesMap{}, false))
+				n.Set(0, note)
+
+				return n
+			},
+			&Document{
+				NotesWithActionRequired: notes.Notes{},
+				Notes:                   NoteCollection{},
+			},
+		},
+		{
+			"mapped do not publish notes are skipped",
+			func() *notes.ReleaseNotes {
+				n := notes.NewReleaseNotes()
+				note := makeReleaseNote(notes.KindBug, "Mapped note should not be published.")
+				noteMap := &notes.ReleaseNotesMap{}
+				require.NoError(t, yaml.Unmarshal([]byte("pr: 0\nreleasenote:\n  do_not_publish: true\n"), noteMap))
+				require.NoError(t, note.ApplyMap(noteMap, false))
+				n.Set(0, note)
+
+				return n
+			},
+			&Document{
+				NotesWithActionRequired: notes.Notes{},
+				Notes:                   NoteCollection{},
 			},
 		},
 	}

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -474,6 +474,67 @@ func TestApplyMap(t *testing.T) {
 	testApplyMapHelper(t, "maps/testdata/applymap-unit-test/", makeNewNote)
 }
 
+func TestApplyMapPreservesDoNotPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		note     func(t *testing.T) *ReleaseNote
+		expected bool
+	}{
+		{
+			name: "keeps normal release notes publishable",
+			note: func(t *testing.T) *ReleaseNote {
+				return &ReleaseNote{}
+			},
+			expected: false,
+		},
+		{
+			name: "keeps unmapped release notes marked not to publish",
+			note: func(t *testing.T) *ReleaseNote {
+				return &ReleaseNote{DoNotPublish: true}
+			},
+			expected: true,
+		},
+		{
+			name: "keeps release-note-none when a map overrides the note",
+			note: func(t *testing.T) *ReleaseNote {
+				note := &ReleaseNote{DoNotPublish: true}
+				require.NoError(t, note.ApplyMap(&ReleaseNotesMap{}, false))
+				return note
+			},
+			expected: true,
+		},
+		{
+			name: "keeps map-level suppression",
+			note: func(t *testing.T) *ReleaseNote {
+				doNotPublish := true
+				note := &ReleaseNote{}
+				noteMap := &ReleaseNotesMap{}
+				noteMap.ReleaseNote.DoNotPublish = &doNotPublish
+				require.NoError(t, note.ApplyMap(noteMap, false))
+				return note
+			},
+			expected: true,
+		},
+		{
+			name: "keeps map-level suppression when later maps omit do_not_publish",
+			note: func(t *testing.T) *ReleaseNote {
+				doNotPublish := true
+				note := &ReleaseNote{}
+				noteMap := &ReleaseNotesMap{}
+				noteMap.ReleaseNote.DoNotPublish = &doNotPublish
+				require.NoError(t, note.ApplyMap(noteMap, false))
+				require.NoError(t, note.ApplyMap(&ReleaseNotesMap{}, false))
+				return note
+			},
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.note(t).DoNotPublish)
+		})
+	}
+}
+
 func TestApplyMapNoSigs(t *testing.T) {
 	makeNewNote := func() *ReleaseNote {
 		return &ReleaseNote{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation

#### What this PR does / why we need it:

Fixes release note rendering so PRs marked `release-note-none` stay out of the generated document even when a release notes map exists for the PR. The document builder now skips any note marked `DoNotPublish`, regardless of whether it was mapped.

The tests cover unmapped `release-note-none` notes, mapped `release-note-none` notes, and mapped notes explicitly suppressed with `releasenote.do_not_publish: true`. The map documentation also clarifies that merely adding a map does not clear a PR-level `release-note-none` exclusion.

#### Which issue(s) this PR fixes:

Fixes #4456

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

## Testing

- `go test ./pkg/notes ./pkg/notes/document -run 'TestApplyMap|TestApplyMapPreservesDoNotPublish|TestNew' -count=1`
- `go test ./pkg/notes -count=1`
- `git diff --name-only origin/master...HEAD -- '*.go' | xargs gofmt -l`
- `git diff --check origin/master...HEAD`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/master..HEAD`
