### PR TITLE
schedule-builder: fix EOL branches without a next release

### DIFF
--- a/cmd/schedule-builder/cmd/markdown.go
+++ b/cmd/schedule-builder/cmd/markdown.go
@@ -243,8 +243,8 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 
 	for i, sched := range schedule.Schedules {
 		for {
-			if sched.Next == nil {
-				logrus.Warnf("Next release not set for %s, skipping", sched.Release)
+			if sched.Next == nil && sched.EndOfLifeDate == "" {
+				logrus.Warnf("Next release and end of life date not set for %s, skipping", sched.Release)
 
 				break
 			}
@@ -261,14 +261,39 @@ func updatePatchSchedule(refTime time.Time, schedule PatchSchedule, eolBranches 
 					break
 				}
 
+				// The branch may have no next release left, for example if the
+				// final patch release already got shipped. In that case fall
+				// back to the latest previous patch and the scheduled end of
+				// life date.
+				var finalPatchRelease string
+
+				endOfLifeDate := sched.EndOfLifeDate
+
+				switch {
+				case sched.Next != nil:
+					finalPatchRelease = sched.Next.Release
+					endOfLifeDate = sched.Next.TargetDate
+				case len(sched.PreviousPatches) > 0:
+					finalPatchRelease = sched.PreviousPatches[0].Release
+				default:
+					return fmt.Errorf("no patch release found for end of life release %s", sched.Release)
+				}
+
 				logrus.Infof("Moving %s to end of life", sched.Release)
 				eolBranches.Branches = append([]*EolBranch{{
 					Release:           sched.Release,
-					FinalPatchRelease: sched.Next.Release,
-					EndOfLifeDate:     sched.Next.TargetDate,
+					FinalPatchRelease: finalPatchRelease,
+					EndOfLifeDate:     endOfLifeDate,
 				}}, eolBranches.Branches...)
 
 				removeSchedules = append(removeSchedules, i)
+
+				break
+			}
+
+			// Not yet past end of life but no next release to advance.
+			if sched.Next == nil {
+				logrus.Warnf("Next release not set for %s, skipping", sched.Release)
 
 				break
 			}

--- a/cmd/schedule-builder/cmd/markdown_test.go
+++ b/cmd/schedule-builder/cmd/markdown_test.go
@@ -453,6 +453,69 @@ func TestUpdatePatchSchedule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "succeed to move end of life release without next release",
+			refTime: time.Date(2024, 4, 3, 0, 0, 0, 0, time.UTC),
+			givenSchedule: PatchSchedule{
+				Schedules: []*Schedule{
+					{ // EOL, final patch release already shipped so next is unset
+						Release:       "1.20",
+						EndOfLifeDate: "2023-12-12",
+						PreviousPatches: []*PatchRelease{
+							{
+								Release:            "1.20.10",
+								CherryPickDeadline: "2023-12-08",
+								TargetDate:         "2023-12-12",
+							},
+							{
+								Release:            "1.20.9",
+								CherryPickDeadline: "2023-11-10",
+								TargetDate:         "2023-11-14",
+							},
+						},
+					},
+				},
+				UpcomingReleases: []*PatchRelease{
+					{
+						CherryPickDeadline: "2024-04-12",
+						TargetDate:         "2024-04-17",
+					},
+					{
+						CherryPickDeadline: "2024-05-10",
+						TargetDate:         "2024-05-14",
+					},
+					{
+						CherryPickDeadline: "2024-06-07",
+						TargetDate:         "2024-06-11",
+					},
+				},
+			},
+			expectedSchedule: PatchSchedule{
+				UpcomingReleases: []*PatchRelease{
+					{
+						CherryPickDeadline: "2024-04-12",
+						TargetDate:         "2024-04-17",
+					},
+					{
+						CherryPickDeadline: "2024-05-10",
+						TargetDate:         "2024-05-14",
+					},
+					{
+						CherryPickDeadline: "2024-06-07",
+						TargetDate:         "2024-06-11",
+					},
+				},
+			},
+			expectedEolBranches: EolBranches{
+				Branches: []*EolBranch{
+					{
+						Release:           "1.20",
+						FinalPatchRelease: "1.20.10",
+						EndOfLifeDate:     "2023-12-12",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scheduleFile, err := os.CreateTemp(t.TempDir(), "schedule-")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`schedule-builder` skipped release branches with no `next` patch release before ever checking their end of life date, so branches whose final patch already shipped (e.g. 1.33) were never moved to `eol.yaml`. The end of life check now runs first, falling back to the newest `previousPatches` entry and the scheduled `endOfLifeDate`.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
Fixed `schedule-builder` not moving a release branch to `eol.yaml` when the branch no longer has a `next` patch release set
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes/release-engineering 