### PR TITLE
Add Debian Trixie support for debian-base

### DIFF
--- a/images/build/debian-base/cloudbuild.yaml
+++ b/images/build/debian-base/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 1500s
 
 options:
   substitutionOption: ALLOW_LOOSE

--- a/images/build/debian-base/trixie/Dockerfile
+++ b/images/build/debian-base/trixie/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/images/build/debian-base/trixie/Dockerfile.build
+++ b/images/build/debian-base/trixie/Dockerfile.build
@@ -1,0 +1,100 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+
+FROM $BASEIMAGE AS certs
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install ca-certificates and dependencies
+RUN apt-get update \
+    && apt-get install -y ca-certificates
+
+FROM $BASEIMAGE
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy only ca-certificates without any dependencies
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Smaller package install size.
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+# Convenience script for building on this base image.
+COPY clean-install /usr/local/bin/clean-install
+
+# An attempt to fix issues like:
+# ```
+# Error while loading /usr/sbin/dpkg-split: No such file or directory
+# Error while loading /usr/sbin/dpkg-deb: No such file or directory
+# ```
+# See: https://github.com/docker/buildx/issues/495
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    ln -s /bin/tar /usr/sbin/tar && \
+    ln -s /bin/rm /usr/sbin/rm
+
+# Update system packages.
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+# Remove unnecessary packages.
+RUN dpkg --purge --force-remove-essential \
+        bash \
+        e2fsprogs \
+        libss2 \
+        libcom-err2 \
+        libext2fs2 \
+        logsave \
+        ncurses-base \
+        ncurses-bin \
+        tzdata \
+    && apt-get autoremove --purge -y
+
+# No-op stubs replace some unnecessary binaries that may be depended on in the install process (in
+# particular we don't run an init process).
+WORKDIR /usr/local/bin
+RUN touch noop && \
+    chmod 555 noop && \
+    ln -s noop runlevel && \
+    ln -s noop invoke-rc.d && \
+    ln -s noop update-rc.d
+WORKDIR /
+
+# Cleanup cached and unnecessary files.
+RUN apt-get autoremove -y && \
+    apt-get clean -y && \
+    tar -czf /usr/share/copyrights.tar.gz /usr/share/common-licenses /usr/share/doc/*/copyright && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /usr/share/common-licenses* \
+        /usr/share/bash-completion \
+        ~/.bashrc \
+        ~/.profile \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    mkdir -p /usr/share/man/man1 /usr/share/man/man2 \
+        /usr/share/man/man3 /usr/share/man/man4 \
+        /usr/share/man/man5 /usr/share/man/man6 \
+        /usr/share/man/man7 /usr/share/man/man8

--- a/images/build/debian-base/trixie/Dockerfile.build
+++ b/images/build/debian-base/trixie/Dockerfile.build
@@ -56,7 +56,7 @@ RUN dpkg --purge --force-remove-essential \
         e2fsprogs \
         libss2 \
         libcom-err2 \
-        libext2fs2 \
+        libext2fs2t64 \
         logsave \
         ncurses-base \
         ncurses-bin \

--- a/images/build/debian-base/trixie/clean-install
+++ b/images/build/debian-base/trixie/clean-install
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/images/build/debian-base/trixie/excludes
+++ b/images/build/debian-base/trixie/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/man/*

--- a/images/build/debian-base/variants.yaml
+++ b/images/build/debian-base/variants.yaml
@@ -2,3 +2,6 @@ variants:
   bookworm:
     CONFIG: 'bookworm'
     IMAGE_VERSION: 'bookworm-v1.0.8'
+  trixie:
+    CONFIG: 'trixie'
+    IMAGE_VERSION: 'trixie-v1.0.0'


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds support to build the `debian-base` image based on Debian Trixie. This is required because the previous version (Bookworm) is out of support as of 2026-06-10, and will no longer receive patches or updated packages (e.g. python 3.12). This was originally proposed in https://github.com/kubernetes/release/pull/4312.

I listed all of the dependencies using `debian:trixie-slim` to verify I had them correct. I successfully built the image using:

```
CONFIG=trixie IMAGE_VERSION=trixie-v1.0.0 make build
```

Note: we *may* have to revisit the cloud build timeouts based on the other PR (though it failed to build). We will also need to update the defaults in the main `images/build/debian-base` makefile. I'll send a followup for this one.


#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Add Debian Trixie support for debian-base
```
