### PR TITLE
release gcb-docker-gcloud as a releng image

### DIFF
--- a/images/releng/gcb-docker-gcloud/Dockerfile
+++ b/images/releng/gcb-docker-gcloud/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION=1
+# Includes bash, docker, and gcloud
+FROM golang:${GO_VERSION}-alpine
+# upstream go image sets GOTOOLCHAIN=local
+# this means that we won't auto-select the appropriate go for the project being
+# built, so we set it back to auto, which is the default if GOTOOLCHAIN is not set
+ENV GOTOOLCHAIN=auto
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ARG DOCKER_VERSION
+
+# Install gcloud, docker, and bash
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+WORKDIR /workspace
+
+RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories && \
+    apk --no-cache add curl python3 py-crcmod bash \
+    libc6-compat openssh-client git gnupg zip tar \
+    docker-cli-buildx \
+    docker-cli~=${DOCKER_VERSION} make
+
+RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz
+
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud components install alpha beta gke-gcloud-auth-plugin gsutil && \
+    gcloud --version && \
+    gcloud auth configure-docker gcr.io,us-central1-docker.pkg.dev && \
+    gcloud info > /workspace/gcloud-info.txt
+
+RUN echo ${IMAGE_ARG} > /workspace/image-reference.txt
+
+# Default home for cloudbuild jobs is /builder/home
+RUN mkdir -p /builder/home
+
+COPY ["runner.sh", \
+    "/usr/local/bin/"]
+
+ENTRYPOINT ["/usr/local/bin/runner.sh"]

--- a/images/releng/gcb-docker-gcloud/OWNERS
+++ b/images/releng/gcb-docker-gcloud/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - upodroid

--- a/images/releng/gcb-docker-gcloud/README.md
+++ b/images/releng/gcb-docker-gcloud/README.md
@@ -1,0 +1,15 @@
+# gcb-docker-gcloud image
+
+This image is available for Google Cloud Build jobs that want to use a
+combination of `docker`, `gcloud`, and `go` all in the same build step
+
+## contents
+
+- base:
+  - golang:1.26.5-alpine3.24
+- languages:
+  - `go`
+- tools:
+  - `docker`
+  - `docker-buildx` and `tonistiigi/binfmt` for multi-arch support
+  - `gcloud` via rapid channel, with default components

--- a/images/releng/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/releng/gcb-docker-gcloud/cloudbuild.yaml
@@ -1,0 +1,35 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+      - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+      - --build-arg=DOCKER_VERSION=$_DOCKER_VERSION
+      - --build-arg=GO_VERSION=$_GO_VERSION
+      - .
+    dir: images/releng/gcb-docker-gcloud
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - tag
+      - gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+      - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - gcr.io/$PROJECT_ID/gcb-docker-gcloud
+      - -a
+  - name: gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
+    args:
+      - docker
+      - run
+      - --platform
+      - linux/riscv64
+      - alpine
+      - uname
+      - -a
+substitutions:
+  _GIT_TAG: "12345"
+  _DOCKER_VERSION: "29"
+  _GO_VERSION: "1.26.5"
+tags:
+  - gcb-docker-gcloud

--- a/images/releng/gcb-docker-gcloud/runner.sh
+++ b/images/releng/gcb-docker-gcloud/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic runner script
+
+early_exit_handler() {
+    if [ -n "${WRAPPED_COMMAND_PID:-}" ]; then
+        kill -TERM "$WRAPPED_COMMAND_PID" || true
+    fi
+}
+
+trap early_exit_handler INT TERM
+
+set -o errexit
+
+# Handle initialising buildx multiarch
+if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
+    export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+fi
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
+
+docker buildx create \
+    --name multiarch-multiplatform-builder \
+    --driver docker-container \
+    --bootstrap --use
+
+# actually start bootstrap and the job
+set -o xtrace
+"$@" &
+WRAPPED_COMMAND_PID=$!
+set +o errexit
+wait $WRAPPED_COMMAND_PID
+EXIT_VALUE=$?
+set +o xtrace
+
+# preserve exit value from job / bootstrap
+exit ${EXIT_VALUE}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
I want to release https://github.com/kubernetes/test-infra/tree/master/images/gcb-docker-gcloud to registry.k8s.io. 

`gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de` will now be pulled as `registry.k8s.io/releng/gcb-docker-gcloud:v20260127`

In order to do this, I need to transfer the image to this repo and build it out of here. I'm also going to use this opportunity to make a breaking change and drop https://github.com/kubernetes/test-infra/blob/058c26adcd251f37a719a96b39a458660a14f974/images/gcb-docker-gcloud/buildx-entrypoint.sh this script and ask users to update their cloudbuild files like [this](https://github.com/kubernetes/test-infra/commit/43737a0e03d2de02a033db4a12f93c3c96accee4#diff-86307ea5910794d71368252dec2dbdbc2996c417a835b834b92c1804922e86d4).

The only guarantee this image makes is that go, gcloud, and docker always work with Google Cloud Build.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes https://github.com/kubernetes/k8s.io/issues/9599

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
