### PR TITLE
k8s-cloud/ci-builder: bump to Go 1.26.5 for 1.34 and 1.35

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -269,14 +269,14 @@ dependencies:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.35-cross1.25)"
-    version: v1.35.0-go1.25.12-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.35-cross1.26)"
+    version: v1.35.0-go1.26.5-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
-  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.25)"
-    version: v1.34.0-go1.25.12-bullseye.0
+  - name: "registry.k8s.io/build-image/kube-cross: dependents k8s-cloud-builder (v1.34-cross1.26)"
+    version: v1.34.0-go1.26.5-bullseye.0
     refPaths:
       - path: images/k8s-cloud-builder/variants.yaml
         match: "KUBE_CROSS_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
@@ -306,14 +306,14 @@ dependencies:
 
   # Golang (previous release branch: 1.35)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.35)"
-    version: 1.25.12
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
 
   # Golang (previous release branch: 1.34)
   - name: "golang: after kubernetes/kubernetes update (previous release branches: 1.34)"
-    version: 1.25.12
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: \d+.\d+(alpha|beta|rc)?\.?(\d+)?
@@ -334,13 +334,13 @@ dependencies:
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.35)"
-    version: 1.25.12
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: releng tooling for k8s-ci-builder (previous release branches: 1.34)"
-    version: 1.25.12
+    version: 1.26.5
     refPaths:
       - path: images/releng/k8s-ci-builder/variants.yaml
         match: "GO_VERSION_TOOLING: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"

--- a/images/k8s-cloud-builder/variants.yaml
+++ b/images/k8s-cloud-builder/variants.yaml
@@ -5,9 +5,9 @@ variants:
   v1.36-cross1.26-bullseye:
     CONFIG: 'cross1.26'
     KUBE_CROSS_VERSION: 'v1.36.0-go1.26.5-bullseye.0'
-  v1.35-cross1.25-bullseye:
-    CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.35.0-go1.25.12-bullseye.0'
-  v1.34-cross1.25-bullseye:
-    CONFIG: 'cross1.25'
-    KUBE_CROSS_VERSION: 'v1.34.0-go1.25.12-bullseye.0'
+  v1.35-cross1.26-bullseye:
+    CONFIG: 'cross1.26'
+    KUBE_CROSS_VERSION: 'v1.35.0-go1.26.5-bullseye.0'
+  v1.34-cross1.26-bullseye:
+    CONFIG: 'cross1.26'
+    KUBE_CROSS_VERSION: 'v1.34.0-go1.26.5-bullseye.0'

--- a/images/releng/k8s-ci-builder/variants.yaml
+++ b/images/releng/k8s-ci-builder/variants.yaml
@@ -21,11 +21,11 @@ variants:
     OS_CODENAME: 'bookworm'
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: '1.25.12'
-    GO_VERSION_TOOLING: '1.25.12'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: '1.25.12'
-    GO_VERSION_TOOLING: '1.25.12'
+    GO_VERSION: '1.26.5'
+    GO_VERSION_TOOLING: '1.26.5'
     OS_CODENAME: 'bookworm'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

Bump 1.34 and 1.35 variants of k8s-cloud-builder and k8s-ci-builder to Go 1.26.5

This should have been a part of the followup to https://github.com/kubernetes/release/issues/4266. Kubernetes patch builds for 1.34 and 1.35 are failing because the images were never created.

Failing jobs:
- https://console.cloud.google.com/cloud-build/builds;region=us-central1/927c24fc-7641-490a-94da-89b548dd852c;step=2?project=k8s-release
- https://console.cloud.google.com/cloud-build/builds;region=us-central1/56102cf2-8f05-43cb-9c8e-f010b40a1c4c?project=k8s-release

#### Which issue(s) this PR fixes:

Part of #4266 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Update k8s-cloud-builder and k8s-ci-builder for 1.34 and 1.35 to Go 1.26.5
```
