### PR TITLE
Bump go and golangci-lint versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
   #     match: "GO_VERSION: '\\d+.\\d+(alpha|beta|rc)?\\.?(\\d+)?'"
 
   - name: "golang: go.mod"
-    version: 1.26
+    version: 1.27
     refPaths:
       - path: go.mod
         match: go \d+.\d+
@@ -347,7 +347,7 @@ dependencies:
 
   # golangci-lint-version
   - name: "golangci-lint"
-    version: v2.12
+    version: v2.13
     refPaths:
       - path: .github/workflows/lint.yml
         match: "version: v\\d+.\\d+?\\.?(\\d+)?"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/release
 
-go 1.26.0
+go 1.27.0
 
 require (
 	cloud.google.com/go/storage v1.62.3


### PR DESCRIPTION


#### What type of PR is this?
/kind cleanup
/kind feature


#### What this PR does / why we need it:
- Bump go and golangci-lint versions

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Bump go to 1.27 and golangci-lint versions
```
