### PR TITLE
Update and weaken kubelet iptables dependency

### DIFF
--- a/cmd/krel/templates/latest/kubelet/kubelet.spec
+++ b/cmd/krel/templates/latest/kubelet/kubelet.spec
@@ -16,7 +16,7 @@ Source0: %{name}_%{version}.orig.tar.gz
 Source1: %{name}.rpmlintrc
 
 BuildRequires: systemd
-Requires: iptables >= 1.4.21
+Recommends: iptables >= 1.8.4
 {{ range $dep := .Metadata.Dependencies }}
 Requires: {{ $dep.Name }} {{ $dep.VersionConstraint }}
 {{ end }}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
Specifically inspired by https://github.com/kubernetes/enhancements/issues/5343#issuecomment-5546700706; having kubelet require `iptables` creates problems on RHEL10, where trying to install `iptables` ends up pulling in `kernel-modules-extra` since iptables is no longer available by default there.

Kubelet itself does not require iptables. While it will create [`KUBE-FIREWALL`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3178-iptables-cleanup/README.md#martian-packet-blocking) and [`KUBE-IPTABLES-HINT`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3178-iptables-cleanup/README.md#iptables-wrapper) chains if iptables is installed, it does this only to support _other_ iptables-using components on the system.

This PR downgrades the `Requires: iptables` to `Recommends: iptables`, which means `dnf` will still pull in `iptables` by default, but you can at least say `dnf install --setopt=install_weak_deps=False kubelet` to make it not.

I decided to do that rather than `Suggests: iptables` (which is ignored by default) because in some clusters, there may be containerized components that make use of [iptables-wrappers](https://github.com/kubernetes-sigs/iptables-wrappers), and assume that _something_ has ensured that iptables will be installed on the system, which it might not otherwise be if you installed from some sort of minimal cloud base install.

Still, this means we'll have to update the [install docs](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl) to tell RHEL10 users to pass the `install_weak_deps=False` option. I don't know if there's a better option though?

(Though if we [drop the kubernetes-cni package](https://github.com/kubernetes/release/issues/4156) then maybe we could [drop the kubelet iptables dependency too](https://github.com/kubernetes/release/issues/4434) at the same time, as part of an overall dependency-modernizing update?)

Meanwhile, in addition to the problem with RHEL10, the suggested iptables version in the spec is ancient, and [as of 1.37 we no longer even support iptables 1.4](https://github.com/kubernetes/kubernetes/pull/139247), so we should bump it to something more modern. (1.8.0-1.8.2 had [a bug that broke kubelet](https://github.com/kubernetes/kubernetes/issues/82361) and 1.8.3 had [a bug that kinda broke iptables-wrappers](https://github.com/kubernetes/kubernetes/pull/82966#issuecomment-551220689), so 1.8.4 is the oldest usable version of 1.8)

#### Which issue(s) this PR fixes:
also, problems discussed in https://github.com/kubernetes/enhancements/issues/5343

#### Does this PR introduce a user-facing change?
```release-note
The official kubelet packages now list iptables as a recommended depency
rather than a requirement, so users on RHEL10 can install with appropriate
options (e.g., `dnf install --setopt=install_weak_deps=False kubelet`) to
ignore the iptables dependency.
```
