### PR TITLE
Add attestation signing step to stage job

### DIFF
--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -15,6 +15,7 @@ steps:
       - "clone"
       - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
 
+  # Clone k/release
   - name: gcr.io/cloud-builders/git
     entrypoint: "bash"
     dir: "go/src/k8s.io/release"
@@ -25,6 +26,7 @@ steps:
         echo "Checking out ${_TOOL_REF}"
         git checkout ${_TOOL_REF}
 
+  # Download (or build) krel
   - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
     dir: go/src/k8s.io/release
     env:
@@ -36,6 +38,7 @@ steps:
     args:
       - ./hack/get-krel
 
+  # Build and stage the release artifacts
   - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
     dir: "/workspace"
     env:
@@ -61,6 +64,19 @@ steps:
       - "--branch=${_RELEASE_BRANCH}"
       - "--build-version=${_BUILDVERSION}"
 
+  # Sign and re-upload the attestations generated during the build. 
+  - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
+    dir: "/workspace"
+    args:
+      - "bin/krel"
+      - "sign"
+      - "attestation"
+      - "--in-place"
+      - "--impersonate-service-account=krel-staging@k8s-releng-prod.iam.gserviceaccount.com"
+      - "--log-level=${_LOG_LEVEL}"
+      - "${_STAGE_BUCKET}/stage/${_BUILDVERSION}/provenance.json"
+
+  # Stage the packages that will go to OBS
   - name: gcr.io/k8s-staging-releng/k8s-cloud-builder:${_KUBE_CROSS_VERSION}
     dir: "/workspace"
     env:
@@ -105,3 +121,8 @@ substitutions:
   # _GIT_TAG will be filled with a git-based tag of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: "12345"
+
+  # _STAGE_BUCKET is set by krel gcb to the mock or production bucket where
+  # the artifacts are staged. We default to the mock bucket so that a job
+  # submitted by hand can never touch production.
+  _STAGE_BUCKET: "gs://5d7373bbdcb8270361b96548387bf2a9ad0d48758c35"

--- a/pkg/gcp/gcb/gcb.go
+++ b/pkg/gcp/gcb/gcb.go
@@ -507,6 +507,10 @@ func (g *GCB) SetGCBSubstitutions(toolOrg, toolRepo, toolRef, gcsBucket, forceBu
 	gcbSubs["PATCH_VERSION_TAG"] = strconv.FormatUint(primeSemver.Patch, 10)
 	gcbSubs["KUBERNETES_VERSION_TAG"] = primeSemver.String()
 
+	// Bucket where the artifacts get staged, mock or production, so that
+	// stage jobs can locate the artifacts to sign.
+	gcbSubs["STAGE_BUCKET"] = gcsBucket
+
 	if g.options.Release {
 		gcbSubs["KUBERNETES_GCS_BUCKET"] = fmt.Sprintf("%s/stage/%s/%s/gcs-stage/%s", gcsBucket, buildVersion, versions.Prime(), versions.Prime())
 		if g.options.NoMock {

--- a/pkg/gcp/gcb/gcb_test.go
+++ b/pkg/gcp/gcb/gcb_test.go
@@ -159,6 +159,7 @@ func TestSubmitGcbFailure(t *testing.T) {
 	}
 }
 
+//nolint:maintidx // complex but acceptable
 func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 	testcases := []struct {
 		name           string
@@ -198,6 +199,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -228,6 +230,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 				"FASTLY_SERVICE_NAME":    "dl.k8s.dev",
 			},
 		},
@@ -257,6 +260,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -285,6 +289,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -317,6 +322,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -349,6 +355,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -378,6 +385,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 		{
@@ -406,6 +414,7 @@ func TestSetGCBSubstitutionsSuccess(t *testing.T) {
 				"K8S_ORG":                git.DefaultGithubOrg,
 				"K8S_REPO":               git.DefaultGithubRepo,
 				"K8S_REF":                git.DefaultRef,
+				"STAGE_BUCKET":           "gs://test-bucket",
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR updates the staging cloud build job, adding a step to sign the provenance attestation generated during the build. 

In addition to the Job YAML update, this PR also adds a small change to krel to define a `STAGE_BUCKET` substitution. This is set by krel to the correct name of the staging bucket  depending if we are in `mock`/`nomock` mode.

#### Which issue(s) this PR fixes:

None

Part of https://github.com/kubernetes/enhancements/issues/3027

#### Special notes for your reviewer:

:warning: **Needs** https://github.com/kubernetes/release/pull/4505

For now, we will sign by impersonating the `krel-staging@` service account. This only gives us SLSA 2 but on the upside we preserve the same identity signing the binaries.

Once we have signed provenance working, I will factor out artifact and provenance signing to an independent job and block the cloudbuild GCP account from impersonating `krel-staging@` so that the build cannot have access to the signer identity (thus lifting the release process to SLSA3).

**Note:**
This change will cause the attestation verification during release to fail. It's OK as the check is non-fatal. I will focus next on adding the proper attestation verification according to the SLSA spec.

#### Does this PR introduce a user-facing change?

```release-note
Staging now signs the provenance attestation
```
