### PR TITLE
Update debian-base from Bookworm to Trixie by default

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -367,12 +367,12 @@ dependencies:
     refPaths:
       - path: images/releng/ci/variants.yaml
         match: "OS_CODENAME: 'trixie'"
+      - path: images/build/debian-base/Makefile
+        match: CONFIG\ \?=\ trixie
 
   - name: "Debian: codename (default)"
     version: bookworm
     refPaths:
-      - path: images/build/debian-base/Makefile
-        match: CONFIG\ \?=\ bookworm
       - path: images/build/debian-base/variants.yaml
         match: "CONFIG: 'bookworm'"
       - path: images/build/go-runner/Makefile
@@ -387,12 +387,12 @@ dependencies:
         match: "OS_CODENAME: 'bookworm'"
 
   - name: "registry.k8s.io/build-image/debian-base"
-    version: bookworm-v1.0.8
+    version: trixie-v1.0.0
     refPaths:
       - path: images/build/debian-base/Makefile
-        match: IMAGE_VERSION\ \?=\ bookworm-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+        match: IMAGE_VERSION\ \?=\ trixie-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
       - path: images/build/debian-base/variants.yaml
-        match: "IMAGE_VERSION: 'bookworm-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
+        match: "IMAGE_VERSION: 'trixie-v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"
 
   - name: "registry.k8s.io/build-image/debian-base: dependents"
     version: bookworm-v1.0.7

--- a/images/build/debian-base/Makefile
+++ b/images/build/debian-base/Makefile
@@ -19,8 +19,8 @@ IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
 TAG ?= $(shell git describe --tags --always --dirty)
-IMAGE_VERSION ?= bookworm-v1.0.8
-CONFIG ?= bookworm
+IMAGE_VERSION ?= trixie-v1.0.0
+CONFIG ?= trixie
 
 TAR_FILE ?= rootfs.tar
 ARCH ?= amd64


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is a follow up to github.com/kubernetes/release/pull/4501, which starts building Debian 13 (Trixie). This changes the Makefile to build using Trixie by default.

Bookworm is EoL, so often does not receive security patches. Many updated OS system packages (e.g. python) are also not available via the Debian sources.

Validated it successfully built locally using `make build`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update the default `debian-base` image to build from Debian 12 (Bookworm) to 13 (Trixie).
```
