### PR TITLE
Add RISC-V build for the kube-cross image

### DIFF
--- a/images/build/cross/Makefile
+++ b/images/build/cross/Makefile
@@ -30,7 +30,7 @@ IMGNAME = kube-cross
 KUBERNETES_VERSION ?= v1.37.0
 GO_VERSION ?= 1.26.5
 GO_MAJOR_VERSION ?= 1.26
-OS_CODENAME ?= bullseye
+OS_CODENAME ?= trixie
 REVISION ?= 0
 TYPE ?= default
 
@@ -55,8 +55,8 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 #       not supported in specific architectures
 PLATFORMS ?= linux/amd64 linux/arm64 #linux/arm
 
-KUBE_DYNAMIC_CROSSPLATFORMS ?= "arm64 armhf i386 ppc64el s390x"
-KUBE_CROSSPLATFORMS ?= "linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x darwin/amd64 windows/amd64 windows/386"
+KUBE_DYNAMIC_CROSSPLATFORMS ?= "arm64 armhf i386 ppc64el s390x riscv64"
+KUBE_CROSSPLATFORMS ?= "linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x linux/riscv64 darwin/amd64 windows/amd64 windows/386"
 
 # for legacy images only build linux/amd64
 ifeq ($(TYPE), legacy)

--- a/images/build/cross/default/Dockerfile
+++ b/images/build/cross/default/Dockerfile
@@ -29,8 +29,8 @@ ENV GOARM 7
 
 # the default value for KUBE_DYNAMIC_CROSSPLATFORMS and KUBE_CROSSPLATFORMS is set for
 # backward compatibility with the old Dockerfile. 
-ARG KUBE_DYNAMIC_CROSSPLATFORMS="arm64 armhf i386 ppc64el s390x"
-ARG KUBE_CROSSPLATFORMS="linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x darwin/amd64 windows/amd64 windows/386"
+ARG KUBE_DYNAMIC_CROSSPLATFORMS="arm64 armhf i386 ppc64el s390x riscv64"
+ARG KUBE_CROSSPLATFORMS="linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x linux/riscv64 darwin/amd64 windows/amd64 windows/386"
 
 ENV KUBE_DYNAMIC_CROSSPLATFORMS=${KUBE_DYNAMIC_CROSSPLATFORMS}
 ENV KUBE_CROSSPLATFORMS=${KUBE_CROSSPLATFORMS}
@@ -79,7 +79,7 @@ RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
   && if [ ${targetArch} = "arm64" ]; then \
     apt-get update \
     && apt-get install -y build-essential gcc-x86-64-linux-gnu \
-    && apt-get install -y crossbuild-essential-ppc64el crossbuild-essential-s390x; \
+    && apt-get install -y crossbuild-essential-ppc64el crossbuild-essential-s390x crossbuild-essential-riscv64; \
 fi
 
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a RISC-V build to the kube-cross container image produced; no code changes.

We need it, as K3s supports building for `riscv64` (relevant discussions are [here](https://github.com/k3s-io/k3s/issues/7151) and [here](https://github.com/k3s-io/k3s/pull/7778)), but the pause image is incompatible with the architecture. The pause image is built using the kube-cross container (relevant PR [here](https://github.com/kubernetes/kubernetes/pull/141291)), which now lacks a cross-compiler for `riscv64`. This is a necessary step towards eventual RISC-V support in  Kubernetes.

#### Which issue(s) this PR fixes:

There is no open RISC-V issue in release, but there is an open discussion on [adding support for the RISC-V architecture in Kubernetes](https://github.com/kubernetes/kubernetes/issues/132836).

#### Special notes for your reviewer:

A cross-compiler for `riscv64` is available in Debian `trixie` onwards, so I have updated the base image to the latest Debian stable (all previous releases have passed their EOL and are currently in LTS anyway).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
